### PR TITLE
fix: count checks toward receipts by material-state applicability

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -638,9 +638,11 @@ the frontier merely advanced.
   `gaps` is the exact sorted typed `CaseGap` tuple after check/semantic/availability accounting, and
   `applicable_check` is the exact readable `CheckRecordedPayload` that still applies to this
   material state or `None`. A check applies when no event of a material family has been appended
-  after its subject frontier; an immaterial advance — `check_recorded`, `receipt_recorded`,
-  `session_opened`, `session_resumed` — never revokes it. Frontier equality is not the rule: a
-  check necessarily advances the frontier past the subject it tested. The application constructs this context; the builder never imports a
+  after the check's own record: the check's atomic result events — the `finding_recorded` records
+  it returned and its `check_recorded` — land with it and never revoke it, and an immaterial
+  advance — `receipt_recorded`, `session_opened`, `session_resumed` — never revokes it either.
+  Frontier equality is not the rule: a check necessarily advances the frontier past the subject
+  it tested. The application constructs this context; the builder never imports a
   port type or re-derives applicability.
 - `build_receipt(context, receipt_id, task_id, session_id, generated_at,
   versions: ReceiptVersionSlice, redaction_profile, include) -> ReceiptDocument`. Every

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -528,6 +528,10 @@ review was not run; they must not reuse blocked-by-policy wording. The not-reque
 deterministic-only check and forces coverage incompleteness without changing the deterministic
 verdict.
 
+The check-applicability gap family follows the same material-state rule: `check_not_applicable`
+means material work was appended after the recorded check and superseded its verdict, never that
+the frontier merely advanced.
+
 ## 9. Kernel (`kernel/`)
 
 - `ProjectionState` (frozen): `frontier`, `head_digest`, `plans`, `obligations`, `decisions`,
@@ -633,7 +637,10 @@ verdict.
   `availability` is the current `CaseAvailabilityFacts`, `coverage` is the weakest material fold,
   `gaps` is the exact sorted typed `CaseGap` tuple after check/semantic/availability accounting, and
   `applicable_check` is the exact readable `CheckRecordedPayload` that still applies to this
-  material state or `None`. The application constructs this context; the builder never imports a
+  material state or `None`. A check applies when no event of a material family has been appended
+  after its subject frontier; an immaterial advance — `check_recorded`, `receipt_recorded`,
+  `session_opened`, `session_resumed` — never revokes it. Frontier equality is not the rule: a
+  check necessarily advances the frontier past the subject it tested. The application constructs this context; the builder never imports a
   port type or re-derives applicability.
 - `build_receipt(context, receipt_id, task_id, session_id, generated_at,
   versions: ReceiptVersionSlice, redaction_profile, include) -> ReceiptDocument`. Every

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -78,7 +78,7 @@ from yoetz.kernel.projections import (
     empty_projection_state,
     projection_digest,
 )
