### PR TITLE
fix: bind semantic provenance to the policy digest that authorized the dispatch

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -407,6 +407,12 @@ commitment when applicable; and the validated terminal status/reason pair. The e
 and wire conversions are frozen in `domain/findings.md` and
 `semantic-provenance-1.0.0.schema.json`.
 
+`policy_digest` and `privacy_policy_digest` on `ProviderAttemptProvenance` and
+`SemanticProvenance` are bound by the outbound gateway to the effective policy digest that
+authorized the physical dispatch — the same value carried by `ApprovedOutboundCase.policy_digest`,
+`EgressAuthorization.policy_digest`, and `EgressReceipt.policy.policy_digest`. A provider adapter
+never asserts them. On a successful dispatch they are never placeholder or all-zero values.
+
 A deterministic candidate/finding forbids provenance. A semantic-model-derived candidate/finding
 requires receipt-finalized provenance whose status/reason is exactly
 `succeeded/semantic_completed`; failed, refused, stale, late, invalid, timeout, or unavailable

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -46,6 +46,7 @@ from yoetz.domain.privacy import (
     PRIVACY_REQUEST_COMMITMENT_ALGORITHM,
     ApprovedLocalDisclosureCase,
     ApprovedOutboundCase,
+    ApprovedProviderCase,
     ConsentSource,
     EgressAuthorization,
     EgressChannel,
@@ -542,6 +543,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
         dispatch_started_at = self._clock.now_utc()
         try:
             result = await evaluator.evaluate(case, deadline)
+            result = _with_policy_digest(result, case)
             result = _with_request_commitment(result, commitment)
             outcome, receipt_reason = _result_outcome(result)
         except Exception:  # noqa: BLE001 - an ambiguous transport failure never leaks native text
@@ -722,7 +724,12 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
         except Exception:  # noqa: BLE001 - a lost consume race is bounded here
             return _local_unavailable_result(case)
 
-        return await evaluator.evaluate(case, deadline)
+        result = await evaluator.evaluate(case, deadline)
+        # Only the rebind is fenced here: an evaluator failure keeps propagating exactly as before.
+        try:
+            return _with_policy_digest(result, case)
+        except ValueError:
+            return _local_unavailable_result(case)
 
     # -- lifecycle ------------------------------------------------------------------------------
 
@@ -782,6 +789,36 @@ def _with_request_commitment(result: SemanticResult, commitment: str) -> Semanti
     """Carry the gateway-bound request commitment into the receipt-bound semantic outcome."""
 
     return replace(result, provenance=replace(result.provenance, request_commitment=commitment))
+
+
+def _with_policy_digest(result: SemanticResult, case: ApprovedProviderCase) -> SemanticResult:
+    """Bind provenance to the policy digest that actually authorized this physical dispatch.
+
+    The gateway, not the provider adapter, is the authority on which policy admitted an attempt: it
+    already refuses to dispatch unless ``case.policy_digest`` equals both the authorization's and
+    the current registry's policy digest (see :meth:`OutboundPrivacyGateway._predispatch_reason`),
+    and it stamps that same value onto :class:`EgressReceipt`. Rebinding here makes provenance and
+    the egress receipt agree by construction, and keeps a foreign adapter from ever asserting what
+    authorized it.
+
+    A dispatch that reached a provider and succeeded must carry a real digest. An all-zero
+    placeholder surviving the rebind means the authorizing policy digest was itself a placeholder,
+    so the attempt is refused rather than recorded as if a real policy had authorized it: external
+    dispatch degrades to the bounded ``outcome_unknown`` receipt and local dispatch to the bounded
+    unavailable result. Genuinely-blocked results that never reached a provider keep their
+    :attr:`SemanticStatus.UNAVAILABLE` zeros untouched.
+    """
+
+    provenance = replace(
+        result.provenance,
+        policy_digest=case.policy_digest,
+        privacy_policy_digest=case.policy_digest,
+    )
+    if provenance.status is SemanticStatus.SUCCEEDED and (
+        provenance.policy_digest == _ZERO_DIGEST or provenance.privacy_policy_digest == _ZERO_DIGEST
+    ):
+        raise ValueError("privacy_gateway_provenance_policy_digest_placeholder")
+    return replace(result, provenance=provenance)
 
 
 def _result_outcome(result: SemanticResult) -> tuple[PrivacyOutcome, PrivacyReason | None]:

--- a/src/yoetz/adapters/providers/fake.py
+++ b/src/yoetz/adapters/providers/fake.py
@@ -10,7 +10,7 @@ and never invents richer provenance than a live adapter would produce.
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from threading import Lock
 from typing import Final
 
@@ -87,6 +87,24 @@ def _provenance(
         token_usage=token_usage,
         cost_fields=cost_fields,
         failure_class=failure_class,
+    )
+
+
+def _with_policy_digest(result: SemanticResult, policy_digest: str) -> SemanticResult:
+    """Bind a scripted step's provenance to the policy digest that authorized this dispatch.
+
+    A script is authored before any case exists, so the scripted steps carry a placeholder digest.
+    Rebinding at dispatch time keeps the fake honest in exactly the way a live adapter is: the
+    approved case is the only source of the policy digest, and the fake never asserts one of its
+    own. The gateway rebinds this again, authoritatively; doing it here means the fake is never
+    wrong even when driven directly.
+    """
+
+    return replace(
+        result,
+        provenance=replace(
+            result.provenance, policy_digest=policy_digest, privacy_policy_digest=policy_digest
+        ),
     )
 
 
@@ -230,7 +248,9 @@ class ScriptedFakeSemanticEvaluator:
         if self._clock is not None:
             now = self._clock.monotonic_seconds() + step.delay_seconds
             if deadline.expired(now):
-                return SemanticResultTimeout(_provenance(SemanticStatus.TIMEOUT))
+                return _with_policy_digest(
+                    SemanticResultTimeout(_provenance(SemanticStatus.TIMEOUT)), case.policy_digest
+                )
         elif step.delay_seconds:
             await anyio.sleep(step.delay_seconds)
-        return step.result
+        return _with_policy_digest(step.result, case.policy_digest)

--- a/src/yoetz/adapters/providers/local_model.py
+++ b/src/yoetz/adapters/providers/local_model.py
@@ -196,6 +196,7 @@ def _provenance(
     profile: LocalModelEndpointProfile,
     status: SemanticStatus,
     *,
+    policy_digest: str,
     latency_ms: int,
     failure_class: SemanticFailureClass | None = None,
 ) -> ProviderAttemptProvenance:
@@ -207,8 +208,8 @@ def _provenance(
         sdk_version=profile.protocol_version,
         prompt_digest=profile.capability_evidence_digest,
         schema_digest=profile.capability_evidence_digest,
-        policy_digest=profile.release_resource_digest,
-        privacy_policy_digest=profile.release_resource_digest,
+        policy_digest=policy_digest,
+        privacy_policy_digest=policy_digest,
         sampling_params=SamplingParams(_MAX_LOCAL_OUTPUT_TOKENS),
         latency_ms=latency_ms,
         status=status,
@@ -261,6 +262,7 @@ def normalize_local_response(
     raw: bytes,
     profile: LocalModelEndpointProfile,
     *,
+    policy_digest: str,
     latency_ms: int,
 ) -> SemanticResult:
     """Parse and validate one bounded local-model response into a closed semantic result.
@@ -268,6 +270,10 @@ def normalize_local_response(
     Missing installed tuple/socket/resolver/evidence, peer or generation mismatch, unsupported
     schema/model, refusal, or invalid/truncated output all return bounded status with no raw
     response retention beyond this call.
+
+    ``policy_digest`` is the policy digest that authorized this disclosure, carried by the approved
+    case. The adapter never mints one of its own; the outbound gateway rebinds it authoritatively
+    after this returns.
     """
 
     if type(raw) is not bytes or not 0 < len(raw) <= _MAX_LOCAL_RESPONSE_BYTES:
@@ -275,6 +281,7 @@ def normalize_local_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
             ),
@@ -288,13 +295,20 @@ def normalize_local_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
             ),
             raw_size=len(raw),
         )
     return SemanticResultSuccess(
-        judgment, _provenance(profile, SemanticStatus.SUCCEEDED, latency_ms=latency_ms)
+        judgment,
+        _provenance(
+            profile,
+            SemanticStatus.SUCCEEDED,
+            policy_digest=policy_digest,
+            latency_ms=latency_ms,
+        ),
     )
 
 
