### PR TITLE
fix: restore receipt-backed semantic dispatch and local control flows

### DIFF
--- a/docs/adr/ADR-008-local-service-vault-trust-boundary.md
+++ b/docs/adr/ADR-008-local-service-vault-trust-boundary.md
@@ -156,8 +156,12 @@ after the helper's local two-entry match; unlock is available only for an alread
 passphrase vault. Their handles are not interchangeable. The pure confidential protocol maps the
 wire purpose to one one-shot `SecretHandle(SecretPurpose.vault_unlock)` consumed by the trusted
 unlock coordinator; ordinary clients cannot construct it. The helper must prove a same-user,
-foreground controlling TTY; read directly from `/dev/tty` in no-echo mode; reject stdin,
-redirection, pipes, environment/config/argument input, and noninteractive execution; establish a
+foreground controlling TTY; read directly from `/dev/tty` in no-echo mode; require stdin and
+stderr to be TTYs for the same user-visible terminal, and require the process to be in the
+foreground process group of `/dev/tty`. Terminal-device ownership and device-number equality with
+`/dev/tty` are not user-identity evidence: macOS may expose a root-owned, device-distinct
+controlling-terminal alias. The helper still rejects stdin redirection, pipes,
+environment/config/argument input, and noninteractive execution; establish a
 separately typed peer-authenticated connection; and erase mutable buffers best-effort after the
 service consumes them. No MCP registry, `ServiceClient`, or public application method can reach
 this channel. **Amendment (ADR-015/016):** the founder-authorized `yoetz consent` /

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from types import MappingProxyType
 from typing import Protocol
@@ -542,6 +542,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
         dispatch_started_at = self._clock.now_utc()
         try:
             result = await evaluator.evaluate(case, deadline)
+            result = _with_request_commitment(result, commitment)
             outcome, receipt_reason = _result_outcome(result)
         except Exception:  # noqa: BLE001 - an ambiguous transport failure never leaks native text
             result = _unknown_outcome_result(case, binding)
@@ -775,6 +776,12 @@ def _bounded_policy_binding(authorization: EgressAuthorization) -> ReceiptPolicy
         authorization.policy_digest,
         _scope_digest(authorization.scope),
     )
+
+
+def _with_request_commitment(result: SemanticResult, commitment: str) -> SemanticResult:
+    """Carry the gateway-bound request commitment into the receipt-bound semantic outcome."""
+
+    return replace(result, provenance=replace(result.provenance, request_commitment=commitment))
 
 
 def _result_outcome(result: SemanticResult) -> tuple[PrivacyOutcome, PrivacyReason | None]:

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -753,7 +753,15 @@ class OpenAIResponsesEvaluator:
                 )
             )
 
-        body_object = _build_body_object(case)
+        # The one-attempt transport compares the SDK's exact serialized bytes to the
+        # privacy gateway's audited body.  Reconstructing keyword arguments here can
+        # preserve a different insertion order from the canonical rendering, which
+        # correctly fails closed as a body mismatch before credential injection.
+        # Decode the canonical rendering and pass that mapping through unchanged.
+        rendered_body = strict_json_parse(render_case(case).body)
+        if type(rendered_body) is not dict:
+            raise ValueError("openai_rendered_body_invalid")
+        body_object = cast(dict[str, Any], rendered_body)
 
         try:
             openai_module = importlib.import_module("openai")
@@ -776,12 +784,7 @@ class OpenAIResponsesEvaluator:
             http_client=http_client,
         )
         try:
-            response = await client.responses.create(
-                model=body_object["model"],
-                input=body_object["input"],
-                max_output_tokens=OPENAI_MAX_OUTPUT_TOKENS,
-                text=body_object["text"],
-            )
+            response = await client.responses.create(**body_object)
         except Exception as exc:  # noqa: BLE001 - classified below, never re-raised raw
             elapsed_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
             return classify_provider_failure(exc, self._profile, latency_ms=elapsed_ms)

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -158,7 +158,11 @@ def check_internal_json(result: CheckCommitResult) -> dict[str, JsonValue]:
         "semantic_provenance": (
             None
             if result.semantic_provenance is None
-            else semantic_provenance_to_json(result.semantic_provenance)
+            # Public Pydantic validation deliberately accepts a built-in dict here
+            # before inspecting the safe identity fields.  The domain encoder
+            # returns an immutable JsonObject, so thaw only its root container;
+            # nested values remain canonical JSON mappings.
+            else dict(semantic_provenance_to_json(result.semantic_provenance).items())
         ),
         "coverage": coverage_to_json(result.coverage),
         "versions": {
@@ -846,12 +850,23 @@ async def execute_check_commit(app: Application, request: CheckRequest) -> Check
 
     scope = normalize_check_scope(request)
     packs = _selected_packs(request)
+    required_capabilities = {
+        RuntimeCapability.WRITE,
+        RuntimeCapability.PAYLOAD_READ,
+    }
+    # A ready service grants SEMANTIC independently of the ordinary write route.  Preserve that
+    # admission on non-deterministic checks; otherwise the leased task runtime loses the
+    # capability and reports provider_not_configured before the configured evaluator can run.
+    # An explicitly semantic request while semantic verification is disabled retains the existing
+    # honest not-configured result instead of becoming a routing failure.
+    if request.mode != "deterministic_only" and app.verification_policy.semantic != "disabled":
+        required_capabilities.add(RuntimeCapability.SEMANTIC)
     runtime = await app.runtime.route(
         RouteCommand(
             request.session_id,
             request.writer_id,
             RouteAccess.WRITE,
-            frozenset({RuntimeCapability.WRITE, RuntimeCapability.PAYLOAD_READ}),
+            frozenset(required_capabilities),
         )
     )
     try:

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -42,6 +42,7 @@ from yoetz.domain.privacy import (
     ReceiptSecretScan,
     ReceiptTransformations,
 )
+from yoetz.observability.logging import record_unexpected_exception_without_raising
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.ids import IdPort
 from yoetz.ports.privacy import (
@@ -85,7 +86,9 @@ type LocalDisclosureResult = (
     LocalDisclosureApproved | LocalDisclosureBlocked | LocalDisclosureUnavailable
 )
 
-_SEMANTIC_PURPOSE = "semantic_check"
+# This value crosses the privacy-policy boundary, so it must match the
+# documented/recipe vocabulary and the stored provider-credential binding.
+_SEMANTIC_PURPOSE = "semantic-review"
 _MEDIA_TYPE = "application/json"
 _SCHEMA_ID = "yoetz-semantic-case-1.0.0"
 
@@ -100,6 +103,7 @@ class SemanticEgressSuccess:
     result: SemanticResultSuccess
     case_digest: str
     privacy_receipt_id: str | None = None
+    request_commitment: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +143,7 @@ class SemanticEgressProviderOutcome:
     )
     case_digest: str
     privacy_receipt_id: str | None = None
+    request_commitment: str | None = None
 
 
 type SemanticEgressResult = (
@@ -681,7 +686,13 @@ class PrivacyCoordinator:
                     + timedelta(seconds=max(60, llm.authorization_ttl_seconds or 60)),
                 )
             )
