### PR TITLE
docs: enhance semantic readiness reporting and error handling

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -83,6 +83,10 @@ binding returns `self`, and different-ID binding is invalid. `as_public_dict()` 
 ordinary dictionary with exactly `code`, `message`, `retryable`, and bound `correlation_id`; it
 adds `safe_details` only when nonempty, as a new ordinary dictionary in ASCII key order. The frozen
 public-error JSON Schema remains a structural superset of this exact mapping-only runtime emitter.
+Allowlisted `safe_details` keys include structural recovery fields such as `reason_code`,
+`sequence`, and `head_digest` (for `FRONTIER_CONFLICT` current-head recovery). Protocol reason
+`response_projection_failed` marks an MCP post-commit shaping failure: the write may already be
+durable, so the public error is retryable and same-`request_id` resume is the recovery path.
 Internal-only value error: `ProtocolValueError(reason_code: str)` — bounded reason codes, never
 free text from input. CLI exit classes (0/2/10/11/20/30/40/70/130) map from codes in
 `cli/exits.py` only.

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -82,8 +82,16 @@ The report names each condition and the exact next command when one is unmet:
 
 1. `verification.semantic` is not `disabled`
 2. a provider endpoint is bound in `config.toml`
-3. a provider credential is connected (service capability `external_provider`)
+3. **the bound provider's** credential is connected (service capability `external_provider`)
 4. the effective privacy policy enables the `llm_inference` channel
+
+Condition 3 is per-provider, not "any credential". If you rebind the endpoint from one preset to
+another and do not run the credential ceremony for the new one, the old credential does not carry
+over: readiness stays false and checks report `credential_unavailable` rather than a
+misleading ready state.
+
+Conditions 3 and 4 are independent. Closing only one moves the failure without making semantic
+review work — the check reason changes, the outcome does not.
 
 `semantic_ready: true` is structural readiness only. It does not prove live provider dispatch.
 

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -70,6 +70,23 @@ https_origin = "https://llm.example.com:8443"
 You can edit `config.toml` by hand. Bare `yoetz` also exposes the same binding under **LLM provider**
 in the interactive menu.
 