-from yoetz.kernel.reducers import replay
+from yoetz.kernel.reducers import is_material_event_family, replay
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.ids import IdPort
 from yoetz.ports.ledger import (
@@ -132,9 +132,11 @@ from yoetz.protocol.canonical import (
 )
 from yoetz.protocol.coverage import (
     AuthorshipAssurance,
+    Coverage,
     PublicationChannel,
     coverage_for_channel,
     coverage_to_json,
+    weakest,
 )
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
@@ -661,6 +663,36 @@ def _status_gap_codes(markers: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(sorted({marker.split(":", 1)[0] for marker in markers}, key=str.encode))
 
 
+def _compact_status_coverage(
+    records: tuple[LedgerRecord, ...], projection: ProjectionState
+) -> Coverage:
+    """Fold the applicable check's coverage into the compact-status baseline.
+
+    The newest record's envelope (often an engine-derived ``receipt_recorded``) hardcodes
+    ``check_types=(none,)`` even immediately after a rich check; the check's real coverage
+    lives in its payload. The receipt applicability rule decides whether the projected latest
+    check still covers this state: it does unless material work was appended after it.
+    """
+
+    baseline = records[-1].coverage
+    latest = projection.latest_tested_state
+    if latest is None:
+        return baseline
+    check_record = next(
+        (record for record in records if record.event_id == latest.source_check_event_id),
+        None,
+    )
+    if check_record is None or type(check_record.payload) is not CheckRecordedPayload:
+        return baseline
+    if any(
+        is_material_event_family(record.schema.name)
+        and record.ledger.ingestion_sequence > check_record.ledger.ingestion_sequence
+        for record in records
+    ):
+        return baseline
+    return weakest(baseline, check_record.payload.coverage)
+
+
 def _obligation_item(
     obligation: str,
     record: object,
@@ -921,7 +953,9 @@ def _projection_items(
                 open_obligations=open_obligations[:10],
                 unresolved_findings=unresolved_findings[:10],
                 freshness=projection.freshness.value,
-                coverage=CoverageModel.model_validate(coverage_to_json(records[-1].coverage)),
+                coverage=CoverageModel.model_validate(
+                    coverage_to_json(_compact_status_coverage(records, projection))
+                ),
                 gaps=_status_gap_codes(projection.coverage_gaps),
             ),
         )

--- a/src/yoetz/application/receipt.py
+++ b/src/yoetz/application/receipt.py
@@ -43,7 +43,7 @@ from yoetz.kernel.receipt_builder import (
     ReceiptFindingState,
     build_receipt,
 )
-from yoetz.kernel.reducers import replay
+from yoetz.kernel.reducers import is_material_event_family, replay
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.ids import IdPort
@@ -301,24 +301,34 @@ def _context(
     applicable: CheckRecordedPayload | None = None
     gaps = list(case.gaps)
     latest = projection.latest_tested_state
-    if latest is not None and latest.subject_frontier == frontier:
+    check_record: LedgerRecord | None = None
+    if latest is not None:
         for record in records:
             if record.event_id == latest.source_check_event_id:
-                if type(record.payload) is CheckRecordedPayload:
-                    applicable = record.payload
-                else:
-                    gaps.append(
-                        CaseGap(
-                            f"check_payload_unavailable:{latest.source_check_event_id}",
-                            "check_payload_unavailable",
-                            (latest.source_check_event_id,),
-                        )
-                    )
+                check_record = record
                 break
-    elif latest is None:
+    if latest is None:
         gaps.append(CaseGap("check_not_recorded", "check_not_recorded", ()))
-    else:
+    elif check_record is not None and any(
+        is_material_event_family(record.schema.name)
+        and record.ledger.ingestion_sequence > check_record.ledger.ingestion_sequence
+        for record in records
+    ):
+        # Applicability follows the material state, not frontier equality: a check applies to
+        # this receipt when no material-family event was appended after the check itself. Its
+        # own events (returned findings plus check_recorded) land atomically right after the
+        # tested frontier, so anything later is genuinely newer work that supersedes it.
         gaps.append(CaseGap("check_not_applicable", "check_not_applicable", ()))
+    elif check_record is not None and type(check_record.payload) is CheckRecordedPayload:
+        applicable = check_record.payload
+    else:
+        gaps.append(
+            CaseGap(
+                f"check_payload_unavailable:{latest.source_check_event_id}",
+                "check_payload_unavailable",
+                (latest.source_check_event_id,),
+            )
+        )
     if applicable is None and not any(
         gap.code in {"check_not_recorded", "check_not_applicable", "check_payload_unavailable"}
         for gap in gaps

--- a/src/yoetz/kernel/receipt_builder.py
+++ b/src/yoetz/kernel/receipt_builder.py
@@ -233,7 +233,7 @@ def _validate_applicable_check(context: ReceiptBuildContext) -> None:
         raise ValueError(_CONTEXT_INVALID)
     if (
         check.subject_frontier != latest.subject_frontier
-        or check.subject_frontier != context.subject_frontier
+        or check.subject_frontier.sequence > context.subject_frontier.sequence
         or check.verdict is not latest.verdict
         or check.returned_finding_ids != latest.returned_finding_ids
         or check.suppressed_count != latest.suppressed_count
@@ -707,15 +707,14 @@ def _check_absence_sentence(
 
     if "check_not_applicable" in gap_codes:
         tested = (
-            "an earlier subject"
+            "an earlier subject frontier"
             if tested_subject_sequence is None
             else f"subject frontier {tested_subject_sequence}"
         )
         return (
-            f"A check is recorded, but it tested {tested} rather than frontier "
-            f"{frontier.sequence}, so it does not contribute to this receipt's coverage. Any "
-            "verdict it returned, including one backed by external review, stands only for what "
-            "it tested. Re-run check at this frontier to make it count."
+            f"A check is recorded at {tested}, but material work was published after it, so "
+            f"its verdict no longer covers frontier {frontier.sequence}. Re-run check at this "
+            "frontier to restore coverage."
         )
     if "check_not_recorded" in gap_codes:
         return (
@@ -817,9 +816,9 @@ def _sections(
             SEMANTIC_REVIEW_NOT_CONFIGURED_GAP in gap_codes
             or SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP in gap_codes
         )
-        # A check that ran and succeeded still contributes nothing unless it tested this exact
-        # subject. Saying only `check_not_applicable` next to a fresh successful check reads as a
-        # contradiction; the 2026-07-27 dogfood could not tell which of four readings was meant.
+        # A check that ran and succeeded still contributes nothing once material work lands
+        # after it. Saying only `check_not_applicable` next to a fresh successful check reads as
+        # a contradiction; the 2026-07-27 dogfood could not tell which of four readings was meant.
         check_absence = _check_absence_sentence(gap_codes, frontier, tested_subject_sequence)
         if check_absence:
             gap_body = f"{check_absence} Coverage is limited by: {', '.join(gap_codes)}."

--- a/src/yoetz/kernel/reducers.py
+++ b/src/yoetz/kernel/reducers.py
@@ -67,6 +67,7 @@ __all__ = [
     "ReplayIndex",
     "empty_replay_index",
     "extend_replay_index",
+    "is_material_event_family",
     "reduce_event",
     "replay",
 ]
@@ -87,6 +88,11 @@ _MATERIAL_FAMILIES: Final = frozenset(
         "result_recorded",
     }
 )
+
+
+def is_material_event_family(name: str) -> bool:
+    """True when an event of this family invalidates a previously recorded check."""
+    return name in _MATERIAL_FAMILIES
 
 
 def _corrupt() -> ValueError:

--- a/tests/integration/application/test_respond_status_receipt.py
+++ b/tests/integration/application/test_respond_status_receipt.py
@@ -42,6 +42,7 @@ from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
 from yoetz.ports.ledger import CheckCommitResult
 from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
 from yoetz.protocol.canonical import JsonValue
+from yoetz.protocol.coverage import CheckType
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.models import (
     CheckRequest,
@@ -49,6 +50,7 @@ from yoetz.protocol.models import (
     PublishWorkRequest,
     ReceiptRequest,
     RespondRequest,
+    StatusCompactPageModel,
     StatusEvidencePageModel,
     StatusFindingsPageModel,
     StatusRequest,
@@ -789,9 +791,9 @@ async def test_receipt_build_context_is_complete() -> None:
     versions = cast(Mapping[str, JsonValue], document["versions"])
     assert versions["package_version"] == "0.1.0"
     assert versions["resource_manifest_digest"] == _DIGEST
-    # The response advanced the frontier past the last check, so the frozen case honestly
-    # reports the check as no longer applicable at this exact frontier rather than silently
-    # reusing stale check facts.
+    # The response is material work published after the last check, so the frozen case honestly
+    # reports the check as superseded by that material change rather than silently reusing stale
+    # check facts. Frontier arithmetic alone (an immaterial advance) never produces this gap.
     assert receipt.coverage.known_gaps == ("check_not_applicable",)
     gaps = cast(tuple[Mapping[str, JsonValue], ...], document["gaps"])
     assert any(cast(str, gap["code"]) == "check_not_applicable" for gap in gaps)
@@ -805,11 +807,10 @@ async def test_receipt_build_context_is_complete() -> None:
         for section in sections
         if cast(str, section["key"]) == "limitations_and_coverage"
     )
-    assert "A check is recorded, but it tested subject frontier" in limitations
-    assert f"rather than frontier {receipt.subject_frontier.sequence}" in limitations
-    # Name the trap directly: a successful external review does not travel to a later subject.
-    assert "including one backed by external review" in limitations
-    assert "Re-run check at this frontier to make it count." in limitations
+    assert "A check is recorded at subject frontier" in limitations
+    assert "material work was published after it" in limitations
+    assert f"no longer covers frontier {receipt.subject_frontier.sequence}" in limitations
+    assert "Re-run check at this frontier to restore coverage." in limitations
 
     text_wire: dict[str, JsonValue] = {
         **receipt_wire,
@@ -824,3 +825,125 @@ async def test_receipt_build_context_is_complete() -> None:
     # the human wording rather than the wire enum spelling (spaces, not underscores).
     assert "unresolved findings remain" in text_receipt.human_text
     assert text_receipt.conclusion == receipt.conclusion
+
+
+async def test_successful_check_contributes_to_receipt_at_resulting_head() -> None:
+    """2026-07-27 run-2 regression: a check at subject frontier N appends its own events
+    (``check_recorded`` plus one ``finding_recorded`` per returned finding), landing past N.
+    A receipt taken at that head must still count the check: applicability follows the material
+    state, never frontier equality, which could never hold."""
+
+    app, _runtime, _ = _build_app(seed_offset=7)
+    started, checked, _obligation = await _bootstrap_finding(app, seed=1000)
+    # The check's own events (one check_recorded plus one finding_recorded per returned finding)
+    # advance the frontier past the tested subject, so strict frontier equality could never hold.
+    assert checked.findings
+    assert checked.result_frontier.sequence > checked.subject_frontier.sequence
+
+    receipt_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 1010)),
+        "task_id": started.task_id,
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(checked.result_frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+    receipt = await app.receipt(ReceiptRequest.model_validate(receipt_wire))
+
+    assert "check_not_applicable" not in receipt.coverage.known_gaps
+    # The applicable check's coverage folds into the receipt, so its check types carry through.
+    assert CheckType.DETERMINISTIC in receipt.coverage.check_types
+    # The bootstrap finding is unresolved, so the conclusion still cannot be strong; what
+    # changes is that the check now contributes instead of being dropped by frontier arithmetic.
+    assert receipt.conclusion == "unresolved_findings_remain"
+    assert receipt.suppressed_finding_count == 0
+
+    # An immaterial advance never revokes the check: a receipt taken after the first receipt's
+    # own ``receipt_recorded`` event still applies the same check.
+    later_wire: dict[str, JsonValue] = {
+        **receipt_wire,
+        "request_id": protocol_id("req_", 1011),
+        "expected_frontier": _frontier(receipt.result_frontier),
+    }
+    later = await app.receipt(ReceiptRequest.model_validate(later_wire))
+    assert "check_not_applicable" not in later.coverage.known_gaps
+    assert CheckType.DETERMINISTIC in later.coverage.check_types
+
+    # Compact status reports the applicable check's coverage, not the newest envelope baseline:
+    # the head record is the receipt's own engine-derived event (check_types=(none,)), yet the
+    # check still shows through. This was the run-2 symptom (`check_types=["none"]` at head).
+    status = await app.status(
+        StatusRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 1012)),
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "view": "compact",
+                "limit": "10",
+            }
+        )
+    )
+    compact = cast(StatusCompactPageModel, status.page)
+    assert CheckType.DETERMINISTIC in compact.items[0].coverage.check_types
+
+
+async def test_material_work_after_check_produces_check_not_applicable() -> None:
+    """The gap still fires when it should: material work published after the check supersedes
+    its verdict, and the limitations wording says exactly that."""
+
+    app, _runtime, _ = _build_app(seed_offset=8)
+    started, checked, _obligation = await _bootstrap_finding(app, seed=1100)
+
+    publish_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 1110)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(checked.result_frontier),
+        "event_drafts": (
+            {
+                "event_id": protocol_id("evt_", 1111),
+                "schema": {"name": "claim_recorded", "version": "1.0.0"},
+                "occurred_at": "2026-07-19T12:00:02.000Z",
+                "causal_parents": (),
+                "payload": {
+                    "claim_id": protocol_id("clm_", 1112),
+                    "claim_kind": "material",
+                    "statement": "New material work landed after the check.",
+                    "supporting_refs": (),
+                    "obligation_refs": (),
+                },
+                "artifact_refs": (),
+                "evidence_refs": (),
+            },
+        ),
+    }
+    published = await app.publish_work(PublishWorkRequest.model_validate(publish_wire))
+
+    receipt = await app.receipt(
+        ReceiptRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 1113)),
+                "task_id": started.task_id,
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(published.result_frontier),
+                "format": "json",
+                "include": "standard",
+                "redaction_profile": "full_local",
+            }
+        )
+    )
+
+    assert "check_not_applicable" in receipt.coverage.known_gaps
+    assert receipt.document is not None
+    document = cast(Mapping[str, JsonValue], receipt.document)
+    sections = cast(tuple[Mapping[str, JsonValue], ...], document["sections"])
+    limitations = next(
+        cast(str, section["body"])
+        for section in sections
+        if cast(str, section["key"]) == "limitations_and_coverage"
+    )
+    assert "material work was published after it" in limitations
+    assert "Re-run check at this frontier to restore coverage." in limitations

