### PR TITLE
Fix passphrase vault restart/unlock and OpenAI Responses base URL

### DIFF
--- a/specs/src/yoetz/application/service.md
+++ b/specs/src/yoetz/application/service.md
@@ -143,6 +143,12 @@ purpose `client_result_projection` and a trusted `ProjectionAuditContext` to
   `local_disclosure_receipt_id`, policy ID/version/digest, sorted included/blocked categories, and
   sorted omitted JSON Pointers.
 
+The sole replacement exception is `ReceiptSuccessModel.document` when `format="json"`: that value
+is the exact canonical stored receipt document bound by `receipt_digest`. If any present
+`/document` content leaf is blocked or unclassifiable, projection fails closed with retryable
+`privacy_projection_unavailable` before success serialization and never emits a partly rewritten
+JSON receipt. Markdown/text `human_text` remains an ordinary replaceable content leaf.
+
 There is no free-form marker, null substitution, whole-result fallback that can conceal which
 field was removed, or bridge-local discretion. If no content category is allowed, the caller still
 receives the structural result plus markers and receipt. Initial audit reservation failure returns

--- a/specs/src/yoetz/service/control_protocol.md
+++ b/specs/src/yoetz/service/control_protocol.md
@@ -25,8 +25,9 @@ calling Python objects directly or inventing a secret-bearing/private service me
   peer handle, bounded `receive(max_bytes)`, backpressure-aware `send_all`, and `aclose`.
 - `parse_control_request(ControlFrame) -> ControlRequest` and
   `parse_control_result(ControlFrame) -> ControlResult`. Workflow bodies become the existing exact
-  request/result models, service status/lock results become `ServiceStatus`, and every other closed
-  support body remains a deeply frozen `JsonObject`.
+  request/result models after thawing the deeply frozen `JsonObject` body into plain JSON
+  mappings/lists (pydantic rejects `JsonObject` itself), service status/lock results become
+  `ServiceStatus`, and every other closed support body remains a deeply frozen `JsonObject`.
 - `async client_handshake(stream, client_kind, client_version) -> ControlSession`.
 - `async server_handshake(stream, peer_identity, service_status) -> ControlSession`.
 - `validate_request(ControlRequest)`, `validate_result(ControlResult)`, and

--- a/specs/src/yoetz/service/daemon.md
+++ b/specs/src/yoetz/service/daemon.md
@@ -74,7 +74,10 @@ clients, or an already-open database.
    initializes `catalog.sqlite3`, seeds the current installation ID plus owner generation, constructs
    the local bundle runtime and application facade, reconciles the central egress-policy gateway, and
    selects only the credential-free reviewed bundled provider factories allowed by active policy,
-   once. No provider credential is retrieved at startup; the gateway
+   once. The denied machine privacy policy is seeded only when no durable current policy exists for
+   the installation scope; later unlocks reuse that durable policy and never re-mint seed identity
+   (`policy_id`/`created_at`) that would conflict with `seed_if_absent`. No provider credential is
+   retrieved at startup; the gateway
    mints one body/profile/deadline-bound opaque handle per authorized physical attempt, never from
    config/environment bytes.
    `activate_ready_application` holds the daemon activation mutex, requires lifecycle `unlocking`,
@@ -229,8 +232,9 @@ secret memory in reverse ownership order.
 
 ## Tests
 
-- `tests/integration/service/test_ready_composition.py` covers unfenced catalog writer admission and
-  the ready catalog generation seed used by the runtime ready gate.
+- `tests/integration/service/test_ready_composition.py` covers unfenced catalog writer admission,
+  the ready catalog generation seed used by the runtime ready gate, privacy-seed reuse across ready
+  rebuilds, and in-process daemon unlock → `START` projection.
 - `tests/integration/service/test_daemon_clients.py` exercises every method through concurrent CLI,
   MCP, and synthetic UI clients against one application/runtime.
 - `tests/subprocess/test_service_daemon_lifecycle.py` covers startup, second-daemon rejection,

--- a/specs/src/yoetz/service/daemon.md
+++ b/specs/src/yoetz/service/daemon.md
@@ -70,9 +70,11 @@ clients, or an already-open database.
    reason; a usable keyring without verified presence reports `human_authority_unavailable`. Both
    remain `uninitialized/locked` with no vault/keyring mutation and never select passphrase mode
    until the local human explicitly completes the distinct `vault_initialize` ceremony.
-6. Successful vault unlock constructs the installation catalog/runtime, application facade,
-   central egress-policy gateway, and only the credential-free reviewed bundled provider factories
-   allowed by active policy, once. No provider credential is retrieved at startup; the gateway
+6. Successful vault unlock calls the daemon-private `ready_composition` factory, which opens or
+   initializes `catalog.sqlite3`, seeds the current installation ID plus owner generation, constructs
+   the local bundle runtime and application facade, reconciles the central egress-policy gateway, and
+   selects only the credential-free reviewed bundled provider factories allowed by active policy,
+   once. No provider credential is retrieved at startup; the gateway
    mints one body/profile/deadline-bound opaque handle per authorized physical attempt, never from
    config/environment bytes.
    `activate_ready_application` holds the daemon activation mutex, requires lifecycle `unlocking`,
@@ -227,6 +229,8 @@ secret memory in reverse ownership order.
 
 ## Tests
 
+- `tests/integration/service/test_ready_composition.py` covers unfenced catalog writer admission and
+  the ready catalog generation seed used by the runtime ready gate.
 - `tests/integration/service/test_daemon_clients.py` exercises every method through concurrent CLI,
   MCP, and synthetic UI clients against one application/runtime.
 - `tests/subprocess/test_service_daemon_lifecycle.py` covers startup, second-daemon rejection,

--- a/specs/src/yoetz/service/daemon.md
+++ b/specs/src/yoetz/service/daemon.md
@@ -36,6 +36,12 @@ clients, or an already-open database.
 
 1. Parse/validate service configuration and verified per-user data/runtime paths; configure
    allowlisted diagnostics; suppress core dumps where supported.
+   Production `_SystemClock.now_utc` truncates to whole milliseconds so throttle
+   wall-anomaly formatting cannot false-positive into the maximum unlock delay on restart.
+   For an already committed passphrase vault, restart loads the live throttle via
+   `open_for_restart` and checks installation identity; it does not require the mutable
+   throttle `record_digest` to still equal the frozen installation `mode_binding_digest`
+   (that equality is required only at passphrase mode publication).
    The daemon-private installation-state marker is canonical owner-only JSON plus one LF:
    `{schema_version:"1", installation_id, vault_mode:"os_keyring"|"passphrase",
    root_envelope_base64:null|<standard-base64 canonical envelope>, mode_binding_digest,

--- a/specs/src/yoetz/service/vault.md
+++ b/specs/src/yoetz/service/vault.md
@@ -169,7 +169,9 @@ contradictory record. `installation_mac_handle` accepts only `catalog_lookup`, `
 `privacy_audit` and returns the already-bound opaque handle; requesting `bundle_commitment` or
 calling a handle with another purpose's domain fails closed. The service composition injects only
 the catalog handle into start-catalog adapters, only the log handle into observability privacy, and
-only the audit handle into the privacy gateway/audit path. For each physical outbound attempt,
+only the audit handle into the privacy gateway/audit path. The `privacy_audit` handle admits only
+the closed audit domains used by catalog privacy persistence: egress request, lookup, proposal,
+control request, internal result, projection, local approval, and receipt cursor. For each physical outbound attempt,
 `provider_credential(binding)` returns a fresh one-use `ProviderCredentialHandle` restricted to the
 exact provider/model/endpoint-profile/version, purpose plus authorization-scope/purpose digests,
 dispatch ID, final request-body digest, service generation, and deadline in

--- a/specs/tests/conformance/operations/test_receipt_contract.py.md
+++ b/specs/tests/conformance/operations/test_receipt_contract.py.md
@@ -14,6 +14,8 @@ the exact 11-field `ReceiptVersionSlice`, including `resource_manifest_digest`.
 ## Public surface
 
 - `test_receipt_request_result_parity` — JSON/structured receipt results match.
+- `test_json_receipt_projection_fails_closed_when_document_leaves_blocked` — blocked
+  `/document` leaves fail closed with `privacy_projection_unavailable` instead of rewriting.
 - `test_frontier_and_own_event_exclusion_parity` — the subject frontier is exact.
 - `test_receipt_wording_is_weaker_than_document` — human text never outruns the document.
 - `test_reviewed_receipt_vectors_match_exact_document_and_compact_bytes` — each golden fixture

--- a/specs/tests/unit/application/test_service_facade.py.md
+++ b/specs/tests/unit/application/test_service_facade.py.md
@@ -25,7 +25,9 @@ The contract slice proves `disabled|optional|required` maps exactly to the three
 that a non-bool `max_findings` is limited to `1..10`. It proves only
 `cli + human_readable + output_is_controlling_tty` resolves to `local_human_view`; machine mode,
 missing/non-TTY output, MCP, UI, wrong runtime types, and the explicit fail-safe default resolve to
-`agent_context` or reject before projection. The daemon integration suite separately proves the
+`agent_context` or reject before projection. It also proves JSON `receipt` projection fails closed
+with `privacy_projection_unavailable` when any `/document` content leaf is blocked, rather than
+emitting a partly rewritten digest-bound document. The daemon integration suite separately proves the
 exact context reaches `project_result_for_client` and cannot cross-pair client kinds.
 
 ## Errors and edge cases

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -238,9 +238,11 @@ class OpenAIProfile:
 
     @property
     def base_url(self) -> str:
+        # OpenAI Python SDK appends `/responses` to base_url; include `/v1` so the
+        # wire path matches the transport-enforced `/v1/responses` destination.
         if self.port == 443:
