### PR TITLE
Set up cloud-agent environment for the new yoetz repo

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Idempotent cloud-agent dependency setup for the yoetz repo.
+set -euo pipefail
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+# Prefer the repo-pinned Node over any exec-daemon shim.
+export NVM_DIR="${HOME}/.nvm"
+# shellcheck disable=SC1091
+[ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+nvm install 26.5.0
+nvm alias default 26.5.0
+nvm use 26.5.0
+export PATH="${NVM_DIR}/versions/node/v26.5.0/bin:${PATH}"
+
+# package.json engines pin npm@12.0.1
+npm install -g npm@12.0.1
+hash -r
+npm ci
+
+# Python toolchain: uv + locked project deps (requires-python 3.14).
+if ! command -v uv >/dev/null 2>&1 || [[ "$(uv --version 2>/dev/null || true)" != "uv 0.11.29"* ]]; then
+  curl -LsSf https://astral.sh/uv/0.11.29/install.sh | sh
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+uv python install 3.14
+uv sync --all-groups --locked
+
+# Quick sanity so a bad snapshot fails install instead of the agent mid-task.
+uv run python --version
+uv run yoetz --version
+npx --no-install pyright --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ venvPath = "."
 venv = ".venv"
 
 [tool.pytest.ini_options]
-addopts = ["--strict-config", "--strict-markers"]
+addopts = ["--strict-config", "--strict-markers", "--import-mode=importlib"]
+pythonpath = ["tests"]
 testpaths = ["tests"]
 markers = [
     "fault: destructive or abrupt-fault subprocess case; excluded from bounded PR runs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The cloud environment for this slug still had the old **yoetz-legacy** install script (`pip install -r app/server/llm/requirements.txt`, Node 20). This PR adds a repo-owned setup that matches the current Python/`uv` + Node/pyright toolchain so cloud agents can actually boot and work.

## Changes
- `.cursor/environment.json` + `.cursor/install.sh` — idempotent install for Node `26.5.0`, npm `12.0.1`, uv `0.11.29`, Python `3.14`, `uv sync --all-groups --locked`, plus a short CLI/pyright sanity check
- `pyproject.toml` — pytest `--import-mode=importlib` and `pythonpath = ["tests"]` so same-basename test modules collect (already noted as needed in the capability specs)

## Verified in this cloud session
- `uv sync` + `yoetz --version` → `0.1.0`
- `npm run typecheck` → 0 errors
- `uv run ruff check src tests` → clean
- `uv run pytest tests/unit -q --timeout=60` → **843 passed**

## Follow-up (dashboard)
After merge, save a fresh VM snapshot from the Cloud Agents environment page if you want faster boots. The personal environment’s old update script is superseded by `.cursor/environment.json` once this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a598e07-ee32-4918-8095-81ffad1112bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a598e07-ee32-4918-8095-81ffad1112bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated development environment setup with pinned Node.js and Python tooling.
  * Added dependency installation and environment validation checks.
* **Tests**
  * Improved test configuration with stricter marker handling and consistent import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->