--- a/tests/unit/kernel/test_receipt_builder.py
+++ b/tests/unit/kernel/test_receipt_builder.py
@@ -388,6 +388,38 @@ def test_context_requires_explicit_availability_and_applicable_check() -> None:
         )
 
 
+def test_applicable_check_at_earlier_subject_frontier_builds() -> None:
+    """Applicability follows the material state, not frontier equality: a check recorded at an
+    earlier subject frontier still applies to this context. The builder trusts the application's
+    applicability decision and never re-derives it."""
+
+    coverage = _coverage()
+    check = replace(
+        _check(CheckVerdict.NO_ISSUE_DETECTED, coverage),
+        subject_frontier=Frontier(1, _DIGEST),
+    )
+    receipt = _build(_context(check=check))
+    assert receipt.conclusion is ReceiptConclusion.NO_UNRESOLVED_DETERMINISTIC_FINDINGS
+    assert receipt.suppressed_finding_count == 0
+
+
+def test_applicable_check_ahead_of_context_is_rejected() -> None:
+    coverage = _coverage()
+    check = _check(CheckVerdict.NO_ISSUE_DETECTED, coverage)
+    projection = cast("ProjectionState", _projection(check=check))
+    ahead = replace(check, subject_frontier=Frontier(3, "sha256:" + "3" * 64))
+    with pytest.raises(ValueError, match="receipt_build_context_invalid"):
+        ReceiptBuildContext(
+            projection=projection,
+            subject_frontier=_FRONTIER,
+            availability=CaseAvailabilityFacts(),
+            coverage=coverage,
+            gaps=(),
+            finding_states=(),
+            applicable_check=ahead,
+        )
+
+
 def test_receipt_version_slice_is_exact() -> None:
     context = _context(check=_check(CheckVerdict.NO_ISSUE_DETECTED, _coverage()))
     receipt = _build(context)


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #34
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gate: receipt coverage is **not** in the areas needing maintainer acknowledgement
  (privacy/egress, storage/durability, release/packaging, new ADRs), so this proceeded once #34
  existed. **No ADR is needed**: `docs/INTERFACES.md` already specifies material-state
  applicability ("still applies to this material state"), so this restores the written contract
  rather than changing it — do not read this coverage change as a spec change.