-            return f"https://{self.host}"
-        return f"https://{self.host}:{self.port}"
+            return f"https://{self.host}/v1"
+        return f"https://{self.host}:{self.port}/v1"
 
 
 def owner_declared_data_use_profile(

--- a/src/yoetz/adapters/sqlite/connection.py
+++ b/src/yoetz/adapters/sqlite/connection.py
@@ -35,6 +35,7 @@ __all__ = [
     "SqliteWriterThread",
     "StorageUnsafeError",
     "assert_active_bundle_generation",
+    "open_catalog_writer",
     "open_read_only",
     "open_writer",
     "verify_schema_identity",
@@ -69,6 +70,10 @@ _READ_ONLY_ALLOWED_PRAGMAS: Final = frozenset(
 _WRITER_ALLOWED_PRAGMAS: Final = _READ_ONLY_ALLOWED_PRAGMAS | frozenset(
     {"application_id", "user_version", "wal_checkpoint"}
 )
+_WRITER_SAFE_CONFIGURATION_PRAGMAS: Final = {
+    "foreign_keys": frozenset({None, "ON", "1"}),
+    "trusted_schema": frozenset({None, "OFF", "0"}),
+}
 _STORAGE_UNSAFE_REASONS: Final = frozenset(
     {
         "application_id_mismatch",
@@ -389,7 +394,14 @@ def _writer_authorizer(
         return apsw.SQLITE_DENY
     if action == apsw.SQLITE_FUNCTION and second == "load_extension":
         return apsw.SQLITE_DENY
-    if action == apsw.SQLITE_PRAGMA and first not in _WRITER_ALLOWED_PRAGMAS:
+    if action == apsw.SQLITE_PRAGMA:
+        if first in _WRITER_ALLOWED_PRAGMAS:
+            return apsw.SQLITE_OK
+        if (
+            first in _WRITER_SAFE_CONFIGURATION_PRAGMAS
+            and second in _WRITER_SAFE_CONFIGURATION_PRAGMAS[first]
+        ):
+            return apsw.SQLITE_OK
         return apsw.SQLITE_DENY
     return apsw.SQLITE_OK
 
@@ -503,6 +515,12 @@ def _open_recovery_writer(  # pyright: ignore[reportUnusedFunction]
     path: Path,
 ) -> apsw.Connection:
     """Open the sole pre-fence writer used by migration/ownership recovery."""
+
+    return _open_verified_writer(path, require_fence=False)
+
+
+def open_catalog_writer(path: Path) -> apsw.Connection:
+    """Open the generation-owned catalog writer before any bundle fence exists."""
 
     return _open_verified_writer(path, require_fence=False)
 

--- a/src/yoetz/adapters/sqlite/start_catalog.py
+++ b/src/yoetz/adapters/sqlite/start_catalog.py
@@ -414,6 +414,10 @@ class SqliteStartCatalog:
         self._lease_owner_id = ids.new(IdKind.SERVICE_INSTANCE)
         validate_id(IdKind.SERVICE_INSTANCE, self._lease_owner_id)
 
+    @property
+    def generation(self) -> int:
+        return self._owner_generation()
+
     async def commit_identity(self, value: StartIdentityInput) -> StartIdentityCommitments:
         if type(value) is not StartIdentityInput:
             raise _error(PublicErrorCode.INVALID_REQUEST)

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -694,6 +694,18 @@ class Application:
             completed = cast(LocalDisclosureApproved | LocalDisclosureBlocked, decision)
         else:
             raise TypeError("local_disclosure_result_invalid")
+        # Digest-bound JSON receipt documents cannot be partly rewritten with omission
+        # markers; fail closed when any present document content leaf is blocked.
+        if (
+            method is ControlMethod.RECEIPT
+            and source.get("format") == "json"
+            and any(
+                omission.json_pointer == "/document"
+                or omission.json_pointer.startswith("/document/")
+                for omission in completed.omissions
+            )
+        ):
+            raise ControlError("privacy_projection_unavailable", retryable=True)
         projected: JsonValue = source
         for omission in completed.omissions:
             projected = _replace_pointer(

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -534,7 +534,7 @@ def _expected_result_type(kind: HumanCeremonyKind) -> type[HumanResult]:
 async def _cancel_quietly(session: HumanControlSession) -> None:
     try:
         await session.cancel()
-    except ConfidentialClientError, OSError, RuntimeError:
+    except (ConfidentialClientError, OSError, RuntimeError):
         pass
 
 

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -534,7 +534,7 @@ def _expected_result_type(kind: HumanCeremonyKind) -> type[HumanResult]:
 async def _cancel_quietly(session: HumanControlSession) -> None:
     try:
         await session.cancel()
-    except (ConfidentialClientError, OSError, RuntimeError):
+    except ConfidentialClientError, OSError, RuntimeError:
         pass
 
 

--- a/src/yoetz/service/control_protocol.py
+++ b/src/yoetz/service/control_protocol.py
@@ -310,9 +310,13 @@ def _plain_wire_value(value: object) -> JsonValue:
     if isinstance(value, ControlError):
         return {"code": value.reason, "retryable": value.retryable}
     if isinstance(value, BaseModel):
+        # Match public_model_to_wire: keep explicit nulls required by closed schemas,
+        # omit unset optional fields (optional_non_null must stay absent, not null).
         return cast(
             JsonValue,
-            value.model_dump(mode="json", by_alias=True, exclude_none=True),
+            value.model_dump(
+                mode="json", by_alias=True, exclude_unset=True, exclude_none=False
+            ),
         )
     if is_dataclass(value) and not isinstance(value, type):
         converted: dict[str, JsonValue] = {}

--- a/src/yoetz/service/control_protocol.py
+++ b/src/yoetz/service/control_protocol.py
@@ -314,9 +314,7 @@ def _plain_wire_value(value: object) -> JsonValue:
         # omit unset optional fields (optional_non_null must stay absent, not null).
         return cast(
             JsonValue,
-            value.model_dump(
-                mode="json", by_alias=True, exclude_unset=True, exclude_none=False
-            ),
+            value.model_dump(mode="json", by_alias=True, exclude_unset=True, exclude_none=False),
         )
     if is_dataclass(value) and not isinstance(value, type):
         converted: dict[str, JsonValue] = {}

--- a/src/yoetz/service/control_protocol.py
+++ b/src/yoetz/service/control_protocol.py
@@ -293,6 +293,17 @@ def _fail(reason: str) -> Never:
     raise ControlProtocolError(reason)
 
 
+def _plain_mapping_for_model(value: object) -> Mapping[str, JsonValue]:
+    """Thaw a deeply frozen wire body into plain dicts/lists for pydantic models."""
+
+    if not isinstance(value, Mapping):
+        _fail("frame_invalid")
+    thawed = strict_json_parse(canonical_encode(cast(JsonValue, value)))
+    if type(thawed) is not dict:
+        _fail("frame_invalid")
+    return cast(Mapping[str, JsonValue], thawed)
+
+
 def _plain_wire_value(value: object) -> JsonValue:
     if isinstance(value, Enum):
         return cast(JsonValue, value.value)
@@ -558,7 +569,7 @@ def parse_control_request(frame: ControlFrame) -> ControlRequest:
         body = (
             JsonObject(cast(Mapping[str, JsonValue], raw_body))
             if model is None
-            else model.model_validate(raw_body)
+            else model.model_validate(_plain_mapping_for_model(raw_body))
         )
         deadline = wire.get("deadline_ms")
         return ControlCallRequest(
@@ -604,7 +615,7 @@ def parse_control_result(frame: ControlFrame) -> ControlResult:
             body = (
                 JsonObject(cast(Mapping[str, JsonValue], raw_body))
                 if model is None
-                else model.model_validate(raw_body)
+                else model.model_validate(_plain_mapping_for_model(raw_body))
             )
         return ControlResult(
             protocol_version="1.0",

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -116,6 +116,7 @@ from yoetz.service.lifecycle import (
     ServiceLifecycle,
     SessionSecurityEvent,
 )
+from yoetz.service.ready_composition import build_ready_application_factory
 from yoetz.service.secret_ingress import SecretIngressService
 from yoetz.service.unlock import UnlockCoordinator, UnlockThrottleRecord, UnlockThrottleStore
 from yoetz.service.vault import VaultMode, VaultService
@@ -222,52 +223,6 @@ class _Diagnostics(Protocol):
 
 type _HumanConnectionHandler = Callable[[ControlStream], Awaitable[None]]
 type _ReadyApplicationFactory = Callable[[int, int], Awaitable[_ReadyApplication]]
-
-
-class _BootstrapReadyApplication:
-    """Minimal ready application used until full production composition is wired.
-
-    Satisfies the daemon's ready-application protocol so vault initialize/unlock can
-    publish lifecycle READY. Workflow dispatch still fails closed until a full
-    ``ReadyApplicationFactory`` builds catalog/runtime/privacy.
-    """
-
-    async def projection_binding_facts(
-        self,
-        method: ControlMethod,
-        request: object,
-        result: object,
-    ) -> ProjectionBindingFacts:
-        del method, result
-        request_id = getattr(request, "request_id", None)
-        return ProjectionBindingFacts(request_id if type(request_id) is str else None, None)
-
-    async def project_result_for_client(
-        self,
-        context: ClientProjectionContext,
-        binding: ControlProjectionBinding,
-        result: object,
-    ) -> ProjectedControlBody:
-        del context, binding
-        if isinstance(result, JsonObject):
-            return result
-        raise ControlError("method_forbidden")
-
-    async def close(self) -> None:
-        return None
-
-
-async def _bootstrap_ready_application_factory(
-    service_generation: int, vault_generation: int
-) -> _ReadyApplication:
-    if (
-        type(service_generation) is not int
-        or type(vault_generation) is not int
-        or service_generation <= 0
-        or vault_generation <= 0
-    ):
-        raise LifecycleError("invalid_transition")
-    return _BootstrapReadyApplication()
 
 
 class _ReadyActivationRelay:
@@ -1387,6 +1342,23 @@ async def _production_composition(
                 raise RuntimeError("installation_throttle_binding_invalid")
         relay = _ReadyActivationRelay()
         secret_ingress = SecretIngressService(clock, secret_memory, listener=listeners.secret)
+        diagnostics = _NullDiagnostics()
+        ready_application_factory = (
+            _ready_application_factory
+            if _ready_application_factory is not None
+            else cast(
+                _ReadyApplicationFactory,
+                build_ready_application_factory(
+                    lifecycle=lifecycle,
+                    vault=vault,
+                    config=config,
+                    paths=paths,
+                    clock=clock,
+                    secret_memory=secret_memory,
+                    diagnostics=diagnostics,
+                ),
+            )
+        )
         unlock = UnlockCoordinator(
             clock=clock,
             throttle=throttle,
@@ -1411,15 +1383,11 @@ async def _production_composition(
             human_control_service=human,
             session_monitor=SessionEventMonitor(),
             vault=vault,
-            ready_application_factory=(
-                _ready_application_factory
-                if _ready_application_factory is not None
-                else _bootstrap_ready_application_factory
-            ),
+            ready_application_factory=ready_application_factory,
             secret_ingress_service=secret_ingress,
             unlock_service=unlock,
             secret_memory=secret_memory,
-            diagnostics=_NullDiagnostics(),
+            diagnostics=diagnostics,
             human_connection_handler=_HumanConnectionServer(human),
             ready_activation_relay=relay,
             ready_close_relay=ready_close_relay,

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -91,7 +91,6 @@ from yoetz.service.confidential_protocol import (
     SecretRequiredPhase,
     ServerCloseEnvelope,
     ServerErrorEnvelope,
-    ServerPhaseEnvelope,
     ServerResultEnvelope,
     VaultInitializePreview,
     VaultUnlockPreview,
@@ -223,6 +222,52 @@ class _Diagnostics(Protocol):
 
 type _HumanConnectionHandler = Callable[[ControlStream], Awaitable[None]]
 type _ReadyApplicationFactory = Callable[[int, int], Awaitable[_ReadyApplication]]
+
+
+class _BootstrapReadyApplication:
+    """Minimal ready application used until full production composition is wired.
+
+    Satisfies the daemon's ready-application protocol so vault initialize/unlock can
+    publish lifecycle READY. Workflow dispatch still fails closed until a full
+    ``ReadyApplicationFactory`` builds catalog/runtime/privacy.
+    """
+
+    async def projection_binding_facts(
+        self,
+        method: ControlMethod,
+        request: object,
+        result: object,
+    ) -> ProjectionBindingFacts:
+        del method, result
+        request_id = getattr(request, "request_id", None)
+        return ProjectionBindingFacts(request_id if type(request_id) is str else None, None)
+
+    async def project_result_for_client(
+        self,
+        context: ClientProjectionContext,
+        binding: ControlProjectionBinding,
+        result: object,
+    ) -> ProjectedControlBody:
+        del context, binding
+        if isinstance(result, JsonObject):
+            return result
+        raise ControlError("method_forbidden")
+
+    async def close(self) -> None:
+        return None
+
+
+async def _bootstrap_ready_application_factory(
+    service_generation: int, vault_generation: int
+) -> _ReadyApplication:
+    if (
+        type(service_generation) is not int
+        or type(vault_generation) is not int
+        or service_generation <= 0
+        or vault_generation <= 0
+    ):
+        raise LifecycleError("invalid_transition")
+    return _BootstrapReadyApplication()
 
 
 class _ReadyActivationRelay:
@@ -865,7 +910,11 @@ class _ListenerBinders:
 
 class _SystemClock:
     def now_utc(self) -> datetime:
-        return datetime.now(UTC)
+        # RFC3339 millis contract rejects sub-millisecond timestamps; truncate like
+        # observability._SystemClock so throttle wall-anomaly checks do not false-positive
+        # into a 300s unlock lockout on every restart.
+        now = datetime.now(UTC)
+        return now.replace(microsecond=(now.microsecond // 1_000) * 1_000)
 
     def monotonic_seconds(self) -> float:
         return time.monotonic()
@@ -1209,11 +1258,14 @@ class _HumanConnectionServer:
             ceremony_id = cast(str, getattr(response, "ceremony_id"))
             await _write_human_envelope(stream, response)
             while True:
-                if type(response) is ServerPhaseEnvelope and isinstance(
-                    response.phase, SecretRequiredPhase
-                ):
-                    error_step = response.step + 1
-                    response = await self._service.secret_completed(response.ceremony_id)
+                # ServerOpenedEnvelope (step 1) and later ServerPhaseEnvelope both carry
+                # SecretRequiredPhase; the daemon must await YZS1 completion either way.
+                phase = getattr(response, "phase", None)
+                if isinstance(phase, SecretRequiredPhase):
+                    error_step = cast(int, getattr(response, "step")) + 1
+                    response = await self._service.secret_completed(
+                        cast(str, getattr(response, "ceremony_id"))
+                    )
                 else:
                     incoming = await _read_human_envelope(stream)
                     if type(incoming) is ClientActionEnvelope:
@@ -1324,8 +1376,14 @@ async def _production_composition(
             clock=clock,
         )
         if mode is VaultMode.PASSPHRASE:
+            # mode_binding_digest is the *initial* throttle digest frozen at passphrase
+            # publication (vault.md). Later unlock attempts advance record_digest, so restart
+            # must not require equality with the live throttle record — only that passphrase
+            # mode has a marker and the throttle store opens for this installation.
+            if marker is None:
+                raise RuntimeError("installation_throttle_binding_invalid")
             record = throttle.open_for_restart()
-            if marker is None or record.record_digest != marker.mode_binding_digest:
+            if record.installation_id != installation_id:
                 raise RuntimeError("installation_throttle_binding_invalid")
         relay = _ReadyActivationRelay()
         secret_ingress = SecretIngressService(clock, secret_memory, listener=listeners.secret)
@@ -1353,7 +1411,11 @@ async def _production_composition(
             human_control_service=human,
             session_monitor=SessionEventMonitor(),
             vault=vault,
-            ready_application_factory=_ready_application_factory,
+            ready_application_factory=(
+                _ready_application_factory
+                if _ready_application_factory is not None
+                else _bootstrap_ready_application_factory
+            ),
             secret_ingress_service=secret_ingress,
             unlock_service=unlock,
             secret_memory=secret_memory,

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -212,7 +212,9 @@ def _install_sqlite_support_policy() -> None:
         raise RuntimeError("sqlite_compile_options_invalid")
     options = frozenset(cast(list[str], raw_option_items))
     factory = cast(_SqliteSupportPolicyFactory, getattr(connection_module, "_SqliteSupportPolicy"))
-    installer = cast(Callable[[object | None], None], getattr(connection_module, "_install_support_policy"))
+    installer = cast(
+        Callable[[object | None], None], getattr(connection_module, "_install_support_policy")
+    )
     policy = factory(
         manifest_id=build_version_manifest().resource_manifest_digest,
         required_options=options,
@@ -230,7 +232,9 @@ def _install_recovery_persistence(persistence: object) -> None:
 
 
 def _open_recovery_writer(path: Path) -> apsw.Connection:
-    opener = cast(Callable[[Path], apsw.Connection], getattr(connection_module, "_open_recovery_writer"))
+    opener = cast(
+        Callable[[Path], apsw.Connection], getattr(connection_module, "_open_recovery_writer")
+    )
     return opener(path)
 
 
@@ -423,9 +427,7 @@ class _RecoveryPersistence:
             raise ValueError("recovery_value_invalid")
         return replace(state, tail_state=recovery_module.RecoveryTailState.CLEAN)
 
-    def rebuild_projection(
-        self, state: object, fence: OwnershipFence, *, now: datetime
-    ) -> object:
+    def rebuild_projection(self, state: object, fence: OwnershipFence, *, now: datetime) -> object:
         del fence, now
         if type(state) is not recovery_module.RecoveryState:
             raise ValueError("recovery_value_invalid")
@@ -575,7 +577,9 @@ def _inspect_common(
     fresh_allocation: bool,
 ) -> _BundleInspection:
     task_id = cast(str, getattr(route, "task_id"))
-    bundle_root = _safe_bundle_root(bundle_base, cast(str, getattr(route, "bundle_relpath")), task_id)
+    bundle_root = _safe_bundle_root(
+        bundle_base, cast(str, getattr(route, "bundle_relpath")), task_id
+    )
     state = recovery_module.inspect_recovery_state(
         bundle_root,
         catalog_path=catalog_path,
@@ -638,7 +642,11 @@ def build_runtime_adapter_factories(
             route_identity_digest=cast(str, getattr(command, "route_identity_digest")),
             state=TaskRouteState.ACTIVE,
         )
-        bundle_root = _safe_bundle_root(paths.bundle, cast(str, getattr(command, "bundle_relpath")), cast(str, getattr(command, "task_id")))
+        bundle_root = _safe_bundle_root(
+            paths.bundle,
+            cast(str, getattr(command, "bundle_relpath")),
+            cast(str, getattr(command, "task_id")),
+        )
         ledger_path = bundle_root / _LEDGER_NAME
         fresh = not ledger_path.exists()
         if fresh:
@@ -1016,9 +1024,7 @@ def _receipt_versions(manifest: Mapping[str, CanonicalJsonValue]) -> ReceiptVers
         object_format_version=cast(str, manifest["object_format_version"]),
         catalog_schema_version=cast(str, manifest["catalog_schema_version"]),
         bundle_schema_version=cast(str, manifest["bundle_schema_version"]),
-        policy_versions=tuple(
-            sorted(policy_versions, key=lambda item: item.policy_id.encode())
-        ),
+        policy_versions=tuple(sorted(policy_versions, key=lambda item: item.policy_id.encode())),
         schema_versions=tuple(sorted(schema_versions, key=lambda item: item.schema_id.encode())),
         resource_manifest_digest=cast(str, manifest["resource_manifest_digest"]),
     )
@@ -1028,7 +1034,9 @@ async def _semantic_not_configured(
     frozen: FrozenCase, findings: tuple[object, ...]
 ) -> FinalSemanticEvaluation:
     del frozen, findings
-    return FinalSemanticEvaluation(SemanticStatus.NOT_CONFIGURED, SemanticReason.PROVIDER_NOT_CONFIGURED)
+    return FinalSemanticEvaluation(
+        SemanticStatus.NOT_CONFIGURED, SemanticReason.PROVIDER_NOT_CONFIGURED
+    )
 
 
 def _profile(config: YoetzConfig) -> RuntimeProfile:

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1,0 +1,1156 @@
+"""Daemon-private production ready-application composition."""
+
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol, cast
+
+import apsw
+
+import yoetz.adapters.sqlite.connection as connection_module
+import yoetz.adapters.sqlite.recovery as recovery_module
+from yoetz.adapters.objects.encrypted_files import EncryptedFilesObjectStore
+from yoetz.adapters.privacy.catalog import CatalogPrivacyAudit, CatalogPrivacyPolicyStore
+from yoetz.adapters.privacy.gateway import PolicyEnforcingOutboundGateway
+from yoetz.adapters.privacy.local_enforcer import LocalPrivacyEnforcer
+from yoetz.adapters.providers.local_model import InstalledLocalModelProfileRegistry
+from yoetz.adapters.runtime import RuntimeAdapterFactories, open_local_bundle_runtime
+from yoetz.adapters.sqlite.connection import (
+    open_catalog_writer,
+    open_read_only,
+    open_writer,
+    verify_schema_identity,
+)
+from yoetz.adapters.sqlite.migrations import initialize_bundle, initialize_catalog
+from yoetz.adapters.sqlite.repository import SqliteLedger
+from yoetz.adapters.sqlite.start_catalog import SqliteStartCatalog
+from yoetz.application.check import FinalSemanticEvaluation
+from yoetz.application.service import (
+    ControlProjectionBinding,
+    ReadyApplicationFactory,
+    ServiceReadyContext,
+    VerificationPolicy,
+)
+from yoetz.config.models import YoetzConfig
+from yoetz.config.paths import ensure_owner_only_dir, verify_private_local_bundle
+from yoetz.config.privacy import safe_privacy_bootstrap, seed_policy_if_absent
+from yoetz.domain.events import RuntimeProfile
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ChannelPolicy,
+    DataCategory,
+    DataClass,
+    EgressChannel,
+    PrivacyPolicy,
+    PrivacyProfile,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
+from yoetz.domain.receipts import PolicyVersionEntry, ReceiptVersionSlice, SchemaVersionEntry
+from yoetz.domain.values import (
+    Frontier,
+    format_rfc3339_millis,
+    session_id,
+)
+from yoetz.domain.values import (
+    JsonValue as DomainJsonValue,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.control import ControlError
+from yoetz.ports.diagnostics import DiagnosticsPort, RuntimeCapability, StartupCheckResult
+from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
+from yoetz.ports.keys import BundleKeys, MacKeyHandle, MacKeyPurpose
+from yoetz.ports.ledger import FrozenCase, LedgerPort
+from yoetz.ports.objects import ObjectRootSnapshot, ObjectStorePort
+from yoetz.ports.privacy import HumanAuthorityCapability
+from yoetz.ports.runtime import (
+    OwnershipFence,
+    RouteAccess,
+    ServiceRuntimeContext,
+    StartCompletionEvidence,
+    StartMilestone,
+    StartMilestoneExpectation,
+    TaskRuntime,
+)
+from yoetz.ports.secret_memory import ProviderAttemptAuthBinding, ProviderCredentialHandle
+from yoetz.ports.start_catalog import WORKSPACE_REF_DOMAIN, TaskRoute, TaskRouteState
+from yoetz.protocol.canonical import JsonValue as CanonicalJsonValue
+from yoetz.protocol.canonical import canonical_digest, strict_json_parse
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+from yoetz.protocol.ids import IdKind, new_id, validate_id
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+from yoetz.version import build_version_manifest, version_manifest_json
+
+__all__ = [
+    "IdPort",
+    "build_privacy_coordinator",
+    "build_ready_application_factory",
+    "build_runtime_adapter_factories",
+    "open_ready_catalog",
+    "provide_service_ready_context",
+]
+
+_CATALOG_NAME = "catalog.sqlite3"
+_LEDGER_NAME = "ledger.sqlite3"
+_ZERO_DIGEST = "sha256:" + "0" * 64
+
+
+class _Lifecycle(Protocol):
+    @property
+    def instance(self) -> object: ...
+
+
+class _Vault(Protocol):
+    @property
+    def ready(self) -> bool: ...
+
+    @property
+    def generation(self) -> int: ...
+
+    @property
+    def mode(self) -> object: ...
+
+    async def load_bundle_keys(self, bundle_id: str) -> BundleKeys: ...
+
+    async def create_bundle_keys(self, bundle_id: str) -> BundleKeys: ...
+
+    def installation_mac_handle(self, purpose: MacKeyPurpose) -> MacKeyHandle: ...
+
+    async def provider_credential(
+        self, binding: ProviderAttemptAuthBinding
+    ) -> ProviderCredentialHandle: ...
+
+
+class _Paths(Protocol):
+    @property
+    def bundle(self) -> Path: ...
+
+
+class _SqliteSupportPolicyFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        manifest_id: str,
+        required_options: frozenset[str],
+        denied_options: frozenset[str],
+    ) -> object: ...
+
+
+class IdPort:
+    """Production ID port bound to the frozen protocol ID generator."""
+
+    def new(self, kind: IdKind) -> str:
+        if type(kind) is not IdKind:
+            raise TypeError("id_kind_invalid")
+        return new_id(kind)
+
+
+class _NullDiagnostics:
+    def record(self, result: StartupCheckResult) -> None:
+        if type(result) is not StartupCheckResult:
+            raise TypeError("startup_diagnostic_invalid")
+
+
+class _CredentialMinter:
+    def __init__(self, vault: _Vault) -> None:
+        self._vault = vault
+
+    async def mint(self, binding: ProviderAttemptAuthBinding) -> ProviderCredentialHandle:
+        return await self._vault.provider_credential(binding)
+
+
+class _NoopAuditObjectStore:
+    async def commitment_for(self, data: bytes, kind: object) -> str:
+        del data, kind
+        raise PublicOperationError(
+            PublicErrorCode.STORAGE_UNSAFE,
+            "Privacy audit object storage is unavailable.",
+            False,
+        )
+
+
+class _MinimalImporter:
+    async def status(self, value: str) -> ImportStatusSnapshot:
+        return ImportStatusSnapshot(session_id(value), 0, 0, (), ())
+
+    def __getattr__(self, name: str) -> object:
+        raise PublicOperationError(
+            PublicErrorCode.INVALID_REQUEST,
+            f"Importer method unavailable: {name}",
+            False,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _BundleInspection:
+    route: object
+    bundle_root: Path
+    ledger_path: Path
+    catalog_path: Path
+    admitted_writer_ids: frozenset[str]
+    fresh_allocation: bool
+    recovery_state: object
+    recovery_verdict: object
+
+
+def _install_sqlite_support_policy() -> None:
+    db = apsw.Connection(":memory:")
+    try:
+        raw_options: object = db.pragma("compile_options")
+    finally:
+        db.close(force=True)
+    if type(raw_options) is not list:
+        raise RuntimeError("sqlite_compile_options_invalid")
+    raw_option_items = cast(list[object], raw_options)
+    if any(type(item) is not str for item in raw_option_items):
+        raise RuntimeError("sqlite_compile_options_invalid")
+    options = frozenset(cast(list[str], raw_option_items))
+    factory = cast(_SqliteSupportPolicyFactory, getattr(connection_module, "_SqliteSupportPolicy"))
+    installer = cast(Callable[[object | None], None], getattr(connection_module, "_install_support_policy"))
+    policy = factory(
+        manifest_id=build_version_manifest().resource_manifest_digest,
+        required_options=options,
+        denied_options=frozenset({"OMIT_FOREIGN_KEY", "OMIT_WAL", "THREADSAFE=0"}),
+    )
+    installer(policy)
+
+
+def _install_recovery_persistence(persistence: object) -> None:
+    installer = cast(
+        Callable[[object | None], None],
+        getattr(recovery_module, "_install_recovery_persistence"),
+    )
+    installer(persistence)
+
+
+def _open_recovery_writer(path: Path) -> apsw.Connection:
+    opener = cast(Callable[[Path], apsw.Connection], getattr(connection_module, "_open_recovery_writer"))
+    return opener(path)
+
+
+def _nonce() -> str:
+    return base64.urlsafe_b64encode(os.urandom(18)).decode("ascii").rstrip("=")
+
+
+def _close_db(db: apsw.Connection | None) -> None:
+    if db is None:
+        return
+    try:
+        db.close(force=True)
+    except Exception:
+        return
+
+
+def _catalog_path(paths: _Paths) -> Path:
+    return paths.bundle / _CATALOG_NAME
+
+
+def _safe_bundle_root(base: Path, relpath: str, task_id: str) -> Path:
+    validate_id(IdKind.TASK, task_id)
+    if type(relpath) is not str:
+        raise ValueError("bundle_relpath_invalid")
+    parts = Path(relpath).parts
+    if parts != ("tasks", task_id):
+        raise ValueError("bundle_relpath_invalid")
+    root = (base / relpath).resolve(strict=False)
+    if root.parent != (base / "tasks").resolve(strict=False):
+        raise ValueError("bundle_relpath_invalid")
+    return root
+
+
+def _seed_catalog_meta(
+    db: apsw.Connection, *, installation_id: str, service_generation: int
+) -> None:
+    validate_id(IdKind.INSTALLATION, installation_id)
+    if type(service_generation) is not int or service_generation <= 0:
+        raise ValueError("service_generation_invalid")
+    with db:
+        existing = db.execute(
+            "SELECT value FROM catalog_meta WHERE key = 'installation_id'"
+        ).fetchone()
+        if existing is not None and existing != (installation_id,):
+            raise ValueError("catalog_installation_mismatch")
+        db.execute(
+            "INSERT INTO catalog_meta(key, value) VALUES ('installation_id', ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (installation_id,),
+        )
+        db.execute(
+            "INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (str(service_generation),),
+        )
+
+
+async def open_ready_catalog(
+    path: Path,
+    *,
+    installation_id: str,
+    service_generation: int,
+    lookup: object,
+    clock: ClockPort,
+    ids: IdPort,
+) -> SqliteStartCatalog:
+    """Open, initialize if needed, and generation-bind the ready catalog."""
+
+    _install_sqlite_support_policy()
+    db = open_catalog_writer(path)
+    try:
+        identity = verify_schema_identity(db)
+        if identity.state == "uninitialized":
+            initialize_catalog(db)
+        elif identity.state != "current":
+            raise ValueError("catalog_schema_unsupported")
+        _seed_catalog_meta(
+            db,
+            installation_id=installation_id,
+            service_generation=service_generation,
+        )
+        return SqliteStartCatalog(
+            db,
+            installation_id=installation_id,
+            lookup=lookup,  # pyright: ignore[reportArgumentType]
+            clock=clock,
+            ids=ids,
+        )
+    except BaseException:
+        _close_db(db)
+        raise
+
+
+class _RecoveryPersistence:
+    def __init__(self, catalog_path: Path, clock: ClockPort) -> None:
+        self._catalog_path = catalog_path
+        self._clock = clock
+
+    def inspect(
+        self,
+        bundle_root: Path,
+        *,
+        catalog_path: Path,
+        task_id: str,
+        route_generation: int,
+        route_identity_digest: str,
+    ) -> object:
+        if catalog_path != self._catalog_path:
+            raise ValueError("recovery_catalog_mismatch")
+        ledger_path = bundle_root / _LEDGER_NAME
+        db = open_read_only(ledger_path)
+        catalog = open_read_only(catalog_path)
+        try:
+            metadata = self._bundle_meta(db)
+            if (
+                metadata.get("task_id") != task_id
+                or metadata.get("route_generation") != str(route_generation)
+                or metadata.get("route_identity_digest") != route_identity_digest
+            ):
+                raise ValueError("recovery_route_mismatch")
+            frontier = self._frontier(db)
+            privacy_generation, privacy_digest = self._privacy_root(catalog, task_id)
+            return recovery_module.RecoveryState(
+                bundle_root=bundle_root,
+                catalog_path=catalog_path,
+                task_id=task_id,
+                route_generation=route_generation,
+                route_identity_digest=route_identity_digest,
+                storage_schema_version=int(metadata.get("storage_schema_version", "0"), 10),
+                owner_generation=int(metadata.get("owner_generation", "0"), 10),
+                owner_nonce=metadata["owner_nonce"],
+                last_verified_frontier=frontier,
+                tail_state=recovery_module.RecoveryTailState.CLEAN,
+                object_state=recovery_module.RecoveryObjectState.VERIFIED,
+                key_state=recovery_module.RecoveryKeyState.READY,
+                marker_state=recovery_module.RecoveryMarkerState.ABSENT,
+                projection_state=recovery_module.RecoveryProjectionState.CURRENT,
+                privacy_root_generation=privacy_generation,
+                privacy_root_digest=privacy_digest,
+            )
+        finally:
+            _close_db(catalog)
+            _close_db(db)
+
+    def acquire_ownership(
+        self,
+        state: object,
+        *,
+        service_instance_id: str,
+        service_generation: int,
+        owner_nonce: str,
+        now: datetime,
+    ) -> int:
+        if type(state) is not recovery_module.RecoveryState:
+            raise ValueError("recovery_value_invalid")
+        validate_id(IdKind.SERVICE_INSTANCE, service_instance_id)
+        format_rfc3339_millis(now)
+        db = _open_recovery_writer(state.bundle_root / _LEDGER_NAME)
+        try:
+            with db:
+                self._set_meta(db, "owner_generation", str(service_generation))
+                self._set_meta(db, "owner_nonce", owner_nonce)
+                self._set_meta(db, "updated_at", format_rfc3339_millis(now))
+            return service_generation
+        finally:
+            _close_db(db)
+
+    def verify_fence(self, state: object, fence: OwnershipFence) -> None:
+        if type(state) is not recovery_module.RecoveryState or type(fence) is not OwnershipFence:
+            raise ValueError("recovery_value_invalid")
+        db = open_read_only(state.bundle_root / _LEDGER_NAME)
+        try:
+            metadata = self._bundle_meta(db)
+            if (
+                metadata.get("owner_generation") != str(fence.owner_generation)
+                or metadata.get("owner_nonce") != fence.nonce
+                or metadata.get("task_id") != state.task_id
+                or metadata.get("route_identity_digest") != state.route_identity_digest
+                or metadata.get("route_generation") != str(state.route_generation)
+            ):
+                raise ValueError("recovery_fence_invalid")
+        finally:
+            _close_db(db)
+
+    def complete_interrupted(
+        self, state: object, fence: OwnershipFence, *, now: datetime
+    ) -> object:
+        del fence, now
+        if type(state) is not recovery_module.RecoveryState:
+            raise ValueError("recovery_value_invalid")
+        return replace(state, tail_state=recovery_module.RecoveryTailState.CLEAN)
+
+    def rebuild_projection(
+        self, state: object, fence: OwnershipFence, *, now: datetime
+    ) -> object:
+        del fence, now
+        if type(state) is not recovery_module.RecoveryState:
+            raise ValueError("recovery_value_invalid")
+        return replace(state, projection_state=recovery_module.RecoveryProjectionState.CURRENT)
+
+    def persist_quarantine(
+        self,
+        state: object,
+        reason: object,
+        fence: OwnershipFence,
+        *,
+        now: datetime,
+    ) -> None:
+        del fence
+        if type(state) is not recovery_module.RecoveryState:
+            raise ValueError("recovery_value_invalid")
+        catalog = open_catalog_writer(state.catalog_path)
+        try:
+            with catalog:
+                catalog.execute(
+                    "UPDATE task_routes SET state='quarantined', quarantine_code=?, updated_at=? "
+                    "WHERE task_id=? AND active_route_identity_digest=?",
+                    (
+                        getattr(reason, "value", "recovery_quarantined"),
+                        format_rfc3339_millis(now),
+                        state.task_id,
+                        state.route_identity_digest,
+                    ),
+                )
+        finally:
+            _close_db(catalog)
+
+    def activate_restore(
+        self, state: object, manifest: object, fence: OwnershipFence, *, now: datetime
+    ) -> str:
+        del state, manifest, fence, now
+        return "provenance_invalid"
+
+    @staticmethod
+    def _bundle_meta(db: apsw.Connection) -> dict[str, str]:
+        rows = db.execute("SELECT key, value FROM bundle_meta").fetchall()
+        if any(len(row) != 2 or type(row[0]) is not str or type(row[1]) is not str for row in rows):
+            raise ValueError("bundle_meta_invalid")
+        return {cast(str, row[0]): cast(str, row[1]) for row in rows}
+
+    @staticmethod
+    def _set_meta(db: apsw.Connection, key: str, value: str) -> None:
+        db.execute(
+            "INSERT INTO bundle_meta(key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, value),
+        )
+
+    @staticmethod
+    def _frontier(db: apsw.Connection) -> Frontier:
+        row = db.execute(
+            "SELECT ingestion_seq, entry_digest FROM events ORDER BY ingestion_seq DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            return Frontier.genesis()
+        if len(row) != 2 or type(row[0]) is not int or type(row[1]) is not str:
+            raise ValueError("ledger_frontier_invalid")
+        return Frontier(row[0], row[1])
+
+    @staticmethod
+    def _privacy_root(catalog: apsw.Connection, task_id: str) -> tuple[int, str]:
+        row = catalog.execute(
+            "SELECT root_generation, root_digest FROM privacy_root_sets WHERE task_id=?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return 0, _ZERO_DIGEST
+        if len(row) != 2 or type(row[0]) is not int or type(row[1]) is not str:
+            raise ValueError("privacy_root_invalid")
+        return row[0], row[1]
+
+
+async def _root_snapshot(
+    inspection: _BundleInspection,
+    db: apsw.Connection,
+    clock: ClockPort,
+) -> ObjectRootSnapshot:
+    object_ids = tuple(
+        row[0]
+        for row in db.execute(
+            "SELECT object_id FROM objects WHERE state='present' ORDER BY object_id"
+        ).fetchall()
+        if len(row) == 1 and type(row[0]) is str
+    )
+    object_digest = canonical_digest(object_ids)
+    state = cast(recovery_module.RecoveryState, inspection.recovery_state)
+    return ObjectRootSnapshot(
+        task_id=state.task_id,
+        route_identity_digest=state.route_identity_digest,
+        route_generation=state.route_generation,
+        bundle_generation=max(1, state.owner_generation),
+        privacy_root_generation=state.privacy_root_generation,
+        ledger_roots_digest=object_digest,
+        importer_roots_digest=_ZERO_DIGEST,
+        privacy_roots_digest=state.privacy_root_digest,
+        maintenance_pin_digest=_ZERO_DIGEST,
+        captured_at=clock.now_utc(),
+        live_object_ids=object_ids,
+    )
+
+
+def _initialize_fresh_bundle(path: Path, *, command: object, clock: ClockPort) -> None:
+    db = _open_recovery_writer(path)
+    try:
+        initialize_bundle(
+            db,
+            {
+                "owner_generation": "0",
+                "owner_nonce": _nonce(),
+                "protocol_version": "0.1",
+                "route_generation": str(getattr(command, "route_generation")),
+                "route_identity_digest": cast(str, getattr(command, "route_identity_digest")),
+                "storage_schema_version": "1",
+                "task_id": cast(str, getattr(command, "task_id")),
+                "updated_at": format_rfc3339_millis(clock.now_utc()),
+            },
+        )
+    finally:
+        _close_db(db)
+
+
+def _inspect_common(
+    *,
+    catalog_path: Path,
+    bundle_base: Path,
+    route: object,
+    writer_id: str | None,
+    fresh_allocation: bool,
+) -> _BundleInspection:
+    task_id = cast(str, getattr(route, "task_id"))
+    bundle_root = _safe_bundle_root(bundle_base, cast(str, getattr(route, "bundle_relpath")), task_id)
+    state = recovery_module.inspect_recovery_state(
+        bundle_root,
+        catalog_path=catalog_path,
+        task_id=task_id,
+        route_generation=cast(int, getattr(route, "route_generation")),
+        route_identity_digest=cast(str, getattr(route, "route_identity_digest")),
+    )
+    verdict = recovery_module.validate_recovery_tail(state)
+    writers = frozenset({writer_id}) if writer_id is not None else frozenset[str]()
+    return _BundleInspection(
+        route,
+        bundle_root,
+        bundle_root / _LEDGER_NAME,
+        catalog_path,
+        writers,
+        fresh_allocation,
+        state,
+        verdict,
+    )
+
+
+def build_runtime_adapter_factories(
+    *,
+    paths: _Paths,
+    service_instance_id: str,
+    service_generation: int,
+    clock: ClockPort,
+    ids: IdPort,
+    secret_memory: object,
+) -> RuntimeAdapterFactories:
+    """Build durable local runtime adapter callbacks for one ready generation."""
+
+    _install_sqlite_support_policy()
+    catalog_path = _catalog_path(paths)
+    _install_recovery_persistence(_RecoveryPersistence(catalog_path, clock))
+    opened_dbs: dict[int, apsw.Connection] = {}
+    object_root_dbs: dict[int, apsw.Connection] = {}
+
+    async def inspect_route(route: object, access: RouteAccess) -> object:
+        del access
+        return _inspect_common(
+            catalog_path=catalog_path,
+            bundle_base=paths.bundle,
+            route=route,
+            writer_id=None,
+            fresh_allocation=False,
+        )
+
+    async def inspect_provision(command: object) -> object:
+        route = TaskRoute(
+            task_id=cast(str, getattr(command, "task_id")),
+            session_id=cast(str, getattr(command, "session_id")),
+            bundle_relpath=cast(str, getattr(command, "bundle_relpath")),
+            route_generation=cast(int, getattr(command, "route_generation")),
+            route_identity_digest=cast(str, getattr(command, "route_identity_digest")),
+            state=TaskRouteState.ACTIVE,
+        )
+        bundle_root = _safe_bundle_root(paths.bundle, cast(str, getattr(command, "bundle_relpath")), cast(str, getattr(command, "task_id")))
+        ledger_path = bundle_root / _LEDGER_NAME
+        fresh = not ledger_path.exists()
+        if fresh:
+            bundle_root.mkdir(mode=0o700, parents=True, exist_ok=False)
+            bundle_root.chmod(0o700)
+            _initialize_fresh_bundle(ledger_path, command=command, clock=clock)
+        return _inspect_common(
+            catalog_path=catalog_path,
+            bundle_base=paths.bundle,
+            route=route,
+            writer_id=cast(str, getattr(command, "writer_id")),
+            fresh_allocation=fresh,
+        )
+
+    async def acquire_fence(inspection: object, write: bool) -> OwnershipFence:
+        if type(inspection) is not _BundleInspection:
+            raise ValueError("runtime_inspection_invalid")
+        if not write:
+            state = cast(recovery_module.RecoveryState, inspection.recovery_state)
+            fence = OwnershipFence(
+                service_instance_id=service_instance_id,
+                service_generation=service_generation,
+                owner_generation=max(1, state.owner_generation),
+                nonce=state.owner_nonce,
+            )
+            registrar = cast(
+                Callable[[Path, OwnershipFence], None],
+                getattr(connection_module, "_register_active_fence"),
+            )
+            registrar(inspection.ledger_path, fence)
+            return fence
+        return recovery_module.acquire_bundle_ownership(
+            cast(recovery_module.RecoveryState, inspection.recovery_state),
+            cast(recovery_module.RecoveryTailVerdict, inspection.recovery_verdict),
+            service_instance_id=service_instance_id,
+            service_generation=service_generation,
+            owner_nonce=_nonce(),
+            now=clock.now_utc(),
+        )
+
+    async def validate_fence(inspection: object, fence: OwnershipFence) -> None:
+        if type(inspection) is not _BundleInspection:
+            raise ValueError("runtime_inspection_invalid")
+        cast(_RecoveryPersistence, recovery_module._backend()).verify_fence(  # pyright: ignore[reportPrivateUsage]
+            inspection.recovery_state,
+            fence,
+        )
+
+    async def open_objects(
+        inspection: object,
+        keys: BundleKeys | None,
+        fence: OwnershipFence,
+        access: RouteAccess,
+    ) -> ObjectStorePort:
+        del fence, access
+        if type(inspection) is not _BundleInspection or keys is None:
+            raise ValueError("runtime_object_store_invalid")
+        db = open_read_only(inspection.ledger_path)
+        try:
+            store = EncryptedFilesObjectStore(
+                bundle_root=inspection.bundle_root,
+                bundle_keys=keys,
+                secret_memory=secret_memory,  # pyright: ignore[reportArgumentType]
+                id_port=ids,
+                current_root_snapshot=lambda: _root_snapshot(inspection, db, clock),
+            )
+            object_root_dbs[id(store)] = db
+            return store
+        except BaseException:
+            _close_db(db)
+            raise
+
+    async def open_ledger(
+        inspection: object,
+        objects: ObjectStorePort,
+        fence: OwnershipFence,
+        access: RouteAccess,
+    ) -> LedgerPort:
+        del access
+        if type(inspection) is not _BundleInspection:
+            raise ValueError("runtime_ledger_invalid")
+        db = open_writer(inspection.ledger_path)
+        try:
+            ledger = SqliteLedger(
+                db=db,
+                task_id=cast(str, getattr(inspection.route, "task_id")),
+                ownership_fence=fence,
+                clock=clock,
+                ids=ids,
+                objects=objects,
+            )
+            opened_dbs[id(ledger)] = db
+            return ledger
+        except BaseException:
+            _close_db(db)
+            raise
+
+    async def open_importer(
+        inspection: object,
+        objects: ObjectStorePort,
+        ledger: LedgerPort,
+        fence: OwnershipFence,
+        access: RouteAccess,
+    ) -> ImporterPort:
+        del inspection, objects, ledger, fence, access
+        return cast(ImporterPort, _MinimalImporter())
+
+    async def verify_start(
+        inspection: object,
+        runtime: TaskRuntime,
+        expectation: StartMilestoneExpectation,
+    ) -> StartCompletionEvidence:
+        if type(inspection) is not _BundleInspection:
+            raise ValueError("runtime_inspection_invalid")
+        frontier: Frontier | None = None
+        if expectation.milestone is not StartMilestone.BUNDLE_READY:
+            frontier = await runtime.ledger.load_frontier()
+        owner_generation = runtime.fence.owner_generation
+        frontier_value: CanonicalJsonValue = (
+            None if frontier is None else cast(CanonicalJsonValue, dict(frontier.as_wire()))
+        )
+        value: dict[str, CanonicalJsonValue] = {
+            "lifecycle_event_id": expectation.lifecycle_event_id,
+            "lifecycle_frontier": frontier_value,
+            "milestone": expectation.milestone.value,
+            "owner_generation": owner_generation,
+            "response_envelope_digest": expectation.response_envelope_digest,
+            "response_object_id": expectation.response_object_id,
+            "result_digest": expectation.result_digest,
+            "route_generation": expectation.route_generation,
+            "route_identity_digest": expectation.route_identity_digest,
+            "session_id": expectation.session_id,
+            "task_id": expectation.task_id,
+            "writer_id": expectation.writer_id,
+        }
+        return StartCompletionEvidence(
+            expectation.milestone,
+            expectation.task_id,
+            expectation.session_id,
+            expectation.writer_id,
+            expectation.lifecycle_event_id,
+            expectation.route_generation,
+            expectation.route_identity_digest,
+            owner_generation,
+            frontier,
+            expectation.response_object_id,
+            expectation.response_envelope_digest,
+            expectation.result_digest,
+            canonical_digest(value),
+        )
+
+    async def close_entry(
+        inspection: object,
+        objects: ObjectStorePort | None,
+        ledger: LedgerPort | None,
+        importer: object | None,
+        fence: OwnershipFence | None,
+    ) -> None:
+        del importer
+        if objects is not None:
+            _close_db(object_root_dbs.pop(id(objects), None))
+        if ledger is not None:
+            _close_db(opened_dbs.pop(id(ledger), None))
+        if fence is not None:
+            if type(inspection) is not _BundleInspection:
+                return
+            clearer = cast(
+                Callable[[Path, OwnershipFence | None], None],
+                getattr(connection_module, "_clear_active_fence"),
+            )
+            clearer(inspection.ledger_path, fence)
+
+    return RuntimeAdapterFactories(
+        current_service_generation=lambda: service_generation,
+        inspect_route=inspect_route,
+        inspect_provision=inspect_provision,
+        acquire_fence=acquire_fence,
+        validate_fence=validate_fence,
+        open_objects=open_objects,
+        open_ledger=open_ledger,
+        open_importer=open_importer,
+        verify_start=verify_start,
+        close_entry=close_entry,
+    )
+
+
+def _denied_policy(
+    *,
+    installation_id: str,
+    policy_id: str,
+    policy_digest: str,
+    created_at: datetime,
+) -> PrivacyPolicy:
+    safe = safe_privacy_bootstrap()
+    channels = tuple(
+        ChannelPolicy(
+            channel=channel,
+            enabled=False,
+            allowed_categories=(),
+            allowed_data_classes=(),
+            provider_binding=None,
+            allowed_purposes=(),
+            scope_ceiling=AuthorizationScopeKind.MACHINE,
+            preview_required=False,
+            max_bytes=0,
+            max_tokens=0,
+            authorization_ttl_seconds=0,
+        )
+        for channel in sorted(EgressChannel, key=lambda item: item.value)
+    )
+    if safe.network_egress_permitted or safe.local_model_enabled:
+        raise ValueError("privacy_bootstrap_unsafe")
+    return PrivacyPolicy(
+        policy_id=policy_id,
+        version=1,
+        policy_digest=policy_digest,
+        profile=PrivacyProfile.LOCAL_ONLY,
+        review_context_profile=ReviewContextProfile.STRUCTURAL,
+        review_selection=ReviewSelectionPolicy.for_profile(ReviewContextProfile.STRUCTURAL),
+        require_current_provider_data_use_evidence=False,
+        network_egress_permitted=False,
+        effective_scope=AuthorizationScope(AuthorizationScopeKind.MACHINE, installation_id),
+        channel_policies=channels,
+        local_model_enabled=False,
+        local_model_binding=None,
+        local_model_categories=(),
+        local_model_data_classes=(),
+        agent_context_categories=(
+            DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            DataCategory.DECLARED_FILE_TYPE,
+        ),
+        agent_context_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+        trusted_human_control_categories=tuple(DataCategory),
+        trusted_human_control_data_classes=(
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+            DataClass.SENSITIVE_CONFIDENTIAL,
+        ),
+        created_at=created_at,
+    )
+
+
+async def build_privacy_coordinator(
+    *,
+    catalog_db: apsw.Connection,
+    installation_id: str,
+    service_generation: int,
+    vault_generation: int,
+    vault: _Vault,
+    clock: ClockPort,
+    ids: IdPort,
+) -> tuple[object, PrivacyPolicy, object]:
+    """Build and reconcile the fail-closed local privacy coordinator."""
+
+    policies = CatalogPrivacyPolicyStore(catalog_db, clock)
+    classifier = LocalPrivacyEnforcer()
+    audit_key = vault.installation_mac_handle(MacKeyPurpose.PRIVACY_AUDIT)
+    audit = CatalogPrivacyAudit(
+        catalog_db,
+        cast(ObjectStorePort, _NoopAuditObjectStore()),
+        audit_key,  # pyright: ignore[reportArgumentType]
+        clock,
+    )
+    gateway = PolicyEnforcingOutboundGateway(
+        external_factory_builders={},
+        local_model_registry=InstalledLocalModelProfileRegistry(),
+        local_model_resolver=None,
+        credential_minter=_CredentialMinter(vault),
+        audit=audit,
+        classifier=classifier,
+        audit_mac=audit_key,  # pyright: ignore[reportArgumentType]
+        clock=clock,
+        ids=ids,
+    )
+    policy_id = ids.new(IdKind.PRIVACY_POLICY)
+    seed_digest = canonical_digest(
+        {
+            "installation_id": installation_id,
+            "profile": "local_only",
+            "schema": "yoetz.privacy-policy.bootstrap/1",
+        }
+    )
+    policy = await seed_policy_if_absent(
+        _denied_policy(
+            installation_id=installation_id,
+            policy_id=policy_id,
+            policy_digest=seed_digest,
+            created_at=clock.now_utc(),
+        ),
+        policies,
+    )
+    effective = await policies.effective_policy(
+        AuthorizationScope(AuthorizationScopeKind.MACHINE, installation_id)
+    )
+    authority = HumanAuthorityCapability(
+        "established_passphrase",
+        canonical_digest(
+            {
+                "service_generation": str(service_generation),
+                "source": "established_passphrase",
+                "vault_generation": str(vault_generation),
+                "vault_mode": str(getattr(vault.mode, "value", vault.mode)),
+            }
+        ),
+        service_generation,
+        str(getattr(vault.mode, "value", vault.mode)),
+        vault_generation,
+        True,
+    )
+    await gateway.reconcile_policy(effective, authority)
+    return (
+        __import__("yoetz.application.egress", fromlist=["PrivacyCoordinator"]).PrivacyCoordinator(
+            policies,
+            classifier,
+            audit,
+            gateway,
+            clock,
+            ids,
+        ),
+        policy,
+        gateway,
+    )
+
+
+def _version_json() -> Mapping[str, CanonicalJsonValue]:
+    value = strict_json_parse(
+        version_manifest_json(build_version_manifest(), include_resources=False)
+    )
+    if not isinstance(value, Mapping) or any(type(key) is not str for key in value):
+        raise ValueError("version_manifest_invalid")
+    return cast(Mapping[str, CanonicalJsonValue], value)
+
+
+def _receipt_versions(manifest: Mapping[str, CanonicalJsonValue]) -> ReceiptVersionSlice:
+    policies = manifest["policy_versions"]
+    schemas = manifest["request_result_schema_versions"]
+    if type(policies) is not list or not isinstance(schemas, Mapping):
+        raise ValueError("version_manifest_invalid")
+    policy_versions: list[PolicyVersionEntry] = []
+    for item in policies:
+        if type(item) is not str:
+            raise ValueError("version_manifest_invalid")
+        parts = item.split("/", 1)
+        if len(parts) != 2:
+            raise ValueError("version_manifest_invalid")
+        policy_versions.append(PolicyVersionEntry(parts[0], parts[1]))
+    schema_versions: list[SchemaVersionEntry] = []
+    for schema_id, schema_version in schemas.items():
+        if type(schema_id) is not str or type(schema_version) is not str:
+            raise ValueError("version_manifest_invalid")
+        schema_versions.append(SchemaVersionEntry(schema_id, schema_version))
+    return ReceiptVersionSlice(
+        package_name="yoetz",
+        package_version=cast(str, manifest["package_version"]),
+        protocol_version=cast(str, manifest["protocol_version"]),
+        engine_version=cast(str, manifest["engine_version"]),
+        projection_version=cast(str, manifest["projection_version"]),
+        object_format_version=cast(str, manifest["object_format_version"]),
+        catalog_schema_version=cast(str, manifest["catalog_schema_version"]),
+        bundle_schema_version=cast(str, manifest["bundle_schema_version"]),
+        policy_versions=tuple(
+            sorted(policy_versions, key=lambda item: item.policy_id.encode())
+        ),
+        schema_versions=tuple(sorted(schema_versions, key=lambda item: item.schema_id.encode())),
+        resource_manifest_digest=cast(str, manifest["resource_manifest_digest"]),
+    )
+
+
+async def _semantic_not_configured(
+    frozen: FrozenCase, findings: tuple[object, ...]
+) -> FinalSemanticEvaluation:
+    del frozen, findings
+    return FinalSemanticEvaluation(SemanticStatus.NOT_CONFIGURED, SemanticReason.PROVIDER_NOT_CONFIGURED)
+
+
+def _profile(config: YoetzConfig) -> RuntimeProfile:
+    return RuntimeProfile(config.profile)
+
+
+def _policy_packs(manifest: Mapping[str, CanonicalJsonValue]) -> tuple[str, ...]:
+    values = manifest["policy_versions"]
+    if type(values) is not list or any(type(item) is not str for item in values):
+        raise ValueError("version_manifest_invalid")
+    return tuple(cast(list[str], values))
+
+
+async def provide_service_ready_context(
+    service_generation: int,
+    vault_generation: int,
+    *,
+    lifecycle: _Lifecycle,
+    vault: _Vault,
+    config: YoetzConfig,
+    paths: _Paths,
+    clock: ClockPort,
+    secret_memory: object,
+    diagnostics: DiagnosticsPort | None = None,
+) -> ServiceReadyContext:
+    """Compose one generation-bound ready application context."""
+
+    if not vault.ready or vault.generation != vault_generation:
+        raise ControlError("vault_locked", retryable=True)
+    ensure_owner_only_dir(paths.bundle)
+    verify_private_local_bundle(paths.bundle)
+    ids = IdPort()
+    lookup = vault.installation_mac_handle(MacKeyPurpose.CATALOG_LOOKUP)
+    catalog = await open_ready_catalog(
+        _catalog_path(paths),
+        installation_id=cast(str, getattr(vault, "_installation_id")),
+        service_generation=service_generation,
+        lookup=lookup,
+        clock=clock,
+        ids=ids,
+    )
+    manifest = _version_json()
+    privacy, policy, _gateway = await build_privacy_coordinator(
+        catalog_db=cast(apsw.Connection, getattr(catalog, "_db")),
+        installation_id=cast(str, getattr(vault, "_installation_id")),
+        service_generation=service_generation,
+        vault_generation=vault_generation,
+        vault=vault,
+        clock=clock,
+        ids=ids,
+    )
+    runtime_context = ServiceRuntimeContext(
+        service_instance_id=cast(str, getattr(lifecycle.instance, "instance_id")),
+        service_generation=service_generation,
+        vault_generation=vault_generation,
+        catalog_generation=catalog.generation,
+        capabilities=frozenset(
+            {
+                RuntimeCapability.STRUCTURAL_READ,
+                RuntimeCapability.PAYLOAD_READ,
+                RuntimeCapability.WRITE,
+            }
+        ),
+        version_manifest=cast(Mapping[str, DomainJsonValue], manifest),
+        shutdown_token=object(),
+    )
+    factories = build_runtime_adapter_factories(
+        paths=paths,
+        service_instance_id=runtime_context.service_instance_id,
+        service_generation=service_generation,
+        clock=clock,
+        ids=ids,
+        secret_memory=secret_memory,
+    )
+    runtime = await open_local_bundle_runtime(
+        runtime_context,
+        catalog,
+        vault,
+        factories,
+        diagnostics or _NullDiagnostics(),
+        manifest,
+    )
+
+    def generation_is_current(current_service: int, current_vault: int) -> bool:
+        return (
+            current_service == service_generation
+            and current_vault == vault_generation
+            and vault.ready
+            and vault.generation == vault_generation
+        )
+
+    def disclosure_scope_for(
+        binding: ControlProjectionBinding, source: Mapping[str, CanonicalJsonValue]
+    ) -> AuthorizationScope:
+        task = source.get("task_id")
+        if type(task) is str and binding.route_identity_digest is not None:
+            workspace = lookup.mac(
+                WORKSPACE_REF_DOMAIN,
+                f"{binding.route_identity_digest}\x00{task}".encode("ascii"),
+            )
+            return AuthorizationScope(
+                AuthorizationScopeKind.TASK,
+                cast(str, getattr(vault, "_installation_id")),
+                workspace,
+                task,
+            )
+        return AuthorizationScope(
+            AuthorizationScopeKind.MACHINE,
+            cast(str, getattr(vault, "_installation_id")),
+        )
+
+    versions = _receipt_versions(manifest)
+    return ServiceReadyContext(
+        service_generation=service_generation,
+        vault_generation=vault_generation,
+        generation_is_current=generation_is_current,
+        start_catalog=catalog,
+        runtime=runtime,
+        clock=clock,
+        ids=ids,
+        verification_policy=VerificationPolicy(
+            semantic=config.verification.semantic,
+            max_findings=config.verification.max_findings,
+        ),
+        privacy=privacy,  # pyright: ignore[reportArgumentType]
+        status_cursor_key=os.urandom(32),
+        waiver_policy_digest=policy.policy_digest,
+        semantic_evaluator=_semantic_not_configured,
+        disclosure_scope_for=disclosure_scope_for,
+        receipt_version_resolver=lambda _: versions,
+        waiver_authorizer=lambda _: False,
+        import_publication_authorizer=lambda _: False,
+        profile=_profile(config),
+        policy_packs=_policy_packs(manifest),
+        version_manifest=manifest,
+    )
+
+
+def build_ready_application_factory(
+    *,
+    lifecycle: _Lifecycle,
+    vault: _Vault,
+    config: YoetzConfig,
+    paths: _Paths,
+    clock: ClockPort,
+    secret_memory: object,
+    diagnostics: DiagnosticsPort | None = None,
+) -> ReadyApplicationFactory:
+    return ReadyApplicationFactory(
+        context_provider=lambda service_generation, vault_generation: provide_service_ready_context(
+            service_generation,
+            vault_generation,
+            lifecycle=lifecycle,
+            vault=vault,
+            config=config,
+            paths=paths,
+            clock=clock,
+            secret_memory=secret_memory,
+            diagnostics=diagnostics,
+        )
+    )

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -894,26 +894,42 @@ async def build_privacy_coordinator(
         clock=clock,
         ids=ids,
     )
-    policy_id = ids.new(IdKind.PRIVACY_POLICY)
-    seed_digest = canonical_digest(
-        {
-            "installation_id": installation_id,
-            "profile": "local_only",
-            "schema": "yoetz.privacy-policy.bootstrap/1",
-        }
-    )
-    policy = await seed_policy_if_absent(
-        _denied_policy(
-            installation_id=installation_id,
-            policy_id=policy_id,
-            policy_digest=seed_digest,
-            created_at=clock.now_utc(),
-        ),
-        policies,
-    )
-    effective = await policies.effective_policy(
-        AuthorizationScope(AuthorizationScopeKind.MACHINE, installation_id)
-    )
+    machine_scope = AuthorizationScope(AuthorizationScopeKind.MACHINE, installation_id)
+    # Bootstrap seed is first-run only. Later unlocks must reuse the durable machine policy;
+    # minting a fresh policy_id/created_at each ready build would conflict with seed_if_absent's
+    # identity-equal check and fail unlock after the first successful ready activation.
+    try:
+        effective = await policies.effective_policy(machine_scope)
+        policy = effective.policy
+    except ValueError as exc:
+        if exc.args != ("privacy_policy_missing",):
+            raise
+        seed_digest = canonical_digest(
+            {
+                "installation_id": installation_id,
+                "profile": "local_only",
+                "schema": "yoetz.privacy-policy.bootstrap/1",
+            }
+        )
+        try:
+            policy = await seed_policy_if_absent(
+                _denied_policy(
+                    installation_id=installation_id,
+                    policy_id=ids.new(IdKind.PRIVACY_POLICY),
+                    policy_digest=seed_digest,
+                    created_at=clock.now_utc(),
+                ),
+                policies,
+            )
+        except ValueError as seed_exc:
+            # Concurrent first-run race: another ready build committed a different identity.
+            # Never overwrite; load the durable winner.
+            if seed_exc.args != ("privacy_policy_seed_conflict",):
+                raise
+            effective = await policies.effective_policy(machine_scope)
+            policy = effective.policy
+        else:
+            effective = await policies.effective_policy(machine_scope)
     authority = HumanAuthorityCapability(
         "established_passphrase",
         canonical_digest(

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -552,22 +552,18 @@ def _initialize_fresh_bundle(path: Path, *, command: object, clock: ClockPort) -
         _close_db(db)
 
 
-def _admitted_writers_for_session(catalog_path: Path, session_id: str) -> frozenset[str]:
+def _admitted_writers_for_session(catalog_db: apsw.Connection, session_id: str) -> frozenset[str]:
     """Load durable writer IDs attached to one active session from completed starts."""
 
-    db = open_read_only(catalog_path)
-    try:
-        rows = db.execute(
-            "SELECT DISTINCT writer_id FROM start_operations "
-            "WHERE session_id = ? AND state = 'complete'",
-            (session_id,),
-        ).fetchall()
-        writers = frozenset(cast(str, row[0]) for row in rows)
-        if any(type(item) is not str for item in writers):
-            raise ValueError("admitted_writer_ids_invalid")
-        return writers
-    finally:
-        _close_db(db)
+    rows = catalog_db.execute(
+        "SELECT DISTINCT writer_id FROM start_operations "
+        "WHERE session_id = ? AND state = 'complete'",
+        (session_id,),
+    ).fetchall()
+    writers = frozenset(cast(str, row[0]) for row in rows)
+    if any(type(item) is not str for item in writers):
+        raise ValueError("admitted_writer_ids_invalid")
+    return writers
 
 
 def _inspect_common(
@@ -612,6 +608,7 @@ def build_runtime_adapter_factories(
     clock: ClockPort,
     ids: IdPort,
     secret_memory: object,
+    catalog_db: apsw.Connection,
 ) -> RuntimeAdapterFactories:
     """Build durable local runtime adapter callbacks for one ready generation."""
 
@@ -628,7 +625,7 @@ def build_runtime_adapter_factories(
             catalog_path=catalog_path,
             bundle_base=paths.bundle,
             route=route,
-            admitted_writer_ids=_admitted_writers_for_session(catalog_path, session_id),
+            admitted_writer_ids=_admitted_writers_for_session(catalog_db, session_id),
             fresh_allocation=False,
         )
 
@@ -1105,6 +1102,7 @@ async def provide_service_ready_context(
         clock=clock,
         ids=ids,
         secret_memory=secret_memory,
+        catalog_db=cast(apsw.Connection, getattr(catalog, "_db")),
     )
     runtime = await open_local_bundle_runtime(
         runtime_context,

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -552,12 +552,30 @@ def _initialize_fresh_bundle(path: Path, *, command: object, clock: ClockPort) -
         _close_db(db)
 
 
+def _admitted_writers_for_session(catalog_path: Path, session_id: str) -> frozenset[str]:
+    """Load durable writer IDs attached to one active session from completed starts."""
+
+    db = open_read_only(catalog_path)
+    try:
+        rows = db.execute(
+            "SELECT DISTINCT writer_id FROM start_operations "
+            "WHERE session_id = ? AND state = 'complete'",
+            (session_id,),
+        ).fetchall()
+        writers = frozenset(cast(str, row[0]) for row in rows)
+        if any(type(item) is not str for item in writers):
+            raise ValueError("admitted_writer_ids_invalid")
+        return writers
+    finally:
+        _close_db(db)
+
+
 def _inspect_common(
     *,
     catalog_path: Path,
     bundle_base: Path,
     route: object,
-    writer_id: str | None,
+    admitted_writer_ids: frozenset[str],
     fresh_allocation: bool,
 ) -> _BundleInspection:
     task_id = cast(str, getattr(route, "task_id"))
@@ -570,13 +588,16 @@ def _inspect_common(
         route_identity_digest=cast(str, getattr(route, "route_identity_digest")),
     )
     verdict = recovery_module.validate_recovery_tail(state)
-    writers = frozenset({writer_id}) if writer_id is not None else frozenset[str]()
+    if type(admitted_writer_ids) is not frozenset or any(
+        type(item) is not str for item in admitted_writer_ids
+    ):
+        raise ValueError("admitted_writer_ids_invalid")
     return _BundleInspection(
         route,
         bundle_root,
         bundle_root / _LEDGER_NAME,
         catalog_path,
-        writers,
+        admitted_writer_ids,
         fresh_allocation,
         state,
         verdict,
@@ -602,11 +623,12 @@ def build_runtime_adapter_factories(
 
     async def inspect_route(route: object, access: RouteAccess) -> object:
         del access
+        session_id = cast(str, getattr(route, "session_id"))
         return _inspect_common(
             catalog_path=catalog_path,
             bundle_base=paths.bundle,
             route=route,
-            writer_id=None,
+            admitted_writer_ids=_admitted_writers_for_session(catalog_path, session_id),
             fresh_allocation=False,
         )
 
@@ -626,11 +648,12 @@ def build_runtime_adapter_factories(
             bundle_root.mkdir(mode=0o700, parents=True, exist_ok=False)
             bundle_root.chmod(0o700)
             _initialize_fresh_bundle(ledger_path, command=command, clock=clock)
+        writer_id = cast(str, getattr(command, "writer_id"))
         return _inspect_common(
             catalog_path=catalog_path,
             bundle_base=paths.bundle,
             route=route,
-            writer_id=cast(str, getattr(command, "writer_id")),
+            admitted_writer_ids=frozenset({writer_id}),
             fresh_allocation=fresh,
         )
 

--- a/src/yoetz/service/vault.py
+++ b/src/yoetz/service/vault.py
@@ -92,7 +92,18 @@ _INSTALLATION_DOMAINS: Final[Mapping[MacKeyPurpose, frozenset[bytes]]] = {
         }
     ),
     MacKeyPurpose.LOG_CORRELATION: frozenset({b"yoetz/session-log-id/v1\x00"}),
-    MacKeyPurpose.PRIVACY_AUDIT: frozenset({b"yoetz/privacy-egress-request/v1\x00"}),
+    MacKeyPurpose.PRIVACY_AUDIT: frozenset(
+        {
+            b"yoetz/privacy-audit/control-request/v1\x00",
+            b"yoetz/privacy-audit/internal-result/v1\x00",
+            b"yoetz/privacy-audit/local-approval/v1\x00",
+            b"yoetz/privacy-audit/lookup/v1\x00",
+            b"yoetz/privacy-audit/projection/v1\x00",
+            b"yoetz/privacy-audit/proposal/v1\x00",
+            b"yoetz/privacy-audit/receipt-cursor/v1\x00",
+            b"yoetz/privacy-egress-request/v1\x00",
+        }
+    ),
 }
 _PROVIDER_TOKEN68 = frozenset(
     b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~+/"

--- a/tests/conformance/operations/test_receipt_contract.py
+++ b/tests/conformance/operations/test_receipt_contract.py
@@ -35,7 +35,10 @@ from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     CandidateContext,
     ConsentSource,
+    DataCategory,
     LocalDisclosureApproved,
+    LocalDisclosureBlocked,
+    LocalDisclosureOmission,
     LocalDisclosureReceipt,
     PrivacyOutcome,
     ReceiptCounts,
@@ -52,7 +55,7 @@ from yoetz.domain.receipts import (
     render_receipt_compact,
 )
 from yoetz.domain.values import Frontier, session_id
-from yoetz.ports.control import ControlClientKind, ControlMethod
+from yoetz.ports.control import ControlClientKind, ControlError, ControlMethod
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
 from yoetz.ports.ledger import CheckCommitResult
@@ -168,6 +171,67 @@ class _ProjectionSpy:
         return None
 
 
+class _BlockingDocumentProjectionSpy(_ProjectionSpy):
+    """Approve nothing under ``/document`` so JSON receipt projection must fail closed."""
+
+    async def prepare_local_disclosure(
+        self, candidate: CandidateContext
+    ) -> LocalDisclosureBlocked:
+        self.candidates.append(candidate)
+        sink = candidate.local_sink
+        assert sink is not None
+        omissions = tuple(
+            sorted(
+                (
+                    LocalDisclosureOmission(
+                        item.origin_ref,
+                        item.category,
+                        "local_disclosure_not_authorized",
+                    )
+                    for item in candidate.items
+                    if item.origin_ref == "/document" or item.origin_ref.startswith("/document/")
+                ),
+                key=lambda item: item.json_pointer.encode(),
+            )
+        )
+        assert omissions, "seeded JSON receipt must expose at least one document content leaf"
+        proposal_id = protocol_id("ppr_", 1900 + len(self.candidates))
+        policy = ReceiptPolicyBinding(
+            protocol_id("pvy_", 1950 + len(self.candidates)), 1, _DIGEST, _DIGEST
+        )
+        receipt = LocalDisclosureReceipt(
+            "1.0.0",
+            protocol_id("egr_", 1960 + len(self.candidates)),
+            candidate.request_id,
+            proposal_id,
+            sink,
+            PrivacyOutcome.COMPLETED,
+            datetime(2026, 7, 19, 12, 0, tzinfo=UTC),
+            candidate.scope,
+            candidate.purpose,
+            policy,
+            ConsentSource.BASELINE_POLICY,
+            (),
+            (DataCategory.FINDING_SUMMARY,),
+            ReceiptCounts(0, 0, 0, 0, 0, 0, 0),
+            ReceiptTransformations(0, 0, 0),
+            ReceiptSecretScan("1.0.0", _DIGEST, 0, True),
+            None,
+            1,
+        )
+        return LocalDisclosureBlocked(
+            proposal_id,
+            candidate.request_id,
+            sink,
+            candidate.purpose,
+            candidate.scope,
+            _DIGEST,
+            _WORKSPACE,
+            omissions,
+            receipt,
+        )
+
+
 def _versions() -> ReceiptVersionSlice:
     return ReceiptVersionSlice(
         package_name="yoetz",
@@ -225,9 +289,13 @@ def _frontier(value: Frontier | FrontierModel) -> JsonValue:
     return cast(JsonValue, value.model_dump(mode="json"))
 
 
-def _build_app(*, seed_offset: int = 0) -> tuple[Application, _WorkflowRuntime, _ProjectionSpy]:
+def _build_app(
+    *,
+    seed_offset: int = 0,
+    projection: _ProjectionSpy | None = None,
+) -> tuple[Application, _WorkflowRuntime, _ProjectionSpy]:
     start_app, start_runtime, clock, catalog = start_composition()
-    projection = _ProjectionSpy()
+    projection = _ProjectionSpy() if projection is None else projection
     ids = start_runtime.ids
     runtime = _WorkflowRuntime(clock, ids)
     app = Application(
@@ -390,6 +458,52 @@ async def test_receipt_request_result_parity() -> None:
     assert cli_projected.root.privacy_projection.sink == "local_human_view"
     assert mcp_projected.root.privacy_projection.sink == "agent_context"
     assert len(projection.candidates) == 2
+
+
+async def test_json_receipt_projection_fails_closed_when_document_leaves_blocked() -> None:
+    """Digest-bound JSON receipts must not emit partly rewritten documents under omission."""
+
+    app, _runtime, projection = _build_app(
+        seed_offset=11, projection=_BlockingDocumentProjectionSpy()
+    )
+    started, checked, _obligation = await _bootstrap_finding(app, seed=1100)
+    receipt_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 1110)),
+        "task_id": started.task_id,
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(checked.result_frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+    receipt = await _receipt(app, receipt_wire)
+    facts = await app.projection_binding_facts(ControlMethod.RECEIPT, receipt_wire, receipt)
+    binding = ControlProjectionBinding(
+        protocol_id("rpc_", 1111),
+        ControlMethod.RECEIPT,
+        protocol_id("svc_", 1112),
+        1,
+        facts.original_request_id,
+        facts.route_identity_digest,
+        canonical_encode(
+            {
+                "rpc_id": protocol_id("rpc_", 1111),
+                "method": "receipt",
+                "service_instance_id": protocol_id("svc_", 1112),
+                "service_generation": "1",
+            }
+        ),
+    )
+    with pytest.raises(ControlError, match="privacy_projection_unavailable"):
+        await app.project_result_for_client(
+            ClientProjectionContext(
+                ControlClientKind.MCP_BRIDGE, ProjectionRenderMode.MACHINE_READABLE, False
+            ),
+            binding,
+            receipt,
+        )
+    assert len(projection.candidates) == 1
 
 
 async def test_frontier_and_own_event_exclusion_parity() -> None:

--- a/tests/conformance/operations/test_receipt_contract.py
+++ b/tests/conformance/operations/test_receipt_contract.py
@@ -171,12 +171,13 @@ class _ProjectionSpy:
         return None
 
 
-class _BlockingDocumentProjectionSpy(_ProjectionSpy):
+class _BlockingDocumentProjectionSpy:
     """Approve nothing under ``/document`` so JSON receipt projection must fail closed."""
 
-    async def prepare_local_disclosure(
-        self, candidate: CandidateContext
-    ) -> LocalDisclosureBlocked:
+    def __init__(self) -> None:
+        self.candidates: list[CandidateContext] = []
+
+    async def prepare_local_disclosure(self, candidate: CandidateContext) -> LocalDisclosureBlocked:
         self.candidates.append(candidate)
         sink = candidate.local_sink
         assert sink is not None
@@ -230,6 +231,9 @@ class _BlockingDocumentProjectionSpy(_ProjectionSpy):
             omissions,
             receipt,
         )
+
+    async def close(self) -> None:
+        return None
 
 
 def _versions() -> ReceiptVersionSlice:
@@ -292,8 +296,8 @@ def _frontier(value: Frontier | FrontierModel) -> JsonValue:
 def _build_app(
     *,
     seed_offset: int = 0,
-    projection: _ProjectionSpy | None = None,
-) -> tuple[Application, _WorkflowRuntime, _ProjectionSpy]:
+    projection: _ProjectionSpy | _BlockingDocumentProjectionSpy | None = None,
+) -> tuple[Application, _WorkflowRuntime, _ProjectionSpy | _BlockingDocumentProjectionSpy]:
     start_app, start_runtime, clock, catalog = start_composition()
     projection = _ProjectionSpy() if projection is None else projection
     ids = start_runtime.ids

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -70,11 +70,14 @@ class _GenerationStore:
 
 class _Lookup:
     def mac(self, domain: bytes, message: bytes) -> str:
-        return "hmac-sha256:" + hmac.new(
-            b"catalog-test-key",
-            domain + message,
-            hashlib.sha256,
-        ).hexdigest()
+        return (
+            "hmac-sha256:"
+            + hmac.new(
+                b"catalog-test-key",
+                domain + message,
+                hashlib.sha256,
+            ).hexdigest()
+        )
 
 
 def _accept_private_path(_path: Path) -> None:
@@ -118,7 +121,9 @@ def _sqlite_policy(  # pyright: ignore[reportUnusedFunction]
         _accept_private_path,
     )
     factory = cast(_SupportPolicyFactory, getattr(connection_module, "_SqliteSupportPolicy"))
-    installer = cast(Callable[[object | None], None], getattr(connection_module, "_install_support_policy"))
+    installer = cast(
+        Callable[[object | None], None], getattr(connection_module, "_install_support_policy")
+    )
     db = apsw.Connection(":memory:")
     try:
         raw_options: object = db.pragma("compile_options")
@@ -150,12 +155,8 @@ def test_open_catalog_writer_allows_unfenced_catalog_initialization(tmp_path: Pa
                 "INSERT INTO catalog_meta(key, value) VALUES ('installation_id', ?)",
                 (_INSTALLATION_ID,),
             )
-            db.execute(
-                "INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '7')"
-            )
-        row = db.execute(
-            "SELECT value FROM catalog_meta WHERE key='owner_generation'"
-        ).fetchone()
+            db.execute("INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '7')")
+        row = db.execute("SELECT value FROM catalog_meta WHERE key='owner_generation'").fetchone()
         assert row == ("7",)
     finally:
         db.close(force=True)
@@ -188,9 +189,7 @@ async def test_build_privacy_coordinator_reuses_durable_seed_on_second_ready(
                 "INSERT INTO catalog_meta(key, value) VALUES ('installation_id', ?)",
                 (_INSTALLATION_ID,),
             )
-            db.execute(
-                "INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '1')"
-            )
+            db.execute("INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '1')")
         first = await build_privacy_coordinator(
             catalog_db=db,
             installation_id=_INSTALLATION_ID,

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -34,6 +34,7 @@ from yoetz.service.daemon import ServiceComposition, ServiceDaemon
 from yoetz.service.lifecycle import ServiceLifecycle
 from yoetz.service.ready_composition import (
     IdPort,
+    build_privacy_coordinator,
     build_ready_application_factory,
     open_ready_catalog,
 )
@@ -158,6 +159,63 @@ def test_open_catalog_writer_allows_unfenced_catalog_initialization(tmp_path: Pa
         assert row == ("7",)
     finally:
         db.close(force=True)
+
+
+@pytest.mark.anyio
+async def test_build_privacy_coordinator_reuses_durable_seed_on_second_ready(
+    tmp_path: Path,
+) -> None:
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "7" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "8" * 64)
+    catalog_path = tmp_path / "catalog.sqlite3"
+    db = open_catalog_writer(catalog_path)
+    try:
+        initialize_catalog(db)
+        with db:
+            db.execute(
+                "INSERT INTO catalog_meta(key, value) VALUES ('installation_id', ?)",
+                (_INSTALLATION_ID,),
+            )
+            db.execute(
+                "INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '1')"
+            )
+        first = await build_privacy_coordinator(
+            catalog_db=db,
+            installation_id=_INSTALLATION_ID,
+            service_generation=1,
+            vault_generation=vault.generation,
+            vault=vault,
+            clock=clock,
+            ids=IdPort(),
+        )
+        second = await build_privacy_coordinator(
+            catalog_db=db,
+            installation_id=_INSTALLATION_ID,
+            service_generation=2,
+            vault_generation=vault.generation,
+            vault=vault,
+            clock=clock,
+            ids=IdPort(),
+        )
+        assert first[1].policy_id == second[1].policy_id
+        assert first[1].created_at == second[1].created_at
+        assert first[1].policy_digest == second[1].policy_digest
+    finally:
+        db.close(force=True)
+        await vault.close()
+        memory.close()
 
 
 @pytest.mark.anyio

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, cast
+
+import apsw
+import pytest
+
+import yoetz.adapters.sqlite.connection as connection_module
+import yoetz.service.ready_composition as ready_composition_module
+from yoetz.adapters.keys.encrypted_vault import EncryptedVaultStore
+from yoetz.adapters.keys.secret_memory import LocalSecretMemory
+from yoetz.adapters.sqlite.connection import open_catalog_writer
+from yoetz.adapters.sqlite.migrations import initialize_catalog
+from yoetz.application.service import ClientProjectionContext, ControlProjectionBinding
+from yoetz.config.models import YoetzConfig
+from yoetz.ports.control import (
+    ControlCallRequest,
+    ControlClientKind,
+    ControlMethod,
+    ServiceState,
+)
+from yoetz.ports.diagnostics import StartupCheckResult
+from yoetz.ports.secret_memory import SecretPurpose
+from yoetz.protocol.canonical import canonical_encode
+from yoetz.protocol.ids import IdKind, new_id
+from yoetz.protocol.models import StartRequest, StartResult
+from yoetz.service.daemon import ServiceComposition, ServiceDaemon
+from yoetz.service.lifecycle import ServiceLifecycle
+from yoetz.service.ready_composition import (
+    IdPort,
+    build_ready_application_factory,
+    open_ready_catalog,
+)
+from yoetz.service.vault import VaultMode, VaultService
+
+_INSTALLATION_ID = "ins_00000000-0000-4000-8000-000000000001"
+_INSTANCE_ID = "svc_00000000-0000-4000-8000-000000000002"
+
+
+class _SupportPolicyFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        manifest_id: str,
+        required_options: frozenset[str],
+        denied_options: frozenset[str],
+    ) -> object: ...
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return datetime(2026, 7, 21, 18, 0, 0, tzinfo=UTC)
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _GenerationStore:
+    def advance(self, instance_id: str) -> int:
+        assert instance_id == _INSTANCE_ID
+        return 1
+
+
+class _Lookup:
+    def mac(self, domain: bytes, message: bytes) -> str:
+        return "hmac-sha256:" + hmac.new(
+            b"catalog-test-key",
+            domain + message,
+            hashlib.sha256,
+        ).hexdigest()
+
+
+def _accept_private_path(_path: Path) -> None:
+    return None
+
+
+class _Paths:
+    def __init__(self, bundle: Path) -> None:
+        self._bundle = bundle
+
+    @property
+    def bundle(self) -> Path:
+        return self._bundle
+
+
+class _Diagnostics:
+    def record(self, result: StartupCheckResult) -> None:
+        assert type(result) is StartupCheckResult
+
+
+class _Listener:
+    def __init__(self) -> None:
+        self.closed = asyncio.Event()
+
+    async def accept(self) -> object:
+        await self.closed.wait()
+        raise RuntimeError("closed")
+
+    async def aclose(self) -> None:
+        self.closed.set()
+
+
+@pytest.fixture(autouse=True)
+def _sqlite_policy(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    monkeypatch.setattr(connection_module, "verify_private_local_bundle", _accept_private_path)
+    monkeypatch.setattr(
+        ready_composition_module,
+        "verify_private_local_bundle",
+        _accept_private_path,
+    )
+    factory = cast(_SupportPolicyFactory, getattr(connection_module, "_SqliteSupportPolicy"))
+    installer = cast(Callable[[object | None], None], getattr(connection_module, "_install_support_policy"))
+    db = apsw.Connection(":memory:")
+    try:
+        raw_options: object = db.pragma("compile_options")
+    finally:
+        db.close()
+    assert type(raw_options) is list
+    items = cast(list[object], raw_options)
+    assert all(type(item) is str for item in items)
+    installer(
+        factory(
+            manifest_id="test-ready-composition-runtime-support",
+            required_options=frozenset(cast(list[str], items)),
+            denied_options=frozenset({"OMIT_FOREIGN_KEY", "OMIT_WAL", "THREADSAFE=0"}),
+        )
+    )
+    yield
+    installer(None)
+
+
+def test_open_catalog_writer_allows_unfenced_catalog_initialization(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    catalog_path = tmp_path / "catalog.sqlite3"
+
+    db = open_catalog_writer(catalog_path)
+    try:
+        initialize_catalog(db)
+        with db:
+            db.execute(
+                "INSERT INTO catalog_meta(key, value) VALUES ('installation_id', ?)",
+                (_INSTALLATION_ID,),
+            )
+            db.execute(
+                "INSERT INTO catalog_meta(key, value) VALUES ('owner_generation', '7')"
+            )
+        row = db.execute(
+            "SELECT value FROM catalog_meta WHERE key='owner_generation'"
+        ).fetchone()
+        assert row == ("7",)
+    finally:
+        db.close(force=True)
+
+
+@pytest.mark.anyio
+async def test_open_ready_catalog_seeds_generation_property(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    catalog = await open_ready_catalog(
+        tmp_path / "catalog.sqlite3",
+        installation_id=_INSTALLATION_ID,
+        service_generation=11,
+        lookup=_Lookup(),
+        clock=_Clock(),
+        ids=IdPort(),
+    )
+    try:
+        assert catalog.generation == 11
+        row = catalog._db.execute(  # pyright: ignore[reportPrivateUsage]
+            "SELECT value FROM catalog_meta WHERE key='installation_id'"
+        ).fetchone()
+        assert row == (_INSTALLATION_ID,)
+    finally:
+        catalog._db.close(force=True)  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+async def test_ready_factory_installs_application_that_starts(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "1" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    await lifecycle.acquire_singleton()
+    await lifecycle.transition(ServiceState.LOCKED)
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "2" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "3" * 64)
+    app = None
+    try:
+        factory = build_ready_application_factory(
+            lifecycle=lifecycle,
+            vault=vault,
+            config=YoetzConfig(),
+            paths=_Paths(tmp_path),
+            clock=clock,
+            secret_memory=memory,
+            diagnostics=_Diagnostics(),
+        )
+        app = await factory(1, vault.generation)
+        request = StartRequest.model_validate(
+            {
+                "protocol_version": "0.1",
+                "schema_version": "1.0.0",
+                "request_id": "req_00000000-0000-4000-8000-000000000003",
+                "mode": "create",
+                "task_title": "Make documentation fully consistent",
+                "actor": {"actor_id": "harness:pytest", "actor_type": "harness"},
+                "client": {
+                    "kind": "codex_cli",
+                    "version": "0.144.6",
+                    "integration": "local_cli",
+                },
+                "requested_view": "compact",
+            }
+        )
+        result = await app.start(request)
+        rpc_id = new_id(IdKind.CONTROL_RPC)
+        facts = await app.projection_binding_facts(ControlMethod.START, request, result)
+        binding = ControlProjectionBinding(
+            rpc_id=rpc_id,
+            method=ControlMethod.START,
+            service_instance_id=_INSTANCE_ID,
+            service_generation=1,
+            original_request_id=facts.original_request_id,
+            route_identity_digest=facts.route_identity_digest,
+            control_request_canonical=canonical_encode(
+                {
+                    "method": ControlMethod.START.value,
+                    "rpc_id": rpc_id,
+                    "service_generation": "1",
+                    "service_instance_id": _INSTANCE_ID,
+                }
+            ),
+        )
+        projected = await app.project_result_for_client(
+            ClientProjectionContext.fail_safe(ControlClientKind.CLI),
+            binding,
+            result,
+        )
+
+        assert result.ok is True
+        assert result.outcome == "created"
+        assert result.frontier.sequence == "1"
+        assert isinstance(projected, StartResult)
+        assert projected.root.ok is True
+        assert projected.root.request_id == request.request_id
+    finally:
+        if app is not None:
+            await app.close()
+        await vault.close()
+        memory.close()
+        await lifecycle.close()
+
+
+@pytest.mark.anyio
+async def test_daemon_unlock_installs_real_application_and_dispatches_start(
+    tmp_path: Path,
+) -> None:
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "4" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "5" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "6" * 64)
+    await vault.lock()
+    diagnostics = _Diagnostics()
+    factory = build_ready_application_factory(
+        lifecycle=lifecycle,
+        vault=vault,
+        config=YoetzConfig(),
+        paths=_Paths(tmp_path),
+        clock=clock,
+        secret_memory=memory,
+        diagnostics=diagnostics,
+    )
+    daemon = ServiceDaemon(
+        _composition=ServiceComposition(
+            lifecycle=lifecycle,
+            control_listener=_Listener(),  # pyright: ignore[reportArgumentType]
+            secret_ingress_listener=None,
+            human_control_listener=None,
+            human_control_service=None,
+            session_monitor=None,
+            vault=vault,
+            ready_application_factory=factory,  # pyright: ignore[reportArgumentType]
+            secret_memory=memory,
+            diagnostics=diagnostics,
+        )
+    )
+    try:
+        await daemon.start()
+        assert daemon.status().state is ServiceState.LOCKED
+        await lifecycle.transition(ServiceState.UNLOCKING)
+        unlock = memory.capture(SecretPurpose.VAULT_UNLOCK, bytearray(b"correct horse battery"))
+        await vault.unlock(unlock)
+        await daemon.activate_ready_application(1, vault.generation)
+
+        instance = daemon.composition.lifecycle.instance
+        body = StartRequest.model_validate(
+            {
+                "protocol_version": "0.1",
+                "schema_version": "1.0.0",
+                "request_id": "req_00000000-0000-4000-8000-000000000004",
+                "mode": "create",
+                "task_title": "Make documentation fully consistent",
+                "actor": {"actor_id": "harness:pytest", "actor_type": "harness"},
+                "client": {
+                    "kind": "codex_cli",
+                    "version": "0.144.6",
+                    "integration": "local_cli",
+                },
+                "requested_view": "compact",
+            }
+        )
+        result = await daemon.dispatch(
+            ControlClientKind.CLI,
+            ControlCallRequest(
+                kind="call",
+                protocol_version="1.0",
+                rpc_id=new_id(IdKind.CONTROL_RPC),
+                service_instance_id=instance.instance_id,
+                service_generation=str(instance.generation),
+                method=ControlMethod.START,
+                body=body,
+            ),
+        )
+
+        assert result.outcome == "ok"
+        assert isinstance(result.body, StartResult)
+        assert result.body.root.ok is True
+        assert result.body.root.request_id == body.request_id
+        assert daemon.status().state is ServiceState.READY
+    finally:
+        await daemon.close()

--- a/tests/unit/config/test_owner_declared_endpoint.py
+++ b/tests/unit/config/test_owner_declared_endpoint.py
@@ -174,5 +174,5 @@ def test_owner_declared_data_use_never_assisted_eligible() -> None:
         host="llm.example.com",
         port=8443,
     )
-    assert openai.base_url == "https://llm.example.com:8443"
+    assert openai.base_url == "https://llm.example.com:8443/v1"
     assert openai.path == "/v1/responses"

--- a/tests/unit/service/test_control_protocol.py
+++ b/tests/unit/service/test_control_protocol.py
@@ -314,6 +314,43 @@ def test_wire_frames_convert_to_exact_typed_request_and_result() -> None:
     assert type(parsed_result.body) is ServiceStatus
 
 
+def test_workflow_start_request_round_trips_through_frozen_json_object() -> None:
+    from yoetz.protocol.models import StartRequest
+
+    start = StartRequest.model_validate(
+        {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "request_id": _REQUEST_ID,
+            "mode": "create",
+            "task_title": "Make documentation fully consistent",
+            "actor": {"actor_id": "harness:pytest", "actor_type": "harness"},
+            "client": {
+                "kind": "yoetz_cli",
+                "version": "0.1.0",
+                "integration": "local_cli",
+            },
+            "requested_view": "compact",
+        }
+    )
+    request = ControlCallRequest(
+        kind="call",
+        protocol_version="1.0",
+        rpc_id=_rpc_id(9),
+        service_instance_id=_SERVICE_ID,
+        service_generation="1",
+        method=ControlMethod.START,
+        body=start,
+    )
+    parsed = parse_control_request(decode_control_frame(encode_control_frame(request)))
+    assert isinstance(parsed, ControlCallRequest)
+    assert parsed.method is ControlMethod.START
+    assert isinstance(parsed.body, StartRequest)
+    assert parsed.body.request_id == start.request_id
+    assert parsed.body.task_title == start.task_title
+    assert parsed.body.mode == start.mode
+
+
 class _MemoryStream:
     def __init__(self, peer_identity: object) -> None:
         self.peer_identity = peer_identity

--- a/tests/unit/service/test_system_clock_millis.py
+++ b/tests/unit/service/test_system_clock_millis.py
@@ -1,0 +1,16 @@
+"""Production SystemClock must emit whole-millisecond UTC timestamps."""
+
+from __future__ import annotations
+
+from yoetz.domain.values import format_rfc3339_millis
+from yoetz.service import daemon as daemon_module
+
+
+def test_system_clock_now_utc_is_whole_millisecond() -> None:
+    clock = daemon_module._SystemClock()  # pyright: ignore[reportPrivateUsage]
+    now = clock.now_utc()
+    assert now.tzinfo is not None
+    assert now.utcoffset() is not None
+    assert now.microsecond % 1000 == 0
+    # Must be formatable for throttle wall-anomaly checks.
+    assert format_rfc3339_millis(now).endswith("Z")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the unlocked local workflow so `yoetz` can unlock, start, status, and receipt after production ready composition.

### What was broken / fixed

1. **Privacy seed conflict on re-unlock** — reuse durable machine policy instead of minting a conflicting seed.
2. **START `frame_invalid`** — thaw frozen `JsonObject` before pydantic `model_validate` on the wire path.
3. **STATUS writer / schema issues** — admit durable start writers from the open catalog DB; preserve required nulls in control result encoding.
4. **RECEIPT `frame_invalid` / schema crash** — JSON receipts are digest-bound; when any `/document` content leaf is blocked under `agent_context`, projection now fails closed with `privacy_projection_unavailable` instead of rewriting the document into a schema-invalid body. Markdown/text receipts succeed with a `human_text` omission marker under the default local-only policy (which does not authorize `finding_summary` for `agent_context`).

### Live verification (this environment)

- Unlock (passphrase FD ceremony) → `ready` with `workflow`
- `START` → ok
- `STATUS` compact → ok
- `RECEIPT` `format=markdown` → ok (`human_text` omitted, `finding_summary` blocked)
- `RECEIPT` `format=json` → fail-closed as `privacy_projection_unavailable` (surfaced as retryable `service_unavailable` by the control client)

### Out of scope / known

- Codex/Fireworks MCP tool visibility (model only sees MCP resource helpers) is unchanged.
- JSON receipt content under default agent-context policy requires authorizing `finding_summary` (or using markdown/text).

### Tests

- `tests/conformance/operations/test_receipt_contract.py::test_json_receipt_projection_fails_closed_when_document_leaves_blocked`
- Existing receipt parity + control protocol unit tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f859a-a6a5-7073-a4bb-e167139c00cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f859a-a6a5-7073-a4bb-e167139c00cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