-        except Exception:
+        except Exception as exc:
+            record_unexpected_exception_without_raising(
+                exc,
+                component="privacy_egress",
+                operation="audit_prepare_failed",
+                request_id=candidate.request_id,
+            )
             return SemanticEgressBlocked(
                 candidate.request_id,
                 PrivacyOutcome.AUDIT_FAILED,
@@ -815,7 +826,13 @@ class PrivacyCoordinator:
                 minted = await self._audit.authorize(
                     proposal.privacy_proposal_id, proposal.prepared_case_digest, now
                 )
-            except Exception:
+            except Exception as exc:
+                record_unexpected_exception_without_raising(
+                    exc,
+                    component="privacy_egress",
+                    operation="audit_authorize_failed",
+                    request_id=candidate.request_id,
+                )
                 return SemanticEgressBlocked(
                     candidate.request_id,
                     PrivacyOutcome.AUDIT_FAILED,
@@ -911,6 +928,7 @@ class PrivacyCoordinator:
                 receipt_id = state.receipt_id
         except Exception:
             receipt_id = None
+        request_commitment = getattr(result.provenance, "request_commitment", None)
         if type(result) is SemanticResultSuccess:
             return SemanticEgressSuccess(
                 request_id,
@@ -919,6 +937,7 @@ class PrivacyCoordinator:
                 result,
                 case_digest,
                 privacy_receipt_id=receipt_id,
+                request_commitment=request_commitment,
             )
         if type(result) in {
             SemanticResultRefused,
@@ -934,6 +953,7 @@ class PrivacyCoordinator:
                 result,  # type: ignore[arg-type]
                 case_digest,
                 privacy_receipt_id=receipt_id,
+                request_commitment=request_commitment,
             )
         return SemanticEgressBlocked(
             request_id,

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+from yoetz.domain.findings import SemanticDispatchKind
 from yoetz.domain.privacy import (
     ApprovedLocalDisclosureCase,
     ApprovedLocalItem,
@@ -99,7 +100,8 @@ class SemanticEgressSuccess:
 
     request_id: str
     privacy_proposal_id: str
-    authorization_id: str
+    authorization_id: str | None
+    dispatch_kind: SemanticDispatchKind
     result: SemanticResultSuccess
     case_digest: str
     privacy_receipt_id: str | None = None
@@ -134,6 +136,7 @@ class SemanticEgressProviderOutcome:
     request_id: str
     privacy_proposal_id: str
     authorization_id: str | None
+    dispatch_kind: SemanticDispatchKind
     result: (
         SemanticResultRefused
         | SemanticResultTimeout
@@ -152,6 +155,80 @@ type SemanticEgressResult = (
     | SemanticEgressBlocked
     | SemanticEgressProviderOutcome
 )
+
+
+def _semantic_result_outcome(
+    result: SemanticResult,
+) -> tuple[PrivacyOutcome, PrivacyReason | None]:
+    if type(result) is SemanticResultSuccess:
+        return PrivacyOutcome.COMPLETED, None
+    if type(result) is SemanticResultRefused:
+        return PrivacyOutcome.PROVIDER_REFUSED, PrivacyReason.PROVIDER_REFUSED
+    if type(result) is SemanticResultTimeout:
+        return PrivacyOutcome.TIMEOUT, PrivacyReason.PROVIDER_TIMEOUT
+    if type(result) is SemanticResultInvalid:
+        return PrivacyOutcome.INVALID_RESPONSE, PrivacyReason.PROVIDER_INVALID_RESPONSE
+    if type(result) is SemanticResultLate:
+        return PrivacyOutcome.LATE, PrivacyReason.LATE
+    if type(result) is SemanticResultUnavailable:
+        return PrivacyOutcome.TRANSPORT_FAILED, PrivacyReason.TRANSPORT_FAILED
+    raise TypeError("semantic_egress_result_invalid")
+
+
+def _semantic_local_receipt(
+    candidate: CandidateContext,
+    effective: EffectivePrivacyPolicy,
+    proposal: DisclosureProposal,
+    minimized: MinimizedDisclosure,
+    consent: ConsentSource,
+    outcome: PrivacyOutcome,
+    reason: PrivacyReason | None,
+    finished_at: datetime,
+    ids: IdPort,
+) -> LocalDisclosureReceipt:
+    included_count = len(minimized.included_item_ids)
+    candidate_count = len(minimized.source_item_digests)
+    omitted_count = max(0, candidate_count - included_count)
+    return LocalDisclosureReceipt(
+        "1.0.0",
+        ids.new(IdKind.EGRESS_RECEIPT),
+        candidate.request_id,
+        proposal.privacy_proposal_id,
+        LocalDisclosureSink.LOCAL_MODEL,
+        outcome,
+        finished_at,
+        candidate.scope,
+        candidate.purpose,
+        ReceiptPolicyBinding(
+            effective.policy.policy_id,
+            effective.policy.version,
+            effective.effective_digest,
+            _scope_digest(candidate.scope),
+        ),
+        consent,
+        minimized.approved_categories,
+        minimized.blocked_categories,
+        ReceiptCounts(
+            candidate_count,
+            included_count,
+            omitted_count,
+            included_count,
+            omitted_count,
+            minimized.byte_count,
+            minimized.byte_count,
+            minimized.token_count,
+            None,
+        ),
+        ReceiptTransformations(omitted_count, 0, omitted_count),
+        ReceiptSecretScan(
+            minimized.scanner_registry_version,
+            minimized.scanner_profile_digest,
+            len(minimized.forbidden_findings),
+            not minimized.forbidden_findings,
+        ),
+        reason,
+        1,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -807,7 +884,6 @@ class PrivacyCoordinator:
         subject_digest: str,
         authorization: object | None = None,
     ) -> SemanticEgressResult:
-        del consent
         binding = candidate.provider_binding
         assert binding is not None
         now = self._clock.now_utc()
@@ -818,28 +894,6 @@ class PrivacyCoordinator:
                 PrivacyReason.AUTHORIZATION_EXPIRED,
                 privacy_proposal_id=proposal.privacy_proposal_id,
             )
-        minted: EgressAuthorization
-        if type(authorization) is EgressAuthorization:
-            minted = authorization
-        else:
-            try:
-                minted = await self._audit.authorize(
-                    proposal.privacy_proposal_id, proposal.prepared_case_digest, now
-                )
-            except Exception as exc:
-                record_unexpected_exception_without_raising(
-                    exc,
-                    component="privacy_egress",
-                    operation="audit_authorize_failed",
-                    request_id=candidate.request_id,
-                )
-                return SemanticEgressBlocked(
-                    candidate.request_id,
-                    PrivacyOutcome.AUDIT_FAILED,
-                    PrivacyReason.AUDIT_FAILED,
-                    privacy_proposal_id=proposal.privacy_proposal_id,
-                )
-        authorization = minted
 
         if binding.transport == "local_af_unix":
             local_case = ApprovedLocalDisclosureCase(
@@ -868,15 +922,54 @@ class PrivacyCoordinator:
                     PrivacyReason.OUTCOME_UNKNOWN,
                     privacy_proposal_id=proposal.privacy_proposal_id,
                 )
+            outcome, reason = _semantic_result_outcome(result)
+            receipt = _semantic_local_receipt(
+                candidate,
+                effective,
+                proposal,
+                minimized,
+                consent,
+                outcome,
+                reason,
+                self._clock.now_utc(),
+                self._ids,
+            )
+            try:
+                await self._audit.complete_local_disclosure(proposal.privacy_proposal_id, receipt)
+            except Exception:
+                pass
             return await self._map_provider_result(
                 candidate.request_id,
                 proposal.privacy_proposal_id,
                 None,
+                SemanticDispatchKind.LOCAL_MODEL,
                 proposal.prepared_case_digest,
                 subject_digest,
                 result,
             )
 
+        minted: EgressAuthorization
+        if type(authorization) is EgressAuthorization:
+            minted = authorization
+        else:
+            try:
+                minted = await self._audit.authorize(
+                    proposal.privacy_proposal_id, proposal.prepared_case_digest, now
+                )
+            except Exception as exc:
+                record_unexpected_exception_without_raising(
+                    exc,
+                    component="privacy_egress",
+                    operation="audit_authorize_failed",
+                    request_id=candidate.request_id,
+                )
+                return SemanticEgressBlocked(
+                    candidate.request_id,
+                    PrivacyOutcome.AUDIT_FAILED,
+                    PrivacyReason.AUDIT_FAILED,
+                    privacy_proposal_id=proposal.privacy_proposal_id,
+                )
+        authorization = minted
         case = ApprovedOutboundCase(
             self._ids.new(IdKind.OUTBOUND_CASE),
             candidate.request_id,
@@ -907,6 +1000,7 @@ class PrivacyCoordinator:
             candidate.request_id,
             proposal.privacy_proposal_id,
             authorization.authorization_id,
+            SemanticDispatchKind.EXTERNAL,
             proposal.prepared_case_digest,
             subject_digest,
             result,
@@ -917,6 +1011,7 @@ class PrivacyCoordinator:
         request_id: str,
         privacy_proposal_id: str,
         authorization_id: str | None,
+        dispatch_kind: SemanticDispatchKind,
         case_digest: str,
         subject_digest: str,
         result: SemanticResult,
@@ -933,7 +1028,8 @@ class PrivacyCoordinator:
             return SemanticEgressSuccess(
                 request_id,
                 privacy_proposal_id,
-                authorization_id or "",
+                authorization_id,
+                dispatch_kind,
                 result,
                 case_digest,
                 privacy_receipt_id=receipt_id,
@@ -950,6 +1046,7 @@ class PrivacyCoordinator:
                 request_id,
                 privacy_proposal_id,
                 authorization_id,
+                dispatch_kind,
                 result,  # type: ignore[arg-type]
                 case_digest,
                 privacy_receipt_id=receipt_id,

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1273,7 +1273,20 @@ def _privacy_decision_command(kind: str) -> Callable[..., None]:
     ) -> None:
         module = importlib.import_module("yoetz.cli.privacy_control")
         operation = cast(Callable[[str], Awaitable[object]], getattr(module, f"decide_{kind}"))
-        _finish(run_async(lambda: _trusted_call(lambda: operation(pending_id), json_output)))
+
+        async def run_decision() -> object:
+            if kind != "policy":
+                return await operation(pending_id)
+            passphrase = _auto_unlock_store().load()
+            if passphrase is None:
+                return await operation(pending_id)
+            auto_operation = cast(
+                Callable[[str, bytearray], Awaitable[object]],
+                getattr(module, "decide_policy_with_local_reauthentication"),
+            )
+            return await auto_operation(pending_id, passphrase)
+
+        _finish(run_async(lambda: _trusted_call(run_decision, json_output)))
 
     return command
 

--- a/src/yoetz/cli/privacy_control.py
+++ b/src/yoetz/cli/privacy_control.py
@@ -30,6 +30,7 @@ __all__ = [
     "PrivacyLocalEditResult",
     "decide_disclosure",
     "decide_policy",
+    "decide_policy_with_local_reauthentication",
 ]
 
 
@@ -45,6 +46,8 @@ class PrivacyLocalEditResult:
 async def _decide(
     decision_kind: Literal["policy", "disclosure"],
     pending_id: str,
+    *,
+    passphrase: bytearray | None = None,
 ) -> PrivacyDecisionResult | PrivacyLocalEditResult:
     target = PrivacyPendingTarget(decision_kind, pending_id)
     kind = (
@@ -93,6 +96,7 @@ async def _decide(
                         kind,
                         target,
                         current,
+                        passphrase=passphrase,
                     )
                     if observed_decision is not None:
                         raise HumanCeremonyCliError("result_invalid")
@@ -123,6 +127,25 @@ async def decide_policy(
     if decision is not None and passphrase is not None:
         return await _decide_policy_supplied(pending_id, decision, passphrase)
     return await _decide("policy", pending_id)
+
+
+async def decide_policy_with_local_reauthentication(
+    pending_id: str,
+    passphrase: bytearray,
+) -> PrivacyDecisionResult | PrivacyLocalEditResult:
+    """Keep policy approval explicit while using a provisioned local unlock secret.
+
+    The caller obtains the secret from the same per-installation platform store
+    used for restart auto-unlock.  The policy preview and approve/deny decision
+    still happen on the controlling terminal; only the subsequent
+    reauthentication secret is supplied without asking a user to know a
+    generated value.
+    """
+
+    try:
+        return await _decide("policy", pending_id, passphrase=passphrase)
+    finally:
+        _overwrite(passphrase)
 
 
 async def _decide_policy_supplied(

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -830,6 +830,16 @@ async def _interactive_provider_setup(
         wipe_auto_passphrase()
         return service, provider_report
 
+    # A Keychain-provisioned passphrase vault is already ready without the
+    # human knowing its generated passphrase. Load that same scoped secret
+    # only for the one provider-reauthentication ceremony, so setup asks for
+    # the provider key but never unexpectedly asks the user for a passphrase.
+    if auto_passphrase is None and service.get("vault_mode") == "passphrase":
+        current_config = load_config({}, os.environ, None)
+        auto_passphrase = AutoUnlockPassphraseStore(
+            bundle_root(_data_dir=current_config.storage.data_dir)
+        ).load()
+
     storage = provider_credential_profile_binding(
         provider.provider_id,
         provider.model,

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -185,11 +185,13 @@ class _ForegroundTerminal:
         try:
             if not os.isatty(fd):
                 raise HumanCeremonyCliError("tty_required")
-            terminal_stat = os.fstat(fd)
-            terminal_device = terminal_stat.st_rdev
-            if terminal_stat.st_uid != os.geteuid():
-                raise HumanCeremonyCliError("tty_mismatch")
-            if os.fstat(0).st_rdev != terminal_device or os.fstat(2).st_rdev != terminal_device:
+            # macOS can expose /dev/tty as a root-owned controlling-terminal alias
+            # with a different device number than the user's terminal endpoints.
+            # The alias is still the correct no-echo input surface. Require stdin
+            # and stderr to be terminals for the same user-visible endpoint, then
+            # separately verify that this process is foreground on /dev/tty.
+            # Terminal device ownership is not a reliable user-identity signal.
+            if os.fstat(0).st_rdev != os.fstat(2).st_rdev:
                 raise HumanCeremonyCliError("tty_mismatch")
             if os.tcgetpgrp(fd) != os.getpgrp():
                 raise HumanCeremonyCliError("background_process")

--- a/src/yoetz/ports/semantic.py
+++ b/src/yoetz/ports/semantic.py
@@ -24,6 +24,7 @@ from yoetz.domain.values import (
     Frontier,
     SubjectStateRelation,
     finding_id,
+    validate_commitment,
     validate_sha256_digest,
 )
 from yoetz.kernel.deterministic_checks import (
@@ -1174,6 +1175,7 @@ class ProviderAttemptProvenance:
     token_usage: TokenUsage | None = None
     cost_fields: CostFields | None = None
     failure_class: SemanticFailureClass | None = None
+    request_commitment: str | None = None
 
     def __post_init__(self) -> None:
         if not _valid_pattern(self.provider, _IDENTITY_PATTERN, 128):
@@ -1215,6 +1217,8 @@ class ProviderAttemptProvenance:
             raise ProtocolValueError("invalid_semantic_provenance")
         if self.failure_class is not None and type(self.failure_class) is not SemanticFailureClass:
             raise ProtocolValueError("invalid_semantic_failure_class")
+        if self.request_commitment is not None:
+            validate_commitment(self.request_commitment)
 
 
 def _validate_result_provenance(

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -1556,7 +1556,16 @@ class _HumanConnectionServer:
             raise
         except Exception as exc:
             code = _human_error_code(exc)
-            error = ServerErrorEnvelope(code, False, ceremony_id, error_step)
+            # Correlation starts only once the client sends an action or the
+            # daemon starts a secret ingress step.  A terminal can close just
+            # after ServerOpened; that has a ceremony id but no valid next step
+            # to put on a correlated error envelope.
+            error = ServerErrorEnvelope(
+                code,
+                False,
+                ceremony_id if error_step is not None else None,
+                error_step,
+            )
             try:
                 await _write_human_envelope(stream, error)
                 if ceremony_id is not None and error_step is not None:
@@ -1568,6 +1577,18 @@ class _HumanConnectionServer:
             except Exception:
                 pass
         finally:
+            # A foreground terminal can disappear between the opened preview and
+            # its next action (for example, Ctrl-C at a secret prompt).  The
+            # human-control service owns one ceremony globally, so leaving it
+            # active would make every later ceremony fail state_forbidden until
+            # the daemon is restarted.  A completed/cancelled ceremony has
+            # already cleared itself; in that case cancel simply reports replay
+            # and is deliberately ignored.
+            if ceremony_id is not None:
+                try:
+                    await self._service.cancel(ceremony_id)
+                except Exception:
+                    pass
             await stream.aclose()
 
 

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1294,13 +1294,23 @@ def _provider_provenance(
     reason: SemanticReason,
     ids: IdPort,
 ) -> SemanticProvenance | None:
-    """Bind a completed external attempt to its durable receipt and request commitment."""
+    """Bind a completed attempt to its dispatch-specific durable privacy authority."""
 
-    if (
-        result.privacy_receipt_id is None
-        or result.authorization_id is None
-        or result.request_commitment is None
-    ):
+    if result.privacy_receipt_id is None:
+        return None
+    if result.dispatch_kind is SemanticDispatchKind.EXTERNAL:
+        if result.authorization_id is None or result.request_commitment is None:
+            return None
+        egress_authorization_id = result.authorization_id
+        local_disclosure_reservation_id = None
+        request_commitment = result.request_commitment
+    elif result.dispatch_kind is SemanticDispatchKind.LOCAL_MODEL:
+        if result.authorization_id is not None or result.request_commitment is not None:
+            return None
+        egress_authorization_id = None
+        local_disclosure_reservation_id = result.privacy_proposal_id
+        request_commitment = None
+    else:
         return None
     attempt = result.result.provenance
     return SemanticProvenance(
@@ -1316,7 +1326,7 @@ def _provider_provenance(
         sampling_params=attempt.sampling_params,
         latency_ms=attempt.latency_ms,
         semantic_attempt_id=ids.new(IdKind.SEMANTIC_ATTEMPT),
-        dispatch_kind=SemanticDispatchKind.EXTERNAL,
+        dispatch_kind=result.dispatch_kind,
         privacy_receipt_id=result.privacy_receipt_id,
         status=status,
         reason=reason,
@@ -1324,8 +1334,9 @@ def _provider_provenance(
         token_usage=attempt.token_usage,
         cost_fields=attempt.cost_fields,
         failure_class=attempt.failure_class,
-        egress_authorization_id=result.authorization_id,
-        request_commitment=result.request_commitment,
+        egress_authorization_id=egress_authorization_id,
+        local_disclosure_reservation_id=local_disclosure_reservation_id,
+        request_commitment=request_commitment,
     )
 
 

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -92,6 +92,7 @@ from yoetz.kernel.policies.observation_advice import (
     ObservationAdviceCandidate,
     ObservationCompositionFact,
 )
+from yoetz.observability.logging import record_unexpected_exception_without_raising
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.control import ControlError
 from yoetz.ports.diagnostics import DiagnosticsPort, RuntimeCapability, StartupCheckResult
@@ -1286,60 +1287,88 @@ def _map_blocked(outcome: PrivacyOutcome, reason: object) -> FinalSemanticEvalua
     return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
 
 
-def _map_provider_outcome(result: SemanticEgressProviderOutcome) -> FinalSemanticEvaluation:
+def _provider_provenance(
+    result: SemanticEgressSuccess | SemanticEgressProviderOutcome,
+    *,
+    status: SemanticStatus,
+    reason: SemanticReason,
+    ids: IdPort,
+) -> SemanticProvenance | None:
+    """Bind a completed external attempt to its durable receipt and request commitment."""
+
+    if (
+        result.privacy_receipt_id is None
+        or result.authorization_id is None
+        or result.request_commitment is None
+    ):
+        return None
+    attempt = result.result.provenance
+    return SemanticProvenance(
+        provider=attempt.provider,
+        endpoint_profile_id=attempt.endpoint_profile_id,
+        endpoint_profile_version=attempt.endpoint_profile_version,
+        model=attempt.model,
+        sdk_version=attempt.sdk_version,
+        prompt_digest=attempt.prompt_digest,
+        schema_digest=attempt.schema_digest,
+        policy_digest=attempt.policy_digest,
+        privacy_policy_digest=attempt.privacy_policy_digest,
+        sampling_params=attempt.sampling_params,
+        latency_ms=attempt.latency_ms,
+        semantic_attempt_id=ids.new(IdKind.SEMANTIC_ATTEMPT),
+        dispatch_kind=SemanticDispatchKind.EXTERNAL,
+        privacy_receipt_id=result.privacy_receipt_id,
+        status=status,
+        reason=reason,
+        provider_request_id=attempt.provider_request_id,
+        token_usage=attempt.token_usage,
+        cost_fields=attempt.cost_fields,
+        failure_class=attempt.failure_class,
+        egress_authorization_id=result.authorization_id,
+        request_commitment=result.request_commitment,
+    )
+
+
+def _map_provider_outcome(
+    result: SemanticEgressProviderOutcome, ids: IdPort
+) -> FinalSemanticEvaluation:
     provider = result.result
+    status: SemanticStatus
+    reason: SemanticReason
     if type(provider) is SemanticResultRefused:
-        return FinalSemanticEvaluation(SemanticStatus.REFUSED, SemanticReason.PROVIDER_REFUSED)
-    if type(provider) is SemanticResultTimeout:
-        return FinalSemanticEvaluation(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT)
-    if type(provider) is SemanticResultInvalid:
+        status, reason = SemanticStatus.REFUSED, SemanticReason.PROVIDER_REFUSED
+    elif type(provider) is SemanticResultTimeout:
+        status, reason = SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT
+    elif type(provider) is SemanticResultInvalid:
+        status, reason = SemanticStatus.INVALID, SemanticReason.RESPONSE_SCHEMA_INVALID
+    elif type(provider) is SemanticResultLate:
+        status, reason = SemanticStatus.LATE, SemanticReason.DEADLINE_AUTHORITY_LOST
+    elif type(provider) is SemanticResultUnavailable:
+        status, reason = SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE
+    else:
+        return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
+    provenance = _provider_provenance(result, status=status, reason=reason, ids=ids)
+    if provenance is None:
         return FinalSemanticEvaluation(
-            SemanticStatus.INVALID, SemanticReason.RESPONSE_SCHEMA_INVALID
+            SemanticStatus.UNAVAILABLE, SemanticReason.RECEIPT_PERSISTENCE_UNKNOWN
         )
-    if type(provider) is SemanticResultLate:
-        return FinalSemanticEvaluation(SemanticStatus.LATE, SemanticReason.DEADLINE_AUTHORITY_LOST)
-    if type(provider) is SemanticResultUnavailable:
-        return FinalSemanticEvaluation(
-            SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE
-        )
-    return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
+    return FinalSemanticEvaluation(status, reason, provenance=provenance)
 
 
 def _map_egress_to_final(result: object, ids: IdPort) -> FinalSemanticEvaluation:
     """Map privacy egress outcomes to check FinalSemanticEvaluation without inventing findings."""
 
     if type(result) is SemanticEgressSuccess:
-        if result.privacy_receipt_id is None:
+        provenance = _provider_provenance(
+            result,
+            status=SemanticStatus.SUCCEEDED,
+            reason=SemanticReason.SEMANTIC_COMPLETED,
+            ids=ids,
+        )
+        if provenance is None:
             return FinalSemanticEvaluation(
                 SemanticStatus.UNAVAILABLE, SemanticReason.RECEIPT_PERSISTENCE_UNKNOWN
             )
-        attempt = result.result.provenance
-        authorization = result.authorization_id or None
-        if authorization == "":
-            authorization = None
-        provenance = SemanticProvenance(
-            provider=attempt.provider,
-            endpoint_profile_id=attempt.endpoint_profile_id,
-            endpoint_profile_version=attempt.endpoint_profile_version,
-            model=attempt.model,
-            sdk_version=attempt.sdk_version,
-            prompt_digest=attempt.prompt_digest,
-            schema_digest=attempt.schema_digest,
-            policy_digest=attempt.policy_digest,
-            privacy_policy_digest=attempt.privacy_policy_digest,
-            sampling_params=attempt.sampling_params,
-            latency_ms=attempt.latency_ms,
-            semantic_attempt_id=ids.new(IdKind.SEMANTIC_ATTEMPT),
-            dispatch_kind=SemanticDispatchKind.EXTERNAL,
-            privacy_receipt_id=result.privacy_receipt_id,
-            status=SemanticStatus.SUCCEEDED,
-            reason=SemanticReason.SEMANTIC_COMPLETED,
-            provider_request_id=attempt.provider_request_id,
-            token_usage=attempt.token_usage,
-            cost_fields=attempt.cost_fields,
-            failure_class=attempt.failure_class,
-            egress_authorization_id=authorization,
-        )
         return FinalSemanticEvaluation(
             SemanticStatus.SUCCEEDED,
             SemanticReason.SEMANTIC_COMPLETED,
@@ -1353,7 +1382,7 @@ def _map_egress_to_final(result: object, ids: IdPort) -> FinalSemanticEvaluation
     if type(result) is SemanticEgressBlocked:
         return _map_blocked(result.outcome, result.reason)
     if type(result) is SemanticEgressProviderOutcome:
-        return _map_provider_outcome(result)
+        return _map_provider_outcome(result, ids)
     return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
 
 
@@ -1409,7 +1438,7 @@ def _privacy_gated_semantic_evaluator(
                 request_id=frozen.lease.operation_id,
                 channel=EgressChannel.LLM_INFERENCE,
                 local_sink=None,
-                purpose="semantic_check",
+                purpose="semantic-review",
                 scope=scope,
                 subject_digest=canonical_digest(
                     cast(
@@ -1437,7 +1466,13 @@ def _privacy_gated_semantic_evaluator(
             deadline = Deadline(clock.now_utc(), clock.monotonic_seconds() + 60.0)
             result = await privacy.evaluate_semantic(candidate, deadline)
             return _map_egress_to_final(result, ids)
-        except Exception:
+        except Exception as exc:
+            record_unexpected_exception_without_raising(
+                exc,
+                component="semantic_composition",
+                operation="semantic_evaluation_failed",
+                request_id=frozen.lease.operation_id,
+            )
             return FinalSemanticEvaluation(
                 SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE
             )
@@ -1626,7 +1661,7 @@ async def provide_service_ready_context(
                 request_id=ids.new(IdKind.REQUEST),
                 channel=EgressChannel.LLM_INFERENCE,
                 local_sink=None,
-                purpose="semantic_check",
+                purpose="semantic-review",
                 scope=machine_scope,
                 subject_digest=subject,
                 provider_binding=provider_binding,

--- a/src/yoetz/service/vault.py
+++ b/src/yoetz/service/vault.py
@@ -95,6 +95,7 @@ _INSTALLATION_DOMAINS: Final[Mapping[MacKeyPurpose, frozenset[bytes]]] = {
     MacKeyPurpose.LOG_CORRELATION: frozenset({b"yoetz/session-log-id/v1\x00"}),
     MacKeyPurpose.PRIVACY_AUDIT: frozenset(
         {
+            b"yoetz/privacy-audit/authorization/v1\x00",
             b"yoetz/privacy-audit/control-request/v1\x00",
             b"yoetz/privacy-audit/internal-result/v1\x00",
             b"yoetz/privacy-audit/local-approval/v1\x00",

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -200,8 +200,10 @@ class _Runtime:
     def __init__(self, task: TaskRuntime) -> None:
         self.task = task
         self.release_count = 0
+        self.last_command: RouteCommand | None = None
 
-    async def route(self, _command: RouteCommand) -> TaskRuntime:
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        self.last_command = command
         return self.task
 
     async def release(self, runtime: TaskRuntime) -> None:
@@ -313,6 +315,9 @@ async def test_semantic_required_unavailable_preserves_deterministic_truth() -> 
     assert result.semantic_status is SemanticStatus.NOT_CONFIGURED
     assert result.semantic_provenance is None
     assert result.coverage.known_gaps == ("semantic_review_not_configured",)
+    runtime = cast(_Runtime, app.runtime)
+    assert runtime.last_command is not None
+    assert RuntimeCapability.SEMANTIC in runtime.last_command.required_capabilities
 
 
 @pytest.mark.anyio

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Buffer, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -29,6 +29,19 @@ from yoetz.ports.control import (
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind, new_id
 from yoetz.protocol.models import PublishWorkRequest, PublishWorkResult, StartRequest, StartResult
+from yoetz.service.confidential_protocol import (
+    ClientOpenEnvelope,
+    EmptyVaultTarget,
+    HumanCeremonyBinding,
+    HumanCeremonyKind,
+    KeyringRetryPhase,
+    ServerCloseEnvelope,
+    ServerErrorEnvelope,
+    ServerOpenedEnvelope,
+    VaultUnlockPreview,
+    decode_human_frame,
+    encode_human_frame,
+)
 from yoetz.service.daemon import ServiceComposition, ServiceDaemon
 from yoetz.service.lifecycle import LifecycleError, ServiceLifecycle
 from yoetz.service.vault import VaultMode
@@ -638,3 +651,83 @@ async def test_service_entry_point_installs_the_structural_log_sink(
         await daemon_module.run_service()
 
     assert installed == [LogMode.SERVICE]
+
+
+@pytest.mark.anyio
+async def test_human_connection_cancels_an_open_ceremony_when_terminal_disconnects() -> None:
+    """An interrupted foreground setup must not block every later ceremony."""
+
+    ceremony_id = "a" * 64
+
+    class _Stream:
+        def __init__(self) -> None:
+            self._incoming = bytearray(
+                encode_human_frame(
+                    ClientOpenEnvelope(
+                        "b" * 64,
+                        HumanCeremonyKind.VAULT_UNLOCK,
+                        EmptyVaultTarget(expected_mode="passphrase"),
+                    )
+                )
+            )
+            self.sent: list[bytes] = []
+            self.closed = False
+
+        @property
+        def peer_identity(self) -> object:
+            return object()
+
+        async def receive(self, max_bytes: int) -> bytes:
+            if not self._incoming:
+                return b""
+            size = min(max_bytes, len(self._incoming))
+            chunk = bytes(self._incoming[:size])
+            del self._incoming[:size]
+            return chunk
+
+        async def send_all(self, data: Buffer) -> None:
+            self.sent.append(bytes(data))
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    class _HumanService:
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+
+        async def open_ceremony(self, request: ClientOpenEnvelope) -> ServerOpenedEnvelope:
+            return ServerOpenedEnvelope(
+                ceremony_id,
+                1,
+                HumanCeremonyBinding(
+                    binding_version=1,
+                    ceremony_id=ceremony_id,
+                    connection_nonce=request.connection_nonce,
+                    ceremony_kind=HumanCeremonyKind.VAULT_UNLOCK,
+                    service_instance_id=_INSTANCE_ID,
+                    service_generation=7,
+                    vault_generation=3,
+                    policy_generation=None,
+                    target_digest="sha256:" + "2" * 64,
+                    expires_at_monotonic_ms=1_000_000,
+                ),
+                VaultUnlockPreview(),
+                KeyringRetryPhase(),
+            )
+
+        async def cancel(self, received_ceremony_id: str) -> ServerCloseEnvelope:
+            self.cancelled.append(received_ceremony_id)
+            return ServerCloseEnvelope(received_ceremony_id, 3, "cancelled")
+
+    stream = _Stream()
+    service = _HumanService()
+    handler = daemon_module._HumanConnectionServer(service)  # pyright: ignore[reportPrivateUsage, reportArgumentType]
+
+    await handler(stream)
+
+    assert service.cancelled == [ceremony_id]
+    assert stream.closed
+    assert [type(decode_human_frame(item)) for item in stream.sent] == [
+        ServerOpenedEnvelope,
+        ServerErrorEnvelope,
+    ]

--- a/tests/packaging/test_clean_install.py
+++ b/tests/packaging/test_clean_install.py
@@ -12,7 +12,7 @@ Scope notes (documented, not silently narrowed):
 * A full "deterministic receipt" for the six-operation slice requires an unlocked vault. Unlocking
   a passphrase vault for real goes through ``yoetz/cli/unlock.py``'s ``_ForegroundTerminal``, which
   deliberately requires a genuine controlling TTY (opens ``/dev/tty``, checks
-  ``os.tcgetpgrp``/uid/isatty on fd 0 and 2) -- a real security control, not something to relax.
+  ``os.tcgetpgrp``/isatty plus matching stdin/stderr terminal endpoints) -- a real security control, not something to relax.
   This file proves the six operations against the real, freshly-installed, running-but-locked
   service: each one must produce a bounded, non-crashing, documented exit code (never a hidden
   runtime, never a Python traceback, never a leaked checkout path) rather than a fabricated

--- a/tests/packaging/test_uninstall_and_data_retention.py
+++ b/tests/packaging/test_uninstall_and_data_retention.py
@@ -8,7 +8,7 @@ offline wheel afterward rediscovers the preserved data untouched.
 Scope note: exercising this against a fully unlocked vault would require driving the real
 foreground passphrase-vault ceremony, which needs a genuine controlling TTY
 (``yoetz/cli/unlock.py``'s ``_ForegroundTerminal`` opens ``/dev/tty`` and checks
-``os.tcgetpgrp``/uid/isatty on fd 0 and 2). That is real, deliberate, out-of-scope-to-relax product
+``os.tcgetpgrp``/isatty plus matching stdin/stderr terminal endpoints). That is real, deliberate, out-of-scope-to-relax product
 security (not a gap in this file), and is exercised in ``test_clean_install.py``/
 ``test_offline_reinstall.py`` instead. This file's own invariant -- "package removal never deletes
 user ledger/object/backup/key data" -- does not require an unlocked vault to prove: it is proven by

--- a/tests/subprocess/test_privacy_human_control.py
+++ b/tests/subprocess/test_privacy_human_control.py
@@ -32,12 +32,14 @@ from yoetz.service.confidential_protocol import (
 )
 
 MODE = sys.argv[1]
+AUTO_SECRET = b"policy-secret-canary-2026"
 REAL_OPEN = os.open
 def OPEN_TTY(path, flags):
     assert path == "/dev/tty"
     return os.dup(0)
 unlock_helper.os.open = OPEN_TTY
-TARGET = PrivacyPendingTarget("policy" if MODE == "policy" else "disclosure", "pending-1")
+POLICY_MODE = MODE in {"policy", "auto_policy"}
+TARGET = PrivacyPendingTarget("policy" if POLICY_MODE else "disclosure", "pending-1")
 TARGET_DIGEST = canonical_digest({"decision_kind": TARGET.decision_kind, "kind": TARGET.kind, "pending_id": TARGET.pending_id})
 CEREMONY = "1" * 64
 INSTANCE = "svc_11111111-1111-4111-8111-111111111111"
@@ -65,7 +67,7 @@ class Session:
             1, CEREMONY, "3" * 64, kind, INSTANCE, 7, 3, 5, TARGET_DIGEST,
             int(time.monotonic() * 1000) + 60000,
         )
-        if MODE == "policy":
+        if POLICY_MODE:
             preview = PrivacyPolicyDecisionPreview(
                 "pending-1", "sha256:" + "4" * 64,
                 ("source-content",), ("workspace",),
@@ -86,7 +88,7 @@ class Session:
             self.stage = 2
         else: raise AssertionError(type(action).__name__)
     async def wait_phase_or_result(self):
-        if MODE != "policy":
+        if not POLICY_MODE:
             return PrivacyDecisionResult("committed", "sha256:" + "8" * 64)
         if self.stage == 1:
             return AuthorizationRequiredPhase(("secret_reauthentication",))
@@ -112,8 +114,14 @@ privacy_control.HumanControlClient = Client
 
 async def main():
     result = await (
-        privacy_control.decide_policy("pending-1")
-        if MODE == "policy"
+        (
+            privacy_control.decide_policy_with_local_reauthentication(
+                "pending-1", bytearray(AUTO_SECRET)
+            )
+            if MODE == "auto_policy"
+            else privacy_control.decide_policy("pending-1")
+        )
+        if POLICY_MODE
         else privacy_control.decide_disclosure("pending-1")
     )
     print(json.dumps({
@@ -260,6 +268,24 @@ def test_policy_approval_reauthenticates_without_echo_or_secret_output() -> None
         "result": "committed",
         "secret_lengths": [len(_SECRET_CANARY)],
     }
+    assert _SECRET_CANARY not in transcript
+    assert _SECRET_CANARY not in stdout
+
+
+@pytest.mark.skipif(not hasattr(termios, "TIOCSCTTY"), reason="requires a POSIX controlling TTY")
+def test_policy_approval_uses_provisioned_reauthentication_without_prompting() -> None:
+    process, master_fd, slave_fd = _spawn_tty_probe("auto_policy")
+    transcript = bytearray()
+    deadline = time.monotonic() + 10
+    _read_until(master_fd, transcript, b"Decision [approve/deny/edit]: ", deadline)
+    os.write(master_fd, b"approve\n")
+    observed, stdout = _finish_tty_probe(process, master_fd, slave_fd, transcript)
+    assert observed == {
+        "actions": ["approve", "secret_reauthentication"],
+        "result": "committed",
+        "secret_lengths": [len(_SECRET_CANARY)],
+    }
+    assert b"Passphrase: " not in transcript
     assert _SECRET_CANARY not in transcript
     assert _SECRET_CANARY not in stdout
 

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -643,3 +643,84 @@ def test_uninitialized_setup_stops_after_write_with_failed_readback(
     assert initialized == []
     assert service == {"reachable": True, "state": "locked", "vault_mode": "uninitialized"}
     assert report["credential_reason"] == "auto_unlock_unverified"
+
+
+def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthentication(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fresh Keychain-backed setup must ask only for the provider credential."""
+
+    import yoetz.adapters.keys.os_keyring as keyring_module
+    import yoetz.cli.provider_binding as binding_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+    import yoetz.config.paths as paths_module
+    import yoetz.config.write as write_module
+
+    loaded: list[bytes] = []
+    supplied_reauthentication: list[bytes | None] = []
+
+    def fake_load(_store: object) -> bytearray:
+        loaded.append(b"a" * 48)
+        return bytearray(b"a" * 48)
+
+    def fake_load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            storage=SimpleNamespace(data_dir=tmp_path),
+            provider=SimpleNamespace(
+                provider_id="fireworks",
+                model="accounts/fireworks/models/minimax-m3",
+                endpoint_profile_id="fireworks-responses",
+                endpoint_profile_version="1.0.0",
+            ),
+        )
+
+    def fake_bundle_root(*, _data_dir: Path | None = None) -> Path:
+        del _data_dir
+        return tmp_path.resolve()
+
+    def fake_write(_choice: str, *, model: str) -> tuple[Path, object]:
+        assert _choice == "fireworks"
+        assert model == "accounts/fireworks/models/minimax-m3"
+        return tmp_path / "config.toml", object()
+
+    async def fake_set(
+        _target: object,
+        _credential: bytearray | None,
+        reauthentication: bytearray | None,
+    ) -> SimpleNamespace:
+        supplied_reauthentication.append(None if reauthentication is None else bytes(reauthentication))
+        return SimpleNamespace(activation_status="stored")
+
+    async def fake_reachability(*, start_if_absent: bool = False) -> dict[str, object]:
+        del start_if_absent
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    def fake_provider_preset(_provider: str) -> SimpleNamespace:
+        return SimpleNamespace(choice="fireworks")
+
+    monkeypatch.setattr(keyring_module.AutoUnlockPassphraseStore, "load", fake_load)
+    monkeypatch.setattr(config_module, "load_config", fake_load_config)
+    monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
+    monkeypatch.setattr(binding_module, "apply_provider_endpoint_choice", fake_write)
+    monkeypatch.setattr(unlock_module, "set_provider_credential", fake_set)
+    monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
+    monkeypatch.setattr(
+        write_module,
+        "provider_preset",
+        fake_provider_preset,
+    )
+
+    _service, report = asyncio.run(
+        setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
+            {"reachable": True, "state": "ready", "vault_mode": "passphrase"},
+            provider_choice="fireworks",
+            model="accounts/fireworks/models/minimax-m3",
+        )
+    )
+
+    assert loaded == [b"a" * 48]
+    assert supplied_reauthentication == [b"a" * 48]
+    assert report["binding"] == "configured"
+    assert report["credential"] == "stored"

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -690,7 +690,9 @@ def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthenticat
         _credential: bytearray | None,
         reauthentication: bytearray | None,
     ) -> SimpleNamespace:
-        supplied_reauthentication.append(None if reauthentication is None else bytes(reauthentication))
+        supplied_reauthentication.append(
+            None if reauthentication is None else bytes(reauthentication)
+        )
         return SimpleNamespace(activation_status="stored")
 
     async def fake_reachability(*, start_if_absent: bool = False) -> dict[str, object]:

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -1,0 +1,185 @@
+"""The pinned OpenAI SDK must preserve the audited Responses request body exactly."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from yoetz.adapters.providers.openai_responses import (
+    OneAttemptCredentialTransport,
+    OpenAIProfile,
+    OpenAIResponsesEvaluator,
+    owner_declared_data_use_profile,
+    render_case,
+)
+from yoetz.domain.privacy import ApprovedOutboundCase, DataCategory, ProviderBinding
+from yoetz.ports.secret_memory import ProviderAttemptAuthBinding, ProviderAuthTransportCallback
+from yoetz.ports.semantic import Deadline, SemanticResultSuccess
+from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
+
+_NOW = datetime(2026, 7, 25, tzinfo=UTC)
+_DIGEST = "sha256:" + "c" * 64
+_JUDGMENT = '{"conclusion":"no_material_discrepancy","reviewer_challenges":[]}'
+
+
+class _CaptureTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.request_body: bytes | None = None
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.request_body = await request.aread()
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "resp_test",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": _JUDGMENT}],
+                    }
+                ],
+            },
+        )
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 0.0
+
+
+class _Credential:
+    async def authorize_attempt[T](
+        self,
+        binding: ProviderAttemptAuthBinding,
+        inject_and_start: ProviderAuthTransportCallback[T],
+    ) -> T:
+        del binding
+        secret = bytearray(b"nonsecret-test-credential")
+        view = memoryview(secret)
+        try:
+            return await inject_and_start.inject_and_start(view)
+        finally:
+            view.release()
+            for index in range(len(secret)):
+                secret[index] = 0
+
+def _case() -> ApprovedOutboundCase:
+    payload = canonical_encode({"schema": "yoetz.semantic-check-candidate/1"})
+    return ApprovedOutboundCase(
+        case_id="cas_60000000-0000-4000-8000-000000000001",
+        request_id="req_60000000-0000-4000-8000-000000000001",
+        payload=payload,
+        media_type="application/json",
+        schema_id="yoetz-semantic-case-1.0.0",
+        included_item_ids=("case-packet",),
+        approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        blocked_categories=(),
+        byte_count=len(payload),
+        token_count=8,
+        provider_binding=ProviderBinding(
+            "fireworks",
+            "accounts/fireworks/models/minimax-m3",
+            "fireworks-responses",
+            "1.0.0",
+            "external",
+        ),
+        purpose="semantic-review",
+        authorization_id="aut_60000000-0000-4000-8000-000000000001",
+        policy_digest=_DIGEST,
+        case_digest="sha256:" + "d" * 64,
+    )
+
+
+@pytest.mark.anyio
+async def test_pinned_sdk_preserves_the_rendered_responses_body() -> None:
+    profile = OpenAIProfile(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+        timeout_seconds=60,
+        supports_structured_outputs=True,
+        data_use_profile=owner_declared_data_use_profile(
+            reviewed_at=_NOW,
+            expires_at=_NOW + timedelta(days=30),
+            evidence_digest=_DIGEST,
+        ),
+        host="api.fireworks.ai",
+        base_path_prefix="/inference/v1",
+    )
+    case = _case()
+    rendered = render_case(case)
+    body = cast(dict[str, Any], strict_json_parse(rendered.body))
+    import openai
+
+    capture = _CaptureTransport()
+    client = openai.AsyncOpenAI(
+        api_key="nonsecret-test-sentinel",
+        base_url=profile.base_url,
+        http_client=httpx.AsyncClient(transport=capture),
+    )
+    try:
+        await client.responses.create(**body)
+    finally:
+        await client.close()
+
+    assert capture.request_body == rendered.body
+
+
+@pytest.mark.anyio
+async def test_evaluator_dispatches_the_audited_rendered_body_verbatim() -> None:
+    profile = OpenAIProfile(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+        timeout_seconds=60,
+        supports_structured_outputs=True,
+        data_use_profile=owner_declared_data_use_profile(
+            reviewed_at=_NOW,
+            expires_at=_NOW + timedelta(days=30),
+            evidence_digest=_DIGEST,
+        ),
+        host="api.fireworks.ai",
+        base_path_prefix="/inference/v1",
+    )
+    case = _case()
+    rendered = render_case(case)
+    binding = ProviderAttemptAuthBinding(
+        provider_id="fireworks",
+        model_id="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+        purpose="semantic-review",
+        authorization_scope_digest=_DIGEST,
+        purpose_digest=canonical_digest({"purpose": "semantic-review"}),
+        dispatch_id="dsp_60000000-0000-4000-8000-000000000001",
+        request_body_digest=rendered.body_sha256,
+        service_generation=1,
+        monotonic_deadline=30.0,
+    )
+    capture = _CaptureTransport()
+    transport = OneAttemptCredentialTransport(
+        rendered=rendered,
+        credential=_Credential(),
+        binding=binding,
+        host=profile.host,
+        port=profile.port,
+        path=profile.path,
+    )
+    cast(Any, transport)._inner = capture
+    result = await OpenAIResponsesEvaluator(profile, transport, _Clock()).evaluate(
+        case,
+        Deadline(_NOW + timedelta(seconds=30), 30.0),
+    )
+
+    assert type(result) is SemanticResultSuccess
+    assert capture.request_body == rendered.body

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -71,6 +71,7 @@ class _Credential:
             for index in range(len(secret)):
                 secret[index] = 0
 
+
 def _case() -> ApprovedOutboundCase:
     payload = canonical_encode({"schema": "yoetz.semantic-check-candidate/1"})
     return ApprovedOutboundCase(

--- a/tests/unit/application/test_semantic_local_egress.py
+++ b/tests/unit/application/test_semantic_local_egress.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import yoetz.service.ready_composition as ready_composition
+from builders.privacy_policies import local_only_policy
+from yoetz.adapters.providers.fake import scripted_success
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressSuccess
+from yoetz.domain.findings import SemanticDispatchKind
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    ConsentSource,
+    DataClass,
+    DisclosureProposal,
+    EgressChannel,
+    LocalDisclosureReceipt,
+    LocalDisclosureSink,
+    PrivacyOutcome,
+    ProviderBinding,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline, SemanticJudgment
+from yoetz.protocol.models import DataCategory, SemanticReason, SemanticStatus
+
+_NOW = datetime(2026, 7, 26, tzinfo=UTC)
+_REQUEST = "req_30000000-0000-4000-8000-000000000001"
+_TASK = "tsk_30000000-0000-4000-8000-000000000002"
+_PROPOSAL = "ppr_30000000-0000-4000-8000-000000000003"
+_CASE_DIGEST = "sha256:" + "c" * 64
+_SUBJECT_DIGEST = "sha256:" + "d" * 64
+_ITEM_DIGEST = "sha256:" + "e" * 64
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Audit:
+    def __init__(self, *, persist: bool) -> None:
+        self.persist = persist
+        self.receipt: LocalDisclosureReceipt | None = None
+        self.authorize_calls = 0
+
+    async def authorize(self, *args: object) -> object:
+        self.authorize_calls += 1
+        raise AssertionError("local semantic dispatch must not mint network authority")
+
+    async def complete_local_disclosure(
+        self, reservation_id: str, receipt: LocalDisclosureReceipt
+    ) -> None:
+        assert reservation_id == _PROPOSAL
+        if not self.persist:
+            raise RuntimeError("receipt_write_failed")
+        self.receipt = receipt
+
+    async def load(self, request_id: str, subject_digest: str) -> object | None:
+        assert (request_id, subject_digest) == (_REQUEST, _SUBJECT_DIGEST)
+        if self.receipt is None:
+            return None
+        return SimpleNamespace(receipt_id=self.receipt.receipt_id)
+
+
+class _Gateway:
+    def __init__(self) -> None:
+        self.result = scripted_success(SemanticJudgment("no_material_discrepancy", ())).result
+
+    async def dispatch_local_semantic(self, case: object, deadline: Deadline) -> object:
+        del case, deadline
+        return self.result
+
+
+def _binding() -> ProviderBinding:
+    return ProviderBinding(
+        "local-test",
+        "local/test-model",
+        "local-af-unix",
+        "1.0.0",
+        "local_af_unix",
+    )
+
+
+def _scope() -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        "ins_30000000-0000-4000-8000-000000000004",
+        "hmac-sha256:" + "f" * 64,
+        _TASK,
+    )
+
+
+def _effective(binding: ProviderBinding) -> EffectivePrivacyPolicy:
+    policy = replace(
+        local_only_policy(),
+        local_model_enabled=True,
+        local_model_binding=binding,
+        local_model_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        local_model_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+    )
+    return EffectivePrivacyPolicy(policy, 1, policy.policy_digest)
+
+
+def _candidate(binding: ProviderBinding) -> CandidateContext:
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        _scope(),
+        _SUBJECT_DIGEST,
+        binding,
+        (),
+    )
+
+
+def _proposal(binding: ProviderBinding) -> DisclosureProposal:
+    return DisclosureProposal(
+        _PROPOSAL,
+        _REQUEST,
+        _TASK,
+        (_ITEM_DIGEST,),
+        b"{}",
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (),
+        (),
+        _CASE_DIGEST,
+        None,
+        LocalDisclosureSink.LOCAL_MODEL,
+        "semantic-review",
+        _scope(),
+        1,
+        local_only_policy().policy_digest,
+        2,
+        1,
+        _NOW + timedelta(minutes=1),
+        "hmac-sha256:" + "a" * 64,
+    )
+
+
+def _minimized() -> MinimizedDisclosure:
+    return MinimizedDisclosure(
+        b"{}",
+        ("case-packet",),
+        (_ITEM_DIGEST,),
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (),
+        (),
+        2,
+        1,
+        _CASE_DIGEST,
+        "semantic-local-test-v1",
+        "sha256:" + "b" * 64,
+        (),
+    )
+
+
+async def _dispatch(*, persist: bool) -> tuple[object, _Audit]:
+    binding = _binding()
+    audit = _Audit(persist=persist)
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, object()),
+        cast(PrivacyClassifierPort, object()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        ready_composition.IdPort(),
+    )
+    result = await coordinator._dispatch_approved(  # pyright: ignore[reportPrivateUsage]
+        _candidate(binding),
+        _effective(binding),
+        _proposal(binding),
+        _minimized(),
+        ConsentSource.BASELINE_POLICY,
+        Deadline(_NOW + timedelta(minutes=1), 60.0),
+        subject_digest=_SUBJECT_DIGEST,
+    )
+    return result, audit
+
+
+@pytest.mark.anyio
+async def test_local_semantic_success_persists_receipt_and_finalizes_local_provenance() -> None:
+    result, audit = await _dispatch(persist=True)
+
+    assert isinstance(result, SemanticEgressSuccess)
+    assert result.authorization_id is None
+    assert result.dispatch_kind is SemanticDispatchKind.LOCAL_MODEL
+    assert result.request_commitment is None
+    assert audit.authorize_calls == 0
+    assert audit.receipt is not None
+    assert audit.receipt.sink is LocalDisclosureSink.LOCAL_MODEL
+    assert audit.receipt.outcome is PrivacyOutcome.COMPLETED
+    final = ready_composition._map_egress_to_final(  # pyright: ignore[reportPrivateUsage]
+        result, ready_composition.IdPort()
+    )
+    assert final.status is SemanticStatus.SUCCEEDED
+    assert final.provenance is not None
+    assert final.provenance.dispatch_kind is SemanticDispatchKind.LOCAL_MODEL
+    assert final.provenance.privacy_receipt_id == audit.receipt.receipt_id
+    assert final.provenance.local_disclosure_reservation_id == _PROPOSAL
+    assert final.provenance.egress_authorization_id is None
+    assert final.provenance.request_commitment is None
+
+
+@pytest.mark.anyio
+async def test_local_semantic_success_fails_closed_when_receipt_is_not_durable() -> None:
+    result, audit = await _dispatch(persist=False)
+
+    assert isinstance(result, SemanticEgressSuccess)
+    assert audit.authorize_calls == 0
+    final = ready_composition._map_egress_to_final(  # pyright: ignore[reportPrivateUsage]
+        result, ready_composition.IdPort()
+    )
+    assert final.status is SemanticStatus.UNAVAILABLE
+    assert final.reason is SemanticReason.RECEIPT_PERSISTENCE_UNKNOWN
+    assert final.provenance is None
+
+
+@pytest.mark.anyio
+async def test_external_semantic_success_still_requires_authority_and_request_commitment() -> None:
+    local, _audit = await _dispatch(persist=True)
+    assert isinstance(local, SemanticEgressSuccess)
+    external = replace(
+        local,
+        authorization_id="aut_30000000-0000-4000-8000-000000000005",
+        dispatch_kind=SemanticDispatchKind.EXTERNAL,
+        request_commitment="hmac-sha256:" + "6" * 64,
+    )
+
+    final = ready_composition._map_egress_to_final(  # pyright: ignore[reportPrivateUsage]
+        external, ready_composition.IdPort()
+    )
+    assert final.status is SemanticStatus.SUCCEEDED
+    assert final.provenance is not None
+    assert final.provenance.dispatch_kind is SemanticDispatchKind.EXTERNAL
+    assert final.provenance.egress_authorization_id == external.authorization_id
+    assert final.provenance.request_commitment == external.request_commitment
+    assert final.provenance.local_disclosure_reservation_id is None
+
+    unbound = ready_composition._map_egress_to_final(  # pyright: ignore[reportPrivateUsage]
+        replace(external, request_commitment=None), ready_composition.IdPort()
+    )
+    assert unbound.status is SemanticStatus.UNAVAILABLE
+    assert unbound.reason is SemanticReason.RECEIPT_PERSISTENCE_UNKNOWN
+    assert unbound.provenance is None

--- a/tests/unit/cli/test_auto_unlock.py
+++ b/tests/unit/cli/test_auto_unlock.py
@@ -182,5 +182,47 @@ async def test_auto_unlock_repair_maps_missing_trusted_tty_to_usage_failure(
     assert capsys.readouterr().err == "invalid_request: the command input is invalid\n"
 
 
+def test_foreground_terminal_accepts_macos_controlling_tty_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A macOS /dev/tty alias may be root-owned and device-distinct from stdio."""
+
+    opened: list[int] = []
+    closed: list[int] = []
+
+    def fake_open(_path: str, _flags: int) -> int:
+        opened.append(9)
+        return 9
+
+    def fake_close(fd: int) -> None:
+        closed.append(fd)
+
+    def fake_fstat(fd: int) -> SimpleNamespace:
+        if fd in {0, 2}:
+            return SimpleNamespace(st_rdev=101, st_uid=501)
+        assert fd == 9
+        return SimpleNamespace(st_rdev=202, st_uid=0)
+
+    def fake_isatty(_fd: int) -> bool:
+        return True
+
+    def fake_tcgetpgrp(_fd: int) -> int:
+        return 41
+
+    monkeypatch.setattr(unlock_module.os, "isatty", fake_isatty)
+    monkeypatch.setattr(unlock_module.os, "open", fake_open)
+    monkeypatch.setattr(unlock_module.os, "close", fake_close)
+    monkeypatch.setattr(unlock_module.os, "fstat", fake_fstat)
+    monkeypatch.setattr(unlock_module.os, "tcgetpgrp", fake_tcgetpgrp)
+    monkeypatch.setattr(unlock_module.os, "getpgrp", lambda: 41)
+
+    terminal = unlock_module._ForegroundTerminal()  # pyright: ignore[reportPrivateUsage]
+    with terminal:
+        assert terminal.fd == 9
+
+    assert opened == [9]
+    assert closed == [9]
+
+
 async def _async_value(value: Any) -> Any:
     return value

--- a/tests/unit/service/test_vault_state.py
+++ b/tests/unit/service/test_vault_state.py
@@ -97,6 +97,10 @@ async def test_bundle_and_installation_handles_are_generation_fenced(tmp_path: P
 
     catalog = service.installation_mac_handle(MacKeyPurpose.CATALOG_LOOKUP)
     assert catalog.mac(b"yoetz/start-title/v1\x00", b"title").startswith("hmac-sha256:")
+    privacy_audit = service.installation_mac_handle(MacKeyPurpose.PRIVACY_AUDIT)
+    assert privacy_audit.mac(
+        b"yoetz/privacy-audit/authorization/v1\x00", b"authorization"
+    ).startswith("hmac-sha256:")
     with pytest.raises(KeyStoreError, match="mac_domain_forbidden"):
         catalog.mac(b"yoetz/session-log-id/v1\x00", b"title")
 


### PR DESCRIPTION
## Issue

- Fixes #27.
- Refs #13 for the broader receipt-backed semantic completion contract.
- Existing issues and PRs were searched for duplicates before this PR was opened.
- This continues the already-open, maintainer-directed repair; the governing privacy and semantic contracts remain ADR-006, ADR-008, ADR-009, and `docs/INTERFACES.md`.

## Documentation

- Behavior change: yes.
- Updated `docs/adr/ADR-008-local-service-vault-trust-boundary.md` for foreground-terminal verification behavior.
- The receipt/provenance repair implements the existing ADR-006 and `docs/INTERFACES.md` contract; it does not introduce a new wire shape.

## Verification

Commands run:

```text
env UV_CACHE_DIR=/private/tmp/yoetz-pr28-uv-cache uv run --locked ruff format --check .
env UV_CACHE_DIR=/private/tmp/yoetz-pr28-uv-cache uv run --locked ruff check .
npx --prefix /Users/shayb/yoetz-core --no-install pyright
env UV_CACHE_DIR=/private/tmp/yoetz-pr28-uv-cache uv run pytest tests/unit/application/test_semantic_local_egress.py tests/integration/privacy/test_egress_gateway.py tests/unit/privacy/test_catalog_audit.py tests/integration/service/test_ready_composition.py tests/integration/application/test_check.py -q
git diff --check
```

Results:

- Ruff format: 421 files already formatted.
- Ruff lint: passed.
- Pinned Pyright: 0 errors, 0 warnings.
- Focused privacy/service/application tests: 34 passed.
- Diff check: passed.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] Every current human and code-review-agent comment is dispositioned by a fix or an explicit reply.

## Summary

- Preserve the canonical rendered provider request body and bind external semantic outcomes to the exact request commitment and durable egress receipt.
- Restore semantic-capability routing and honest provider outcome recording.
- Keep provisioned local reauthentication scoped and overwrite passphrase buffers after use.
- Harden foreground TTY verification and cancel disconnected human-control ceremonies.
- Finalize local AF_UNIX semantic attempts through a durable `LocalDisclosureReceipt`, then publish `LOCAL_MODEL` provenance without inventing a network authorization or request commitment.
- Preserve the fail-closed boundary: missing local or external receipt authority maps to `RECEIPT_PERSISTENCE_UNKNOWN` rather than a false semantic success.
- Apply the Ruff formatting required by `format-lint-type`.