Remediates the highest-severity finding of the 2026-07-27 run-2 dogfood
(`docs/postmortems/2026-07-27-codex-testing-yoetz-openrouter-easy-linking-run2.md`): a
`semantic_required` check succeeded at subject frontier 8 with full external provenance, and the
receipt immediately after reported `conclusion=insufficient_coverage`,
`check_types=["deterministic"]`, `known_gaps=["check_not_applicable"]` — the check contributed
nothing.

**Root cause:** applicability was strict frontier equality, but recording a check appends
`check_recorded` (plus one `finding_recorded` per returned finding), advancing the frontier past
the tested subject — `tests/conformance/adapters/test_memory_sqlite_parity.py` pins exactly this
(+2 for a one-finding check) and is the clearest existing proof the equality could never hold.
With the receipt's subject frontier forced to the ledger head, no frontier existed at which a
check-covered receipt could be obtained. A prior fix (`433acc1`) added explanatory wording; this
PR corrects the coverage.

## Documentation

- Behavior change? `yes` (receipt/status coverage semantics restored to the written contract)
- Docs updated: `docs/INTERFACES.md` — `applicable_check` definition sharpened (a check applies
  when no material-family event was appended after the check's own record; its atomic result
  events and immaterial advances never revoke it) and the gap-family note for
  `check_not_applicable` (material work superseded the check, not mere frontier advance).

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/kernel/test_receipt_builder.py \
              tests/integration/application/test_respond_status_receipt.py \
              tests/conformance/operations/test_receipt_contract.py \
              tests/conformance/honesty/test_receipt_wording.py \
              tests/property/test_receipt_properties.py \
              tests/conformance/adapters/test_memory_sqlite_parity.py \
              tests/integration/application/test_full_workflow.py