@@ -339,7 +353,12 @@ class LocalModelEvaluator:
         now_monotonic = self._clock.monotonic_seconds()
         if deadline.expired(now_monotonic):
             return SemanticResultTimeout(
-                _provenance(self._profile, SemanticStatus.TIMEOUT, latency_ms=0)
+                _provenance(
+                    self._profile,
+                    SemanticStatus.TIMEOUT,
+                    policy_digest=case.policy_digest,
+                    latency_ms=0,
+                )
             )
 
         try:
@@ -351,10 +370,13 @@ class LocalModelEvaluator:
                 _provenance(
                     self._profile,
                     SemanticStatus.UNAVAILABLE,
+                    policy_digest=case.policy_digest,
                     latency_ms=elapsed_ms,
                     failure_class=SemanticFailureClass.TRANSPORT,
                 )
             )
 
         latency_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
-        return normalize_local_response(raw, self._profile, latency_ms=latency_ms)
+        return normalize_local_response(
+            raw, self._profile, policy_digest=case.policy_digest, latency_ms=latency_ms
+        )

--- a/src/yoetz/adapters/providers/openai_chat_completions.py
+++ b/src/yoetz/adapters/providers/openai_chat_completions.py
@@ -250,6 +250,7 @@ def _provenance(
     profile: ChatCompletionsProfile,
     status: SemanticStatus,
     *,
+    policy_digest: str,
     latency_ms: int,
     provider_request_id: str | None = None,
     failure_class: SemanticFailureClass | None = None,
@@ -262,8 +263,8 @@ def _provenance(
         sdk_version="2.46.0",
         prompt_digest=_PROMPT_DIGEST,
         schema_digest=_SCHEMA_DIGEST,
-        policy_digest="sha256:" + "0" * 64,
-        privacy_policy_digest="sha256:" + "0" * 64,
+        policy_digest=policy_digest,
+        privacy_policy_digest=policy_digest,
         sampling_params=SamplingParams(OPENAI_MAX_OUTPUT_TOKENS),
         latency_ms=latency_ms,
         status=status,
@@ -284,6 +285,7 @@ def normalize_response(
     response: object,
     profile: ChatCompletionsProfile,
     *,
+    policy_digest: str,
     latency_ms: int,
     late: bool = False,
 ) -> SemanticResult:
@@ -293,6 +295,10 @@ def normalize_response(
     filtering next, parse/schema validity next, and late-arrival state last. A host that ignored
     the requested structure lands in the invalid branch, which is the honest outcome; there is no
     prose-to-judgment repair path.
+
+    ``policy_digest`` is the policy digest that authorized this dispatch, carried by the approved
+    case. The adapter never mints one of its own; the outbound gateway rebinds it authoritatively
+    after this returns.
     """
 
     provider_request_id = getattr(response, "id", None)
@@ -308,6 +314,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.REFUSED,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
             )
@@ -319,6 +326,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.REFUSED,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
             )
@@ -329,6 +337,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.TIMEOUT,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.TIMEOUT,
@@ -341,6 +350,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -353,6 +363,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -366,6 +377,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -378,6 +390,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.LATE,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
             )
@@ -387,6 +400,7 @@ def normalize_response(
         _provenance(
             profile,
             SemanticStatus.SUCCEEDED,
+            policy_digest=policy_digest,
             latency_ms=latency_ms,
             provider_request_id=provider_request_id,
         ),
@@ -394,7 +408,7 @@ def normalize_response(
 
 
 def classify_provider_failure(
-    error: BaseException, profile: ChatCompletionsProfile, *, latency_ms: int
+    error: BaseException, profile: ChatCompletionsProfile, *, policy_digest: str, latency_ms: int
 ) -> SemanticResult:
     """Map a native provider/transport failure to the public taxonomy without leaking its text."""
 
@@ -403,6 +417,7 @@ def classify_provider_failure(
             _provenance(
                 profile,
                 SemanticStatus.TIMEOUT,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.TIMEOUT,
             )
@@ -412,6 +427,7 @@ def classify_provider_failure(
             _provenance(
                 profile,
                 SemanticStatus.UNAVAILABLE,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.TRANSPORT,
             )
@@ -440,6 +456,7 @@ def classify_provider_failure(
         _provenance(
             profile,
             SemanticStatus.UNAVAILABLE,
+            policy_digest=policy_digest,
             latency_ms=latency_ms,
             failure_class=failure_class,
         )
@@ -489,6 +506,7 @@ class ChatCompletionsEvaluator:
                 _provenance(
                     self._profile,
                     SemanticStatus.TIMEOUT,
+                    policy_digest=case.policy_digest,
                     latency_ms=0,
                     failure_class=SemanticFailureClass.TIMEOUT,
                 )
@@ -503,6 +521,7 @@ class ChatCompletionsEvaluator:
                 _provenance(
                     self._profile,
                     SemanticStatus.UNAVAILABLE,
+                    policy_digest=case.policy_digest,
                     latency_ms=0,
                     failure_class=SemanticFailureClass.UNSUPPORTED_PROFILE,
                 )
@@ -523,9 +542,13 @@ class ChatCompletionsEvaluator:
                 await client.close()
         except Exception as exc:  # noqa: BLE001 - classified below, never re-raised raw
             elapsed_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
-            return classify_provider_failure(exc, self._profile, latency_ms=elapsed_ms)
+            return classify_provider_failure(
+                exc, self._profile, policy_digest=case.policy_digest, latency_ms=elapsed_ms
+            )
         finally:
             await http_client.aclose()
 
         elapsed_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
-        return normalize_response(response, self._profile, latency_ms=elapsed_ms)
+        return normalize_response(
+            response, self._profile, policy_digest=case.policy_digest, latency_ms=elapsed_ms
+        )

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -387,6 +387,7 @@ def _provenance(
     profile: OpenAIProfile,
     status: SemanticStatus,
     *,
+    policy_digest: str,
     latency_ms: int,
     provider_request_id: str | None = None,
     failure_class: SemanticFailureClass | None = None,
@@ -399,8 +400,8 @@ def _provenance(
         sdk_version="2.46.0",
         prompt_digest=_PROMPT_DIGEST,
         schema_digest=_SCHEMA_DIGEST,
-        policy_digest="sha256:" + "0" * 64,
-        privacy_policy_digest="sha256:" + "0" * 64,
+        policy_digest=policy_digest,
+        privacy_policy_digest=policy_digest,
         sampling_params=SamplingParams(OPENAI_MAX_OUTPUT_TOKENS),
         latency_ms=latency_ms,
         status=status,
@@ -462,6 +463,7 @@ def normalize_response(
     response: object,
     profile: OpenAIProfile,
     *,
+    policy_digest: str,
     latency_ms: int,
     late: bool = False,
 ) -> SemanticResult:
@@ -469,6 +471,10 @@ def normalize_response(
 
     Inspection order is fixed: explicit refusal surface first, deadline/cancellation next,
     parse/schema validity next, and late-arrival state last.
+
+    ``policy_digest`` is the policy digest that authorized this dispatch, carried by the approved
+    case. The adapter never mints one of its own; the outbound gateway rebinds it authoritatively
+    after this returns.
     """
 
     provider_request_id = getattr(response, "id", None)
@@ -481,6 +487,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.REFUSED,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
             )
@@ -492,6 +499,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.TIMEOUT,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.TIMEOUT,
@@ -504,6 +512,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -516,6 +525,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -530,6 +540,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.INVALID,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
                 failure_class=SemanticFailureClass.RESPONSE_SCHEMA,
@@ -542,6 +553,7 @@ def normalize_response(
             _provenance(
                 profile,
                 SemanticStatus.LATE,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 provider_request_id=provider_request_id,
             )
@@ -551,6 +563,7 @@ def normalize_response(
         _provenance(
             profile,
             SemanticStatus.SUCCEEDED,
+            policy_digest=policy_digest,
             latency_ms=latency_ms,
             provider_request_id=provider_request_id,
         ),
@@ -558,7 +571,7 @@ def normalize_response(
 
 
 def classify_provider_failure(
-    error: BaseException, profile: OpenAIProfile, *, latency_ms: int
+    error: BaseException, profile: OpenAIProfile, *, policy_digest: str, latency_ms: int
 ) -> SemanticResult:
     """Map a native provider/transport failure to the public taxonomy without leaking its text."""
 
@@ -567,6 +580,7 @@ def classify_provider_failure(
             _provenance(
                 profile,
                 SemanticStatus.TIMEOUT,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.TIMEOUT,
             )
@@ -576,6 +590,7 @@ def classify_provider_failure(
             _provenance(
                 profile,
                 SemanticStatus.UNAVAILABLE,
+                policy_digest=policy_digest,
                 latency_ms=latency_ms,
                 failure_class=SemanticFailureClass.TRANSPORT,
             )
@@ -600,6 +615,7 @@ def classify_provider_failure(
         _provenance(
             profile,
             SemanticStatus.UNAVAILABLE,
+            policy_digest=policy_digest,
             latency_ms=latency_ms,
             failure_class=failure_class,
         )
@@ -748,6 +764,7 @@ class OpenAIResponsesEvaluator:
                 _provenance(
                     self._profile,
                     SemanticStatus.TIMEOUT,
+                    policy_digest=case.policy_digest,
                     latency_ms=0,
                     failure_class=SemanticFailureClass.TIMEOUT,
                 )
@@ -770,6 +787,7 @@ class OpenAIResponsesEvaluator:
                 _provenance(
                     self._profile,
                     SemanticStatus.UNAVAILABLE,
+                    policy_digest=case.policy_digest,
                     latency_ms=0,
                     failure_class=SemanticFailureClass.UNSUPPORTED_PROFILE,
                 )
@@ -787,10 +805,14 @@ class OpenAIResponsesEvaluator:
             response = await client.responses.create(**body_object)
         except Exception as exc:  # noqa: BLE001 - classified below, never re-raised raw
             elapsed_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
-            return classify_provider_failure(exc, self._profile, latency_ms=elapsed_ms)
+            return classify_provider_failure(
+                exc, self._profile, policy_digest=case.policy_digest, latency_ms=elapsed_ms
+            )
         finally:
             await client.close()
             await http_client.aclose()
 
         elapsed_ms = max(0, int((self._clock.monotonic_seconds() - now_monotonic) * 1_000))
-        return normalize_response(response, self._profile, latency_ms=elapsed_ms)
+        return normalize_response(
+            response, self._profile, policy_digest=case.policy_digest, latency_ms=elapsed_ms
+        )

--- a/tests/integration/privacy/test_egress_gateway.py
+++ b/tests/integration/privacy/test_egress_gateway.py
@@ -16,7 +16,12 @@ import hmac as hmac_module
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 
-from yoetz.adapters.privacy.gateway import PolicyEnforcingOutboundGateway
+import pytest
+
+from yoetz.adapters.privacy.gateway import (
+    PolicyEnforcingOutboundGateway,
+    _with_policy_digest,  # pyright: ignore[reportPrivateUsage]
+)
 from yoetz.adapters.privacy.local_enforcer import LocalPrivacyEnforcer
 from yoetz.adapters.providers.factory import external_factory_builders_from_config
 from yoetz.adapters.providers.fake import (
@@ -30,7 +35,7 @@ from yoetz.adapters.providers.local_model import (
 )
 from yoetz.adapters.providers.openai_responses_factory import provider_binding_from_config
 from yoetz.config.write import anthropic_provider
-from yoetz.domain.findings import SemanticFailureClass
+from yoetz.domain.findings import SamplingParams, SemanticFailureClass
 from yoetz.domain.privacy import (
     ApprovedLocalDisclosureCase,
     ApprovedOutboundCase,
@@ -63,6 +68,7 @@ from yoetz.ports.privacy import (
 from yoetz.ports.secret_memory import ProviderAttemptAuthBinding
 from yoetz.ports.semantic import (
     Deadline,
+    ProviderAttemptProvenance,
     SemanticJudgment,
     SemanticResult,
     SemanticResultSuccess,
@@ -70,6 +76,7 @@ from yoetz.ports.semantic import (
 )
 from yoetz.protocol.canonical import canonical_encode
 from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import SemanticStatus
 
 _INSTALLATION = "ins_60000000-0000-4000-8000-000000000001"
 _TASK = "tsk_60000000-0000-4000-8000-000000000002"
@@ -496,6 +503,29 @@ def _case(
     )
 
 
+def _provenance(
+    status: SemanticStatus,
+    *,
+    policy_digest: str,
+    failure_class: SemanticFailureClass | None = None,
+) -> ProviderAttemptProvenance:
+    return ProviderAttemptProvenance(
+        provider=_PROVIDER_ID,
+        endpoint_profile_id=_ENDPOINT_ID,
+        endpoint_profile_version=_ENDPOINT_VERSION,
+        model=_MODEL_ID,
+        sdk_version="0.0.0",
+        prompt_digest=_DIGEST_2,
+        schema_digest=_DIGEST_2,
+        policy_digest=policy_digest,
+        privacy_policy_digest=policy_digest,
+        sampling_params=SamplingParams(128),
+        latency_ms=1,
+        status=status,
+        failure_class=failure_class,
+    )
+
+
 def _deadline(clock: _Clock, *, remaining_seconds: float = 30.0) -> Deadline:
     return Deadline(_NOW + timedelta(minutes=5), clock.monotonic + remaining_seconds)
 
@@ -581,6 +611,62 @@ def test_reconcile_and_dispatch_external_semantic_succeeds() -> None:
     assert receipt.request_commitment.commitment == expected_commitment
     assert receipt.request_commitment.algorithm == "hmac-sha256/yoetz-privacy-egress-request-v1"
     assert receipt.counts.request_body_bytes == len(rendered_body)
+    # Provenance and the egress receipt agree about which policy authorized this dispatch, and
+    # neither carries the placeholder the provider adapter would otherwise have minted.
+    assert result.provenance.policy_digest == receipt.policy.policy_digest
+    assert result.provenance.privacy_policy_digest == receipt.policy.policy_digest
+    assert receipt.policy.policy_digest == policy.policy_digest
+    assert result.provenance.policy_digest != "sha256:" + "0" * 64
+
+
+def test_a_placeholder_policy_digest_can_never_ride_a_successful_dispatch() -> None:
+    """The dispatch-boundary fence, exercised directly at the boundary that owns it.
+
+    Reaching this through the public dispatch path is impossible by construction -- the gateway
+    already refuses to dispatch unless the case, the authorization, and the live registry agree on
+    the policy digest, and a real policy digest is a canonical digest that is never all zeros. That
+    is precisely why the fence is worth pinning: it is the assertion that keeps the pre-fix
+    behaviour (an adapter-minted all-zero digest recorded as if a real policy had authorized it)
+    from silently returning.
+    """
+
+    authorization = _authorization(
+        authorization_id="aut_60000000-0000-4000-8000-000000000090",
+        policy_digest=_DIGEST,
+        service_generation=1,
+    )
+    case = _case(
+        case_id="cas_60000000-0000-4000-8000-000000000091",
+        authorization=authorization,
+        payload=canonical_encode({"note": "hello"}),
+    )
+    zero = "sha256:" + "0" * 64
+    judgment = SemanticJudgment("no_material_discrepancy", ())
+    provenance = _provenance(SemanticStatus.SUCCEEDED, policy_digest=zero)
+
+    # A real policy digest is bound through, replacing whatever the adapter asserted.
+    bound = _with_policy_digest(SemanticResultSuccess(judgment, provenance), case)
+    assert bound.provenance.policy_digest == _DIGEST
+    assert bound.provenance.privacy_policy_digest == _DIGEST
+
+    # A placeholder that survives the rebind is refused rather than recorded as audited.
+    with pytest.raises(ValueError, match="privacy_gateway_provenance_policy_digest_placeholder"):
+        _with_policy_digest(
+            SemanticResultSuccess(judgment, provenance), replace(case, policy_digest=zero)
+        )
+
+    # A genuinely-blocked attempt that never reached a provider keeps its honest zeros.
+    blocked = _with_policy_digest(
+        SemanticResultUnavailable(
+            _provenance(
+                SemanticStatus.UNAVAILABLE,
+                policy_digest=zero,
+                failure_class=SemanticFailureClass.TRANSPORT,
+            )
+        ),
+        replace(case, policy_digest=zero),
+    )
+    assert blocked.provenance.policy_digest == zero
 
 
 def test_dispatch_rejects_authorization_case_mismatch() -> None:

--- a/tests/integration/providers/test_fake_provider_coordinator.py
+++ b/tests/integration/providers/test_fake_provider_coordinator.py
@@ -187,6 +187,16 @@ async def test_fake_success_refusal_timeout_invalid_and_late() -> None:
         SemanticResultLate,
     }
 
+    # Every scripted outcome reports the approved case's policy digest, not the script's
+    # placeholder, and finalization carries that real value through to the recorded provenance.
+    for result in (success, refusal, timeout, invalid, late):
+        assert result.provenance.policy_digest == case.policy_digest
+        assert result.provenance.privacy_policy_digest == case.policy_digest
+    finalized = _finalize(success.provenance, seed="9")
+    assert finalized.policy_digest == case.policy_digest
+    assert finalized.privacy_policy_digest == case.policy_digest
+    assert finalized.policy_digest != "sha256:" + "0" * 64
+
     with pytest.raises(RuntimeError, match="fake_semantic_script_exhausted"):
         await evaluator.evaluate(case, deadline)
 

--- a/tests/unit/adapters/providers/test_chat_completions_request_shape.py
+++ b/tests/unit/adapters/providers/test_chat_completions_request_shape.py
@@ -191,11 +191,15 @@ def test_a_non_external_binding_cannot_reach_the_adapter_at_all() -> None:
 def test_exact_judgment_shape_succeeds() -> None:
     response = _Response(_Choice(_Message(content=_JUDGMENT)))
 
-    result = normalize_response(response, _profile(), latency_ms=12)
+    result = normalize_response(response, _profile(), policy_digest=_DIGEST, latency_ms=12)
 
     assert type(result) is SemanticResultSuccess
     assert result.judgment.conclusion == "no_material_discrepancy"
     assert result.provenance.provider_request_id == "chatcmpl-1"
+    # The adapter reports the policy that authorized the dispatch, never a minted placeholder.
+    assert result.provenance.policy_digest == _case().policy_digest
+    assert result.provenance.privacy_policy_digest == _case().policy_digest
+    assert result.provenance.policy_digest != "sha256:" + "0" * 64
 
 
 def test_prose_answer_degrades_to_invalid_rather_than_a_fabricated_pass() -> None:
@@ -203,7 +207,9 @@ def test_prose_answer_degrades_to_invalid_rather_than_a_fabricated_pass() -> Non
 
     response = _Response(_Choice(_Message(content="Looks good to me! No issues found.")))
 
-    result = normalize_response(response, _profile("prompt_only"), latency_ms=12)
+    result = normalize_response(
+        response, _profile("prompt_only"), policy_digest=_DIGEST, latency_ms=12
+    )
 
     assert type(result) is SemanticResultInvalid
     assert result.provenance.failure_class is SemanticFailureClass.RESPONSE_SCHEMA
@@ -228,14 +234,21 @@ def test_prose_answer_degrades_to_invalid_rather_than_a_fabricated_pass() -> Non
 def test_non_judgment_answers_map_to_their_exact_terminal(
     response: _Response, expected: type[object]
 ) -> None:
-    assert type(normalize_response(response, _profile(), latency_ms=5)) is expected
+    assert (
+        type(normalize_response(response, _profile(), policy_digest=_DIGEST, latency_ms=5))
+        is expected
+    )
 
 
 def test_transport_and_status_failures_keep_their_public_class() -> None:
     import httpx
 
-    timeout = classify_provider_failure(httpx.TimeoutException("x"), _profile(), latency_ms=1)
-    transport = classify_provider_failure(httpx.ConnectError("x"), _profile(), latency_ms=1)
+    timeout = classify_provider_failure(
+        httpx.TimeoutException("x"), _profile(), policy_digest=_DIGEST, latency_ms=1
+    )
+    transport = classify_provider_failure(
+        httpx.ConnectError("x"), _profile(), policy_digest=_DIGEST, latency_ms=1
+    )
 
     assert type(timeout) is SemanticResultTimeout
     assert type(transport) is SemanticResultUnavailable
@@ -250,7 +263,7 @@ def test_transport_and_status_failures_keep_their_public_class() -> None:
     ):
         error = RuntimeError("provider said no")
         error.status_code = status  # pyright: ignore[reportAttributeAccessIssue]
-        result = classify_provider_failure(error, _profile(), latency_ms=1)
+        result = classify_provider_failure(error, _profile(), policy_digest=_DIGEST, latency_ms=1)
         assert type(result) is SemanticResultUnavailable
         assert result.provenance.failure_class is failure_class
 

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -184,3 +184,7 @@ async def test_evaluator_dispatches_the_audited_rendered_body_verbatim() -> None
 
     assert type(result) is SemanticResultSuccess
     assert capture.request_body == rendered.body
+    # The adapter reports the policy that authorized the dispatch, never a minted placeholder.
+    assert result.provenance.policy_digest == case.policy_digest
+    assert result.provenance.privacy_policy_digest == case.policy_digest
+    assert result.provenance.policy_digest != "sha256:" + "0" * 64


### PR DESCRIPTION
Closes #38. One of three independent remediations from the 2026-07-27 run-2 dogfood; siblings #35
and #37 are already merged. Shares no files with either.

## What was wrong

The one genuinely successful external semantic check in run 2 recorded provenance with **all-zero**
`policy_digest` and `privacy_policy_digest`, while the agent-context privacy projection reported the
real nonzero effective policy digest for the same dispatch.

The authorization, request commitment, and privacy receipt still made the dispatch audit-linked, so
this was **not** a privacy failure. It was a provenance-quality failure: provenance and the egress
receipt disagreed about which policy authorized the attempt.

Adapters minted placeholder digests and every layer above passed them through untouched. Nothing
caught it, because `validate_sha256_digest` is a shape-only regex and all-zero is valid shape.

The real value was **already in the adapter's hand**. `SemanticEvaluatorPort.evaluate(case, deadline)`
takes an `ApprovedProviderCase`, both variants carry `policy_digest`, and the gateway *proves* that
value equals the effective policy before dispatching (`gateway.py:586-591`, the staleness fence). It
was simply never plumbed into the `_provenance(profile, status, ...)` helpers.

## What changed

**The gateway is now the authority; adapters no longer assert policy at all.**

- **Gateway rebind.** `_with_policy_digest` binds provenance from `case.policy_digest` immediately
  after `evaluate()` returns, on both the external and local dispatch paths, following the existing
  `_with_request_commitment` `replace(...)` pattern. Provenance and
  `EgressReceipt.policy.policy_digest` now agree by construction, with the staleness fence as the
  proof.
- **Adapters stop lying at the source.** `case.policy_digest` is threaded through the `_provenance`
  helpers in `openai_responses`, `openai_chat_completions`, and `local_model`, so the value is never
  wrong even before the gateway overwrites it. `local_model` stops reporting
  `profile.release_resource_digest` — nonzero, but a *release artifact* digest is not a policy
  digest. `fake.py` rebinds its scripted placeholder at dispatch time, since a script is authored
  before any case exists.
- **A fence that cannot regress.** An all-zero digest on a `SUCCEEDED` result is refused. It lives at
  the **dispatch boundary**, not in `ProviderAttemptProvenance` or `SemanticProvenance` — so
  `tests/unit/domain/test_findings.py` and `fake.py`'s legitimate all-zero construction keep working
  unmodified. External dispatch degrades to the bounded `outcome_unknown` receipt, local to the
  bounded unavailable result; neither crashes and both stay receipted.

Genuinely-blocked paths that never reached a provider (`_preconsume_result`,
`_unknown_outcome_result`, `_local_unavailable_result`, all `SemanticStatus.UNAVAILABLE`) keep their
zeros. Nothing authorized them, so zero is the honest value there.

`normalize_response`, `classify_provider_failure`, and `normalize_local_response` gain a required
keyword-only `policy_digest`. These are adapter-internal public helpers with no callers outside the
adapters and their tests.

## Tests

- **Provenance carries the real digest** — both request-shape suites assert
  `result.provenance.policy_digest == case.policy_digest` and `!= "sha256:" + "0"*64`.
- **Provenance equals the egress receipt** — the invariant that matters, in
  `test_reconcile_and_dispatch_external_semantic_succeeds`, which already held both `result` and
  `receipt`: provenance == `receipt.policy.policy_digest` == `policy.policy_digest`.
- **End to end into the event** — `test_fake_provider_coordinator` asserts every scripted outcome
  reports the case's digest and that `_finalize` (which mirrors `ready_composition._provider_provenance`)
  carries it through to the recorded `SemanticProvenance`.
- **The fence itself** — pinned directly at the boundary that owns it. Reaching it through the public
  dispatch path is impossible by construction, since the gateway already requires case, authorization,
  and live registry to agree on the policy digest and a real one is a canonical digest. That is
  exactly why it is worth pinning: it is what stops the pre-fix behaviour from silently returning.
  The test also asserts an `UNAVAILABLE` result keeps its honest zeros.

## Design gate

`CONTRIBUTING.md:28-37` lists privacy and data-egress behavior as design-gated and this touches
`adapters/privacy/gateway.py`, so #38 was opened before this PR rather than treating "it only changes
a digest value" as an exemption. For the review:

- This **narrows** what a provider adapter is trusted to assert. It loosens no privacy boundary,
  widens no scope, and changes nothing about what leaves the process.
- **No schema, manifest, or canonical-leaf change.** `_SEMANTIC_PROVENANCE_LEAVES` lists field
  *names* (unchanged) and `semantic-provenance-1.0.0.schema.json` types both fields as the shape-only
  `digest` `$ref`, so all-zero was schema-valid before and this is a value-only fix. The fence is
  deliberately code-level to avoid a schema regeneration.

## Open question, deliberately not answered here

`policy_digest` and `privacy_policy_digest` are bound to the **same value**, as they were at every
site before this change; no second distinct digest is wired into this path. Binding both to
`case.policy_digest` is honest and matches the egress receipt. If a genuinely *distinct*
privacy-policy digest is wanted, that is a protocol decision needing an ADR, and it is out of scope
here.

## Verification

```
uv run pytest                    # 2052 passed, 17 skipped, 4 xfailed
uv run ruff check src tests      # All checks passed
uv run ruff format --check src tests
npx --no-install pyright         # 0 errors, 0 warnings, 0 informations
```

The full suite was run rather than just the touched areas, since the fence sits on the dispatch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