+## Readiness (`yoetz provider status`)
+
+Before spending a run on semantic review, ask whether the four structural conditions hold:
+
+```text
+yoetz provider status --json
+```
+
+The report names each condition and the exact next command when one is unmet:
+
+1. `verification.semantic` is not `disabled`
+2. a provider endpoint is bound in `config.toml`
+3. a provider credential is connected (service capability `external_provider`)
+4. the effective privacy policy enables the `llm_inference` channel
+
+`semantic_ready: true` is structural readiness only. It does not prove live provider dispatch.
+
 ## The credential ceremony
 
 ```text

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -186,11 +186,29 @@ def _error(
     *,
     retryable: bool = False,
     reason_code: str | None = None,
+    sequence: int | None = None,
+    head_digest: str | None = None,
 ) -> PublicOperationError:
-    details: dict[str, str] = {}
+    details: dict[str, str | int] = {}
     if reason_code is not None:
         details["reason_code"] = reason_code
+    if sequence is not None:
+        details["sequence"] = sequence
+    if head_digest is not None:
+        details["head_digest"] = head_digest
     return PublicOperationError(code, code.value.lower(), retryable, safe_details=details)
+
+
+def _frontier_conflict(head: Frontier) -> PublicOperationError:
+    """Stale optimistic guard: surface the current head so callers can retry without a status trip."""
+
+    return _error(
+        PublicErrorCode.FRONTIER_CONFLICT,
+        retryable=True,
+        reason_code="frontier_changed",
+        sequence=head.sequence,
+        head_digest=head.head_digest,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1101,7 +1119,7 @@ class MemoryLedgerAdapter:
                 command.expected_frontier is not None
                 and command.expected_frontier != subject.sequence
             ):
-                raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                raise _frontier_conflict(subject)
             writer = self._state.writers.get(command.writer_id)
             if writer is None:
                 writer = _WriterState(command.task_id, command.session_id)
@@ -1179,7 +1197,10 @@ class MemoryLedgerAdapter:
                 or self._state.projection != snapshot_projection
                 or self._state.writers.get(command.writer_id) != snapshot_writer
             ):
-                raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                head = Frontier(
+                    self._state.projection.frontier, self._state.projection.head_digest
+                )
+                raise _frontier_conflict(head)
             if command.operation_kind is OperationKind.RECEIPT and self._pending_import(
                 command.session_id
             ):
@@ -1267,12 +1288,14 @@ class MemoryLedgerAdapter:
             frontier.sequence != projection.frontier
             or frontier.head_digest != projection.head_digest
         ):
-            raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+            raise _frontier_conflict(Frontier(projection.frontier, projection.head_digest))
         async with self._lock:
             if projection != self._state.projection or not any(
                 row.session_id == session_id for row in self._state.records
             ):
-                raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                raise _frontier_conflict(
+                    Frontier(self._state.projection.frontier, self._state.projection.head_digest)
+                )
             by_event = {row.event_id: row for row in self._state.records}
             refs = dict(self._state.object_refs)
             current_records = tuple(
@@ -1558,7 +1581,7 @@ class MemoryLedgerAdapter:
                 projection = self._state.projection
                 frontier = Frontier(projection.frontier, projection.head_digest)
                 if expected_frontier is not None and expected_frontier != frontier.sequence:
-                    raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                    raise _frontier_conflict(frontier)
                 records = self._state.records
                 writer = self._state.writers.get(writer_id)
                 if writer is None or writer.session_id != session_id:
@@ -1619,7 +1642,7 @@ class MemoryLedgerAdapter:
                 raise _error(PublicErrorCode.OPERATION_PENDING, retryable=True)
             current = Frontier(self._state.projection.frontier, self._state.projection.head_digest)
             if current != frontier or self._pending_import(session_id):
-                raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                raise _frontier_conflict(current)
             operation = OperationRecord(
                 writer_id,
                 request_id,
@@ -1901,9 +1924,14 @@ class MemoryLedgerAdapter:
                 raise _error(PublicErrorCode.OPERATION_PENDING, retryable=True)
             current = Frontier(self._state.projection.frontier, self._state.projection.head_digest)
             if current != frozen.case.frontier or self._state.frozen_cases.get(key) != frozen.case:
-                failure = _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                failure = _frontier_conflict(current)
                 canonical = canonical_encode(
-                    {"code": failure.code.value, "reason_code": "frontier_changed"}
+                    {
+                        "code": failure.code.value,
+                        "reason_code": "frontier_changed",
+                        "sequence": current.sequence,
+                        "head_digest": current.head_digest,
+                    }
                 )
                 terminal = replace(
                     record,
@@ -2099,7 +2127,7 @@ class MemoryLedgerAdapter:
                 or self._state.projection != snapshot_projection
                 or self._pending_import(frozen.lease.session_id)
             ):
-                raise _error(PublicErrorCode.FRONTIER_CONFLICT, reason_code="frontier_changed")
+                raise _frontier_conflict(current_head)
             terminal = replace(
                 current_record,
                 state=OperationState.COMPLETE,

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -1197,9 +1197,7 @@ class MemoryLedgerAdapter:
                 or self._state.projection != snapshot_projection
                 or self._state.writers.get(command.writer_id) != snapshot_writer
             ):
-                head = Frontier(
-                    self._state.projection.frontier, self._state.projection.head_digest
-                )
+                head = Frontier(self._state.projection.frontier, self._state.projection.head_digest)
                 raise _frontier_conflict(head)
             if command.operation_kind is OperationKind.RECEIPT and self._pending_import(
                 command.session_id

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -97,8 +97,34 @@ __all__ = ["CheckpointReport", "SqliteLedger"]
 _GENESIS_DIGEST: Final = "genesis"
 
 
-def _public_error(code: PublicErrorCode, *, retryable: bool = False) -> PublicOperationError:
-    return PublicOperationError(code, code.value.lower(), retryable)
+def _public_error(
+    code: PublicErrorCode,
+    *,
+    retryable: bool = False,
+    reason_code: str | None = None,
+    sequence: int | None = None,
+    head_digest: str | None = None,
+) -> PublicOperationError:
+    details: dict[str, str | int] = {}
+    if reason_code is not None:
+        details["reason_code"] = reason_code
+    if sequence is not None:
+        details["sequence"] = sequence
+    if head_digest is not None:
+        details["head_digest"] = head_digest
+    return PublicOperationError(
+        code, code.value.lower(), retryable, safe_details=details if details else None
+    )
+
+
+def _frontier_conflict(head: Frontier) -> PublicOperationError:
+    return _public_error(
+        PublicErrorCode.FRONTIER_CONFLICT,
+        retryable=True,
+        reason_code="frontier_changed",
+        sequence=head.sequence,
+        head_digest=head.head_digest,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -811,7 +837,7 @@ class SqliteLedger:
         self._ensure_writer(command, now)
         current = _head(self._db)
         if current != result.subject_frontier:
-            raise _public_error(PublicErrorCode.FRONTIER_CONFLICT)
+            raise _frontier_conflict(current)
         for record, entry in zip(records, command.entries, strict=True):
             ref = entry.payload_object
             existing = self._db.execute(
@@ -973,7 +999,7 @@ class SqliteLedger:
             records[0].ledger.ingestion_sequence != head.sequence + 1
             or records[0].ledger.previous_entry_digest != head.head_digest
         ):
-            raise _public_error(PublicErrorCode.FRONTIER_CONFLICT)
+            raise _frontier_conflict(head)
         for record in records:
             ref = self._state.object_refs.get(record.payload_ref.object_id)
             if ref is None:

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -488,6 +488,8 @@ class Application:
         default_factory=_empty_support_handlers
     )
     verification_supervisor: ObservationVerificationSupervisor | None = None
+    connected_provider_ids: tuple[str, ...] = ()
+    semantic_ready: bool = False
     _close_lock: asyncio.Lock = field(init=False, repr=False, compare=False)
     _close_task: asyncio.Task[None] | None = field(
         init=False, default=None, repr=False, compare=False
@@ -495,6 +497,12 @@ class Application:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "_close_lock", asyncio.Lock())
+        if type(self.connected_provider_ids) is not tuple or any(
+            type(item) is not str for item in self.connected_provider_ids
+        ):
+            raise TypeError("connected_provider_ids_invalid")
+        if type(self.semantic_ready) is not bool:
+            raise TypeError("semantic_ready_invalid")
 
     async def start(self, request: StartRequest) -> StartInternalResult:
         return await execute_start(self, request)  # pyright: ignore[reportArgumentType]
@@ -833,6 +841,8 @@ class ServiceReadyContext:
     )
     verification_supervisor: ObservationVerificationSupervisor | None = None
     rediscover_pending_verification: Callable[[], Awaitable[None]] | None = None
+    connected_provider_ids: tuple[str, ...] = ()
+    semantic_ready: bool = False
 
     def __post_init__(self) -> None:
         if (
@@ -842,6 +852,12 @@ class ServiceReadyContext:
             or self.vault_generation <= 0
         ):
             raise ValueError("ready_generation_invalid")
+        if type(self.connected_provider_ids) is not tuple or any(
+            type(item) is not str for item in self.connected_provider_ids
+        ):
+            raise TypeError("connected_provider_ids_invalid")
+        if type(self.semantic_ready) is not bool:
+            raise TypeError("semantic_ready_invalid")
 
     def __repr__(self) -> str:
         return "ServiceReadyContext(<redacted>)"
@@ -890,6 +906,8 @@ class ReadyApplicationFactory:
                 context.version_manifest,
                 context.support_handlers,
                 context.verification_supervisor,
+                connected_provider_ids=context.connected_provider_ids,
+                semantic_ready=context.semantic_ready,
             )
             if context.verification_supervisor is not None:
                 await context.verification_supervisor.start()

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -489,6 +489,7 @@ class Application:
     )
     verification_supervisor: ObservationVerificationSupervisor | None = None
     connected_provider_ids: tuple[str, ...] = ()
+    provider_credential_connected: bool = False
     semantic_ready: bool = False
     _close_lock: asyncio.Lock = field(init=False, repr=False, compare=False)
     _close_task: asyncio.Task[None] | None = field(
@@ -501,8 +502,15 @@ class Application:
             type(item) is not str for item in self.connected_provider_ids
         ):
             raise TypeError("connected_provider_ids_invalid")
+        if type(self.provider_credential_connected) is not bool:
+            raise TypeError("provider_credential_connected_invalid")
         if type(self.semantic_ready) is not bool:
             raise TypeError("semantic_ready_invalid")
+        # Readiness may never outrun the resolved binding. A connected provider that is not the
+        # configured one leaves dispatch on the credential-unavailable path, so a readiness flag
+        # set without it would report ready while every check reports unavailable.
+        if self.semantic_ready and not self.provider_credential_connected:
+            raise ValueError("semantic_ready_without_connected_provider_credential")
 
     async def start(self, request: StartRequest) -> StartInternalResult:
         return await execute_start(self, request)  # pyright: ignore[reportArgumentType]
@@ -842,6 +850,7 @@ class ServiceReadyContext:
     verification_supervisor: ObservationVerificationSupervisor | None = None
     rediscover_pending_verification: Callable[[], Awaitable[None]] | None = None
     connected_provider_ids: tuple[str, ...] = ()
+    provider_credential_connected: bool = False
     semantic_ready: bool = False
 
     def __post_init__(self) -> None:
@@ -856,8 +865,15 @@ class ServiceReadyContext:
             type(item) is not str for item in self.connected_provider_ids
         ):
             raise TypeError("connected_provider_ids_invalid")
+        if type(self.provider_credential_connected) is not bool:
+            raise TypeError("provider_credential_connected_invalid")
         if type(self.semantic_ready) is not bool:
             raise TypeError("semantic_ready_invalid")
+        # Readiness may never outrun the resolved binding. A connected provider that is not the
+        # configured one leaves dispatch on the credential-unavailable path, so a readiness flag
+        # set without it would report ready while every check reports unavailable.
+        if self.semantic_ready and not self.provider_credential_connected:
+            raise ValueError("semantic_ready_without_connected_provider_credential")
 
     def __repr__(self) -> str:
         return "ServiceReadyContext(<redacted>)"
@@ -907,6 +923,7 @@ class ReadyApplicationFactory:
                 context.support_handlers,
                 context.verification_supervisor,
                 connected_provider_ids=context.connected_provider_ids,
+                provider_credential_connected=context.provider_credential_connected,
                 semantic_ready=context.semantic_ready,
             )
             if context.verification_supervisor is not None:

--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -332,12 +332,18 @@ async def _exact_frontier(runtime: TaskRuntime, sequence: int | None) -> tuple[F
     async for record in runtime.ledger.load_events(runtime.session_id, through=target):
         found = Frontier(record.ledger.ingestion_sequence, record.entry_digest)
     if found is None or found.sequence != target:
-        raise _error(
+        raise PublicOperationError(
             PublicErrorCode.FRONTIER_CONFLICT,
             (
                 "The requested frontier is unavailable. Call status to read the current frontier, "
                 "then retry idempotently with the same request_id."
             ),
+            True,
+            safe_details={
+                "reason_code": "frontier_changed",
+                "sequence": head.sequence,
+                "head_digest": head.head_digest,
+            },
         )
     return found, head
 

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -885,6 +885,15 @@ credential_app.command("set")(_provider_credential_command("set"))
 credential_app.command("rotate")(_provider_credential_command("rotate"))
 
 
+@provider_app.command("status")
+def provider_status(json_output: _JSON = False) -> None:
+    """Report whether external semantic review is structurally ready to dispatch."""
+
+    from yoetz.cli.provider_status import run_provider_status
+
+    _finish(run_async(lambda: run_provider_status(json_output=json_output)))
+
+
 @provider_app.command("endpoint")
 def provider_endpoint(
     official: Annotated[

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -60,14 +60,21 @@ def _emit(value: Mapping[str, JsonValue], *, json_output: bool) -> None:
 
 
 def _channel_enabled(policy: Mapping[str, object], channel: str) -> bool | None:
-    channels = policy.get("channels")
+    """Read one channel's enabled flag from the canonical effective policy.
+
+    The canonical policy names this list ``channel_policies``; reading any other key silently
+    reports every channel as unknown and makes readiness unreachable.
+    """
+
+    channels = policy.get("channel_policies")
     if not isinstance(channels, list | tuple):
         return None
-    for item in channels:
+    for item in cast("list[object] | tuple[object, ...]", channels):
         if not isinstance(item, Mapping):
             continue
-        if item.get("channel") == channel:
-            return item.get("enabled") is True
+        entry = cast(Mapping[str, object], item)
+        if entry.get("channel") == channel:
+            return entry.get("enabled") is True
     return None
 
 
@@ -182,7 +189,8 @@ async def provider_status_report() -> dict[str, JsonValue]:
         "next_commands": next_commands,
         "notes": (
             "semantic_ready is structural readiness only; it does not prove live provider dispatch.",
-            "credential_connected uses the service external_provider capability when ready.",
+            "credential_connected reports the configured provider's credential, not any provider.",
+            "A credential for a different provider than the bound endpoint does not count.",
         ),
     }
 

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -1,0 +1,195 @@
+"""Read-only semantic readiness report for operator surfaces.
+
+Reports the four conditions that must all hold before external semantic review can
+dispatch, without claiming a live provider smoke or writing any state.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from typing import Final, cast
+
+from yoetz.config.load import load_config
+from yoetz.domain.values import JsonObject
+from yoetz.ports.control import ControlClientKind, ControlError
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.service.client import connect_service
+
+__all__ = ["provider_status_report", "run_provider_status"]
+
+_SCHEMA: Final = "yoetz.provider-status/1"
+
+
+def _stdout_json(value: JsonValue) -> None:
+    sys.stdout.buffer.write(canonical_encode(value) + b"\n")
+    sys.stdout.buffer.flush()
+
+
+def _emit(value: Mapping[str, JsonValue], *, json_output: bool) -> None:
+    if json_output or not sys.stdout.isatty():
+        _stdout_json(dict(value))
+        return
+    print(f"schema: {value.get('schema')}")
+    print(f"semantic_mode: {value.get('verification_semantic')}")
+    print(f"endpoint_bound: {value.get('endpoint_bound')}")
+    binding = value.get("endpoint")
+    if isinstance(binding, Mapping):
+        print(
+            "  "
+            f"provider_id={binding.get('provider_id')} "
+            f"model={binding.get('model')} "
+            f"profile={binding.get('endpoint_profile_id')}"
+        )
+    print(f"credential_connected: {value.get('credential_connected')}")
+    print(f"llm_inference_enabled: {value.get('llm_inference_enabled')}")
+    print(f"semantic_ready: {value.get('semantic_ready')}")
+    blockers = value.get("blockers")
+    if isinstance(blockers, list | tuple) and blockers:
+        print("blockers:")
+        for item in blockers:
+            if isinstance(item, Mapping):
+                print(f"  - {item.get('condition')}: {item.get('next_command')}")
+            else:
+                print(f"  - {item}")
+    next_steps = value.get("next_commands")
+    if isinstance(next_steps, list | tuple) and next_steps:
+        print("next commands:")
+        for step in next_steps:
+            print(f"  - {step}")
+
+
+def _channel_enabled(policy: Mapping[str, object], channel: str) -> bool | None:
+    channels = policy.get("channels")
+    if not isinstance(channels, list | tuple):
+        return None
+    for item in channels:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("channel") == channel:
+            return item.get("enabled") is True
+    return None
+
+
+async def provider_status_report() -> dict[str, JsonValue]:
+    """Compose a nonsecret readiness snapshot from config, service, and policy."""
+
+    config = load_config({}, {}, None)
+    verification_semantic = config.verification.semantic
+    semantic_enabled = verification_semantic != "disabled"
+    endpoint_bound = config.provider is not None
+    endpoint: dict[str, JsonValue] | None = None
+    if config.provider is not None:
+        endpoint = {
+            "provider_id": config.provider.provider_id,
+            "model": config.provider.model,
+            "endpoint_profile_id": config.provider.endpoint_profile_id,
+            "endpoint_profile_version": config.provider.endpoint_profile_version,
+        }
+
+    service_state: str | None = None
+    credential_connected: bool | None = None
+    llm_inference_enabled: bool | None = None
+    policy_profile: str | None = None
+
+    try:
+        client = await connect_service(ControlClientKind.CLI)
+        try:
+            status = await client.service_status()
+            service_state = status.state.value
+            if status.state.value == "ready":
+                credential_connected = "external_provider" in status.capabilities
+                try:
+                    effective = await client.privacy_get_effective(JsonObject({}))
+                except Exception:
+                    effective = None
+                if isinstance(effective, Mapping):
+                    plain = cast(Mapping[str, object], dict(effective))
+                    policy = plain.get("policy")
+                    if isinstance(policy, Mapping):
+                        policy_map = cast(Mapping[str, object], policy)
+                        profile = policy_map.get("profile")
+                        if type(profile) is str:
+                            policy_profile = profile
+                        llm_inference_enabled = _channel_enabled(policy_map, "llm_inference")
+            else:
+                credential_connected = None
+        finally:
+            await client.close()
+    except ControlError as error:
+        service_state = error.reason
+        credential_connected = None
+        llm_inference_enabled = None
+
+    blockers: list[dict[str, JsonValue]] = []
+    if not semantic_enabled:
+        blockers.append(
+            {
+                "condition": "verification.semantic",
+                "state": verification_semantic,
+                "next_command": "set [verification].semantic to optional|required in config.toml",
+            }
+        )
+    if not endpoint_bound:
+        blockers.append(
+            {
+                "condition": "provider_endpoint",
+                "state": "unbound",
+                "next_command": "yoetz provider endpoint --provider <preset> --model <model>",
+            }
+        )
+    if credential_connected is not True:
+        blockers.append(
+            {
+                "condition": "provider_credential",
+                "state": "unknown" if credential_connected is None else "not_connected",
+                "next_command": "yoetz provider credential set",
+            }
+        )
+    if llm_inference_enabled is not True:
+        blockers.append(
+            {
+                "condition": "llm_inference_channel",
+                "state": "unknown" if llm_inference_enabled is None else "disabled",
+                "next_command": "yoetz privacy setup",
+            }
+        )
+
+    semantic_ready = (
+        semantic_enabled
+        and endpoint_bound
+        and credential_connected is True
+        and llm_inference_enabled is True
+    )
+    next_commands = tuple(
+        cast(str, item["next_command"])
+        for item in blockers
+        if type(item.get("next_command")) is str
+    )
+
+    return {
+        "schema": _SCHEMA,
+        "verification_semantic": verification_semantic,
+        "semantic_enabled": semantic_enabled,
+        "endpoint_bound": endpoint_bound,
+        "endpoint": endpoint,
+        "credential_connected": credential_connected,
+        "llm_inference_enabled": llm_inference_enabled,
+        "privacy_profile": policy_profile,
+        "service_state": service_state,
+        "semantic_ready": semantic_ready,
+        "blockers": tuple(blockers),
+        "next_commands": next_commands,
+        "notes": (
+            "semantic_ready is structural readiness only; it does not prove live provider dispatch.",
+            "credential_connected uses the service external_provider capability when ready.",
+        ),
+    }
+
+
+async def run_provider_status(*, json_output: bool) -> int:
+    """Emit the readiness report and return a process exit code."""
+
+    report = await provider_status_report()
+    _emit(report, json_output=json_output)
+    return 0 if report.get("semantic_ready") is True else 20

--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -26,13 +26,16 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "actor",
         "actor_id",
         "actor_type",
+        "artifact_refs",
         "asserted_by",
         "at_frontier",
+        "causal_parents",
         "client",
         "cursor",
         "disposition",
         "display_name",
         "event_drafts",
+        "event_id",
         "evidence_refs",
         "expected_frontier",
         "external_ref",
@@ -46,6 +49,7 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "limit",
         "max_findings",
         "mode",
+        "name",
         "occurred_at",
         "payload",
         "policy_packs",
@@ -55,6 +59,7 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "redaction_profile",
         "request_id",
         "requested_view",
+        "schema",
         "schema_name",
         "schema_version",
         "scope",
@@ -130,9 +135,12 @@ def safe_validation_locations(exc: object) -> tuple[dict[str, str], ...]:
             continue
         pointer = _pointer_for_location(
             item.get("loc"),
-            project_parent_on_unsafe_leaf=raw_reason == "extra_forbidden",
+            # Project to the nearest allowlisted parent so untrusted leaf keys (payload fields,
+            # extras) never appear, while still naming a useful location such as /event_drafts/0.
+            project_parent_on_unsafe_leaf=True,
         )
-        if pointer is None:
+        # Empty pointers (model-level failures with no path) are not actionable; omit them.
+        if pointer is None or pointer == "":
             continue
         reason = _SAFE_VALIDATION_REASONS.get(raw_reason, "invalid_type_or_value")
         projected.append({"field": pointer, "reason": reason})

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -362,11 +362,10 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
             request_id=request_id,
             correlation_id=correlation_id,
         )
+    # Invoke first. Once this returns, a write may already be durable; response shaping must not
+    # collapse that into a non-retryable INTERNAL_ERROR that steers agents away from same-id resume.
     try:
         result = await _invoke_with_reconnect(runtime, request, invoke)
-        wire = public_model_to_wire(result)
-        validated = result_type.model_validate(wire)
-        return result_from_public_model(validated)
     except PublicOperationError as exc:
         # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
         # PublicOperationError escapes the service boundary, keep the exact public code.
@@ -404,6 +403,29 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
             "The bridge could not complete the operation.",
             request_id=request_id,
             correlation_id=correlation_id,
+        )
+
+    try:
+        wire = public_model_to_wire(result)
+        validated = result_type.model_validate(wire)
+        return result_from_public_model(validated)
+    except Exception as exc:
+        correlation_id = record_unexpected_exception_without_raising(
+            exc,
+            component="mcp.bridge",
+            operation=f"{operation}_response_projection_failed",
+            request_id=request_id,
+        )
+        return structured_error_result(
+            PublicErrorCode.INTERNAL_ERROR,
+            (
+                "The operation completed on the local service, but the bridge could not shape "
+                "the response. Retry with the same request_id to load the stored result."
+            ),
+            retryable=True,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            safe_details={"reason_code": "response_projection_failed"},
         )
 
 

--- a/src/yoetz/protocol/errors.py
+++ b/src/yoetz/protocol/errors.py
@@ -152,6 +152,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "redaction_target_required",
     "ref_mirror_mismatch",
     "response_fields_invalid",
+    "response_projection_failed",
     "schema_artifact_role_invalid",
     "schema_artifact_role_mismatch",
     "schema_bytes_invalid",
@@ -185,7 +186,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
 )
 
 _REASON_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$", re.ASCII)
-assert len(_PROTOCOL_REASON_CODE_VALUES) == 133
+assert len(_PROTOCOL_REASON_CODE_VALUES) == 134
 assert len(_PROTOCOL_REASON_CODE_VALUES) == len(set(_PROTOCOL_REASON_CODE_VALUES))
 assert _PROTOCOL_REASON_CODE_VALUES == tuple(sorted(_PROTOCOL_REASON_CODE_VALUES, key=str.encode))
 assert all(_REASON_CODE_PATTERN.fullmatch(value) for value in _PROTOCOL_REASON_CODE_VALUES)
@@ -198,6 +199,7 @@ SAFE_DETAIL_KEYS: tuple[str, ...] = (
     "count",
     "expected_version",
     "field",
+    "head_digest",
     "limit",
     "method",
     "operation",
@@ -206,12 +208,14 @@ SAFE_DETAIL_KEYS: tuple[str, ...] = (
     "reason_code",
     "retry_after_ms",
     "schema_name",
+    "sequence",
     "state",
     "status",
     "view",
 )
 
-_INTEGER_DETAIL_KEYS = frozenset({"count", "limit", "retry_after_ms"})
+_INTEGER_DETAIL_KEYS = frozenset({"count", "limit", "retry_after_ms", "sequence"})
+_HEAD_DIGEST_PATTERN = re.compile(r"^(?:genesis|sha256:[0-9a-f]{64})$", re.ASCII)
 _ENUM_DETAIL_KEYS = frozenset(
     {"component", "method", "operation", "phase", "state", "status", "view"}
 )
@@ -305,6 +309,10 @@ def _normalize_detail(key: str, value: object) -> SafeDetailValue | None:
             and len(value) <= 128
             and _SCHEMA_NAME_PATTERN.fullmatch(value) is not None
         ):
+            return value
+        return None
+    if key == "head_digest":
+        if type(value) is str and _HEAD_DIGEST_PATTERN.fullmatch(value) is not None:
             return value
         return None
     if key == "field" and _valid_json_pointer(value):

--- a/src/yoetz/protocol/models.py
+++ b/src/yoetz/protocol/models.py
@@ -982,7 +982,9 @@ class CheckScopeModel(_ClosedModel):
 
 
 def _validate_model_against_schema(model: BaseModel, schema_name: str) -> None:
-    from yoetz.protocol.schemas import validate_schema_instance
+    from pydantic import ValidationError as PydanticValidationError
+
+    from yoetz.protocol.schemas import SchemaInstanceInvalid, validate_schema_instance
 
     dumped = model.model_dump(
         mode="json",
@@ -990,7 +992,23 @@ def _validate_model_against_schema(model: BaseModel, schema_name: str) -> None:
         exclude_unset=True,
         exclude_none=False,
     )
-    validate_schema_instance(schema_name, "1.0.0", cast(JsonValue, dumped))
+    try:
+        validate_schema_instance(schema_name, "1.0.0", cast(JsonValue, dumped))
+    except SchemaInstanceInvalid as exc:
+        # Re-raise with the JSON Schema absolute path so MCP safe_details can name the field.
+        if exc.absolute_path:
+            raise PydanticValidationError.from_exception_data(
+                type(model).__name__,
+                [
+                    {
+                        "type": "value_error",
+                        "loc": tuple(exc.absolute_path),
+                        "input": None,
+                        "ctx": {"error": ValueError("schema_instance_invalid")},
+                    }
+                ],
+            ) from None
+        raise ValueError("schema_instance_invalid") from None
 
 
 class StartRequestModel(PublicRequestModel):

--- a/src/yoetz/protocol/schemas.py
+++ b/src/yoetz/protocol/schemas.py
@@ -37,6 +37,7 @@ __all__ = [
     "SchemaArtifactRole",
     "SchemaCatalog",
     "SchemaDocument",
+    "SchemaInstanceInvalid",
     "SchemaKind",
     "event_schema_versions",
     "load_schema_catalog",
@@ -720,6 +721,22 @@ def event_schema_versions(catalog: SchemaCatalog) -> Mapping[str, str]:
     return catalog.event_schema_versions
 
 
+class SchemaInstanceInvalid(ProtocolValueError):
+    """Schema admission failure with an optional absolute JSON path for caller recovery."""
+
+    __slots__ = ("absolute_path",)
+
+    absolute_path: tuple[str | int, ...]
+
+    def __init__(self, absolute_path: tuple[str | int, ...] = ()) -> None:
+        if type(absolute_path) is not tuple:
+            raise TypeError("schema_instance_path_invalid")
+        if any(type(item) is not str and type(item) is not int for item in absolute_path):
+            raise TypeError("schema_instance_path_invalid")
+        self.absolute_path = absolute_path
+        super().__init__("schema_instance_invalid")
+
+
 def validate_schema_instance(name: str, version: str, value: JsonValue) -> None:
     """Validate a canonical JSON value against one exact local schema."""
 
@@ -735,7 +752,14 @@ def validate_schema_instance(name: str, version: str, value: JsonValue) -> None:
     try:
         validator_api = cast(_ValidatorProtocol, cast(object, validator))
         validator_api.validate(_plain_validation_value(value))
-    except ValidationError:
-        raise ProtocolValueError("schema_instance_invalid") from None
+    except ValidationError as exc:
+        path_items: list[str | int] = []
+        for item in exc.absolute_path:
+            if type(item) is str or type(item) is int:
+                path_items.append(item)
+            else:
+                path_items = []
+                break
+        raise SchemaInstanceInvalid(tuple(path_items)) from None
     except BaseException:
-        raise ProtocolValueError("schema_instance_invalid") from None
+        raise SchemaInstanceInvalid() from None

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -621,8 +621,9 @@ class ServiceDaemon:
         capabilities = {"confidential_ingress"}
         if lifecycle.state is ServiceState.READY and self._application is not None:
             capabilities.update({"workflow", "maintenance", "import_review"})
-            connected = getattr(self._application, "connected_provider_ids", ())
-            if connected:
+            # Exactly the *configured* provider's credential, not "some provider is connected":
+            # operator readiness surfaces read this capability and must not over-report.
+            if getattr(self._application, "provider_credential_connected", False) is True:
                 capabilities.add("external_provider")
         if self._monitor_state == "active":
             capabilities.add("session_event_monitor")

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -621,6 +621,9 @@ class ServiceDaemon:
         capabilities = {"confidential_ingress"}
         if lifecycle.state is ServiceState.READY and self._application is not None:
             capabilities.update({"workflow", "maintenance", "import_review"})
+            connected = getattr(self._application, "connected_provider_ids", ())
+            if connected:
+                capabilities.add("external_provider")
         if self._monitor_state == "active":
             capabilities.add("session_event_monitor")
         return ServiceStatus(

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1197,7 +1197,7 @@ def _receipt_versions(manifest: Mapping[str, CanonicalJsonValue]) -> ReceiptVers
 async def _semantic_not_configured(
     frozen: FrozenCase, findings: tuple[object, ...]
 ) -> FinalSemanticEvaluation:
-    """Explicit deterministic-only check path when no privacy-ready provider binding exists."""
+    """Explicit path when semantic review is enabled but no provider endpoint is bound."""
 
     del frozen, findings
     return FinalSemanticEvaluation(
@@ -1205,12 +1205,24 @@ async def _semantic_not_configured(
     )
 
 
+async def _semantic_credential_unavailable(
+    frozen: FrozenCase, findings: tuple[object, ...]
+) -> FinalSemanticEvaluation:
+    """Endpoint is bound but no provider credential is connected in this generation."""
+
+    del frozen, findings
+    return FinalSemanticEvaluation(
+        SemanticStatus.UNAVAILABLE, SemanticReason.CREDENTIAL_UNAVAILABLE
+    )
+
+
 def _map_blocked(outcome: PrivacyOutcome, reason: object) -> FinalSemanticEvaluation:
     """Map pre-dispatch privacy blocks to exact semantic status/reason pairs."""
 
     if outcome is PrivacyOutcome.CHANNEL_UNAVAILABLE:
+        # Distinct from missing credential/endpoint: the channel is present but policy forbids it.
         return FinalSemanticEvaluation(
-            SemanticStatus.NOT_CONFIGURED, SemanticReason.PROVIDER_NOT_CONFIGURED
+            SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.CHANNEL_DISABLED
         )
     if outcome is PrivacyOutcome.BLOCKED_FORBIDDEN_DATA:
         return FinalSemanticEvaluation(
@@ -1479,13 +1491,16 @@ async def provide_service_ready_context(
         tuple[str, ...], tuple(getattr(gateway, "connected_provider_ids", lambda: ())())
     )
     semantic_configured = config.verification.semantic != "disabled"
-    semantic_ready = semantic_configured and bool(connected_provider_ids)
+    provider_endpoint_bound = config.provider is not None
+    semantic_ready = semantic_configured and bool(connected_provider_ids) and provider_endpoint_bound
     capabilities = {
         RuntimeCapability.STRUCTURAL_READ,
         RuntimeCapability.PAYLOAD_READ,
         RuntimeCapability.WRITE,
     }
-    if semantic_ready:
+    # Expose SEMANTIC when the operator has not disabled it so check can report *why* it is
+    # unusable (no endpoint vs no credential vs policy), instead of one opaque not_configured.
+    if semantic_configured:
         capabilities.add(RuntimeCapability.SEMANTIC)
     runtime_context = ServiceRuntimeContext(
         service_instance_id=cast(str, getattr(lifecycle.instance, "instance_id")),
@@ -1548,8 +1563,14 @@ async def provide_service_ready_context(
         candidate_binding = provider_binding_from_config(config.provider)
         if candidate_binding.provider_id in connected_provider_ids:
             provider_binding = candidate_binding
-    semantic_evaluator = (
-        _privacy_gated_semantic_evaluator(
+    if not semantic_configured:
+        semantic_evaluator = _semantic_not_configured
+    elif not provider_endpoint_bound:
+        semantic_evaluator = _semantic_not_configured
+    elif not connected_provider_ids or provider_binding is None:
+        semantic_evaluator = _semantic_credential_unavailable
+    else:
+        semantic_evaluator = _privacy_gated_semantic_evaluator(
             cast(PrivacyCoordinator, privacy),
             clock,
             installation_id,
@@ -1558,9 +1579,6 @@ async def provide_service_ready_context(
             lookup,
             ids,
         )
-        if semantic_ready
-        else _semantic_not_configured
-    )
 
     async def _semantic_review(
         candidates: tuple[ObservationAdviceCandidate, ...],
@@ -1696,6 +1714,8 @@ async def provide_service_ready_context(
         support_handlers=observation_handlers,
         verification_supervisor=verification_supervisor,
         rediscover_pending_verification=observation_coordinator.rediscover_pending_verification,
+        connected_provider_ids=connected_provider_ids,
+        semantic_ready=semantic_ready,
     )
 
 

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1492,7 +1492,18 @@ async def provide_service_ready_context(
     )
     semantic_configured = config.verification.semantic != "disabled"
     provider_endpoint_bound = config.provider is not None
-    semantic_ready = semantic_configured and bool(connected_provider_ids) and provider_endpoint_bound
+    # Resolve the binding before readiness: a connected provider that is not the *configured* one
+    # leaves dispatch on the credential-unavailable path, so readiness must track the exact binding
+    # rather than "any provider connected".
+    provider_binding: ProviderBinding | None = None
+    if config.provider is not None:
+        candidate_binding = provider_binding_from_config(config.provider)
+        if candidate_binding.provider_id in connected_provider_ids:
+            provider_binding = candidate_binding
+    provider_credential_connected = provider_binding is not None
+    semantic_ready = (
+        semantic_configured and provider_endpoint_bound and provider_credential_connected
+    )
     capabilities = {
         RuntimeCapability.STRUCTURAL_READ,
         RuntimeCapability.PAYLOAD_READ,
@@ -1558,16 +1569,11 @@ async def provide_service_ready_context(
         )
 
     versions = _receipt_versions(manifest)
-    provider_binding: ProviderBinding | None = None
-    if semantic_ready and config.provider is not None:
-        candidate_binding = provider_binding_from_config(config.provider)
-        if candidate_binding.provider_id in connected_provider_ids:
-            provider_binding = candidate_binding
     if not semantic_configured:
         semantic_evaluator = _semantic_not_configured
     elif not provider_endpoint_bound:
         semantic_evaluator = _semantic_not_configured
-    elif not connected_provider_ids or provider_binding is None:
+    elif provider_binding is None:
         semantic_evaluator = _semantic_credential_unavailable
     else:
         semantic_evaluator = _privacy_gated_semantic_evaluator(
@@ -1715,6 +1721,7 @@ async def provide_service_ready_context(
         verification_supervisor=verification_supervisor,
         rediscover_pending_verification=observation_coordinator.rediscover_pending_verification,
         connected_provider_ids=connected_provider_ids,
+        provider_credential_connected=provider_credential_connected,
         semantic_ready=semantic_ready,
     )
 

--- a/tests/integration/application/test_publish_work.py
+++ b/tests/integration/application/test_publish_work.py
@@ -154,6 +154,35 @@ async def test_forbidden_family_rejects_before_object_publication() -> None:
     assert app.runtime.release_count == 1
 
 
+async def test_same_request_id_replay_returns_the_stored_result_without_rewriting() -> None:
+    """The recovery the MCP post-commit error advertises must actually work.
+
+    When response shaping fails after a durable commit, the bridge tells the caller to retry with
+    the same request_id. That guidance is only honest if an identical replay returns the committed
+    result instead of appending a second event.
+    """
+
+    app, objects = _composition()
+    first = await execute_publish_work(cast(Application, app), _request())
+    durable_after_first = len(objects._data)  # pyright: ignore[reportPrivateUsage]
+
+    second = await execute_publish_work(cast(Application, app), _request())
+
+    assert first.outcome == "accepted"
+    assert second.outcome == "replayed"
+    # The replayed response must describe the same committed events and frontier as the original.
+    assert second.result_frontier == first.result_frontier
+    assert second.subject_frontier == first.subject_frontier
+    assert tuple(item.event_id for item in second.accepted_events) == tuple(
+        item.event_id for item in first.accepted_events
+    )
+    assert tuple(item.ingestion_sequence for item in second.accepted_events) == tuple(
+        item.ingestion_sequence for item in first.accepted_events
+    )
+    # No second write: the replay reads stored state rather than re-publishing.
+    assert len(objects._data) == durable_after_first  # pyright: ignore[reportPrivateUsage]
+
+
 async def test_same_id_changed_logical_request_conflicts_before_reencryption() -> None:
     app, objects = _composition()
     await execute_publish_work(cast(Application, app), _request())
@@ -170,7 +199,7 @@ async def test_same_id_changed_logical_request_conflicts_before_reencryption() -
 
 async def test_stale_expected_frontier_sequence_conflicts() -> None:
     app, _ = _composition()
-    await execute_publish_work(cast(Application, app), _request())
+    first = await execute_publish_work(cast(Application, app), _request())
 
     with pytest.raises(PublicOperationError) as caught:
         await execute_publish_work(
@@ -186,5 +215,6 @@ async def test_stale_expected_frontier_sequence_conflicts() -> None:
     assert caught.value.code is PublicErrorCode.FRONTIER_CONFLICT
     assert caught.value.retryable is True
     assert caught.value.safe_details.get("reason_code") == "frontier_changed"
-    assert caught.value.safe_details.get("sequence") == 1
-    assert type(caught.value.safe_details.get("head_digest")) is str
+    # The conflict must carry the *current* head so a caller can retry without a status round-trip.
+    assert caught.value.safe_details.get("sequence") == first.result_frontier.sequence
+    assert caught.value.safe_details.get("head_digest") == first.result_frontier.head_digest

--- a/tests/integration/application/test_publish_work.py
+++ b/tests/integration/application/test_publish_work.py
@@ -184,3 +184,7 @@ async def test_stale_expected_frontier_sequence_conflicts() -> None:
         )
 
     assert caught.value.code is PublicErrorCode.FRONTIER_CONFLICT
+    assert caught.value.retryable is True
+    assert caught.value.safe_details.get("reason_code") == "frontier_changed"
+    assert caught.value.safe_details.get("sequence") == 1
+    assert type(caught.value.safe_details.get("head_digest")) is str

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -794,6 +794,33 @@ async def test_ready_factory_deterministic_check_records_semantic_not_requested_
         assert resolved.semantic_status.value == "not_configured"
         assert resolved.semantic_reason.value == "provider_not_configured"
         assert "semantic_review_not_requested" not in resolved.coverage.known_gaps
+
+        # The exact r4 dogfood request: semantic_required against an installation with no bound
+        # provider. SEMANTIC is now advertised whenever semantic is not disabled, so this path
+        # advances through SEMANTIC_WAIT; it must still commit an honest incomplete check rather
+        # than erroring or reporting a clean deterministic pass.
+        frontier = resolved.result_frontier
+        required = await app.check(
+            CheckRequest.model_validate(
+                {
+                    **common,
+                    "request_id": "req_00000000-0000-4000-8000-000000000205",
+                    "session_id": started.session_id,
+                    "writer_id": started.writer_id,
+                    "expected_frontier": {
+                        "sequence": str(frontier.sequence),
+                        "head_digest": frontier.head_digest,
+                    },
+                    "mode": "semantic_required",
+                    "max_findings": "3",
+                    "policy_packs": ["work-integrity/0.1.0"],
+                }
+            )
+        )
+        assert required.outcome == "committed"
+        assert required.semantic_status.value == "not_configured"
+        assert required.semantic_reason.value == "provider_not_configured"
+        assert required.verdict.value == "incomplete_check"
     finally:
         if app is not None:
             await app.close()

--- a/tests/packaging/test_checksums_sbom_and_provenance.py
+++ b/tests/packaging/test_checksums_sbom_and_provenance.py
@@ -42,6 +42,21 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _uv_env() -> dict[str, str]:
+    """Environment for ``uv export`` runs that select their lock mode by flag.
+
+    CI exports ``UV_LOCKED=1`` for the ambient ``uv run --locked`` steps, and uv rejects that
+    together with the ``--frozen`` these exports pass, exiting 2 before doing any work. The lock
+    mode belongs to the command, so drop the inherited variable rather than let the surrounding
+    workflow decide it.
+    """
+
+    env = dict(os.environ)
+    env.pop("UV_LOCKED", None)
+    env.pop("UV_FROZEN", None)
+    return env
+
+
 def _build_candidate(out_dir: Path) -> tuple[Path, Path]:
     environment = dict(os.environ)
     environment["TZ"] = "UTC"
@@ -203,6 +218,7 @@ def sbom_document() -> Any:
             "--frozen",
         ],
         cwd=_REPO_ROOT,
+        env=_uv_env(),
         capture_output=True,
         check=True,
         timeout=60,
@@ -247,6 +263,7 @@ def test_sbom_reconciles_with_the_same_locked_target_exported_as_requirements(
             "--frozen",
         ],
         cwd=_REPO_ROOT,
+        env=_uv_env(),
         capture_output=True,
         check=True,
         timeout=60,

--- a/tests/packaging/test_dependency_lock_and_licenses.py
+++ b/tests/packaging/test_dependency_lock_and_licenses.py
@@ -24,6 +24,22 @@ _REPO_ROOT: Final = Path(__file__).resolve().parents[2]
 _BUILD_TIMEOUT: Final = 120
 _PUBLIC_REGISTRY: Final = "https://pypi.org/simple"
 
+
+def _uv_env() -> dict[str, str]:
+    """Environment for ``uv export`` runs that select their lock mode by flag.
+
+    CI exports ``UV_LOCKED=1`` for the ambient ``uv run --locked`` steps, and uv rejects that
+    together with the ``--frozen`` these exports pass, exiting 2 before doing any work. The lock
+    mode belongs to the command, so drop the inherited variable rather than let the surrounding
+    workflow decide it.
+    """
+
+    env = dict(os.environ)
+    env.pop("UV_LOCKED", None)
+    env.pop("UV_FROZEN", None)
+    return env
+
+
 # APSW's own PyPI metadata reports the vague classic marker "any-OSI"; the reviewed disposition is
 # recorded here rather than trusting an uninformative upstream field. APSW itself is zlib-licensed
 # and bundles the public-domain SQLite amalgamation (see ADR-007).
@@ -232,7 +248,12 @@ def _install_isolated(
     for extra in extras:
         export_command += ["--extra", extra]
     subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted local uv binary
-        export_command, cwd=_REPO_ROOT, capture_output=True, check=True, timeout=60
+        export_command,
+        cwd=_REPO_ROOT,
+        env=_uv_env(),
+        capture_output=True,
+        check=True,
+        timeout=60,
     )
     subprocess.run(  # noqa: S603 - fixed argv, no shell
         [

--- a/tests/packaging/test_dependency_lock_and_licenses.py
+++ b/tests/packaging/test_dependency_lock_and_licenses.py
@@ -40,6 +40,36 @@ def _uv_env() -> dict[str, str]:
     return env
 
 
+def _run_checked(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run a tool and fail with its own stderr instead of a bare ``CalledProcessError``.
+
+    ``check=True`` with captured output reports only an exit status, so a uv failure here shows
+    the argv and nothing about the cause. That turned two separate CI breakages into guesswork.
+    """
+
+    completed = subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted local binary
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"command failed with exit status {completed.returncode}: {' '.join(command)}\n"
+            f"stdout:\n{completed.stdout.decode('utf-8', errors='replace')}\n"
+            f"stderr:\n{completed.stderr.decode('utf-8', errors='replace')}"
+        )
+    return completed
+
+
 # APSW's own PyPI metadata reports the vague classic marker "any-OSI"; the reviewed disposition is
 # recorded here rather than trusting an uninformative upstream field. APSW itself is zlib-licensed
 # and bundles the public-domain SQLite amalgamation (see ADR-007).
@@ -224,10 +254,8 @@ def _install_isolated(
     """
 
     venv_dir = tmp_path_factory.mktemp("dependency-lock-venv") / "venv"
-    subprocess.run(  # noqa: S603 - fixed argv, no shell
+    _run_checked(
         ["uv", "venv", "--python", "3.14", str(venv_dir)],
-        capture_output=True,
-        check=True,
         timeout=_BUILD_TIMEOUT,
     )
     python = venv_dir / "bin" / "python"
@@ -247,33 +275,34 @@ def _install_isolated(
     ]
     for extra in extras:
         export_command += ["--extra", extra]
-    subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted local uv binary
+    _run_checked(
         export_command,
         cwd=_REPO_ROOT,
         env=_uv_env(),
-        capture_output=True,
-        check=True,
         timeout=60,
     )
-    subprocess.run(  # noqa: S603 - fixed argv, no shell
+    # No --offline here. The pin comes from the hashed requirements file, not from the network
+    # flag: every version and artifact hash is already fixed by the export above, so a resolution
+    # that drifts from the lock cannot succeed. Installing offline additionally requires each
+    # artifact to be hash-checkable in the local uv cache, which a cache populated only by
+    # `uv sync` is not on a clean machine — the packages install fine but leave nothing this
+    # install can verify, so every run on a fresh CI cache failed on the first entry
+    # (`annotated-doc`). True offline behavior is covered separately by test_offline_reinstall.
+    _run_checked(
         [
             "uv",
             "pip",
             "install",
             "--python",
             str(python),
-            "--offline",
             "-r",
             str(requirements_path),
         ],
-        capture_output=True,
-        check=True,
         timeout=_BUILD_TIMEOUT,
     )
-    subprocess.run(  # noqa: S603 - fixed argv, no shell
+    # The wheel itself is a local file installed with --no-deps, so it needs no index at all.
+    _run_checked(
         ["uv", "pip", "install", "--python", str(python), "--offline", "--no-deps", str(wheel)],
-        capture_output=True,
-        check=True,
         timeout=_BUILD_TIMEOUT,
     )
     return python

--- a/tests/subprocess/test_mcp_service_bridge.py
+++ b/tests/subprocess/test_mcp_service_bridge.py
@@ -337,6 +337,92 @@ async def test_unexpected_bridge_error_logs_public_correlation_id(
     await bridge.close_bridge_runtime(runtime)
 
 
+@pytest.mark.anyio
+async def test_post_commit_response_shaping_failure_is_retryable_with_same_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A durable invoke must not collapse into non-retryable INTERNAL_ERROR on shape failure."""
+
+    correlation_id = "err_00000000-0000-4000-8000-000000000097"
+    client = _FakeClient()
+    _install_clients(monkeypatch, [client])
+    request_id = cast(str, _requests()["publish_work"]["request_id"])
+
+    def boom(_result: object) -> object:
+        raise RuntimeError("post-commit-shape-failure")
+
+    def record(
+        exc: BaseException,
+        *,
+        component: str,
+        operation: str,
+        request_id: str | None = None,
+    ) -> str:
+        del exc, component, operation, request_id
+        return correlation_id
+
+    monkeypatch.setattr(bridge, "public_model_to_wire", boom)
+    monkeypatch.setattr(bridge, "record_unexpected_exception_without_raising", record)
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_requests()["publish_work"], runtime)
+
+    assert result.isError is True
+    assert result.structuredContent is not None
+    error = cast(dict[str, object], result.structuredContent["error"])
+    assert error["code"] == "INTERNAL_ERROR"
+    assert error["retryable"] is True
+    assert error["correlation_id"] == correlation_id
+    assert result.structuredContent["request_id"] == request_id
+    assert "same request_id" in cast(str, error["message"])
+    assert error.get("safe_details") == {"reason_code": "response_projection_failed"}
+    await bridge.close_bridge_runtime(runtime)
+
+
+def test_publish_work_validation_names_event_drafts_field() -> None:
+    from yoetz.mcp.errors import safe_validation_locations
+    from yoetz.protocol.models import PublishWorkRequest
+
+    with pytest.raises(Exception) as captured:
+        PublishWorkRequest.model_validate(
+            {
+                **{
+                    "protocol_version": "0.1",
+                    "schema_version": "1.0.0",
+                    "request_id": _id("request", 9),
+                    "session_id": _id("session", 1),
+                    "writer_id": _id("writer", 1),
+                    "expected_frontier": {"sequence": "0", "head_digest": "genesis"},
+                    "actor": {"actor_id": "harness:mcp", "actor_type": "harness"},
+                    "client": {
+                        "kind": "cooperative_agent",
+                        "version": "0.1.0",
+                        "integration": "cooperative_mcp",
+                    },
+                },
+                "event_drafts": [
+                    {
+                        "event_id": "not-an-id",
+                        "schema": {"name": "plan_published", "version": "1.0.0"},
+                        "occurred_at": "2026-01-01T00:00:00.000Z",
+                        "causal_parents": [],
+                        "payload": {
+                            "plan_version": 1,
+                            "summary": "Plan",
+                            "obligation_refs": [],
+                        },
+                        "artifact_refs": [],
+                        "evidence_refs": [],
+                    }
+                ],
+            }
+        )
+    locations = safe_validation_locations(captured.value)
+    assert locations
+    assert all(item["field"] for item in locations)
+    assert any(item["field"].startswith("/event_drafts") for item in locations)
+
+
 @pytest.fixture
 def _restore_process_logging() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
     """``configure_logging`` mutates process-global state; restore it for every other test."""

--- a/tests/subprocess/test_mcp_service_bridge.py
+++ b/tests/subprocess/test_mcp_service_bridge.py
@@ -380,47 +380,56 @@ async def test_post_commit_response_shaping_failure_is_retryable_with_same_reque
 
 
 def test_publish_work_validation_names_event_drafts_field() -> None:
+    """`event_drafts` is untyped JsonValue to Pydantic, so this exercises schema translation.
+
+    The rejection can only come from `_validate_model_against_schema` re-raising
+    `SchemaInstanceInvalid.absolute_path`; a bare Pydantic field error cannot produce this
+    location. The r4 dogfood returned an empty pointer here, giving the agent nothing to fix.
+    """
+
     from yoetz.mcp.errors import safe_validation_locations
     from yoetz.protocol.models import PublishWorkRequest
 
-    with pytest.raises(Exception) as captured:
-        PublishWorkRequest.model_validate(
-            {
-                **{
-                    "protocol_version": "0.1",
-                    "schema_version": "1.0.0",
-                    "request_id": _id("request", 9),
-                    "session_id": _id("session", 1),
-                    "writer_id": _id("writer", 1),
-                    "expected_frontier": {"sequence": "0", "head_digest": "genesis"},
-                    "actor": {"actor_id": "harness:mcp", "actor_type": "harness"},
-                    "client": {
-                        "kind": "cooperative_agent",
-                        "version": "0.1.0",
-                        "integration": "cooperative_mcp",
+    def arguments(event_id: str) -> dict[str, object]:
+        return {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "request_id": _id("request", 9),
+            "session_id": _id("session", 1),
+            "writer_id": _id("writer", 1),
+            "expected_frontier": {"sequence": "0", "head_digest": "genesis"},
+            "actor": {"actor_id": "harness:mcp", "actor_type": "harness"},
+            "client": {
+                "kind": "cooperative_agent",
+                "version": "0.1.0",
+                "integration": "cooperative_mcp",
+            },
+            "event_drafts": [
+                {
+                    "event_id": event_id,
+                    "schema": {"name": "plan_published", "version": "1.0.0"},
+                    "occurred_at": "2026-01-01T00:00:00.000Z",
+                    "causal_parents": [],
+                    "payload": {
+                        "plan_version": 1,
+                        "summary": "Plan",
+                        "obligation_refs": [],
                     },
-                },
-                "event_drafts": [
-                    {
-                        "event_id": "not-an-id",
-                        "schema": {"name": "plan_published", "version": "1.0.0"},
-                        "occurred_at": "2026-01-01T00:00:00.000Z",
-                        "causal_parents": [],
-                        "payload": {
-                            "plan_version": 1,
-                            "summary": "Plan",
-                            "obligation_refs": [],
-                        },
-                        "artifact_refs": [],
-                        "evidence_refs": [],
-                    }
-                ],
-            }
-        )
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                }
+            ],
+        }
+
+    # Identical payload with a schema-valid event_id is accepted, so the only difference driving
+    # the rejection below is the field the pointer names.
+    PublishWorkRequest.model_validate(arguments(_id("event", 1)))
+
+    with pytest.raises(Exception) as captured:
+        PublishWorkRequest.model_validate(arguments("not-an-id"))
+
     locations = safe_validation_locations(captured.value)
-    assert locations
-    assert all(item["field"] for item in locations)
-    assert any(item["field"].startswith("/event_drafts") for item in locations)
+    assert [item["field"] for item in locations] == ["/event_drafts/0/event_id"]
 
 
 @pytest.fixture

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -1,0 +1,204 @@
+"""Unit tests for the read-only semantic readiness report.
+
+The r4 dogfood spent four runs against an installation that structurally could not dispatch
+semantic review, because nothing surfaced readiness before a check returned
+``provider_not_configured``. These tests pin the two ways such a report can lie: reporting a
+condition it never actually read, and counting a credential that belongs to a different provider
+than the bound endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from yoetz.cli import provider_status as module
+from yoetz.config.models import ProviderProfileConfig, VerificationConfig, YoetzConfig
+
+pytestmark = pytest.mark.anyio
+
+
+def _provider(provider_id: str = "openai") -> ProviderProfileConfig:
+    return ProviderProfileConfig(
+        provider_id=provider_id,
+        endpoint_profile_id="openai-responses",
+        endpoint_profile_version="1.0.0",
+        model="gpt-5.4",
+        capability_profile="openai-responses-structured-1",
+    )
+
+
+def _policy(*, llm_inference_enabled: bool, profile: str = "local_only") -> dict[str, object]:
+    return {
+        "policy": {
+            "profile": profile,
+            "channel_policies": [
+                {"channel": "capability_testing", "enabled": False},
+                {"channel": "llm_inference", "enabled": llm_inference_enabled},
+                {"channel": "update_checks", "enabled": False},
+            ],
+        }
+    }
+
+
+class _Client:
+    def __init__(self, capabilities: tuple[str, ...], policy: dict[str, object]) -> None:
+        self._capabilities = capabilities
+        self._policy = policy
+        self.closed = False
+
+    async def service_status(self) -> Any:
+        class _State:
+            value = "ready"
+
+        class _Status:
+            state = _State()
+            capabilities = self._capabilities
+
+        return _Status()
+
+    async def privacy_get_effective(self, request: object) -> dict[str, object]:
+        del request
+        return self._policy
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    semantic: str = "optional",
+    provider: ProviderProfileConfig | None = None,
+    capabilities: tuple[str, ...] = ("external_provider",),
+    llm_inference_enabled: bool = True,
+) -> _Client:
+    config = YoetzConfig(
+        profile="strict-local" if provider is None else "local-openai",
+        verification=VerificationConfig(semantic=cast(Any, semantic)),
+        provider=provider,
+    )
+    client = _Client(capabilities, _policy(llm_inference_enabled=llm_inference_enabled))
+
+    def _load(*_args: object) -> YoetzConfig:
+        return config
+
+    monkeypatch.setattr(module, "load_config", _load)
+
+    async def _connect(_kind: object) -> _Client:
+        return client
+
+    monkeypatch.setattr(module, "connect_service", _connect)
+    return client
+
+
+async def test_all_four_conditions_met_reports_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _install(monkeypatch, provider=_provider())
+
+    report = await module.provider_status_report()
+
+    assert report["semantic_enabled"] is True
+    assert report["endpoint_bound"] is True
+    assert report["credential_connected"] is True
+    assert report["llm_inference_enabled"] is True
+    assert report["semantic_ready"] is True
+    assert report["blockers"] == ()
+    assert client.closed is True
+
+
+async def test_llm_inference_channel_is_actually_read_from_canonical_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled channel must read as disabled, not as unknown.
+
+    The canonical policy names this list ``channel_policies``. Reading any other key returns None
+    for every channel, which silently makes readiness unreachable on a correctly configured host.
+    """
+
+    _install(monkeypatch, provider=_provider(), llm_inference_enabled=False)
+
+    report = await module.provider_status_report()
+
+    assert report["llm_inference_enabled"] is False
+    assert report["semantic_ready"] is False
+    blockers = cast(tuple[dict[str, object], ...], report["blockers"])
+    channel_blockers = [
+        item for item in blockers if item.get("condition") == "llm_inference_channel"
+    ]
+    assert len(channel_blockers) == 1
+    # "disabled" is a read answer; "unknown" would mean the policy was never inspected.
+    assert channel_blockers[0]["state"] == "disabled"
+    assert channel_blockers[0]["next_command"] == "yoetz privacy setup"
+
+
+async def test_credential_for_a_different_provider_is_not_counted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The service withholds external_provider unless the *configured* provider is connected."""
+
+    _install(monkeypatch, provider=_provider("anthropic"), capabilities=())
+
+    report = await module.provider_status_report()
+
+    assert report["endpoint_bound"] is True
+    assert report["credential_connected"] is False
+    assert report["semantic_ready"] is False
+    blockers = cast(tuple[dict[str, object], ...], report["blockers"])
+    credential = [item for item in blockers if item.get("condition") == "provider_credential"]
+    assert len(credential) == 1
+    assert credential[0]["state"] == "not_connected"
+    assert credential[0]["next_command"] == "yoetz provider credential set"
+
+
+async def test_unbound_endpoint_and_disabled_semantic_are_named_with_next_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(
+        monkeypatch,
+        semantic="disabled",
+        provider=None,
+        capabilities=(),
+        llm_inference_enabled=False,
+    )
+
+    report = await module.provider_status_report()
+
+    assert report["semantic_ready"] is False
+    conditions = tuple(
+        cast(dict[str, object], item)["condition"]
+        for item in cast(tuple[object, ...], report["blockers"])
+    )
+    assert conditions == (
+        "verification.semantic",
+        "provider_endpoint",
+        "provider_credential",
+        "llm_inference_channel",
+    )
+    # Every blocker carries an actionable next command; that is the whole point of the report.
+    assert all(
+        cast(dict[str, object], item)["next_command"]
+        for item in cast(tuple[object, ...], report["blockers"])
+    )
+    assert len(cast(tuple[object, ...], report["next_commands"])) == 4
+
+
+async def test_report_never_claims_a_live_provider_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, provider=_provider())
+
+    report = await module.provider_status_report()
+
+    notes = " ".join(cast(tuple[str, ...], report["notes"]))
+    assert "does not prove live provider dispatch" in notes
+
+
+async def test_exit_code_is_nonzero_when_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, provider=_provider(), capabilities=())
+
+    assert await module.run_provider_status(json_output=True) == 20
+
+
+async def test_exit_code_is_zero_when_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install(monkeypatch, provider=_provider())
+
+    assert await module.run_provider_status(json_output=True) == 0

--- a/tests/unit/protocol/test_errors.py
+++ b/tests/unit/protocol/test_errors.py
@@ -132,6 +132,7 @@ receipt_json_shape_invalid
 redaction_target_required
 ref_mirror_mismatch
 response_fields_invalid
+response_projection_failed
 schema_artifact_role_invalid
 schema_artifact_role_mismatch
 schema_bytes_invalid
@@ -329,7 +330,7 @@ def test_public_error_code_membership() -> None:
 def test_protocol_reason_registry_is_exact_and_import_order_independent() -> None:
     source_values = cast(tuple[str, ...], getattr(errors_module, "_PROTOCOL_REASON_CODE_VALUES"))
     assert source_values == _EXPECTED_REASON_CODES
-    assert len(source_values) == 133
+    assert len(source_values) == 134
     assert source_values == tuple(sorted(source_values, key=str.encode))
     assert len(source_values) == len(set(source_values))
     assert PROTOCOL_REASON_CODES == frozenset(_EXPECTED_REASON_CODES)
@@ -486,6 +487,7 @@ def test_safe_details_allowlist_and_types_are_exact() -> None:
         "count",
         "expected_version",
         "field",
+        "head_digest",
         "limit",
         "method",
         "operation",
@@ -494,6 +496,7 @@ def test_safe_details_allowlist_and_types_are_exact() -> None:
         "reason_code",
         "retry_after_ms",
         "schema_name",
+        "sequence",
         "state",
         "status",
         "view",
@@ -506,6 +509,7 @@ def test_safe_details_allowlist_and_types_are_exact() -> None:
             "count": 0,
             "expected_version": "V2-rc.1",
             "field": "/payload/~0/~1//",
+            "head_digest": "genesis",
             "limit": 9_007_199_254_740_991,
             "method": _SafeEnum.READY,
             "operation": _SafeEnum.READY,
@@ -514,6 +518,7 @@ def test_safe_details_allowlist_and_types_are_exact() -> None:
             "reason_code": "invalid_digest",
             "retry_after_ms": 1,
             "schema_name": "accepted-event",
+            "sequence": 5,
             "state": _SafeEnum.READY,
             "status": _SafeEnum.READY,
             "view": _SafeEnum.READY,

--- a/tests/unit/protocol/test_errors.py
+++ b/tests/unit/protocol/test_errors.py
@@ -542,9 +542,28 @@ def test_safe_details_allowlist_and_types_are_exact() -> None:
         "1",
         _IntegerSubclass(1),
     )
-    for integer_key in ("count", "limit", "retry_after_ms"):
+    for integer_key in ("count", "limit", "retry_after_ms", "sequence"):
         for rejected in rejected_values:
             assert not normalize_safe_details({integer_key: rejected})
+    # head_digest is a frontier recovery field: accept genesis and exact sha256, nothing else.
+    assert normalize_safe_details({"head_digest": "genesis"})["head_digest"] == "genesis"
+    exact_digest = "sha256:" + "0123456789abcdef" * 4
+    assert normalize_safe_details({"head_digest": exact_digest})["head_digest"] == exact_digest
+    for malformed_digest in (
+        "sha256:" + "0" * 63,
+        "sha256:" + "0" * 65,
+        "sha256:" + "A" * 64,
+        "sha256:" + "g" * 64,
+        "sha512:" + "0" * 64,
+        "0" * 64,
+        " sha256:" + "0" * 64,
+        "sha256:" + "0" * 64 + " ",
+        "GENESIS",
+        "",
+    ):
+        assert not normalize_safe_details({"head_digest": malformed_digest})
+    for rejected in (True, 1, 1.0, None):
+        assert not normalize_safe_details({"head_digest": rejected})
     assert not normalize_safe_details({"component": "ready"})
     assert not normalize_safe_details({"component": _UnsafeEnum.UPPER})
     assert normalize_safe_details({"component": _LowerSnake64Enum.VALUE})


### PR DESCRIPTION
Added a new `provider status` command to the CLI for reporting the structural readiness of external semantic review. Updated the internal error handling to include additional safe details such as `reason_code`, `sequence`, and `head_digest` for `FRONTIER_CONFLICT` and `response_projection_failed` scenarios. Improved documentation in `INTERFACES.md` and `providers.md` to clarify the conditions for semantic readiness and the implications of various error states. This enhances user experience by providing clearer guidance on readiness and error recovery paths.

## Issue

- Linked issue: `Fixes #` / `Refs #`
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging,
  ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

## Documentation

- Behavior change? `yes` / `no`
- Docs updated (ADR, `docs/` page, `docs/INTERFACES.md` entry), or `n/a — no behavior change`:

## Verification

Commands run (paste):

```text

```

## Boundaries

- [ ] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [ ] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

<!-- What changed and why, in a few sentences. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `provider status` to report semantic readiness, endpoint binding, credential connection, and privacy-policy/channel readiness (human-readable or JSON).
  - Service status now advertises external-provider capability when credentials are connected.
- **Bug Fixes**
  - Frontier-conflict errors now include retry guidance plus current sequence/head digest details.
  - Post-commit response shaping failures are now retryable and recommend resuming with the same `request_id`.
  - Validation error projections now return more precise, safer field locations.
- **Documentation**
  - Expanded documented safe error details and clarified readiness checks.
- **Tests**
  - Added/updated coverage for replay, retryable MCP errors, and provider-status readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->