### PR TITLE
fix: ensure accepted event summaries are omitted when unpopulated

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -104,6 +104,9 @@ different body (or a body that cannot be prepared), the public code is
 `sequence`, `head_digest`, and accepted-event `count` — never `INVALID_REQUEST` and never a second
 append. If an exact validated full success body was durably stored, replay to the same ordinary
 disclosure sink returns that body without running privacy projection again.
+An accepted event's optional `summary` is non-null when present. Until publication supplies an
+actual summary, the field is absent from both the internal projection document and the public
+success body; an absent summary is never materialized as JSON `null` or reported as policy-omitted.
 Optional `dry_run: true` on `PublishWorkRequest` validates the full batch and returns
 `outcome: "dry_run"` with `evidential: false` and a `would_accept` preview (event ids, schema
 identity, refs) plus coverage/gaps. It appends nothing, records no operation, does not consume

--- a/docs/plans/2026-07-27-run3-residuals/00-INDEX.md
+++ b/docs/plans/2026-07-27-run3-residuals/00-INDEX.md
@@ -1,0 +1,62 @@
+# Run-3 residuals: making Yoetz ready
+
+**Date:** 2026-07-27
+
+**Source:** [`docs/postmortems/2026-07-27-codex-testing-yoetz-grok-easy-linking-run3.md`](../../postmortems/2026-07-27-codex-testing-yoetz-grok-easy-linking-run3.md)
+and the raw trace under `docs/dogfood/2026-07-27-grok-easy-linking/`.
+
+Four defects, five PRs — the first defect splits into a bounded fix and an unbounded hunt. **The
+numbering is execution order.** Work them 1, 2, 3, 4, then 5. Each plan is self-contained: its own
+PR boundary, its own tests, and what it deliberately leaves alone.
+
+All five are open against `main` at `f3d1e62` (PR #40 merged, PR CI green).
+
+| # | Plan | Defect | Why here in the order |
+| --- | --- | --- | --- |
+| 01 | [Accepted-write safety net](01-accepted-write-safety-net.md) | Durable write reported as `INTERNAL_ERROR` | Owns the publish result contract change, so it lands before 03 and 04 touch the same models. Its diagnostic sink also instruments everything after it. |
+| 02 | [Grok interactive selector](02-grok-interactive-selector.md) | `--grok` ignored on an interactive TTY | Touches only `cli/app.py` — zero conflict with anything else, small, and a clean green after the big one. Genuinely parallel if you prefer. |
+| 03 | [Publish replay recovery](03-publish-replay-recovery.md) | Documented recovery path unreachable | Rebases cheaply onto 01. Adds an error code and a status view. |
+| 04 | [Event authoring](04-event-authoring.md) | 9 of 17 MCP calls surfaced as failures | Largest measured friction reduction, and the cheapest of the three to rebase, so it goes last of the bounded work. |
+| 05 | [Accepted-write root cause](05-accepted-write-root-cause.md) | Why projection failed | Duration unknown. Start the reproduction early, land it whenever it resolves — it must never block 01-04. |
+
+### Ordering rationale
+
+Two things drive the sequence, and neither is severity.
+
+**File conflicts.** Plans 01, 03, and 04 all touch `src/yoetz/application/publish_work.py` and
+`src/yoetz/protocol/models.py`, so they are serial. Plan 02 touches only `src/yoetz/cli/app.py` and
+its tests and can be slotted anywhere. Plan 01 goes first among the three because it changes the
+publish result *shape*; the others add to it. Reversing that costs a second round of schema, vector,
+and manifest regeneration.
+
+**Unknown duration.** Plan 05 is research, not implementation. Splitting it out of 01 is what keeps
+one unknown from stalling four bounded PRs — and plan 01's diagnostic sink is what makes 05
+tractable, since the run-3 `correlation_id` currently resolves to nothing at all.
+
+## Standing decisions
+
+Decided for the whole set; not re-litigated inside each plan.
+
+- **Contract freedom: fully open, pre-1.0.** v0.1 is unreleased. Where the right design requires it,
+  these PRs may change wire shapes, add fields, add operations or views, and regenerate schemas,
+  golden vectors, and the resource manifest. Breaking the "frozen contract" framing is permitted;
+  silently breaking it is not — a contract change must update `docs/INTERFACES.md`, the affected
+  ADR, the JSON Schemas under `schemas/`, the vectors under `fixtures/`, and the manifest digests in
+  the same PR. `generate_schemas` does not own every schema — some are hand-authored, and their
+  manifest digests must be refreshed by hand.
+- **One PR per plan.** No plan depends on another plan's code landing first; the order above is
+  about rebase cost, not correctness.
+- **Done bar: code + regression tests.** Each PR lands green with tests at the layer the defect
+  actually lives in. No installed-wheel gate inside the PRs.
+- **Proof is dogfood.** Once these land, a run-4 dogfood is the acceptance evidence for the set.
+  Plans 01, 03, and 05 have never reproduced in-process — they only ever fired on the live daemon
+  plus MCP bridge path — so each names the observable a dogfood must show.
+
+## What the set does not address
+
+- No live xAI credential, egress, request, or receipt. Grok remains structurally implemented and
+  live-unproven.
+- No controlled Yoetz-enabled versus Yoetz-disabled A/B.
+- The `respond` finding-disposition path stays untested by these PRs. Three dogfoods in a row have
+  failed to exercise it because no check produced a finding. Fixing that is a run-4 design problem,
+  not a code defect — the run must be built so a finding is expected.

--- a/docs/plans/2026-07-27-run3-residuals/00-INDEX.md
+++ b/docs/plans/2026-07-27-run3-residuals/00-INDEX.md
@@ -9,7 +9,8 @@ Four defects, five PRs — the first defect splits into a bounded fix and an unb
 numbering is execution order.** Work them 1, 2, 3, 4, then 5. Each plan is self-contained: its own
 PR boundary, its own tests, and what it deliberately leaves alone.
 
-All five are open against `main` at `f3d1e62` (PR #40 merged, PR CI green).
+The plans were drafted against `main` at `f3d1e62` (PR #40 merged, PR CI green). They later landed
+as PRs #43, #45, #47, #49, and #50 respectively.
 
 | # | Plan | Defect | Why here in the order |
 | --- | --- | --- | --- |
@@ -19,7 +20,7 @@ All five are open against `main` at `f3d1e62` (PR #40 merged, PR CI green).
 | 04 | [Event authoring](04-event-authoring.md) | 9 of 17 MCP calls surfaced as failures | Largest measured friction reduction, and the cheapest of the three to rebase, so it goes last of the bounded work. |
 | 05 | [Accepted-write root cause](05-accepted-write-root-cause.md) | Why projection failed | Duration unknown. Start the reproduction early, land it whenever it resolves — it must never block 01-04. |
 
-### Ordering rationale
+## Ordering rationale
 
 Two things drive the sequence, and neither is severity.
 

--- a/docs/plans/2026-07-27-run3-residuals/01-accepted-write-safety-net.md
+++ b/docs/plans/2026-07-27-run3-residuals/01-accepted-write-safety-net.md
@@ -1,0 +1,131 @@
+# 01 — An accepted, durable write must never surface as a failure
+
+**Severity:** critical **PR boundary:** publish response envelope + daemon projection window + diagnostics
+
+**Pairs with:** [05 — root cause](05-accepted-write-root-cause.md). This plan removes the *harm*
+without knowing the *cause*, and is deliberately independent of it. Do 01 first; 05 can run for as
+long as it takes without blocking anything.
+
+## The defect
+
+A valid four-event `publish_work` batch committed atomically, advanced the frontier from 2 to 6, and
+returned:
+
+```json
+{"code": "INTERNAL_ERROR",
+ "message": "The write was accepted and is durable at the frontier in safe_details …",
+ "retryable": true,
+ "correlation_id": "err_aa2423b0-6808-4e28-bea4-d04286307841",
+ "safe_details": {"count": 4, "head_digest": "sha256:4335…", "reason_code": "response_projection_failed", "sequence": 6}}
+```
+
+The same defect appeared in all three of today's dogfoods. It is the single most damaging Yoetz
+behaviour: the product's core promise is an honest record, and its most common write operation
+reports a durable success as an internal error.
+
+## Evidence
+
+- `docs/dogfood/2026-07-27-grok-easy-linking/codex-events.jsonl`, the `publish_work` call with
+  `request_id: req_7b8c9d0e-1f2a-4b34-8567-8d9e0f1a2b34`.
+- The single-event `plan_published` batch earlier in the same session projected fine.
+- `status` immediately afterwards returned `sequence: 6`, `projection_lag: 0`,
+  `rebuild_state: current`. The ledger was never in doubt.
+- It fires in `_project_completed_response`, `src/yoetz/service/daemon.py:762-860` — the post-commit
+  projection window, where only an unexpected exception is reclassified into
+  `ControlError("response_projection_failed")`.
+
+## Why this half ships first
+
+The prior attempt at this defect (`0eee854`) improved the error *message* without changing the
+*outcome*, and the defect recurred in the very next dogfood. The lesson is that the post-commit
+window must stop being able to convert a durable write into a reported failure at all — regardless
+of which specific exception fires inside it.
+
+This plan also owns the publish result contract change, so it should land before plans 03 and 04
+touch the same models. Both rebase cheaply onto it; the reverse costs a second round of schema,
+vector, and manifest regeneration.
+
+## Design
+
+### 1. Return a total acceptance envelope instead of an error
+
+When full response projection fails after the append succeeded, do not raise. Return a smaller
+result that is constructible by construction — built only from what the ledger already handed back
+in `AppendResult`, never from privacy projection or the full closed model:
+
+- `ok: true`
+- `request_id`, `task_id`, `session_id`, `writer_id`
+- `subject_frontier`, `result_frontier`
+- accepted event ids, entry digests, and ingestion sequences
+- `response_completeness: "accepted_projection_unavailable"` with the bounded reason token
+- the `correlation_id` for operator follow-up
+
+The caller gets a true, smaller answer rather than a false failure, and needs no second `status`
+call and no replay. Contract freedom is open pre-1.0, so this lands as a real reduced branch in the
+publish result schema — not an error code bent into a success.
+
+Keep `response_projection_failed` in the protocol reason inventory for reads
+(`read_projection_failed` is unaffected) and for the case where even the minimal envelope cannot be
+built. That case must now be genuinely impossible for a committed publish, and a test must assert
+it.
+
+Delete the `INTERNAL_ERROR` mapping for accepted writes at `src/yoetz/mcp/server.py:317-330`. An
+accepted write no longer reaches it.
+
+### 2. Recover the diagnostic trail
+
+The run-3 error carried `correlation_id: err_aa2423b0-…` and there is no way to find out what it
+meant. `record_unexpected_exception_without_raising`
+(`src/yoetz/observability/logging.py:354-379`) writes a bounded reason token to **stderr only**, and
+the MCP-spawned service's stderr is swallowed by the harness.
+`~/Library/Logs/yoetz/service.stderr.jsonl` held 51 stale bytes from two days before the run. An
+operator hitting this in production cannot diagnose it — and neither can we, which is exactly why
+plan 05 has to start from a reproduction rather than from a log.
+
+Add a durable, bounded, owner-only diagnostic record alongside the existing stderr emission:
+
+- append-only, size-capped ring under `log_dir()`, `0o600`, one JSON object per line;
+- fields limited to what is already caller-safe: `correlation_id`, `component`, `operation`,
+  `reason` token, `request_id`, timestamp. No exception text, no payload, no paths;
+- a read surface — `yoetz service diagnostics --correlation-id err_…` — so the id in an agent-facing
+  error resolves to something.
+
+This is what makes the next occurrence diagnosable in minutes instead of unrecoverable, and it is
+why it belongs in the *first* PR rather than the last: it instruments run 4.
+
+## Files
+
+- `src/yoetz/application/publish_work.py` — `_internal_result`, `execute_publish_work` fallback
+- `src/yoetz/service/daemon.py` — `_project_completed_response` reclassification block
+- `src/yoetz/protocol/models.py` — publish result branch
+- `src/yoetz/mcp/server.py` — remove the accepted-write `INTERNAL_ERROR` path
+- `src/yoetz/observability/logging.py` + a new durable diagnostic sink
+- `src/yoetz/cli/` — the `service diagnostics` read surface
+- `schemas/`, `fixtures/`, `docs/INTERFACES.md`, ADR-002 — contract ripple
+
+## Tests
+
+- Fault injection: force projection to fail after a successful append and assert the total
+  acceptance envelope, the durable frontier, exactly one copy of every event in `status`, and no
+  `INTERNAL_ERROR`.
+- The minimal envelope is constructible for every event-schema mix in `_PUBLISH_SUMMARY_CATEGORY`
+  and `_PUBLISH_FIXED_SUMMARY`.
+- Diagnostic sink: bounded size, `0o600`, no payload leakage, and a correlation id written by the
+  daemon resolves through the read surface.
+- Read-only methods still return `read_projection_failed` with no replay advice.
+
+## Done
+
+Green CI. No test needs to know why projection failed — only that a committed write can no longer
+be reported as one that failed.
+
+## Dogfood observable
+
+Run 4 must show no `publish_work` returning `INTERNAL_ERROR`. If projection still fails internally,
+the agent must still see `ok: true` and must not need a `status` call to learn what landed — and the
+diagnostic sink must contain the matching `correlation_id` for plan 05 to work from.
+
+## Out of scope
+
+The root cause (plan 05). Replay ergonomics (plan 03) — this PR removes the *need* to replay after
+an accepted write; it does not fix replay itself.

--- a/docs/plans/2026-07-27-run3-residuals/02-grok-interactive-selector.md
+++ b/docs/plans/2026-07-27-run3-residuals/02-grok-interactive-selector.md
@@ -1,0 +1,82 @@
+# 04 — `provider endpoint --grok` must not fall into the generic picker
+
+**Severity:** moderate **PR boundary:** CLI predicate and selector test coverage
+
+## The defect
+
+On an interactive TTY, `yoetz provider endpoint --grok` can enter the generic provider picker
+instead of treating `--grok` as the chosen provider. The interactive-picker predicate excludes
+`official` and `fireworks` but not `grok`:
+
+`src/yoetz/cli/app.py:1095-1102`
+
+```python
+if (
+    interactive
+    and not official
+    and not fireworks
+    and provider_name is None
+    and https_origin is None
+    and model is None
+):
+```
+
+Every other branch in the same function already handles `grok` correctly — the mutual-exclusion
+block at `app.py:1112-1120`, the alias map at `1125-1138`, and the dispatch at `1151-1152`. This one
+predicate was missed.
+
+Neither observer agent in run 3 found it, and the tested path (`--grok --model grok-4.5`) works, so
+it is invisible to the existing tests.
+
+## Scope note
+
+This is the only one of the four that is a product defect rather than a Yoetz runtime defect. It
+lives in code introduced by **PR #40**, which merged at `2026-07-27T17:39:36Z` as `f3d1e62`, with
+`a4eed0e "Repair Grok dogfood artifact boundaries"` resolving the committed-symlink CI failure. PR
+CI on `main` is green after that merge. So this is a standalone PR against `main`; there is no
+prerequisite left.
+
+Confirmed still present on `origin/main`: the predicate at `src/yoetz/cli/app.py:1095-1102` has no
+`and not grok`.
+
+## Design
+
+Add `and not grok` to the interactive-picker predicate, so `--grok` with no model on a TTY prompts
+for the Grok model rather than re-asking which provider the operator already named.
+
+Confirm the resulting behaviour matches `--fireworks` exactly. The two selectors should be
+indistinguishable in shape; any difference is a second bug.
+
+## Files
+
+- `src/yoetz/cli/app.py` — the predicate at 1095-1102
+- `tests/subprocess/test_setup_wizard_cli.py` and the CLI test module covering
+  `provider endpoint`
+
+## Tests
+
+The postmortem names three gaps; close all of them.
+
+- `--grok` with no model on an interactive TTY: prompts for the Grok model, does not enter the
+  generic picker. Mirror the existing `--fireworks` test.
+- Interactive menu choice `6` (`grok`, `src/yoetz/cli/provider_binding.py:125`) is exercised
+  directly and writes the expected preset.
+- Selector mutual exclusion across the full matrix: `--official`/`--fireworks`, `--official`/`--grok`,
+  `--fireworks`/`--grok`, each of the three combined with `--provider`, and each combined with an
+  https origin. The predicate at `app.py:1112-1120` already implements these; nothing pins them.
+- The alias set (`grok`, `xai`, `x-ai`) resolves to the same preset.
+- Non-TTY behaviour is unchanged.
+
+## Done
+
+Green CI, and `--grok` on a TTY behaves exactly like `--fireworks`.
+
+## Dogfood observable
+
+None required — this is deterministic CLI behaviour fully covered by tests. It does not need an
+agent run to prove.
+
+## Out of scope
+
+Live xAI credential binding, egress, or any claim of proven Grok interoperability. The preset stays
+structurally implemented and live-unproven until an independently authorized xAI chain runs.

--- a/docs/plans/2026-07-27-run3-residuals/02-grok-interactive-selector.md
+++ b/docs/plans/2026-07-27-run3-residuals/02-grok-interactive-selector.md
@@ -1,48 +1,46 @@
-# 04 — `provider endpoint --grok` must not fall into the generic picker
+# 02 — `provider endpoint --grok` must not fall into the generic picker
 
 **Severity:** moderate **PR boundary:** CLI predicate and selector test coverage
 
+**Status:** completed by PR #45 (`5eeea3a`).
+
 ## The defect
 
-On an interactive TTY, `yoetz provider endpoint --grok` can enter the generic provider picker
+Before PR #45, on an interactive TTY, `yoetz provider endpoint --grok` could enter the generic
+provider picker
 instead of treating `--grok` as the chosen provider. The interactive-picker predicate excludes
-`official` and `fireworks` but not `grok`:
+`official`, `fireworks`, and `grok` on current `main`:
 
-`src/yoetz/cli/app.py:1095-1102`
+`src/yoetz/cli/app.py`
 
 ```python
 if (
     interactive
     and not official
     and not fireworks
+    and not grok
     and provider_name is None
     and https_origin is None
     and model is None
 ):
 ```
 
-Every other branch in the same function already handles `grok` correctly — the mutual-exclusion
-block at `app.py:1112-1120`, the alias map at `1125-1138`, and the dispatch at `1151-1152`. This one
-predicate was missed.
+The mutual-exclusion block, alias map, and dispatch in the same function also handle `grok`.
 
 Neither observer agent in run 3 found it, and the tested path (`--grok --model grok-4.5`) works, so
-it is invisible to the existing tests.
+the original defect was invisible to the existing tests.
 
 ## Scope note
 
-This is the only one of the four that is a product defect rather than a Yoetz runtime defect. It
-lives in code introduced by **PR #40**, which merged at `2026-07-27T17:39:36Z` as `f3d1e62`, with
-`a4eed0e "Repair Grok dogfood artifact boundaries"` resolving the committed-symlink CI failure. PR
-CI on `main` is green after that merge. So this is a standalone PR against `main`; there is no
-prerequisite left.
+This was the only one of the four that was a product defect rather than a Yoetz runtime defect. It
+lived in code introduced by **PR #40**, which merged at `2026-07-27T17:39:36Z` as `f3d1e62`, with
+`a4eed0e "Repair Grok dogfood artifact boundaries"` resolving the committed-symlink CI failure.
+PR #45 added the missing predicate and regression coverage; this plan is closed.
 
-Confirmed still present on `origin/main`: the predicate at `src/yoetz/cli/app.py:1095-1102` has no
-`and not grok`.
+## Implemented design
 
-## Design
-
-Add `and not grok` to the interactive-picker predicate, so `--grok` with no model on a TTY prompts
-for the Grok model rather than re-asking which provider the operator already named.
+PR #45 added `and not grok` to the interactive-picker predicate, so `--grok` with no model on a TTY
+prompts for the Grok model rather than re-asking which provider the operator already named.
 
 Confirm the resulting behaviour matches `--fireworks` exactly. The two selectors should be
 indistinguishable in shape; any difference is a second bug.

--- a/docs/plans/2026-07-27-run3-residuals/03-publish-replay-recovery.md
+++ b/docs/plans/2026-07-27-run3-residuals/03-publish-replay-recovery.md
@@ -1,0 +1,112 @@
+# 02 — Recovery must not require reconstructing the original request body
+
+**Severity:** critical **PR boundary:** replay resolution order + a request-id-keyed read surface
+
+## The defect
+
+Yoetz's documented recovery contract is "retry with the same `request_id` to load the stored
+result." In practice an agent cannot execute it, because the stored result is reachable only by
+re-sending a byte-identical copy of a large nested body — and the same product weakness that made
+the body hard to author the first time makes it impossible to reproduce the second time.
+
+Run 3 proves the loop. After the accepted-write failure on
+`req_7b8c9d0e-1f2a-4b34-8567-8d9e0f1a2b34`, the agent read the remedy, followed it correctly, and
+still got nowhere:
+
+| Attempt | Result |
+| --- | --- |
+| 1 | `INTERNAL_ERROR` / `response_projection_failed`, write durable at sequence 6 |
+| 2 | `INVALID_REQUEST`, `fields: ["/event_drafts/2"]` |
+| 3 | `INVALID_REQUEST`, `fields: ["/event_drafts/3"]` |
+
+Both replays died in **argument schema validation at the MCP bridge, before replay lookup ever
+ran**. PR #37 shipped a replay fix that has now gone three dogfoods without a single valid exercise.
+It is not known to be broken; it is known to be unreachable.
+
+## Evidence
+
+- `docs/dogfood/2026-07-27-grok-easy-linking/codex-events.jsonl`, the four `publish_work` calls
+  sharing `req_7b8c9d0e…`.
+- `_preflight_replay` is called from `execute_publish_work`
+  (`src/yoetz/application/publish_work.py`) only *after* `prepare_publication` and after
+  `request_digest(...)` has been computed over the full submitted body. Everything upstream —
+  including bridge-level schema validation — must succeed before recovery is even attempted.
+
+## Design
+
+### 1. Resolve the operation before the body
+
+Replay lookup keys on `(task_id, writer_id, request_id)`, which is fully determined by the request
+envelope. It must not sit behind validation of `event_drafts`.
+
+- At the bridge, validate the envelope fields first. If `request_id` names a known operation for
+  this writer, route to recovery without validating the event payload.
+- In `execute_publish_work`, resolve the operation record before `prepare_publication`.
+
+Then three outcomes, all honest:
+
+| Case | Result |
+| --- | --- |
+| Operation exists, complete, body digest matches | Stored result. No re-append. Today's behaviour, now reachable. |
+| Operation exists, body digest differs | `REQUEST_IDENTITY_CONFLICT` — a distinct, non-destructive error carrying `sequence`, `head_digest`, `count`, and the accepted event ids. Never `INVALID_REQUEST`, never a re-append. |
+| No operation | Normal publish path. |
+
+The conflict case matters: it is exactly what run 3 hit, and the agent still needs to learn what
+landed. Returning the frontier and the accepted ids inside the conflict lets it continue truthfully
+even when it has lost the original body.
+
+### 2. A read surface keyed by request id
+
+Add `status view=operation`, taking a `request_id` and returning the stored result of that
+operation — outcome, frontiers, accepted event ids and digests, or "no such operation."
+
+`status` is the right home: recovery is a read, it needs no writer semantics or write capability,
+and it keeps the six operations intact. Contract freedom is open pre-1.0, so this lands as a real
+view with schema, vectors, and `docs/INTERFACES.md` updated, not as an undocumented extra.
+
+This is the surface an agent should reach for after *any* ambiguous write, and it replaces "compose
+a duplicate write and hope" with a single safe read.
+
+### 3. Do not let frontier checks pre-empt recovery
+
+An expected-frontier conflict must be evaluated *after* replay resolution. A replay of an already
+accepted operation carries the pre-append frontier by definition; rejecting it as stale before
+looking up the operation would fail exactly the caller who is doing the right thing. Pin this with a
+test — it is the kind of ordering that silently regresses.
+
+## Files
+
+- `src/yoetz/application/publish_work.py` — `_preflight_replay` call site, ordering versus
+  `prepare_publication`, `request_digest`, and the expected-frontier check
+- `src/yoetz/mcp/server.py` — envelope-first validation, recovery routing
+- `src/yoetz/application/status.py`, `src/yoetz/protocol/models.py` — the `operation` view
+- `src/yoetz/protocol/errors.py` — `REQUEST_IDENTITY_CONFLICT`
+- `schemas/`, `fixtures/`, `docs/INTERFACES.md`, `docs/usage/six-operations.md`,
+  `guidance/workflow.md` — the recovery wording currently promises the unreachable path
+
+## Tests
+
+- Force a post-commit projection failure, then replay with the exact original body: stored result
+  returned, no duplicate append, `status` shows exactly one copy of each event.
+- Replay the same `request_id` with a mutated `event_drafts` entry — the literal run-3 sequence:
+  `REQUEST_IDENTITY_CONFLICT` carrying the frontier, no duplicate append, no `INVALID_REQUEST`.
+- Replay with a stale `expected_frontier`: recovery still resolves.
+- `status view=operation` returns the stored result for a completed operation, a bounded
+  not-found for an unknown `request_id`, and refuses a `request_id` belonging to another writer.
+- An operation that is durably underway but not yet complete is reported as pending, not as absent.
+
+## Done
+
+Green CI, and the recorded run-3 replay sequence produces a usable recovery instead of two
+validation errors.
+
+## Dogfood observable
+
+Run 4 must show either no replay needed at all (plan 01 doing its job), or a replay that resolves —
+and never a replay that fails validation. If an ambiguous write occurs, the agent should recover with
+`status view=operation` rather than by re-sending events.
+
+## Out of scope
+
+Making the body easier to author (plan 04). This PR makes recovery independent of the body; plan 04
+reduces how often recovery is needed.

--- a/docs/plans/2026-07-27-run3-residuals/03-publish-replay-recovery.md
+++ b/docs/plans/2026-07-27-run3-residuals/03-publish-replay-recovery.md
@@ -1,6 +1,8 @@
-# 02 — Recovery must not require reconstructing the original request body
+# 03 — Recovery must not require reconstructing the original request body
 
 **Severity:** critical **PR boundary:** replay resolution order + a request-id-keyed read surface
+
+**Status:** completed by PR #47 (`ee44e9b`).
 
 ## The defect
 
@@ -36,11 +38,21 @@ It is not known to be broken; it is known to be unreachable.
 
 ### 1. Resolve the operation before the body
 
-Replay lookup keys on `(task_id, writer_id, request_id)`, which is fully determined by the request
-envelope. It must not sit behind validation of `event_drafts`.
+Replay lookup keys on `(task_id, writer_id, request_id)`. The caller supplies `session_id`,
+`writer_id`, and `request_id` in the ordinary authenticated request envelope; it does not supply or
+select `task_id`. The ready service routes `(session_id, writer_id)` through
+`BundleRuntimePort.route`, which resolves the authoritative task-scoped `TaskRuntime` and its
+`task_id`, and rejects a route whose returned session or writer differs. The operation lookup then
+runs against that task-scoped ledger with `(writer_id, request_id)`, completing the full identity
+tuple without a global request-id lookup. This identity resolution must not sit behind validation
+of `event_drafts`.
 
-- At the bridge, validate the envelope fields first. If `request_id` names a known operation for
-  this writer, route to recovery without validating the event payload.
+- At the bridge, validate the envelope fields first and carry the original `actor` and `client`
+  assertions into the recovery read. Route and authorize the resulting status request through the
+  ordinary service boundary. Only if that task-scoped, writer-scoped lookup finds the operation may
+  the bridge route to recovery without validating the event payload. A route conflict or other
+  bounded authorization error must remain that public error rather than collapsing into payload
+  validation.
 - In `execute_publish_work`, resolve the operation record before `prepare_publication`.
 
 Then three outcomes, all honest:
@@ -57,12 +69,17 @@ even when it has lost the original body.
 
 ### 2. A read surface keyed by request id
 
-Add `status view=operation`, taking a `request_id` and returning the stored result of that
-operation — outcome, frontiers, accepted event ids and digests, or "no such operation."
+Add `status view=operation`, taking the ordinary `session_id` and authenticated `writer_id`
+envelope plus `filter.operation_request_id`, and returning the stored result of that operation —
+outcome, frontiers, accepted event ids and digests, or "no such operation." Routing resolves the
+authoritative `task_id`; the read must never accept a caller-selected task identity or perform a
+global request-id lookup. A request under another writer must receive the same bounded absent
+result as an unknown request id, without disclosing that the operation exists.
 
-`status` is the right home: recovery is a read, it needs no writer semantics or write capability,
-and it keeps the six operations intact. Contract freedom is open pre-1.0, so this lands as a real
-view with schema, vectors, and `docs/INTERFACES.md` updated, not as an undocumented extra.
+`status` is the right home: recovery is a read and needs no write capability, while retaining the
+ordinary task-routing and writer-authorization semantics. It also keeps the six operations intact.
+Contract freedom is open pre-1.0, so this lands as a real view with schema, vectors, and
+`docs/INTERFACES.md` updated, not as an undocumented extra.
 
 This is the surface an agent should reach for after *any* ambiguous write, and it replaces "compose
 a duplicate write and hope" with a single safe read.
@@ -92,7 +109,8 @@ test — it is the kind of ordering that silently regresses.
   `REQUEST_IDENTITY_CONFLICT` carrying the frontier, no duplicate append, no `INVALID_REQUEST`.
 - Replay with a stale `expected_frontier`: recovery still resolves.
 - `status view=operation` returns the stored result for a completed operation, a bounded
-  not-found for an unknown `request_id`, and refuses a `request_id` belonging to another writer.
+  not-found for an unknown `request_id`, and the same absent result for a `request_id` belonging to
+  another writer.
 - An operation that is durably underway but not yet complete is reported as pending, not as absent.
 
 ## Done

--- a/docs/plans/2026-07-27-run3-residuals/04-event-authoring.md
+++ b/docs/plans/2026-07-27-run3-residuals/04-event-authoring.md
@@ -1,6 +1,8 @@
-# 03 — Make the event batch authorable on the first attempt
+# 04 — Make the event batch authorable on the first attempt
 
 **Severity:** critical **PR boundary:** MCP authoring hints, schema examples, dry-run mode, guidance surfacing
+
+**Status:** completed by PR #49 (`d6be382`).
 
 ## The defect
 
@@ -91,7 +93,11 @@ This turns authoring from "guess, fail publicly, retry" into "validate, then pub
 - Each tool description names the guidance resource that covers it, by URI.
 - An `INVALID_REQUEST` on `publish_work` includes the `yoetz://guidance/publication-policy.md` URI;
   `start` and workflow-shaped errors point at `yoetz://guidance/workflow.md`.
-- Only the URI and packaged, manifest-verified content — no synthesized prose in the error path.
+- Guidance-document prose comes only from packaged, manifest-verified guidance resources. The
+  error path may also carry the bounded schema-derived authoring hints from section 1: they are
+  generated at runtime solely from checked-in presentation schemas, resolve only local
+  `#/$defs/` references, preserve the existing size/count caps, and contain no caller-controlled
+  text. No other synthesized prose is permitted in the error path.
 
 ## Files
 

--- a/docs/plans/2026-07-27-run3-residuals/04-event-authoring.md
+++ b/docs/plans/2026-07-27-run3-residuals/04-event-authoring.md
@@ -1,0 +1,133 @@
+# 03 — Make the event batch authorable on the first attempt
+
+**Severity:** critical **PR boundary:** MCP authoring hints, schema examples, dry-run mode, guidance surfacing
+
+## The defect
+
+Nine of seventeen Yoetz MCP calls in run 3 surfaced as failures. Most were authoring mistakes, not
+runtime faults — but authoring friction is the dominant cost of using the product, and it is the
+proximate cause of the unreachable replay in plan 03.
+
+The hint system already exists and provably works at depth 1. It fails at depth 2, which is where
+every expensive mistake happened.
+
+## Evidence
+
+All eight `INVALID_REQUEST` results from `docs/dogfood/2026-07-27-grok-easy-linking/codex-events.jsonl`:
+
+| # | Tool | Hint quality | Outcome |
+| --- | --- | --- | --- |
+| 1 | `start` | `protocol_version admits 0.1; schema_version admits 1.0.0; request_id admits ^req_…` | fixed next call |
+| 2 | `start` | `mode admits attach, create, create_or_attach` | fixed next call |
+| 3 | `publish_work` | full envelope hint | fixed next call |
+| 4 | `publish_work` | **`/event_drafts/0` — "see the examples entry"** | cost a source-reading detour |
+| 5 | `publish_work` | `request_id admits ^req_…` | fixed next call |
+| 6 | `publish_work` | **`/event_drafts/2` — "see the examples entry"** | killed replay attempt 1 |
+| 7 | `publish_work` | **`/event_drafts/3` — "see the examples entry"** | killed replay attempt 2 |
+| 8 | `receipt` | `writer_id admits ^wri_…` | fixed next call |
+
+Every hint that named admitted values was fixed on the next call. Every hint that said "see the
+examples" cost real work. The boundary is explicit in code —
+`src/yoetz/mcp/errors.py:185-188`:
+
+> Only top-level scalar fields; nested pointers would need the `$defs` walk and the example already
+> shows their shape.
+
+The example does not show their shape well enough. Three dogfoods disagree with that comment.
+
+Separately: **the four packaged guidance documents were never read once.** There are zero MCP
+resource reads in the run-3 trace. The single `yoetz://guidance` string in the trace is the agent
+reading `docs/INTERFACES.md` off disk. The product ships harness-neutral guidance and then waits to
+be asked for it, and nobody asks.
+
+## Design
+
+Four levers, all in this PR. They are cheap individually and reinforcing together.
+
+### 1. Walk `$defs` for nested pointers
+
+Extend `authoring_hint` past the `pointer.count("/") != 1` guard so `/event_drafts/2` resolves
+through the array item schema, the discriminated event union, and the payload `$defs` to name
+admitted values — including the nested `action_kind` enum the postmortem called undiscoverable.
+
+**Preserve the safety invariant.** The current docstring is the contract: *"Every character comes
+from the checked-in presentation schema — enum members and the worked example's own keys — so no
+caller-controlled text can reach the message."* The walk must resolve only local `#/$defs/`
+references, must never echo a submitted value, and must stay bounded by the existing
+`_MAX_HINT_FIELDS`, `_MAX_HINT_ENUM_MEMBERS`, and `_MAX_HINT_PATTERN_CHARS` caps. A test must assert
+that a hostile payload value cannot reach the message.
+
+Where a union discriminator is what failed, name the admitted schema names. Where the discriminator
+resolved and a payload field failed, name that field's admitted values.
+
+### 2. A worked example per event family
+
+One complete, valid, checked-in example for each event schema — `plan_published`,
+`action_recorded`, `result_recorded`, `evidence_recorded`, `claim_recorded`, `decision_recorded`,
+`obligation_published`, `response_recorded` — reachable from the input schema and referenced by name
+from the hint. "See the examples entry" is only useful advice when the entry covers the family that
+failed; today it shows the envelope.
+
+Include a cross-referencing example: an action, its result, evidence, and a claim whose
+`supporting_refs` point at the earlier ids. Cross-event reference construction is exactly what the
+run-3 batch was doing and there is no worked example of it anywhere.
+
+### 3. Dry-run validation
+
+Accept `dry_run: true` on `publish_work`. It validates the full batch and returns what would be
+accepted — event ids, resolved schemas, references, coverage — and appends nothing.
+
+Constraints:
+
+- no ledger append, no operation record, no `request_id` consumption, no frontier movement;
+- the result must be explicitly non-evidential and must not be citable as a check, publication, or
+  coverage source — same discipline as `status view=candidate_findings`;
+- rejects with the same hint machinery as a real publish, so an agent can iterate at zero cost.
+
+This turns authoring from "guess, fail publicly, retry" into "validate, then publish."
+
+### 4. Push guidance instead of waiting for it
+
+- Each tool description names the guidance resource that covers it, by URI.
+- An `INVALID_REQUEST` on `publish_work` includes the `yoetz://guidance/publication-policy.md` URI;
+  `start` and workflow-shaped errors point at `yoetz://guidance/workflow.md`.
+- Only the URI and packaged, manifest-verified content — no synthesized prose in the error path.
+
+## Files
+
+- `src/yoetz/mcp/errors.py` — `authoring_hint`, `$defs` resolution, safety invariant
+- `src/yoetz/mcp/server.py` — tool descriptions, guidance URIs in error paths
+- `src/yoetz/mcp/resources.py` — surfacing
+- `src/yoetz/application/publish_work.py`, `src/yoetz/protocol/models.py` — `dry_run`
+- presentation schemas under `schemas/` and `src/yoetz/resources/schemas/` — worked examples
+- `fixtures/`, `docs/INTERFACES.md`, `guidance/publication-policy.md`, resource manifest digests
+
+## Tests
+
+- For each event family, an invalid draft at `/event_drafts/N` produces a hint naming admitted
+  values, not the generic fallback.
+- A nested enum failure (`action_kind`) names its admitted members.
+- Hostile payload values never appear in a hint message.
+- Hints stay within all existing bounds; a deeply nested or oversized schema degrades gracefully to
+  the current fallback rather than raising — a hint must never turn a clear validation error into an
+  internal error, which the existing `except Exception` at `errors.py:135-138` already guarantees
+  and a test must keep guaranteeing.
+- `dry_run: true` appends nothing: frontier unchanged, no operation record, `request_id` still
+  usable for a real publish afterwards.
+- Every worked example validates against its own schema — a stale example is worse than none.
+- Guidance URIs in tool descriptions and errors resolve to real registered resources.
+
+## Done
+
+Green CI, and each of the three run-3 `/event_drafts/N` failures produces an actionable hint.
+
+## Dogfood observable
+
+Run 4's failed-call count should drop sharply from 9 of 17. The specific signal: **no
+`publish_work` failure whose hint is the bare "see the examples entry" fallback.** A secondary
+signal worth watching — whether the agent reads a guidance resource at all, now that one is named.
+
+## Out of scope
+
+Changing what events mean or the publication policy itself. This PR makes the existing contract
+authorable; it does not simplify it.

--- a/docs/plans/2026-07-27-run3-residuals/05-accepted-write-root-cause.md
+++ b/docs/plans/2026-07-27-run3-residuals/05-accepted-write-root-cause.md
@@ -1,0 +1,98 @@
+# 05 — Find why the four-event publish response could not be projected
+
+**Severity:** critical (cause), non-blocking (schedule) **PR boundary:** the specific projection defect + its regression test
+
+**Pairs with:** [01 — safety net](01-accepted-write-safety-net.md). Plan 01 removes the harm. This
+plan removes the cause. It is scheduled last **only because its duration is unknown** — it is a
+research task, and it must never block the three bounded PRs. Start the reproduction early and let
+it run alongside them.
+
+## What is known
+
+A valid four-event `publish_work` batch committed durably and then failed to project a response.
+The batch:
+
+- `request_id: req_7b8c9d0e-1f2a-4b34-8567-8d9e0f1a2b34`, recorded verbatim in
+  `docs/dogfood/2026-07-27-grok-easy-linking/codex-events.jsonl`;
+- four drafts — `action_recorded`, `result_recorded`, `evidence_recorded`, `claim_recorded`, all
+  `1.0.0`;
+- `causal_parents` chained across all four;
+- the claim carries `supporting_refs` and `evidence_refs` referencing both an `evd_` and a `res_`
+  id;
+- three drafts have empty `artifact_refs` and `evidence_refs`; the fourth is populated.
+
+The single-event `plan_published` batch earlier in the same session projected fine. Whatever fails
+is content- or shape-dependent, not a blanket publish failure.
+
+## Two constraints on the search
+
+1. It fires in `_project_completed_response`, `src/yoetz/service/daemon.py:762-860`. Bounded errors
+   pass through untouched; only an unexpected exception is reclassified.
+2. **It does not reproduce in-process.** `tests/integration/application/test_full_workflow.py`
+   already publishes multi-event batches successfully. The failure needs the daemon, the control
+   protocol, the client disclosure sink, and the MCP bridge together.
+
+## Ruled out
+
+- `MAX_EVENTS_PER_BATCH` is 100 (`src/yoetz/protocol/models.py:116`). A four-event batch is far
+  under both the request and the response limit.
+- All four event schemas are registered in `_PUBLISH_SUMMARY_CATEGORY`
+  (`src/yoetz/protocol/models.py:1284-1297`), so `_publish_event_selector` should not reject them.
+
+## Live hypotheses, in order
+
+1. **Disclosure pointer resolution.** `_replace_pointer`,
+   `src/yoetz/application/service.py:437-464`, raises `ValueError("projection_pointer_unresolved")`
+   when a static disclosure pointer does not resolve against the actual document — and its own
+   comment names this exact consequence: *"turns a durable success into an apparent failure the
+   caller cannot replay away."* The publish pointer set includes `/accepted_events/*/summary`
+   (`src/yoetz/protocol/models.py:2547-2551`) while `_accepted_model`
+   (`src/yoetz/application/publish_work.py:607-618`) never sets `summary`. Check how the wildcard
+   expands over a four-element array and whether an absent or null `summary` resolves.
+2. **Success-body validation.** `_validate_success_body` runs against the projected document; a
+   closed model rejecting an omission or a null in a position it does not admit would raise here.
+3. **Stored-response persistence.** `store_publish_response` / `load_publish_response` around
+   `daemon.py:797-836`. Note `store_publish_response` already has a `PublicOperationError` escape
+   hatch but nothing for an unexpected exception.
+
+## Procedure
+
+Do not write a fix first. The previous attempt (`0eee854`) improved the message without finding the
+cause, which is why it recurred.
+
+1. Build a subprocess-level reproduction from the exact recorded payload, in the style of
+   `tests/subprocess/test_mcp_service_bridge.py`. That file is the vehicle — the failure needs the
+   real bridge.
+2. If it does not reproduce immediately, bisect the payload: drop the cross-event refs, then the
+   `causal_parents`, then reduce four events to three to two, then vary the schema mix. The first
+   variant that stops failing names the cause.
+3. If it still will not reproduce, wait for run 4 with plan 01's diagnostic sink in place. The
+   `correlation_id` and bounded reason token will then be recoverable instead of lost to stderr —
+   which is precisely the gap that made this a research task rather than a lookup.
+4. Only once it reproduces deterministically, fix it and pin the reproduction as a regression test.
+
+## Files
+
+Unknown until the cause is found. Expected surface: `src/yoetz/application/service.py`,
+`src/yoetz/protocol/models.py` pointer sets, `src/yoetz/service/daemon.py`.
+
+## Tests
+
+- The exact recorded four-event batch replays through the bridge to a full, normally projected
+  success — not merely to plan 01's reduced envelope.
+- Whatever shape triggered it becomes a permanent case in the multi-event publish matrix.
+
+## Done
+
+Green CI, and the recorded batch produces a complete response.
+
+## Dogfood observable
+
+Run 4 shows a multi-event `publish_work` returning a **normal, complete** success — not the reduced
+`accepted_projection_unavailable` envelope. If the reduced envelope appears, plan 01 is working and
+this plan is not yet finished.
+
+## Out of scope
+
+Everything plan 01 already covers. If this hunt runs long, that is acceptable — plan 01 means the
+product is no longer lying to agents in the meantime.

--- a/docs/plans/2026-07-27-run3-residuals/05-accepted-write-root-cause.md
+++ b/docs/plans/2026-07-27-run3-residuals/05-accepted-write-root-cause.md
@@ -2,6 +2,8 @@
 
 **Severity:** critical (cause), non-blocking (schedule) **PR boundary:** the specific projection defect + its regression test
 
+**Status:** completed by PR #50.
+
 **Pairs with:** [01 — safety net](01-accepted-write-safety-net.md). Plan 01 removes the harm. This
 plan removes the cause. It is scheduled last **only because its duration is unknown** — it is a
 research task, and it must never block the three bounded PRs. Start the reproduction early and let
@@ -38,22 +40,25 @@ is content- or shape-dependent, not a blanket publish failure.
   under both the request and the response limit.
 - All four event schemas are registered in `_PUBLISH_SUMMARY_CATEGORY`
   (`src/yoetz/protocol/models.py:1284-1297`), so `_publish_event_selector` should not reject them.
+- **Missing accepted-event summaries.** On this branch, `_publish_work_result_as_json` preserves
+  total omission for an unset accepted-event `summary`, `_public_model` keeps that omission through
+  the public-model round trip, and `_ACCEPTED_SUMMARY_DISCLOSURE_RULES` applies only when a summary
+  leaf actually exists. An absent summary is neither materialized as `null` nor reported as
+  policy-omitted, so `/accepted_events/*/summary` is no longer a live explanation. Any future
+  `projection_pointer_unresolved` failure must identify a different pointer or a distinct
+  failure-specific shape.
+- **Stored-response persistence.** The recorded response can be stored and replayed byte-for-byte
+  after successful projection; persistence was downstream of the failure.
 
-## Live hypotheses, in order
+## Confirmed cause
 
-1. **Disclosure pointer resolution.** `_replace_pointer`,
-   `src/yoetz/application/service.py:437-464`, raises `ValueError("projection_pointer_unresolved")`
-   when a static disclosure pointer does not resolve against the actual document — and its own
-   comment names this exact consequence: *"turns a durable success into an apparent failure the
-   caller cannot replay away."* The publish pointer set includes `/accepted_events/*/summary`
-   (`src/yoetz/protocol/models.py:2547-2551`) while `_accepted_model`
-   (`src/yoetz/application/publish_work.py:607-618`) never sets `summary`. Check how the wildcard
-   expands over a four-element array and whether an absent or null `summary` resolves.
-2. **Success-body validation.** `_validate_success_body` runs against the projected document; a
-   closed model rejecting an omission or a null in a position it does not admit would raise here.
-3. **Stored-response persistence.** `store_publish_response` / `load_publish_response` around
-   `daemon.py:797-836`. Note `store_publish_response` already has a `PublicOperationError` escape
-   hatch but nothing for an unexpected exception.
+The internal publish result materialized an unset accepted-event summary as explicit JSON `null`.
+For the recorded `claim_recorded` event, the shipped policy included the summary's
+`finding_summary` category, so projection preserved the phantom null. Success-body validation then
+rejected it because the closed wire model permits summary text, an omission marker, or total
+absence — never null. PR #50 omits unset summaries at internal serialization and preserves that
+omission through `_public_model`; the exact four-event batch now projects, stores, and replays as a
+complete success.
 
 ## Procedure
 

--- a/src/yoetz/application/publish_work.py
+++ b/src/yoetz/application/publish_work.py
@@ -223,8 +223,15 @@ class PublishWorkInternalResult:
             "writer_id": self.writer_id,
             "subject_frontier": dict(self.subject_frontier.as_wire().items()),
             "result_frontier": dict(self.result_frontier.as_wire().items()),
+            # An unpopulated optional field (today: every accepted event's ``summary``) must be
+            # absent from the internal body, never an explicit null. The wire contract requires
+            # total omission when unset (``optional_non_null_fields``); a materialized null leaf
+            # is classified as content, survives disclosure whenever the policy includes its
+            # category, and is then rejected by the closed success model — turning a durable
+            # publish into ``response_projection_failed``. Same precedent as respond's internal
+            # body, which already excludes nulls at this exact boundary.
             "accepted_events": tuple(
-                cast(JsonValue, event.model_dump(mode="json", exclude_none=False))
+                cast(JsonValue, event.model_dump(mode="json", exclude_none=True))
                 for event in self.accepted_events
             ),
             "warning_codes": self.warning_codes,

--- a/src/yoetz/application/publish_work.py
+++ b/src/yoetz/application/publish_work.py
@@ -212,6 +212,8 @@ class PublishWorkInternalResult:
     versions: PublishWorkVersionSliceModel
 
     def as_json(self) -> dict[str, JsonValue]:
+        """Serialize the closed internal result without materializing absent optional leaves."""
+
         return {
             "protocol_version": self.protocol_version,
             "schema_version": self.schema_version,

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -488,11 +488,13 @@ def _public_model(method: ControlMethod, value: Mapping[str, JsonValue]) -> Proj
     success = success_type.model_validate(value)
     # ``RespondResponseModel`` declares ``optional_non_null_fields`` (reason/waiver_scope/
     # waiver_expiry) that the frozen wire schema requires to be entirely omitted when absent,
-    # never present as an explicit null. A blanket ``exclude_none=False`` round trip here would
-    # reintroduce that null for an ordinary acknowledged response and crash the reflexive
-    # re-validation below, so respond alone excludes it; the other five operations have no
-    # ordinarily-absent ``optional_non_null_fields`` member and keep the established behavior.
-    exclude_none = method is ControlMethod.RESPOND
+    # never present as an explicit null. ``PublishWorkAcceptedEventModel.summary`` is the same
+    # shape one level down: it is ordinarily absent (nothing populates it today), so a blanket
+    # ``exclude_none=False`` round trip here would reintroduce that null and crash the reflexive
+    # re-validation below. Respond and publish therefore exclude nulls; the other four operations
+    # have no ordinarily-absent ``optional_non_null_fields`` member and keep the established
+    # behavior.
+    exclude_none = method in {ControlMethod.RESPOND, ControlMethod.PUBLISH_WORK}
     return result_type.model_validate(success.model_dump(mode="json", exclude_none=exclude_none))
 
 

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -474,6 +474,8 @@ def _frontier_for_projection(source: Mapping[str, JsonValue]) -> Frontier:
 
 
 def _public_model(method: ControlMethod, value: Mapping[str, JsonValue]) -> ProjectedControlBody:
+    """Validate and normalize one projected success body for its public result model."""
+
     model = {
         ControlMethod.START: (StartSuccessModel, StartResultModel),
         ControlMethod.PUBLISH_WORK: (PublishWorkSuccessModel, PublishWorkResultModel),

--- a/tests/integration/application/test_blocked_content_projection.py
+++ b/tests/integration/application/test_blocked_content_projection.py
@@ -126,11 +126,15 @@ class _BlockEverything:
     """
 
     def __init__(self) -> None:
+        """Track every category presented for a blocked disclosure decision."""
+
         self.blocked_categories: set[str] = set()
 
     async def prepare_local_disclosure(
         self, candidate: CandidateContext
     ) -> LocalDisclosureApproved | LocalDisclosureBlocked:
+        """Block actual content while approving candidates with no content leaves."""
+
         sink = candidate.local_sink
         assert sink is not None
         proposal_id = protocol_id("ppr_", 801)
@@ -316,6 +320,8 @@ def _omission_categories(projected: Mapping[str, JsonValue]) -> set[str]:
 
 
 async def test_blocked_content_projects_for_every_event_family_and_the_compact_view() -> None:
+    """Omit absent publish summaries while still blocking real status content."""
+
     app, privacy = _application()
     started = await app.start(start_request(910, title="Blocked projection"))
     obligation_id = protocol_id("obl_", 911)

--- a/tests/integration/application/test_blocked_content_projection.py
+++ b/tests/integration/application/test_blocked_content_projection.py
@@ -1,9 +1,13 @@
 """Blocked content must project to omission markers, never to a failed operation.
 
-The 2026-07-27 Codex dogfood ran with local disclosure unauthorized, so every content leaf was
-blocked. A four-event publication and a compact ``status`` read both returned
-``response_projection_failed`` while the ledger had already advanced. These cases pin the
-end-to-end projection of blocked content for the exact event families and views from that run.
+The 2026-07-27 Codex dogfood ran with local disclosure unauthorized for most categories. A
+four-event publication and a compact ``status`` read both returned ``response_projection_failed``
+while the ledger had already advanced. The publish half of that failure was not blocked content
+at all: the internal result materialized a phantom ``"summary": null`` leaf per accepted event,
+and the leaf the policy *included* (the claim's ``finding_summary``) crashed the closed wire
+model. Unpopulated summaries are now simply absent, so the publish cases here pin that no
+phantom leaf is ever offered to the policy; the compact ``status`` case still pins real blocked
+content projecting to omission markers for the exact view from that run.
 """
 
 from __future__ import annotations
@@ -37,6 +41,7 @@ from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     CandidateContext,
     ConsentSource,
+    LocalDisclosureApproved,
     LocalDisclosureBlocked,
     LocalDisclosureOmission,
     LocalDisclosureReceipt,
@@ -113,12 +118,19 @@ class _BlockedRuntime(MemoryStartRuntime):
 
 
 class _BlockEverything:
-    """Refuse every content leaf, exactly as an unauthorized local disclosure does."""
+    """Refuse every content leaf, exactly as an unauthorized local disclosure does.
+
+    A candidate with no content items cannot be a blocked decision (``LocalDisclosureBlocked``
+    requires at least one omission), so — exactly like the real coordinator — an empty candidate
+    is simply approved with nothing to disclose.
+    """
 
     def __init__(self) -> None:
         self.blocked_categories: set[str] = set()
 
-    async def prepare_local_disclosure(self, candidate: CandidateContext) -> LocalDisclosureBlocked:
+    async def prepare_local_disclosure(
+        self, candidate: CandidateContext
+    ) -> LocalDisclosureApproved | LocalDisclosureBlocked:
         sink = candidate.local_sink
         assert sink is not None
         proposal_id = protocol_id("ppr_", 801)
@@ -160,6 +172,19 @@ class _BlockEverything:
             None,
             1,
         )
+        if not omissions:
+            return LocalDisclosureApproved(
+                proposal_id,
+                candidate.request_id,
+                sink,
+                candidate.purpose,
+                candidate.scope,
+                _DIGEST,
+                _WORKSPACE,
+                (),
+                (),
+                receipt,
+            )
         return LocalDisclosureBlocked(
             proposal_id,
             candidate.request_id,
@@ -336,12 +361,12 @@ async def test_blocked_content_projects_for_every_event_family_and_the_compact_v
     assert type(plan) is PublishWorkInternalResult
     projected_plan = await _project(app, ControlMethod.PUBLISH_WORK, plan_wire, plan, 920)
 
-    # Blocked summaries are replaced by omission markers rather than leaking or failing.
+    # No accepted-event summary was populated, so there is no content to disclose or withhold.
     events = cast(list[Mapping[str, JsonValue]], projected_plan["accepted_events"])
     assert len(events) == 2
     for event in events:
-        assert cast(Mapping[str, JsonValue], event["summary"])["omitted"] is True
-    assert _omission_categories(projected_plan) == {"task_description"}
+        assert "summary" not in event
+    assert _omission_categories(projected_plan) == set()
 
     action_id = protocol_id("act_", 930)
     work_wire: dict[str, JsonValue] = {
@@ -414,14 +439,11 @@ async def test_blocked_content_projects_for_every_event_family_and_the_compact_v
     assert type(work) is PublishWorkInternalResult
     projected_work = await _project(app, ControlMethod.PUBLISH_WORK, work_wire, work, 940)
 
-    # The exact four families of the run's second publication, spanning three data categories
-    # the first publication never exercised.
-    assert len(cast(list[JsonValue], projected_work["accepted_events"])) == 4
-    assert _omission_categories(projected_work) == {
-        "command_metadata",
-        "evidence_excerpt",
-        "finding_summary",
-    }
+    # The exact four families from the run carry no phantom summary leaves into disclosure.
+    work_events = cast(list[Mapping[str, JsonValue]], projected_work["accepted_events"])
+    assert len(work_events) == 4
+    assert all("summary" not in event for event in work_events)
+    assert _omission_categories(projected_work) == set()
 
     status_wire: dict[str, JsonValue] = {
         **_request_base(protocol_id("req_", 950)),
@@ -439,11 +461,5 @@ async def test_blocked_content_projects_for_every_event_family_and_the_compact_v
     assert cast(Mapping[str, JsonValue], item["task_title"])["omitted"] is True
     assert "obligation_text" in _omission_categories(projected_status)
 
-    # Together the three projections cover every category the run touched.
-    assert {
-        "task_description",
-        "obligation_text",
-        "command_metadata",
-        "evidence_excerpt",
-        "finding_summary",
-    } <= privacy.blocked_categories
+    # Only actual status content is blocked; absent publish summaries create no policy decision.
+    assert {"task_description", "obligation_text"} <= privacy.blocked_categories

--- a/tests/integration/application/test_publish_summary_projection.py
+++ b/tests/integration/application/test_publish_summary_projection.py
@@ -1,0 +1,546 @@
+"""The recorded four-event publish batch must project to a complete success.
+
+2026-07-27 Codex dogfood, ``req_7b8c9d0e-1f2a-4b34-8567-8d9e0f1a2b34``: a durable four-event
+publish (action/result/evidence/claim) surfaced as ``response_projection_failed`` after the
+append had committed. The internal result materialized a phantom ``"summary": null`` leaf on
+every accepted event. While the leaf's category was blocked for the agent context it was
+replaced by an omission marker, so the earlier single ``plan_published`` publish (whose
+``task_description`` summary is blocked by the shipped default) projected cleanly. The defect
+fired as soon as a batch contained an event whose summary category the shipped default policy
+*includes* for the agent context (``claim_recorded`` → ``finding_summary``): the null survived
+disclosure and the closed wire model rejected it (``optional_field_must_not_be_null`` — the
+frozen schema never admits an explicit null summary, only text, an omission, or absence).
+
+An unpopulated summary is now simply absent from the internal body, so projection no longer
+depends on the policy's disposition of a leaf that was never content. These cases replay the
+exact recorded batch through the real privacy coordinator seeded with the shipped default's
+disclosure disposition — the same classification, disclosure decision, and closed-model validation the daemon
+runs for an MCP bridge client — and pin the complete response, including the stored-response
+replay the dogfood never reached.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+
+import yoetz.service.ready_composition as ready_composition
+from builders.ledger_adapters import MemoryObjects, ownership_fence
+from builders.start_application import (
+    MemoryStartRuntime,
+    StartTestLookup,
+    protocol_id,
+    start_composition,
+    start_request,
+)
+from yoetz.adapters.memory.privacy import (
+    MemoryPrivacyAudit,
+    MemoryPrivacyCatalogState,
+    MemoryPrivacyPolicyStore,
+)
+from yoetz.adapters.privacy.local_enforcer import LocalPrivacyEnforcer
+from yoetz.application.egress import PrivacyCoordinator
+from yoetz.application.publish_work import PublishWorkInternalResult
+from yoetz.application.service import (
+    Application,
+    ClientProjectionContext,
+    ControlProjectionBinding,
+    ProjectionRenderMode,
+    VerificationPolicy,
+)
+from yoetz.domain.events import RuntimeProfile
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    LocalDisclosureSink,
+    PrivacyPolicy,
+)
+from yoetz.domain.receipts import (
+    PolicyVersionEntry,
+    ReceiptVersionSlice,
+    SchemaVersionEntry,
+)
+from yoetz.domain.values import Frontier
+from yoetz.ports.control import ControlClientKind, ControlMethod
+from yoetz.ports.diagnostics import RuntimeCapability
+from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
+from yoetz.ports.objects import ObjectStorePort
+from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
+from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.models import (
+    DataCategory,
+    FrontierModel,
+    PublishWorkRequest,
+    public_model_to_wire,
+)
+
+# The exact bootstrap default the ready composition seeds: the ADR-009 agent-context allowlist
+# (bounded structural metadata, declared file type, finding summary, obligation text). Reaching
+# for the private builder on purpose: the regression only means something if the policy under
+# test is identical in disposition to the one the daemon seeds, including the ``finding_summary``
+# inclusion that made the recorded batch crash.
+_denied_policy = cast(
+    "Callable[..., PrivacyPolicy]",
+    getattr(ready_composition, "_denied_policy"),
+)
+
+pytestmark = pytest.mark.anyio
+
+_DIGEST = "sha256:" + "7" * 64
+_WORKSPACE = "hmac-sha256:" + "8" * 64
+_INSTALLATION = protocol_id("ins_", 1204)
+_NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+
+
+class _IdleImporter:
+    async def status(self, session: str) -> ImportStatusSnapshot:
+        from yoetz.domain.values import session_id
+
+        return ImportStatusSnapshot(session_id(session), 0, 0, (), ())
+
+
+_CAPABILITIES = frozenset(
+    {
+        RuntimeCapability.WRITE,
+        RuntimeCapability.STRUCTURAL_READ,
+        RuntimeCapability.PAYLOAD_READ,
+    }
+)
+
+
+class _ProjectionRuntime(MemoryStartRuntime):
+    """Extend the START memory composition with ready writer routing."""
+
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        assert command.writer_id is not None
+        assert command.required_capabilities <= _CAPABILITIES
+        task_id, resources = next(iter(self.resources.items()))
+        ledger, objects = resources
+        assert (command.session_id, command.writer_id) in self.owners
+        return TaskRuntime(
+            task_id,
+            command.session_id,
+            command.writer_id,
+            _CAPABILITIES,
+            ledger,
+            objects,
+            cast(ImporterPort, _IdleImporter()),
+            "0.1.0",
+            "0.1.0",
+            "0.1",
+            "1.0.0",
+            ownership_fence(),
+        )
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _shipped_default_policy() -> PrivacyPolicy:
+    return _denied_policy(
+        installation_id=_INSTALLATION,
+        policy_id=protocol_id("pvy_", 1201),
+        policy_digest=_DIGEST,
+        created_at=_NOW,
+    )
+
+
+def _versions() -> ReceiptVersionSlice:
+    return ReceiptVersionSlice(
+        package_name="yoetz",
+        package_version="0.1.0",
+        protocol_version="0.1",
+        engine_version="0.1.0",
+        projection_version="0.1.0",
+        object_format_version="yoetz-object/1",
+        catalog_schema_version="1",
+        bundle_schema_version="1",
+        policy_versions=(
+            PolicyVersionEntry("research-evidence", "0.1.0"),
+            PolicyVersionEntry("work-integrity", "0.1.0"),
+        ),
+        schema_versions=(SchemaVersionEntry("receipts/receipt-document", "1.0.0"),),
+        resource_manifest_digest=_DIGEST,
+    )
+
+
+def _scope(_: ControlProjectionBinding, source: Mapping[str, JsonValue]) -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        _WORKSPACE,
+        cast(str, source["task_id"]),
+    )
+
+
+async def _semantic_disabled(frozen: object, findings: object) -> object:
+    del frozen, findings
+    raise AssertionError("semantic_evaluator_called_in_deterministic_mode")
+
+
+def _request_base(request_id: str) -> dict[str, JsonValue]:
+    return {
+        "protocol_version": "0.1",
+        "schema_version": "1.0.0",
+        "request_id": request_id,
+        "actor": {
+            "actor_id": "codex-grok-easy-linking",
+            "actor_type": "logical_agent",
+            "display_name": "Codex",
+        },
+        "client": {
+            "kind": "cooperative_agent",
+            "version": "1.0",
+            "integration": "cooperative_mcp",
+        },
+    }
+
+
+def _frontier(value: Frontier | FrontierModel) -> JsonValue:
+    if isinstance(value, Frontier):
+        return cast(JsonValue, dict(value.as_wire().items()))
+    return cast(JsonValue, value.model_dump(mode="json"))
+
+
+async def _application() -> tuple[Application, PrivacyPolicy]:
+    """A ready application whose disclosure boundary is the real coordinator and default policy."""
+
+    start_app, start_runtime, clock, catalog = start_composition()
+    ids = start_runtime.ids
+    privacy_state = MemoryPrivacyCatalogState()
+    policies = MemoryPrivacyPolicyStore(privacy_state, clock)
+    policy = _shipped_default_policy()
+    await policies.seed_if_absent(policy)
+    audit = MemoryPrivacyAudit(
+        privacy_state, cast(ObjectStorePort, MemoryObjects(ids)), StartTestLookup(), clock
+    )
+    coordinator = PrivacyCoordinator(
+        policies,
+        LocalPrivacyEnforcer(),
+        audit,
+        _Gateway(),  # type: ignore[arg-type]
+        clock,
+        ids,
+    )
+    runtime = _ProjectionRuntime(clock, ids)
+    app = Application(
+        start_catalog=catalog.delegate,
+        publish_responses=cast(PublishResponseCatalogPort, catalog.delegate),
+        runtime=cast(BundleRuntimePort, runtime),
+        clock=clock,
+        ids=ids,
+        verification_policy=VerificationPolicy(semantic="disabled", max_findings=3),
+        privacy=coordinator,
+        status_cursor_key=b"publish-summary-projection-cursor",
+        waiver_policy_digest=_DIGEST,
+        semantic_evaluator=_semantic_disabled,
+        disclosure_scope_for=_scope,
+        receipt_version_resolver=lambda _: _versions(),
+        waiver_authorizer=lambda _: False,
+        import_publication_authorizer=lambda _: False,
+        profile=RuntimeProfile.TEST_FAKE,
+        policy_packs=("research-evidence/0.1.0", "work-integrity/0.1.0"),
+        version_manifest=start_app.version_manifest,
+    )
+    return app, policy
+
+
+async def _project(
+    app: Application,
+    request_body: Mapping[str, JsonValue],
+    internal: PublishWorkInternalResult,
+    seed: int,
+) -> Mapping[str, JsonValue]:
+    """Run the daemon's exact post-commit projection sequence for an MCP bridge client."""
+
+    context = ClientProjectionContext(
+        ControlClientKind.MCP_BRIDGE, ProjectionRenderMode.MACHINE_READABLE, False
+    )
+    projected = await app.project_result_for_client(
+        context, await _binding(app, request_body, internal, seed), internal
+    )
+    return public_model_to_wire(projected)
+
+
+# The recorded 2026-07-27 payloads, verbatim from
+# docs/dogfood/2026-07-27-grok-easy-linking/codex-events.jsonl (items 21 and 53). Only the
+# installation-bound identities (request/session/writer/frontier) are supplied by the replay.
+_PLAN_DRAFT: Mapping[str, JsonValue] = {
+    "event_id": "evt_4a1b2c3d-5e6f-4a78-9b01-2c3d4e5f6a78",
+    "schema": {"name": "plan_published", "version": "1.0.0"},
+    "occurred_at": "2026-07-27T00:00:00.000Z",
+    "causal_parents": [],
+    "payload": {
+        "plan_version": 1,
+        "summary": (
+            "Trace reviewed provider setup and exact Chat Completions dispatch; add only the "
+            "Grok/xAI preset and operator shortcuts that preserve credential, privacy, "
+            "request-byte, provenance, and receipt boundaries; verify locally and report live "
+            "interoperability honestly."
+        ),
+        "obligation_refs": [],
+    },
+    "artifact_refs": [],
+    "evidence_refs": [],
+}
+
+_RECORDED_DRAFTS: tuple[Mapping[str, JsonValue], ...] = (
+    {
+        "event_id": "evt_5b2c3d4e-6f7a-4b89-8c12-3d4e5f6a7b89",
+        "schema": {"name": "action_recorded", "version": "1.0.0"},
+        "occurred_at": "2026-07-27T16:55:00.000Z",
+        "causal_parents": ["evt_4a1b2c3d-5e6f-4a78-9b01-2c3d4e5f6a78"],
+        "payload": {
+            "action_id": "act_5b2c3d4e-6f7a-4b89-8c12-3d4e5f6a7b89",
+            "action_kind": "edit",
+            "description": (
+                "Added the exact xAI/Grok preset, Chat Completions factory profile, operator "
+                "aliases, focused tests, and authority documentation."
+            ),
+        },
+        "artifact_refs": [],
+        "evidence_refs": [],
+    },
+    {
+        "event_id": "evt_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90",
+        "schema": {"name": "result_recorded", "version": "1.0.0"},
+        "occurred_at": "2026-07-27T16:56:00.000Z",
+        "causal_parents": ["evt_5b2c3d4e-6f7a-4b89-8c12-3d4e5f6a7b89"],
+        "payload": {
+            "result_id": "res_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90",
+            "action_id": "act_5b2c3d4e-6f7a-4b89-8c12-3d4e5f6a7b89",
+            "outcome": "success",
+            "summary": (
+                "Focused provider, request-shape, and CLI tests passed; temporary config "
+                "exercise resolved one factory and retained unknown data-use posture."
+            ),
+        },
+        "artifact_refs": [],
+        "evidence_refs": [],
+    },
+    {
+        "event_id": "evt_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01",
+        "schema": {"name": "evidence_recorded", "version": "1.0.0"},
+        "occurred_at": "2026-07-27T16:57:00.000Z",
+        "causal_parents": ["evt_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90"],
+        "payload": {
+            "evidence_id": "evd_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01",
+            "evidence_kind": "test_result",
+            "strength": "metadata_only",
+            "observed_at": "2026-07-27T16:57:00.000Z",
+            "reference": "focused pytest slice and temporary nonsecret binding/factory exercise",
+        },
+        "artifact_refs": [],
+        "evidence_refs": [],
+    },
+    {
+        "event_id": "evt_8e5f6a7b-9c0d-4e12-8f45-6a7b8c9d0e12",
+        "schema": {"name": "claim_recorded", "version": "1.0.0"},
+        "occurred_at": "2026-07-27T16:58:00.000Z",
+        "causal_parents": ["evt_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01"],
+        "payload": {
+            "claim_id": "clm_8e5f6a7b-9c0d-4e12-8f45-6a7b8c9d0e12",
+            "claim_kind": "completion",
+            "statement": (
+                "The local Grok/xAI easy-linking path is implemented through the exact provider "
+                "preset and existing Chat Completions dispatch boundary, with live "
+                "interoperability still unverified and unknown provider data-use posture "
+                "preserved."
+            ),
+            "supporting_refs": [
+                "evd_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01",
+                "res_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90",
+            ],
+        },
+        "artifact_refs": [],
+        "evidence_refs": [
+            "evd_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01",
+            "res_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90",
+        ],
+    },
+)
+
+
+async def _publish_recorded_session(
+    app: Application,
+) -> tuple[PublishWorkInternalResult, dict[str, JsonValue]]:
+    """Replay the recorded session: the plan publish, then the four-event batch."""
+
+    started = await app.start(start_request(1210, title="Implement Grok/xAI easy linking"))
+    plan_wire = {
+        **_request_base("req_3f8a0e21-6b4c-4d9f-a127-5e6c7b8d9a01"),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(started.frontier),
+        "event_drafts": [_PLAN_DRAFT],
+    }
+    plan = await app.publish_work(PublishWorkRequest.model_validate(plan_wire))
+    assert type(plan) is PublishWorkInternalResult
+
+    batch_wire: dict[str, JsonValue] = {
+        **_request_base("req_7b8c9d0e-1f2a-4b34-8567-8d9e0f1a2b34"),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(plan.result_frontier),
+        "event_drafts": list(_RECORDED_DRAFTS),
+    }
+    batch = await app.publish_work(PublishWorkRequest.model_validate(batch_wire))
+    assert type(batch) is PublishWorkInternalResult
+    return batch, batch_wire
+
+
+async def test_recorded_four_event_batch_projects_to_a_complete_success() -> None:
+    app, policy = await _application()
+    # The pre-fix crash condition: the shipped default really does include the claim's summary
+    # category for the agent context, so the phantom null leaf survived disclosure.
+    assert DataCategory.FINDING_SUMMARY in policy.agent_context_categories
+    assert DataCategory.COMMAND_METADATA not in policy.agent_context_categories
+    assert DataCategory.EVIDENCE_EXCERPT not in policy.agent_context_categories
+
+    batch, batch_wire = await _publish_recorded_session(app)
+    projected = await _project(app, batch_wire, batch, 1220)
+
+    assert projected["ok"] is True
+    assert projected["outcome"] == "accepted"
+    assert "response_completeness" not in projected
+    events = cast(list[Mapping[str, JsonValue]], projected["accepted_events"])
+    assert [event["event_id"] for event in events] == [
+        "evt_5b2c3d4e-6f7a-4b89-8c12-3d4e5f6a7b89",
+        "evt_6c3d4e5f-7a8b-4c90-8d23-4e5f6a7b8c90",
+        "evt_7d4e5f6a-8b9c-4d01-8e34-5f6a7b8c9d01",
+        "evt_8e5f6a7b-9c0d-4e12-8f45-6a7b8c9d0e12",
+    ]
+    # No summary was ever populated, so the honest shape carries no summary at all — never an
+    # explicit null and never an omission marker for content that does not exist.
+    for event in events:
+        assert "summary" not in event
+    projection = cast(Mapping[str, JsonValue], projected["privacy_projection"])
+    assert projection["sink"] == "agent_context"
+    assert projection["included_categories"] == []
+    assert projection["blocked_categories"] == []
+    assert projection["omitted_pointers"] == []
+
+
+async def test_recorded_batch_stored_response_replays_the_complete_success() -> None:
+    app, _policy = await _application()
+    batch, batch_wire = await _publish_recorded_session(app)
+
+    # The daemon's publish replay path: miss on first completion, hit on the byte-identical retry.
+    first = await app.load_publish_response(batch, LocalDisclosureSink.AGENT_CONTEXT)
+    assert first is None
+    projected = await app.project_result_for_client(
+        ClientProjectionContext(
+            ControlClientKind.MCP_BRIDGE, ProjectionRenderMode.MACHINE_READABLE, False
+        ),
+        await _binding(app, batch_wire, batch, 1240),
+        batch,
+    )
+    persisted = await app.store_publish_response(
+        batch, LocalDisclosureSink.AGENT_CONTEXT, projected
+    )
+
+    replayed = await app.publish_work(PublishWorkRequest.model_validate(batch_wire))
+    assert type(replayed) is PublishWorkInternalResult
+    assert replayed.outcome == "replayed"
+    loaded = await app.load_publish_response(replayed, LocalDisclosureSink.AGENT_CONTEXT)
+    assert loaded is not None
+    assert public_model_to_wire(loaded) == public_model_to_wire(persisted)
+    wire = public_model_to_wire(loaded)
+    assert wire["ok"] is True
+    assert len(cast(list[object], wire["accepted_events"])) == 4
+
+
+async def _binding(
+    app: Application,
+    request_body: Mapping[str, JsonValue],
+    internal: PublishWorkInternalResult,
+    seed: int,
+) -> ControlProjectionBinding:
+    facts = await app.projection_binding_facts(ControlMethod.PUBLISH_WORK, request_body, internal)
+    rpc_id = protocol_id("rpc_", seed)
+    service_instance_id = protocol_id("svc_", seed + 1)
+    return ControlProjectionBinding(
+        rpc_id,
+        ControlMethod.PUBLISH_WORK,
+        service_instance_id,
+        1,
+        facts.original_request_id,
+        facts.route_identity_digest,
+        canonical_encode(
+            {
+                "rpc_id": rpc_id,
+                "method": "publish_work",
+                "service_instance_id": service_instance_id,
+                "service_generation": "1",
+            }
+        ),
+    )
+
+
+async def test_fixed_summary_family_batch_projects_to_a_complete_success() -> None:
+    """``assignment_recorded`` has a fixed, structural summary; its phantom null crashed too.
+
+    The fixed-summary rule classifies the leaf ``public_structural``, so no disclosure decision
+    ever rewrote it — the null reached the closed wire model on every publish of the family.
+    """
+
+    app, _policy = await _application()
+    started = await app.start(start_request(1260, title="Assignment projection"))
+    obligation_id = protocol_id("obl_", 1261)
+    obligation_event_id = protocol_id("evt_", 1262)
+    assignment_event_id = protocol_id("evt_", 1263)
+    batch_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 1264)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(started.frontier),
+        "event_drafts": [
+            {
+                "event_id": obligation_event_id,
+                "schema": {"name": "obligation_published", "version": "1.0.0"},
+                "occurred_at": "2026-07-27T12:00:00.000Z",
+                "causal_parents": [],
+                "payload": {
+                    "obligation_id": obligation_id,
+                    "description": "Track the assignment projection case.",
+                    "acceptance_criteria": "An assignment is recorded.",
+                    "evidence_expectation": "The assignment event.",
+                    "requested_items": [{"item_kind": "change", "value": "assignment"}],
+                    "status": "open",
+                },
+                "artifact_refs": [],
+                "evidence_refs": [],
+            },
+            {
+                "event_id": assignment_event_id,
+                "schema": {"name": "assignment_recorded", "version": "1.0.0"},
+                "occurred_at": "2026-07-27T12:00:01.000Z",
+                "causal_parents": [obligation_event_id],
+                "payload": {
+                    "assignee_actor_id": "codex-grok-easy-linking",
+                    "obligation_ids": [obligation_id],
+                    "scope_description": "Owns the assignment projection case.",
+                },
+                "artifact_refs": [],
+                "evidence_refs": [],
+            },
+        ],
+    }
+    batch = await app.publish_work(PublishWorkRequest.model_validate(batch_wire))
+    assert type(batch) is PublishWorkInternalResult
+    projected = await _project(app, batch_wire, batch, 1270)
+
+    assert projected["ok"] is True
+    events = cast(list[Mapping[str, JsonValue]], projected["accepted_events"])
+    assert [event["schema_name"] for event in events] == [
+        "obligation_published",
+        "assignment_recorded",
+    ]
+    for event in events:
+        assert "summary" not in event

--- a/tests/integration/application/test_publish_summary_projection.py
+++ b/tests/integration/application/test_publish_summary_projection.py
@@ -97,7 +97,11 @@ _NOW = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
 
 
 class _IdleImporter:
+    """Provide a stable idle importer status for projection tests."""
+
     async def status(self, session: str) -> ImportStatusSnapshot:
+        """Return an empty importer snapshot for the requested session."""
+
         from yoetz.domain.values import session_id
 
         return ImportStatusSnapshot(session_id(session), 0, 0, (), ())
@@ -116,6 +120,8 @@ class _ProjectionRuntime(MemoryStartRuntime):
     """Extend the START memory composition with ready writer routing."""
 
     async def route(self, command: RouteCommand) -> TaskRuntime:
+        """Resolve the sole seeded task when the requested writer owns it."""
+
         assert command.writer_id is not None
         assert command.required_capabilities <= _CAPABILITIES
         task_id, resources = next(iter(self.resources.items()))
@@ -138,11 +144,17 @@ class _ProjectionRuntime(MemoryStartRuntime):
 
 
 class _Gateway:
+    """Stand in for an unused outbound gateway."""
+
     async def close(self) -> None:
+        """Close the no-op gateway."""
+
         return None
 
 
 def _shipped_default_policy() -> PrivacyPolicy:
+    """Build the shipped default policy at stable test identities."""
+
     return _denied_policy(
         installation_id=_INSTALLATION,
         policy_id=protocol_id("pvy_", 1201),
@@ -152,6 +164,8 @@ def _shipped_default_policy() -> PrivacyPolicy:
 
 
 def _versions() -> ReceiptVersionSlice:
+    """Return a stable version slice for local disclosure receipts."""
+
     return ReceiptVersionSlice(
         package_name="yoetz",
         package_version="0.1.0",
@@ -171,6 +185,8 @@ def _versions() -> ReceiptVersionSlice:
 
 
 def _scope(_: ControlProjectionBinding, source: Mapping[str, JsonValue]) -> AuthorizationScope:
+    """Bind disclosure to the projected result's task identity."""
+
     return AuthorizationScope(
         AuthorizationScopeKind.TASK,
         _INSTALLATION,
@@ -180,11 +196,15 @@ def _scope(_: ControlProjectionBinding, source: Mapping[str, JsonValue]) -> Auth
 
 
 async def _semantic_disabled(frozen: object, findings: object) -> object:
+    """Fail if deterministic projection unexpectedly invokes semantic evaluation."""
+
     del frozen, findings
     raise AssertionError("semantic_evaluator_called_in_deterministic_mode")
 
 
 def _request_base(request_id: str) -> dict[str, JsonValue]:
+    """Build the common recorded MCP request envelope."""
+
     return {
         "protocol_version": "0.1",
         "schema_version": "1.0.0",
@@ -203,6 +223,8 @@ def _request_base(request_id: str) -> dict[str, JsonValue]:
 
 
 def _frontier(value: Frontier | FrontierModel) -> JsonValue:
+    """Normalize domain and wire frontiers to JSON."""
+
     if isinstance(value, Frontier):
         return cast(JsonValue, dict(value.as_wire().items()))
     return cast(JsonValue, value.model_dump(mode="json"))
@@ -396,6 +418,8 @@ async def _publish_recorded_session(
 
 
 async def test_recorded_four_event_batch_projects_to_a_complete_success() -> None:
+    """Project the exact failed dogfood batch as a complete success."""
+
     app, policy = await _application()
     # The pre-fix crash condition: the shipped default really does include the claim's summary
     # category for the agent context, so the phantom null leaf survived disclosure.
@@ -428,6 +452,8 @@ async def test_recorded_four_event_batch_projects_to_a_complete_success() -> Non
 
 
 async def test_recorded_batch_stored_response_replays_the_complete_success() -> None:
+    """Persist and replay the exact projected response without re-projecting it."""
+
     app, _policy = await _application()
     batch, batch_wire = await _publish_recorded_session(app)
 
@@ -462,6 +488,8 @@ async def _binding(
     internal: PublishWorkInternalResult,
     seed: int,
 ) -> ControlProjectionBinding:
+    """Build the daemon-equivalent projection binding for a recorded publish."""
+
     facts = await app.projection_binding_facts(ControlMethod.PUBLISH_WORK, request_body, internal)
     rpc_id = protocol_id("rpc_", seed)
     service_instance_id = protocol_id("svc_", seed + 1)


### PR DESCRIPTION
Update the publish work internal result to exclude unpopulated optional fields, specifically the `summary` for accepted events. This change prevents the internal body from materializing null values, which previously led to projection failures. Additionally, enhance the `_public_model` function to maintain this behavior across response types.

This fix addresses issues identified during the 2026-07-27 Codex dogfood, where a four-event publish resulted in a `response_projection_failed` due to phantom summary leaves. The adjustments ensure that only valid content is disclosed, aligning with the established wire contract.

## Issue

- Linked issue: `Fixes #` / `Refs #`
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging,
  ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

## Documentation

- Behavior change? `yes` / `no`
- Docs updated (ADR, `docs/` page, `docs/INTERFACES.md` entry), or `n/a — no behavior change`:

## Verification

Commands run (paste):

```text

```

## Boundaries

- [ ] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [ ] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

<!-- What changed and why, in a few sentences. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Publish results now omit unavailable event summaries instead of returning `null`.
  - Multi-event publishing now reliably returns complete success responses, including when results are replayed.
  - Unauthorized disclosure handling no longer creates misleading summary entries or omission markers.

- **Documentation**
  - Clarified summary-field behavior in interface documentation.
  - Added planning and recovery documentation covering publish reliability, replay, diagnostics, CLI selection, event authoring, and root-cause investigation.

- **Tests**
  - Added coverage for multi-event projection, stored-response replay, and summary omission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->