# 58 passed
uv run pytest tests/unit/kernel tests/integration/application \
              tests/conformance/operations tests/conformance/adapters tests/conformance/honesty
# 257 passed
uv run ruff check src/yoetz/application/receipt.py src/yoetz/kernel/receipt_builder.py \
                  src/yoetz/kernel/reducers.py src/yoetz/adapters/memory/ledger.py
# All checks passed
uv run ruff format --check src tests
# 421 files already formatted
npx --no-install pyright
# 0 errors, 0 warnings, 0 informations
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Applicability now follows the material state, matching the kernel's existing staleness concept
(`_MATERIAL_FAMILIES`, which excludes `check_recorded`, `receipt_recorded`, `session_opened`,
`session_resumed`):

- **`kernel/reducers.py`** — expose `is_material_event_family` over the existing private set.
- **`application/receipt.py`** — a check applies when no material-family event was appended after
  the check's own record. The scan runs over the complete genesis-through-frontier window and
  starts *after the check record itself*, so the check's own atomically appended events
  (`finding_recorded` + `check_recorded`, committed in one frontier-guarded
  `commit_check_if_current` batch) never self-invalidate. `check_not_recorded` /
  `check_payload_unavailable` unchanged.
- **`kernel/receipt_builder.py`** — context invariant relaxes from frontier equality to an
  ordering constraint (a check *ahead* of the context still raises); the payload-identity guard
  stays; the builder still never re-derives applicability. The `check_not_applicable` limitation
  is reworded: material work superseded the check; re-run to restore coverage.
- **Compact status** (bounded, read-side only, ~22 lines) — fold the applicable check's payload
  coverage into the compact baseline instead of reporting the newest envelope, which hardcoded
  `check_types=["none"]` right after a rich check. The write-only persisted
  `status_coverage_canonical` column is untouched; SQLite delegates to the same oracle, so
  memory/SQLite parity holds.
- **`check_types`** needed no fold change: `receipt.py` already merges
  `weakest(coverage, applicable.coverage)` and `weakest` unions `check_types`, so an applicable
  semantic check's `semantic_model_derived` (built by `case_coverage(semantic=True)`) carries
  through the same path now proven end-to-end for `deterministic`.

Consequences: `NO_UNRESOLVED_DETERMINISTIC_FINDINGS` is reachable for a clean run;
`check_not_applicable` still fires — correctly — when material work lands after the check (the
golden context test is repointed at that genuine material-change case, not deleted); frozen
`fixtures/receipts/*.case.json` vectors are untouched (they round-trip stored JSON and carry none
of the changed wording).

Tests: kernel unit tests pin that an earlier-frontier check now builds and an ahead check still
raises; integration tests pin that a successful check contributes at the resulting head (including
through the receipt's own immaterial advance, and in compact status) and that material work after
the check still produces the gap with the new wording.