### PR TITLE
fix: let check return a response that contains a finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ released versions.
 
 ### Fixed
 
+- **`check` can return a finding.** A check that raised even one finding committed durably and then
+  failed to project, so the caller received `INTERNAL_ERROR` / `response_projection_failed` and
+  never learned the verdict, the finding, or the semantic outcome — in every mode. The public
+  result models are strict, and the internal result carried each nested entry in an immutable
+  mapping type strict validation does not admit; the check result's projected finding additionally
+  requires `provenance` to be present as an explicit null on a deterministic finding. Nested
+  mappings are now normalized structurally at the one projection boundary — no coercion, no
+  reordering, no defaults, and a genuinely invalid shape is still rejected at the same field.
+
 - **An accepted durable `publish_work` is never reported as a failure.** When full response
   projection fails after the append succeeded, the daemon returns a reduced total-acceptance
   success (`ok: true`, `response_completeness: "accepted_projection_unavailable"`) with frontiers,

--- a/docs/plans/2026-07-28-run4-residuals/00-INDEX.md
+++ b/docs/plans/2026-07-28-run4-residuals/00-INDEX.md
@@ -1,0 +1,94 @@
+# Run-4 residuals: making the reviewer speak
+
+**Date:** 2026-07-28
+
+**Source:** [`docs/dogfood/2026-07-28-chatgpt-oauth-signin/`](../../dogfood/2026-07-28-chatgpt-oauth-signin/)
+and the live reproductions recorded in each plan.
+
+Six defects, six sequential PRs. **The numbering is execution order.** Work them 1 through 6. Each
+plan is self-contained: its own PR boundary, its own tests, and what it deliberately leaves alone.
+
+Drafted against `main` at `d3274a7` (the run-4 baseline, PRs #43/#45/#47/#49/#50 merged).
+
+## The thing this set is actually about
+
+Semantic review is the second reviewer: a model that reads the frozen case and returns *explanation
+and advice* the deterministic policies cannot produce. That value is delivered in exactly one place
+— the `findings` array of a check response.
+
+`check` cannot return any response containing a finding. It never could. So **semantic advice has
+never once reached an agent.** The two semantic successes ever observed — run 3 `item_62`, and the
+live Check A on 2026-07-28 — both returned `findings: []`, so they had nothing to carry and the
+defect stayed hidden. The first time semantic has something to say, it fails exactly as run 4's
+three deterministic checks did.
+
+That is why plan 01 is first and plan 02 is second. Everything else follows.
+
+## The order
+
+| # | Plan | Defect | Why here |
+| --- | --- | --- | --- |
+| 01 | [Check response findings](01-check-response-findings.md) | `check` cannot return any response containing a finding | The reviewer's only delivery channel is broken. Nothing semantic can matter until this lands. Also builds the result-model sweep harness plan 04 reuses. |
+| 02 | [Semantic advice delivery](02-semantic-advice-delivery.md) | A semantic finding has never been projected; semantic can decline to run silently | Proves the channel opened by 01 actually carries semantic advice with its provenance, and makes a non-dispatch always say why. |
+| 03 | [Check projection and coverage](03-check-projection-and-coverage.md) | A check leaves no trace and resets coverage to `["none"]` | A successful semantic check currently erases the record that semantic verification happened. Honesty defect, and semantic-relevant. |
+| 04 | [Null optional sweep](04-null-optional-sweep.md) | Unset optional projected as explicit `null` | Breaks the *default* status view. Third sighting of one class; this plan ends the class. |
+| 05 | [Correlation id propagation](05-correlation-id-propagation.md) | The id in an agent-facing error resolves to nothing | Instruments everything after it. Small. |
+| 06 | [Status operation view](06-status-operation-view.md) | `status view=operation` raises `AttributeError` | The recovery surface shipped in PR #47 is unusable. Isolated. |
+
+## What run 4 established about semantic
+
+Worth stating plainly, because it redirects effort.
+
+**Semantic dispatch works.** Verified live twice on 2026-07-28 against the running service
+(generation 28): `semantic_status: succeeded`, `provider_request_id: resp_357677ac6e1f470c…` and
+`resp_a7ff518926644e7e…`, latency 8437 ms, full provenance chain (egress authorization id, privacy
+receipt id, prompt digest, request commitment, schema digest, sampling params), and
+`coverage.check_types: ["deterministic", "semantic_model_derived"]`.
+
+**There is no evidence of a semantic defect.** Run 4's semantic outcome is *unknown*, not *failed*:
+its check response was destroyed by plan 01's defect before `semantic_status` could be read, and
+plan 03's defect meant the durable projection never stored a second copy.
+
+**`semantic_jobs` and `semantic_attempts` are not the record of dispatch.** Both tables are empty
+even for a check that demonstrably dispatched. Do not use them as dispatch evidence.
+
+**The semantic *finding* path has never executed.** Dispatch succeeding and advice arriving are
+different things. `validate_semantic_judgment` → `CheckProjectedFindingModel` with
+`origin: "semantic_model_derived"` and non-null `provenance` has never been exercised against a
+real provider response. Plan 02 owns that.
+
+## Ordering rationale
+
+**The delivery channel leads.** Plan 01 is the only defect that makes an operation unusable, and it
+is the sole blocker on semantic advice. Plan 02 then proves the channel carries the payload.
+
+**File conflicts are light.** Plans 01 and 04 both live around public result-model validation and
+its tests, so 01's sweep harness is what 04 uses to prove its class is closed. Plan 02 touches
+`service/ready_composition.py` and `application/check.py`; plan 03 is confined to
+`adapters/sqlite/repository.py`; plan 06 to `application/status.py`; plan 05 touches
+`ports/control.py`, `service/daemon.py`, and `mcp/server.py`. Plans 03-06 can be reordered among
+themselves without cost.
+
+## Standing decisions
+
+Carried over from the run-3 residual set; not re-litigated inside each plan.
+
+- **Contract freedom: fully open, pre-1.0.** Where the right design requires it, these PRs may
+  change wire shapes, add fields, and regenerate schemas, golden vectors, and the resource
+  manifest. A contract change must update `docs/INTERFACES.md`, the affected ADR, the JSON Schemas
+  under `schemas/`, the vectors under `fixtures/`, and the manifest digests in the same PR.
+  `generate_schemas` does not own every schema — some are hand-authored, and their manifest digests
+  must be refreshed by hand.
+- **One PR per plan, landed sequentially.** The order above is about severity and rebase cost.
+- **Done bar: code + regression tests.** Each PR lands green with tests at the layer the defect
+  actually lives in. No installed-wheel gate inside the PRs.
+- **Proof is dogfood.** Once these land, a run-5 dogfood is the acceptance evidence for the set.
+  Each plan names the observable a dogfood must show.
+
+## What the set does not address
+
+- The dead entity tables `p1_query_checks`, `p1_query_findings`, `p1_query_obligations` and their
+  siblings. Plan 03 deliberately fixes only the aggregate and the coverage lie.
+- Closure ergonomics. Run 4 ended with two acknowledged-but-unresolved findings and no receipt —
+  honest, but with no route to closure. A design question, not a code defect.
+- A controlled Yoetz-enabled versus Yoetz-disabled A/B.

--- a/docs/plans/2026-07-28-run4-residuals/01-check-response-findings.md
+++ b/docs/plans/2026-07-28-run4-residuals/01-check-response-findings.md
@@ -1,0 +1,131 @@
+# 01 — `check` must be able to return a finding
+
+**Severity:** critical **PR boundary:** public result-model projection + a result-model contract sweep
+
+## The defect
+
+`check` cannot return any response that contains a finding. Not one. In any mode.
+
+The check commits durably — `check_recorded` and `finding_recorded` land in the ledger and the
+frontier advances — and then the response fails to project, so the caller receives
+`INTERNAL_ERROR` / `response_projection_failed` and never learns the verdict, the finding, or the
+semantic outcome.
+
+This is the single most damaging defect in the product. `check` exists to tell an agent what is
+wrong with its work, and the delivery channel for that answer is `findings[]`. It has never worked.
+
+**It is also the sole blocker on semantic advice.** Semantic review returns its explanation as
+findings. The two semantic successes ever observed both returned `findings: []`, which is the only
+reason this stayed hidden — they had nothing to carry. See
+[02 — semantic advice delivery](02-semantic-advice-delivery.md).
+
+## Evidence
+
+Reproduced in-process on the real ready composition (real vault, real SQLite, real privacy
+projection) across every mode. The only variable is whether a finding exists:
+
+| Config | Mode | Findings | Check projection |
+| --- | --- | --- | --- |
+| `semantic = disabled` | `deterministic_only` | 2 | **RAISED** |
+| `semantic = optional` | `semantic_required` | 2 | **RAISED** |
+| `semantic = optional` | `semantic_if_configured` | 2 | **RAISED** |
+| any | any | 0 | ok |
+
+```
+ValidationError: 2 validation errors for CheckSuccessModel
+findings.0
+  Input should be a valid dictionary or instance of CheckProjectedFindingModel
+  [type=model_type, input_value=JsonObject((('finding_id'…)), input_type=JsonObject]
+findings.1
+  … same …
+```
+
+Raised at `src/yoetz/application/service.py:490`, inside `_public_model`:
+
+```python
+success = success_type.model_validate(value)
+```
+
+`_ClosedModel` is configured `strict=True` (`src/yoetz/protocol/models.py:409`). Under strict mode
+pydantic accepts only a real `dict` (or an instance of the target model) for a nested model field.
+The internal result carries nested entries as `JsonObject` — a Mapping, but not a `dict` — so every
+nested element is rejected. Top-level fields survive because they are scalars.
+
+Also confirmed live end to end through the running service on 2026-07-28. One task, two checks,
+identical mode, the finding as the only difference:
+
+- Check A, clean work: `ok=True`, `verdict=no_issue_detected`, `findings=0`,
+  `semantic: succeeded / semantic_completed`, full provenance, complete response.
+- Check B, same task plus one `evidence_does_not_support_claim` finding:
+  `internal_error: the local request could not be completed`, and in the durable sink
+  `service.daemon | check_response_projection_failed | exception_validation_error`.
+
+Why three prior dogfoods missed it: **no check had ever produced a finding.** Run 3's semantic
+check passed only because `findings: []`.
+
+## Design
+
+### 1. Normalize nested mappings once, at the projection boundary
+
+In `_public_model`, convert the internal JSON value to plain `dict`/`list` recursively before
+`model_validate`. One place, above every result model, so no individual serializer has to remember.
+
+Constraints:
+
+- The conversion is structural only. It must not coerce scalars, reorder keys, drop keys, or
+  substitute defaults — a shape that is genuinely invalid must still be rejected, with the same
+  error it raises today.
+- It must not weaken `strict=True`. Relaxing strictness on the closed models is the wrong fix: it
+  would start accepting int-for-string and other coercions across the whole public contract.
+- It must be bounded — the existing depth and size limits on internal results still apply, and a
+  pathological structure must degrade to a rejection rather than unbounded recursion.
+
+### 2. Close the class with a result-model sweep
+
+PR #50 fixed one instance of a projection defect and the class survived to reappear twice. Do not
+repeat that. Add a sweep test that walks every public result model with a nested collection and
+asserts each projects from a realistic internal result:
+
+- `check` — `findings`, `policy_executions`
+- `publish_work` — `accepted_events`
+- `status` — every view's `page.items`, plus the nested `open_obligations` and
+  `unresolved_findings` inside a compact item
+- `respond` — `accepted_event`, `evidence`
+- `receipt` — its nested slices
+- `start` — `compact`
+
+This harness is reused by [04 — null optional sweep](04-null-optional-sweep.md), so build it to be
+extended rather than as a one-off.
+
+## Files
+
+- `src/yoetz/application/service.py` — `_public_model`, the normalization
+- `tests/integration/application/` — the check-with-findings regression
+- a new sweep test module covering every public result model with a nested collection
+
+## Tests
+
+- A `check` returning one finding projects to a complete `CheckSuccessModel`; assert the verdict,
+  the finding id, kind, origin, priority, `summary`, `detail`, and `subject_refs` all survive.
+- The same in `deterministic_only`, `semantic_if_configured`, and `semantic_required` — the defect
+  is mode-independent and the test must say so.
+- A check returning the maximum permitted findings projects.
+- A genuinely malformed nested entry is still rejected, with an error naming the same pointer as
+  today. Normalization must not become a shape-laundering step.
+- The sweep: every public result model with a nested collection projects.
+- No test may assert on `JsonObject` specifically — the invariant is "nested mappings project",
+  not "this one internal type is handled".
+
+## Done
+
+Green CI, and a `check` that produces findings returns them.
+
+## Dogfood observable
+
+Run 5 must show a `check` returning at least one finding to the agent, with its `summary` and
+`detail` text. No `check` may return `INTERNAL_ERROR` / `response_projection_failed`.
+
+## Out of scope
+
+Why a check produces the findings it produces. Semantic delivery and non-dispatch reporting
+(plan 02). The durable projection of check state (plan 03).

--- a/docs/plans/2026-07-28-run4-residuals/02-semantic-advice-delivery.md
+++ b/docs/plans/2026-07-28-run4-residuals/02-semantic-advice-delivery.md
@@ -1,0 +1,164 @@
+# 02 — The second reviewer must deliver its advice, or say why it did not
+
+**Severity:** critical **PR boundary:** semantic finding projection + non-dispatch observability + binding freshness
+
+**Depends on:** [01](01-check-response-findings.md) for the delivery channel. Until 01 lands, no
+semantic finding can reach an agent regardless of what this plan does.
+
+## Why this matters
+
+Semantic review is a second agent reading the frozen case and returning *explanation and advice* —
+the reasoning a deterministic policy cannot produce. It is the difference between "policy
+`work-integrity` fired rule X" and "your evidence is metadata-only, so this completion claim
+overstates what you verified; cite the digest or narrow the claim."
+
+That value is delivered in exactly one place: a finding with `origin: "semantic_model_derived"`
+carrying `summary`, `detail`, and `provenance`. **That path has never executed.**
+
+## The defect, in two parts
+
+### Part A — the semantic finding path is unexercised
+
+Dispatch working and advice arriving are different things, and only the first has ever been proven.
+
+Every observed semantic success returned `findings: []`:
+
+| Run | Semantic outcome | Findings |
+| --- | --- | --- |
+| Run 3 `item_62` (2026-07-27) | `succeeded / semantic_completed`, `provider_request_id: resp_97b64b05…` | **0** |
+| Live Check A (2026-07-28) | `succeeded / semantic_completed`, `provider_request_id: resp_357677ac…` | **0** |
+| Live Check A, second execution | `succeeded / semantic_completed`, `provider_request_id: resp_a7ff5189…` | **0** |
+
+So `validate_semantic_judgment` → `allocate_findings` → `CheckProjectedFindingModel` with
+`origin: "semantic_model_derived"` and non-null `provenance` has never run against a real provider
+response. `CheckProjectedFindingModel` enforces a hard pairing
+(`src/yoetz/protocol/models.py:1654-1657`):
+
+```python
+if self.origin == "deterministic" and self.provenance is not None:
+    raise ValueError("deterministic_finding_provenance_invalid")
+if self.origin == "semantic_model_derived" and self.provenance is None:
+    raise ValueError("semantic_finding_provenance_missing")
+```
+
+Neither branch has ever been exercised end to end. Given plan 01's history — a strict-mode
+rejection that sat latent for four dogfoods because nothing ever populated the array — the semantic
+finding must be proven, not assumed.
+
+### Part B — semantic can decline to run and record nothing
+
+There are three paths on which semantic does not dispatch. Two are completely silent: no job, no
+diagnostic, no log line, nothing durable.
+
+| Path | Where | Reported outcome | Records anything? |
+| --- | --- | --- | --- |
+| `provider is None` | `ready_composition.py:1413` | `not_configured / provider_not_configured` | **no** |
+| route absent or not `ACTIVE` | `ready_composition.py:1416-1417` | `not_configured / provider_not_configured` | **no** |
+| binding unresolved at composition | `ready_composition.py:1635` | `unavailable / credential_unavailable` | **no** |
+| evaluator raises | `ready_composition.py:1478-1490` | `failed / coordinator_failure` | yes — `semantic_composition` / `semantic_evaluation_failed` |
+| evaluator raises above the composition | `check.py:836` bare `except Exception` | `failed / coordinator_failure` | **no** |
+
+In run 4 the durable sink contains **zero** `semantic_composition` records, so the one instrumented
+path did not fire — it was one of the silent ones, and which one is unrecoverable.
+
+The only place the answer would have surfaced is `semantic_status` / `semantic_reason` in the check
+response, which plan 01's defect destroyed; the durable second copy in `p1_query_checks` was never
+written because of plan 03's defect. **Two independent defects erased the reason.**
+
+### Part B2 — the binding is resolved once and never revisited
+
+`provider_binding` is computed at service composition (`ready_composition.py:1554-1563`):
+
+```python
+if candidate_binding.provider_id in connected_provider_ids:
+    provider_binding = candidate_binding
+provider_credential_connected = provider_binding is not None
+```
+
+`connected_provider_ids` reads the generation-fenced registry at that instant. If the vault or the
+credential registry is not ready at composition time, semantic is dead for the **entire service
+generation**, silently, and unlocking afterwards does not revive it. `yoetz provider status` will
+keep reporting the endpoint as bound, so nothing surfaces the difference.
+
+## Design
+
+### 1. Prove the semantic finding path
+
+An integration test that drives a semantic judgment through `validate_semantic_judgment`,
+`allocate_findings`, and the public projection, asserting a finding arrives with
+`origin: "semantic_model_derived"`, non-null `provenance`, and its `summary` and `detail` intact.
+
+Use a deterministic stand-in for the provider so the test is hermetic — the point is the
+projection contract, not live dispatch. Additionally assert the negative pairing: a semantic
+finding without provenance is rejected, and a deterministic finding carrying provenance is
+rejected.
+
+### 2. Every non-dispatch path records a bounded diagnostic
+
+Add `record_unexpected_exception_without_raising`-style emission — or the equivalent bounded
+diagnostic write — to each silent return, with an operation token naming the path:
+
+- `semantic_not_dispatched_provider_unbound`
+- `semantic_not_dispatched_route_inactive`
+- `semantic_not_dispatched_credential_unavailable`
+- `semantic_not_dispatched_coordinator_failure` (the `check.py` bare `except`)
+
+Same discipline as the existing sink: `correlation_id`, `component`, `operation`, bounded reason
+token, `request_id`, timestamp. **No exception text, no payload, no provider identity, no paths.**
+
+The `check.py:836` bare `except Exception` must stop discarding its cause. Keep the fail-closed
+behaviour — it must still never fabricate a clean semantic pass — but record the bounded reason
+token before returning `FAILED / COORDINATOR_FAILURE`.
+
+### 3. Say why, in the response
+
+When semantic does not run, the agent should be able to act on it. `semantic_status` and
+`semantic_reason` already carry this and `semantic_coverage_gap_code` already adds the gap to
+`coverage.known_gaps` — both become visible the moment plan 01 lands. This plan adds no new wire
+field; it adds a test that pins the pairing for each non-dispatch reason so the agent-visible
+answer cannot silently regress.
+
+### 4. Re-resolve the provider binding
+
+Decide and implement one of: re-resolve `provider_binding` at check time rather than caching it
+from composition, or invalidate the composition-time value when the vault or credential generation
+changes. Whichever is chosen, a service that composes with a locked vault and is unlocked
+afterwards must be able to dispatch semantic without a restart, and a test must assert it.
+
+## Files
+
+- `src/yoetz/service/ready_composition.py` — the silent returns, the binding resolution
+- `src/yoetz/application/check.py` — the bare `except` at `_semantic_evaluation`
+- `src/yoetz/observability/diagnostics.py` — no change expected; reuse the existing sink
+- tests under `tests/integration/` for the semantic finding projection and each non-dispatch path
+
+## Tests
+
+- A semantic finding projects with `origin: "semantic_model_derived"`, non-null `provenance`, and
+  its `summary`/`detail` text.
+- A semantic finding missing provenance is rejected; a deterministic finding with provenance is
+  rejected.
+- Each of the four non-dispatch paths produces its distinct bounded diagnostic **and** its exact
+  `semantic_status` / `semantic_reason` pair and coverage gap code.
+- A diagnostic carries no exception text, no payload, no provider identity, no filesystem path.
+- Composing with an unavailable credential and then making it available lets a later check
+  dispatch, with no service restart.
+- `semantic_required` with a non-dispatching semantic path still yields a *projectable* response
+  reporting the reason — the agent is told why, not given an internal error.
+
+## Done
+
+Green CI, a semantic finding demonstrably projects, and every path on which semantic declines to
+run leaves a durable, resolvable record.
+
+## Dogfood observable
+
+Run 5 must be built so semantic has something to say. The signal: at least one finding with
+`origin: "semantic_model_derived"` delivered to the agent with its explanation text and its
+`provider_request_id` provenance. If semantic does not run, the agent must be told which of the
+named reasons applied, and the sink must contain the matching record.
+
+## Out of scope
+
+The delivery channel itself (plan 01). Persisting check state durably (plan 03). Changing what the
+semantic policy asks the model, or the prompt.

--- a/docs/plans/2026-07-28-run4-residuals/03-check-projection-and-coverage.md
+++ b/docs/plans/2026-07-28-run4-residuals/03-check-projection-and-coverage.md
@@ -1,0 +1,129 @@
+# 03 — A check must not erase the record that it happened
+
+**Severity:** high (honesty) **PR boundary:** the SQLite work-projection update statements
+
+## The defect
+
+Running a check leaves no trace in the durable projection, and actively overwrites the task's
+coverage vector with `check_types: ["none"]` — the claim that no check has been performed.
+
+The coverage vector is the load-bearing artifact of the product's honesty promise: *"It will tell
+you exactly what was checked, at what coverage."* Today a check makes that vector say less than the
+truth, permanently, including after a fully successful semantic verification.
+
+## Evidence
+
+A fresh task on 2026-07-28. Check A at ingestion sequence 7 succeeded with live semantic
+verification (`semantic_status: succeeded`, `provider_request_id: resp_357677ac…`,
+`coverage.check_types: ["deterministic", "semantic_model_derived"]` in the response). A second
+check landed at sequence 13. The durable projection afterwards:
+
+```
+frontier_seq              = 13
+latest_check_event_id     = None
+latest_verdict            = None
+latest_coverage_canonical = None
+p1_query_checks           = 0 rows
+status_coverage_canonical = {… "check_types":["none"] …}
+```
+
+Sixteen events, `applied_through_seq = 16`, `unknown_event_count = 0` in run 4's task — the events
+were applied; nothing about the check was retained.
+
+Two distinct causes, both in `src/yoetz/adapters/sqlite/repository.py`:
+
+**Cause 1 — no check column is ever written.** Both projection updates (line 973, the ordinary
+append path, and line 1091, `_persist_derived_records`, which is the path a check takes) set only:
+
+```
+frontier_seq, head_digest, open_obligation_count, unresolved_finding_count,
+freshness, unknown_event_count, task_title_source_event_id,
+status_coverage_canonical, status_gap_codes_canonical
+```
+
+`latest_check_event_id`, `latest_subject_frontier_seq`, `latest_subject_frontier_digest`,
+`latest_verdict`, `latest_returned_finding_ids`, `latest_suppressed_count`, and
+`latest_coverage_canonical` are never assigned after the seed insert in
+`src/yoetz/adapters/sqlite/migrations.py:185`. **The columns already exist**, so no migration and
+no schema-version bump is required.
+
+**Cause 2 — coverage is taken from the last event of the batch.** Both updates write:
+
+```python
+canonical_encode(coverage_to_json(records[-1].coverage))
+```
+
+For an engine-derived check batch the last record is `check_recorded`, whose *envelope* coverage is
+`check_types: ["none"]` with `publication_channels: ["engine_derived"]`. So the check's own event
+overwrites the task's status coverage with the assertion that nothing was checked.
+
+This is why `status view=versions` reported `check_types: ["none"]` after two checks in run 4 — not
+a view bug. The durable state genuinely said that.
+
+## Design
+
+### 1. Populate the check aggregate
+
+On the derived-records path, when the batch contains a `check_recorded` event, write
+`latest_check_event_id`, `latest_subject_frontier_seq`, `latest_subject_frontier_digest`,
+`latest_verdict`, `latest_returned_finding_ids`, `latest_suppressed_count`, and
+`latest_coverage_canonical` from the in-memory projection the reducer already holds.
+
+The values must come from the reducer's own state, not be recomputed from the wire result — the
+durable mirror and the response must not be able to disagree.
+
+`0001.sql:732` and `:742` already carry consistency constraints over `latest_check_event_id`
+being null versus non-null. Honour them; do not relax them. If a partial write would violate a
+constraint, that is the constraint doing its job and the projection is wrong.
+
+### 2. Stop the last event from defining coverage
+
+Status coverage must reflect the *applicable check's* coverage, not the envelope of whichever event
+happened to land last. The reducer already computes the correct value —
+`tests/integration/application/test_respond_status_receipt.py:876-891` asserts exactly this
+behaviour at the application layer, with a comment naming it as the run-2 symptom. The durable
+mirror does not implement it.
+
+Write the projection's own coverage rather than `records[-1].coverage`, on **both** update paths —
+the ordinary append path has the same bug and will exhibit it as soon as anything reads coverage
+from the durable mirror after a restart.
+
+### 3. Prove it survives a restart
+
+The current defect is invisible in-process because the in-memory projection holds the truth. Every
+test for this plan must read the durable mirror back — reopen the bundle, or assert directly
+against `p1_projection_state` — otherwise it will pass against the bug.
+
+## Files
+
+- `src/yoetz/adapters/sqlite/repository.py` — both `UPDATE p1_projection_state` statements
+- tests under `tests/integration/` that reopen the bundle and assert durable state
+
+## Tests
+
+- After a check, `latest_check_event_id`, `latest_verdict`, and `latest_coverage_canonical` are
+  populated in `p1_projection_state`.
+- After a check, `status_coverage_canonical.check_types` reflects the check — `["deterministic"]`,
+  or `["deterministic", "semantic_model_derived"]` when semantic succeeded — and never `["none"]`.
+- The same assertions after closing and reopening the bundle: the mirror, not the cache.
+- A check followed by ordinary published work does not resurrect `["none"]`.
+- The `0001.sql` consistency constraints hold for a task with no check, one check, and two checks.
+- A task that has never been checked still reports `check_types: ["none"]` — the fix must not
+  fabricate coverage.
+
+## Done
+
+Green CI, and a checked task's durable coverage reports what was actually checked.
+
+## Dogfood observable
+
+Run 5: after a successful `check`, `status view=versions` must report
+`coverage.check_types` containing `deterministic` — and `semantic_model_derived` when semantic
+succeeded — rather than `["none"]`.
+
+## Out of scope
+
+Populating the entity tables `p1_query_checks`, `p1_query_check_policy_executions`, and
+`p1_query_check_returned_findings`. They are dead today and nothing observed depends on them; that
+is a larger reducer change with no defect behind it yet. This PR fixes the aggregate and the
+coverage lie only.

--- a/docs/plans/2026-07-28-run4-residuals/04-null-optional-sweep.md
+++ b/docs/plans/2026-07-28-run4-residuals/04-null-optional-sweep.md
@@ -61,8 +61,9 @@ summaries; apply the same discipline here.
 
 ### 2. Sweep every model that declares the constraint
 
-Fourteen models declare `optional_non_null_fields`. For each, determine whether any projection can
-emit `null` for a listed field, fix the ones that can, and pin every one with a test:
+Twenty models declare `optional_non_null_fields` — the table below is the full inventory, verified
+against the declarations in `src/yoetz/protocol/models.py`. For each, determine whether any
+projection can emit `null` for a listed field, fix the ones that can, and pin every one with a test:
 
 | Model | Fields |
 | --- | --- |

--- a/docs/plans/2026-07-28-run4-residuals/04-null-optional-sweep.md
+++ b/docs/plans/2026-07-28-run4-residuals/04-null-optional-sweep.md
@@ -1,0 +1,130 @@
+# 04 — End the unset-optional-becomes-null class
+
+**Severity:** high **PR boundary:** every projection that can emit `null` for a non-null optional
+
+**Reuses:** the result-model sweep harness built in [01](01-check-response-findings.md).
+
+## The defect
+
+An obligation published without `acceptance_criteria` breaks `status view=compact` — the **default
+view** — and `status view=obligations`. The projection materializes the unset optional as explicit
+JSON `null`, and the closed wire model rejects it.
+
+This is the **third** sighting of one class. PR #50 fixed it for accepted-event `summary`; it
+reappeared here in two more views. Fixing this instance alone would be the same mistake a third
+time, so this plan closes the class.
+
+## Evidence
+
+Reproduced in-process on the real ready composition. An obligation with `description` and
+`evidence_expectation` and no `acceptance_criteria` — exactly what run 4's agent published:
+
+```
+status compact      RAISED ValidationError: items.0.open_obligations.0
+    Value error, optional_field_must_not_be_null
+    input_value={'obligation_id': 'obl_…', …, 'acceptance_criteria': None}
+status obligations  RAISED ValidationError: items.0
+    Value error, optional_field_must_not_be_null
+```
+
+`versions`, `findings`, `history`, `evidence`, `advice`, `assignment`, and `candidate_findings`
+project cleanly. Run 4 hit `compact` (`item_32`) and recovered via `versions`; it never called
+`obligations`, so that half went unreported.
+
+The guard is in `_ClosedModel` (`src/yoetz/protocol/models.py:816-823`):
+
+```python
+@model_validator(mode="before")
+def _adapt_json_arrays_and_reject_forbidden_nulls(cls, value: object) -> object:
+    for field_name in cls.optional_non_null_fields:
+        if field_name in source and source[field_name] is None:
+            raise ValueError("optional_field_must_not_be_null")
+```
+
+The contract is deliberate and correct: these fields admit text, an omission marker, or *total
+absence* — never null. The projection is what is wrong.
+
+The two models hit here are `StatusCompactObligationModel`
+(`src/yoetz/protocol/models.py:1978-1994`) and `StatusObligationItemModel` (`:2235-2236`), both
+declaring `optional_non_null_fields = frozenset({"acceptance_criteria"})`.
+
+The in-memory ledger already does this correctly — `src/yoetz/adapters/memory/ledger.py:715-716`
+and `:730-731` omit the key when the value is `None`. The path that runs in production does not.
+
+## Design
+
+### 1. Fix the obligation projection
+
+Omit the key entirely when the source value is unset, rather than emitting `null`, and preserve
+that omission through `_public_model`. This is the shape PR #50 established for accepted-event
+summaries; apply the same discipline here.
+
+### 2. Sweep every model that declares the constraint
+
+Fourteen models declare `optional_non_null_fields`. For each, determine whether any projection can
+emit `null` for a listed field, fix the ones that can, and pin every one with a test:
+
+| Model | Fields |
+| --- | --- |
+| `ActorAssertionModel` | `asserted_by`, `display_name` |
+| `SubjectStateRefModel` | `tree_digest`, `diff_digest`, `described_state` |
+| `PublicErrorModel` | `safe_details` |
+| `StartRequestModel` | `session_id`, `external_ref`, `workspace_ref` |
+| `PublishWorkRequestModel` | `dry_run` |
+| `CheckRequestModel` | `mode`, `scope`, `max_findings`, `policy_packs` |
+| `RespondRequestModel` | (several) |
+| `StatusAssignmentFilterModel` | `actor_id`, `include_resolved` |
+| `StatusCandidateFindingsFilterModel` | `priority` |
+| `StatusEvidenceFilterModel` | `freshness`, `include_unavailable`, `strength` |
+| `StatusFindingsFilterModel` | `disposition`, `include_resolved`, `origin`, `priority` |
+| `StatusHistoryFilterModel` | `actor_id`, `after_sequence`, `schema_name` |
+| `StatusObligationsFilterModel` | `actor_id`, `include_resolved`, `status` |
+| `StatusRequestModel` | `filter` |
+| `PublishWorkAcceptedEventModel` | `summary` — fixed by PR #50; keep its test |
+| `RespondEvidenceSummaryModel` | `description` |
+| `RespondResponseModel` | `reason`, `waiver_scope`, `waiver_expiry` |
+| `StatusCompactObligationModel` | `acceptance_criteria` — this defect |
+| `StatusStructuralSubjectStateModel` | `tree_digest`, `diff_digest` |
+| `StatusObligationItemModel` | `acceptance_criteria` — this defect |
+
+Request models are caller-supplied and already reject null correctly; the audit still needs to
+confirm no *internal* construction path can produce one. Result models are the real risk surface.
+
+### 3. Make the class untestable-to-forget
+
+Extend plan 01's sweep so that for every result model declaring `optional_non_null_fields`, a case
+exists with each such field unset, projected end to end. A new model that declares the constraint
+and has no such case should be visibly missing from the table.
+
+## Files
+
+- the obligation projection path feeding `StatusCompactObligationModel` and
+  `StatusObligationItemModel`
+- `src/yoetz/application/status.py` if the omission needs preserving through the view
+- the sweep test module from plan 01
+
+## Tests
+
+- An obligation with no `acceptance_criteria` projects through `view=compact` and
+  `view=obligations`.
+- An obligation *with* `acceptance_criteria` still projects, with the text intact.
+- An obligation whose `acceptance_criteria` is policy-omitted projects as an omission marker, not
+  as absence and not as null — the three states stay distinguishable.
+- For every result model declaring `optional_non_null_fields`, a case with each field unset
+  projects.
+- The `_ClosedModel` guard still rejects an explicit null — this plan fixes producers, and must not
+  weaken the contract.
+
+## Done
+
+Green CI, and no projection can emit `null` for a field the wire contract forbids it on.
+
+## Dogfood observable
+
+Run 5: `status view=compact` must succeed on a task with an open obligation. No
+`read_projection_failed` on any status view.
+
+## Out of scope
+
+Changing which fields are optional, or the omission-marker contract. This plan makes producers obey
+the existing contract.

--- a/docs/plans/2026-07-28-run4-residuals/05-correlation-id-propagation.md
+++ b/docs/plans/2026-07-28-run4-residuals/05-correlation-id-propagation.md
@@ -1,0 +1,117 @@
+# 05 — The correlation id an agent is shown must resolve
+
+**Severity:** medium **PR boundary:** `ControlError` correlation identity + bridge reuse
+
+## The defect
+
+Every failure the agent sees carries a `correlation_id`. For everything except an accepted
+`publish_work`, that id resolves to nothing, because the id written to the durable diagnostic sink
+and the id handed to the caller are different ids.
+
+The previous residual set built the durable sink specifically so "the id in an agent-facing error
+resolves to something." It half-works: the records are there and they are excellent, but the id
+printed to the agent is not the id under which they are filed.
+
+## Evidence
+
+Run 4, check #1. What the agent was shown, and what the sink holds at the same instant:
+
+```
+$ yoetz service diagnostics --correlation-id err_c233d86e-3e7e-441a-a4e7-b6379f096e8f
+{"correlation_id":"err_c233d86e-…","count":0,"records":[]}
+
+$ yoetz service diagnostics --correlation-id err_7b8ec46e-8d0b-42cf-ba12-85ca1317fc6d
+{"count":1,"records":[{"component":"service.daemon",
+  "operation":"check_response_projection_failed","reason":"exception_validation_error",
+  "request_id":"req_a8b4c004-f0d4-4fbd-825e-0d72e37cae06",
+  "timestamp":"2026-07-28T09:56:10.989Z"}]}
+```
+
+Same failure, same millisecond, two ids. The agent-facing one is a dead end.
+
+The cause is structural. `ControlError` has no correlation field at all —
+`src/yoetz/ports/control.py:270`:
+
+```python
+__slots__ = ("accepted_state", "reason", "retryable")
+```
+
+The daemon mints one and uses it only for the reduced publish envelope
+(`src/yoetz/service/daemon.py:926-942`):
+
+```python
+correlation_id = record_unexpected_exception_without_raising(...)
+if request.method is ControlMethod.PUBLISH_WORK:
+    reduced = _publish_accepted_projection_unavailable(internal, correlation_id=correlation_id, ...)
+    ...
+raise ControlError(reason, retryable=True, accepted_state=accepted_state) from exc
+```
+
+The id dies with that statement. The bridge then mints a fresh one for the client
+(`src/yoetz/mcp/server.py:283`):
+
+```python
+correlation_id if correlation_id is not None else new_id(IdKind.CORRELATION)
+```
+
+The comment at `daemon.py:924-925` states the intent — *"One correlation id for the unexpected
+failure path: shared by the reduced publish envelope and the diagnostic ring; no second mint on
+ControlError fallback"* — and it is true only for `publish_work`.
+
+Exactly one run-4 correlation id resolved: `err_7e5c31e9-…`, the `status view=operation` failure,
+because it was minted at the bridge where the client id is also minted.
+
+## Design
+
+### 1. Carry the correlation id on `ControlError`
+
+Add an optional `correlation_id` to `ControlError` and populate it wherever the daemon has already
+minted one. It is a bounded, structural, service-generated identifier with no caller content — it
+belongs in the same category as `reason` and carries no disclosure risk.
+
+Keep the existing `bind_correlation_id` behaviour at the bridge as the fallback for errors that
+genuinely originate there, so a bridge-level failure still gets an id.
+
+### 2. Bridge reuses rather than mints
+
+Where a `ControlError` arrives carrying an id, the bridge must surface that id to the client rather
+than generating a new one. Where it does not, the bridge mints and records under its own id, as
+today.
+
+### 3. Never two ids for one failure
+
+The invariant to pin: for any single failure, the id in the agent-facing error and the id in the
+diagnostic sink are the same string. A test must assert this for a read failure, a write failure,
+and a bridge-level failure — not just for the accepted-publish path that already works.
+
+## Files
+
+- `src/yoetz/ports/control.py` — `ControlError` correlation field
+- `src/yoetz/service/daemon.py` — pass the minted id into the raised error
+- `src/yoetz/mcp/server.py` — reuse rather than mint
+- `src/yoetz/cli/` — no change expected; `yoetz service diagnostics` already reads the sink
+
+## Tests
+
+- Force a `check` response-projection failure: the `correlation_id` in the public error resolves
+  through `yoetz service diagnostics --correlation-id` to exactly one record.
+- The same for a `status` read failure (`read_projection_failed`).
+- A bridge-level failure with no service-side id still produces a resolvable id.
+- An accepted `publish_work` reduced envelope keeps today's behaviour — the envelope id and the
+  sink id already match, and must continue to.
+- The correlation id never appears in any durable record alongside exception text, payload, or a
+  filesystem path.
+
+## Done
+
+Green CI, and every agent-facing correlation id resolves to its record.
+
+## Dogfood observable
+
+Run 5: any correlation id appearing in an agent-facing error resolves through
+`yoetz service diagnostics --correlation-id` to exactly one record naming the failing operation.
+
+## Out of scope
+
+What the diagnostic records contain, and the sink's format or retention. Adding new diagnostic
+emission points — plan 02 owns the semantic ones.

--- a/docs/plans/2026-07-28-run4-residuals/06-status-operation-view.md
+++ b/docs/plans/2026-07-28-run4-residuals/06-status-operation-view.md
@@ -1,0 +1,107 @@
+# 06 — `status view=operation` must work
+
+**Severity:** medium **PR boundary:** the `operation` branch of `execute_status`
+
+## The defect
+
+`status view=operation` — the recovery surface shipped by PR #47 in the previous residual set —
+raises an `AttributeError` inside the daemon and surfaces as a **non-retryable**
+`INTERNAL_ERROR: "The bridge could not complete the operation."`
+
+It failed on its first real use, at the exact moment it was designed for: the agent had an
+ambiguous `check` and reached for the operation view to recover the stored result.
+
+## Evidence
+
+Run 4 `item_40`. The agent asked for the operation record of the failed check
+(`req_a8b4c004-…`) and received:
+
+```
+INTERNAL_ERROR  "The bridge could not complete the operation."
+correlation_id: err_7e5c31e9-aaf4-41a9-8d7a-cec3fa119f44
+retryable: false
+```
+
+The durable sink holds both halves of that failure, 44 ms apart:
+
+```
+09:56:16.902Z | service.daemon | status_internal_error | exception_attribute_error | req_f5f30b50-…
+09:56:16.946Z | mcp.bridge     | status_internal_error | exception_control_error   | req_f5f30b50-…
+```
+
+The daemon-side reason is `exception_attribute_error` — an `AttributeError`, not a bounded error.
+It escaped `_project_completed_response` and was caught by the generic dispatch handler at
+`src/yoetz/service/daemon.py:700-706`, which means it was raised during `application.status(...)`
+execution, not during response projection.
+
+The `operation` branch is `src/yoetz/application/status.py:746-793`. The exact attribute has not
+been localized; candidates visible on inspection include the `except PublicOperationError` recovery
+branch at `:777-784`, which reads `head.sequence` and reassigns `head` — `head` is bound only in
+the `else` arm of the cursor decode at `:737-738`, so a request with no cursor may reach it
+unbound or stale.
+
+**Do not fix from that guess.** Reproduce first — the previous set's plan 05 established that
+guessing at a projection failure produces a better message and not a fix.
+
+## Design
+
+### 1. Reproduce before fixing
+
+Drive `status view=operation` against a task with:
+
+- a completed `publish_work` operation (the populated path),
+- a completed non-`publish_work` operation — a `check` is what run 4 asked for, and is the case
+  that actually failed,
+- an unknown `request_id`,
+- a `request_id` belonging to a different writer,
+- an operation that is durably underway but not complete.
+
+The run-4 case is the second one. If it does not reproduce in-process, drive it through the daemon
+— the failure was observed there, and the generic dispatch handler is what reclassified it.
+
+### 2. Fix the cause, and make the branch total
+
+Whatever the attribute turns out to be, the branch must be total over its inputs: every path that
+reaches the projection assignment must have `head`, `effective`, `lag`, `projection_version`, and
+`rebuild_state` bound. An unbound-or-stale local in a recovery path is the shape of this bug
+regardless of which name it is.
+
+### 3. An unexpected error here must not be non-retryable
+
+The agent was told `retryable: false` on a read that changed nothing and would very likely succeed
+on a retry with a fresh `request_id`. A read that fails unexpectedly should present as
+`read_projection_failed` — retryable, with the "repeat the request" remedy — not as a terminal
+bridge error. Align this branch with how other read failures are classified.
+
+## Files
+
+- `src/yoetz/application/status.py` — the `operation` branch
+- `src/yoetz/service/daemon.py` — only if the reclassification is wrong for this case
+- tests under `tests/integration/` covering all five operation-view cases
+
+## Tests
+
+- The exact run-4 sequence: a completed `check` operation looked up by `request_id` returns a
+  bounded, honest operation page rather than any internal error.
+- A completed `publish_work` operation returns its stored accepted-event detail — PR #47's
+  intended behaviour, now actually reachable.
+- An unknown `request_id` returns the bounded absent page.
+- A `request_id` belonging to another writer returns the same absent page, disclosing nothing.
+- An operation durably underway but not complete reports pending, not absent.
+- A cursor-less request and a cursor-bearing request both resolve; the recovery branch is covered.
+- No path through the `operation` branch can raise an unbounded exception.
+
+## Done
+
+Green CI, and the recorded run-4 lookup returns a usable answer.
+
+## Dogfood observable
+
+Run 5: if any ambiguous write or check occurs, `status view=operation` resolves it. It must never
+return `INTERNAL_ERROR`, and never `retryable: false` on a read.
+
+## Out of scope
+
+Replay resolution for `check` — the previous set's plan 03 made replay reachable for
+`publish_work` only, and extending it is a separate question. Once plan 01 lands, a `check` that
+produces findings returns normally and the need for replay largely disappears.

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -128,6 +128,22 @@ def _invalid(reason: str = "check_coordinator_invalid") -> ValueError:
     return ValueError(reason)
 
 
+def _projected_finding_json(finding: Finding) -> JsonValue:
+    """Adapt one encoded finding to the CHECK result's projected-finding shape.
+
+    ``findings/finding-1.0.0`` leaves ``provenance`` simply absent on a deterministic finding, and
+    ``finding_to_json`` honors that — it is the encoding events and receipt documents carry. The
+    CHECK result's ``projected_finding`` is stricter: ``provenance`` is *required* and nullable, so
+    a deterministic finding must present it as an explicit null. This mirrors the top-level
+    ``semantic_provenance`` immediately below, which the same result already emits that way.
+    """
+
+    encoded = finding_to_json(finding)
+    if "provenance" in encoded:
+        return encoded
+    return {**dict(encoded.items()), "provenance": None}
+
+
 def check_internal_json(result: CheckCommitResult) -> dict[str, JsonValue]:
     """Serialize sink-independent CHECK success without a privacy projection."""
 
@@ -142,7 +158,7 @@ def check_internal_json(result: CheckCommitResult) -> dict[str, JsonValue]:
         "subject_frontier": dict(result.subject_frontier.as_wire().items()),
         "result_frontier": dict(result.result_frontier.as_wire().items()),
         "verdict": result.verdict.value,
-        "findings": tuple(cast(JsonValue, finding_to_json(item)) for item in result.findings),
+        "findings": tuple(_projected_finding_json(item) for item in result.findings),
         "suppressed_count": str(result.suppressed_count),
         "policy_executions": tuple(
             {

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -44,6 +44,7 @@ from yoetz.ports.publish_response_catalog import (
 from yoetz.ports.runtime import BundleRuntimePort, TaskRuntime
 from yoetz.ports.start_catalog import StartCatalogPort, TaskRouteState
 from yoetz.protocol.canonical import (
+    MAX_JSON_DEPTH,
     JsonValue,
     canonical_digest,
     canonical_encode,
@@ -473,6 +474,35 @@ def _frontier_for_projection(source: Mapping[str, JsonValue]) -> Frontier:
     return frontier_from_json(raw)
 
 
+def _plain_nested_mappings(value: JsonValue, depth: int = 0) -> JsonValue:
+    """Rebuild every nested mapping as a built-in ``dict``, changing nothing else.
+
+    The public result models are ``strict=True``. Strict pydantic accepts only a real ``dict`` (or
+    an instance of the target model) where a nested model is declared, and the internal results
+    carry nested entries as ``JsonObject`` — a genuine ``Mapping``, but not a ``dict``. Top-level
+    fields survived because they are scalars; every nested collection element was rejected.
+
+    The conversion is structural only: scalars are returned untouched, key order is preserved, no
+    key is added or dropped, and sequence containers keep their own type so the closed models'
+    established list-to-tuple adaptation still sees what it saw before. A genuinely invalid shape
+    therefore still fails validation, at the same pointer, with the same error. Depth is bounded by
+    the same ``MAX_JSON_DEPTH`` the internal results are already built under, so a pathological
+    structure degrades to a named rejection inside the projection window rather than recursing
+    without limit.
+    """
+
+    if depth > MAX_JSON_DEPTH:
+        raise ValueError("projection_value_too_deep")
+    if isinstance(value, Mapping):
+        source = cast(Mapping[str, JsonValue], value)
+        return {key: _plain_nested_mappings(item, depth + 1) for key, item in source.items()}
+    if type(value) is tuple:
+        return tuple(_plain_nested_mappings(item, depth + 1) for item in value)
+    if type(value) is list:
+        return [_plain_nested_mappings(item, depth + 1) for item in cast(list[JsonValue], value)]
+    return value
+
+
 def _public_model(method: ControlMethod, value: Mapping[str, JsonValue]) -> ProjectedControlBody:
     """Validate and normalize one projected success body for its public result model."""
 
@@ -487,7 +517,7 @@ def _public_model(method: ControlMethod, value: Mapping[str, JsonValue]) -> Proj
     if model is None:
         return JsonObject(value)
     success_type, result_type = model
-    success = success_type.model_validate(value)
+    success = success_type.model_validate(_plain_nested_mappings(value))
     # ``RespondResponseModel`` declares ``optional_non_null_fields`` (reason/waiver_scope/
     # waiver_expiry) that the frozen wire schema requires to be entirely omitted when absent,
     # never present as an explicit null. ``PublishWorkAcceptedEventModel.summary`` is the same

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -485,20 +485,27 @@ def _plain_nested_mappings(value: JsonValue, depth: int = 0) -> JsonValue:
     The conversion is structural only: scalars are returned untouched, key order is preserved, no
     key is added or dropped, and sequence containers keep their own type so the closed models'
     established list-to-tuple adaptation still sees what it saw before. A genuinely invalid shape
-    therefore still fails validation, at the same pointer, with the same error. Depth is bounded by
-    the same ``MAX_JSON_DEPTH`` the internal results are already built under, so a pathological
-    structure degrades to a named rejection inside the projection window rather than recursing
-    without limit.
+    therefore still fails validation, at the same pointer, with the same error.
+
+    Depth is bounded exactly as ``yoetz.protocol.canonical`` bounds it: a *container* node at
+    ``MAX_JSON_DEPTH`` is rejected, counting the root container as depth zero. Anything the internal
+    results were legitimately built under therefore normalizes, and a structure this boundary would
+    admit but canonicalization would not cannot slip through — a pathological one degrades to a
+    named rejection inside the projection window rather than recursing without limit.
     """
 
-    if depth > MAX_JSON_DEPTH:
-        raise ValueError("projection_value_too_deep")
     if isinstance(value, Mapping):
+        if depth >= MAX_JSON_DEPTH:
+            raise ValueError("projection_value_too_deep")
         source = cast(Mapping[str, JsonValue], value)
         return {key: _plain_nested_mappings(item, depth + 1) for key, item in source.items()}
     if type(value) is tuple:
+        if depth >= MAX_JSON_DEPTH:
+            raise ValueError("projection_value_too_deep")
         return tuple(_plain_nested_mappings(item, depth + 1) for item in value)
     if type(value) is list:
+        if depth >= MAX_JSON_DEPTH:
+            raise ValueError("projection_value_too_deep")
         return [_plain_nested_mappings(item, depth + 1) for item in cast(list[JsonValue], value)]
     return value
 

--- a/tests/builders/projection_workflow.py
+++ b/tests/builders/projection_workflow.py
@@ -1,0 +1,603 @@
+"""One realistic workflow that yields an internal result for every public control method.
+
+Result-model projection defects have now escaped three times in a row — a phantom null on every
+accepted event (PR #50), then nested findings the strict closed models could not accept at all.
+Each fix landed against one operation while the class stayed alive in the others, because nothing
+walked the whole public surface at once.
+
+This builder is that missing seam. It runs a single provider-free workflow through the real ready
+composition — real vault objects, the real privacy coordinator seeded with the shipped default
+policy, the real closed-model validation the daemon runs for an MCP bridge client — and hands back
+the internal result of ``start``, ``publish_work``, ``check``, ``respond``, ``status`` (every view)
+and ``receipt``, each paired with the request body its projection binding is derived from.
+
+Callers assert whatever property they are sweeping for; the builder only guarantees that the
+material is realistic and that every nested collection the public models declare is actually
+populated. Add a new operation or a new view here and every sweep built on it picks it up.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal, cast
+
+import yoetz.service.ready_composition as ready_composition
+from builders.ledger_adapters import MemoryObjects, ownership_fence
+from builders.start_application import (
+    MemoryStartRuntime,
+    StartTestLookup,
+    protocol_id,
+    start_composition,
+    start_request,
+)
+from yoetz.adapters.memory.privacy import (
+    MemoryPrivacyAudit,
+    MemoryPrivacyCatalogState,
+    MemoryPrivacyPolicyStore,
+)
+from yoetz.adapters.privacy.local_enforcer import LocalPrivacyEnforcer
+from yoetz.application.check import FinalSemanticEvaluation
+from yoetz.application.egress import PrivacyCoordinator
+from yoetz.application.publish_work import PublishWorkInternalResult
+from yoetz.application.service import (
+    Application,
+    ClientProjectionContext,
+    ControlProjectionBinding,
+    ProjectionRenderMode,
+    UnprojectedControlBody,
+    VerificationPolicy,
+)
+from yoetz.domain.events import RuntimeProfile
+from yoetz.domain.findings import SemanticDispatchKind, SemanticProvenance
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    PrivacyPolicy,
+)
+from yoetz.domain.receipts import (
+    PolicyVersionEntry,
+    ReceiptVersionSlice,
+    SchemaVersionEntry,
+)
+from yoetz.domain.values import Frontier
+from yoetz.ports.control import ControlClientKind, ControlMethod
+from yoetz.ports.diagnostics import RuntimeCapability
+from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
+from yoetz.ports.objects import ObjectStorePort
+from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
+from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
+from yoetz.ports.semantic import SamplingParams, SemanticJudgment
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.models import (
+    CheckRequest,
+    FrontierModel,
+    PublishWorkRequest,
+    ReceiptRequest,
+    RespondRequest,
+    SemanticReason,
+    SemanticStatus,
+    StatusRequest,
+    public_model_to_wire,
+)
+
+__all__ = [
+    "PROJECTION_DIGEST",
+    "STATUS_VIEWS",
+    "ProjectionCase",
+    "ProjectionWorkflow",
+    "build_projection_application",
+    "frontier_json",
+    "project_case",
+    "request_base",
+    "run_projection_workflow",
+]
+
+PROJECTION_DIGEST = "sha256:" + "7" * 64
+_WORKSPACE = "hmac-sha256:" + "8" * 64
+_INSTALLATION = protocol_id("ins_", 1404)
+_NOW = datetime(2026, 7, 28, 12, 0, tzinfo=UTC)
+
+# The exact ten-view vocabulary ``StatusSuccessModel.view`` declares. Kept as a tuple so a sweep
+# that iterates it fails loudly the day a view is added without a case here.
+STATUS_VIEWS: tuple[str, ...] = (
+    "advice",
+    "assignment",
+    "candidate_findings",
+    "compact",
+    "evidence",
+    "findings",
+    "history",
+    "obligations",
+    "operation",
+    "versions",
+)
+
+_CAPABILITIES = frozenset(
+    {
+        RuntimeCapability.WRITE,
+        RuntimeCapability.STRUCTURAL_READ,
+        RuntimeCapability.PAYLOAD_READ,
+        RuntimeCapability.SEMANTIC,
+    }
+)
+
+# Reaching for the private builder on purpose: a projection regression only means something if the
+# policy under test is identical in disposition to the one the daemon seeds, including the
+# ``finding_summary`` inclusion for the agent context.
+_denied_policy = cast(
+    "Callable[..., PrivacyPolicy]",
+    getattr(ready_composition, "_denied_policy"),
+)
+
+
+class _IdleImporter:
+    """Provide a stable idle importer status for projection tests."""
+
+    async def status(self, session: str) -> ImportStatusSnapshot:
+        """Return an empty importer snapshot for the requested session."""
+
+        from yoetz.domain.values import session_id
+
+        return ImportStatusSnapshot(session_id(session), 0, 0, (), ())
+
+
+class _ProjectionRuntime(MemoryStartRuntime):
+    """Extend the START memory composition with ready writer routing."""
+
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        """Resolve the sole seeded task when the requested writer owns it."""
+
+        assert command.writer_id is not None
+        assert command.required_capabilities <= _CAPABILITIES
+        task_id, resources = next(iter(self.resources.items()))
+        ledger, objects = resources
+        assert (command.session_id, command.writer_id) in self.owners
+        return TaskRuntime(
+            task_id,
+            command.session_id,
+            command.writer_id,
+            _CAPABILITIES,
+            ledger,
+            objects,
+            cast(ImporterPort, _IdleImporter()),
+            "0.1.0",
+            "0.1.0",
+            "0.1",
+            "1.0.0",
+            ownership_fence(),
+        )
+
+
+class _Gateway:
+    """Stand in for an unused outbound gateway."""
+
+    async def close(self) -> None:
+        """Close the no-op gateway."""
+
+        return None
+
+
+def _versions() -> ReceiptVersionSlice:
+    """Return a stable version slice for local disclosure receipts."""
+
+    return ReceiptVersionSlice(
+        package_name="yoetz",
+        package_version="0.1.0",
+        protocol_version="0.1",
+        engine_version="0.1.0",
+        projection_version="0.1.0",
+        object_format_version="yoetz-object/1",
+        catalog_schema_version="1",
+        bundle_schema_version="1",
+        policy_versions=(
+            PolicyVersionEntry("research-evidence", "0.1.0"),
+            PolicyVersionEntry("work-integrity", "0.1.0"),
+        ),
+        schema_versions=(SchemaVersionEntry("receipts/receipt-document", "1.0.0"),),
+        resource_manifest_digest=PROJECTION_DIGEST,
+    )
+
+
+def _scope(_: ControlProjectionBinding, source: Mapping[str, JsonValue]) -> AuthorizationScope:
+    """Bind disclosure to the projected result's task identity."""
+
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        _WORKSPACE,
+        cast(str, source["task_id"]),
+    )
+
+
+async def _semantic_never(frozen: object, findings: object) -> object:
+    """Fail if a deterministic-only composition reaches semantic evaluation."""
+
+    del frozen, findings
+    raise AssertionError("semantic_evaluator_called_in_deterministic_mode")
+
+
+async def _semantic_succeeds(frozen: object, findings: object) -> object:
+    """Return a succeeded semantic outcome that raises no challenge of its own.
+
+    Semantic *delivery* is a separate subject; these sweeps only need semantic to reach
+    ``succeeded`` so that the deterministic findings travel the semantic modes too.
+    """
+
+    del frozen, findings
+    return FinalSemanticEvaluation(
+        SemanticStatus.SUCCEEDED,
+        SemanticReason.SEMANTIC_COMPLETED,
+        judgment=SemanticJudgment("no_material_discrepancy", ()),
+        provenance=SemanticProvenance(
+            provider="fake",
+            endpoint_profile_id="fake",
+            endpoint_profile_version="1.0.0",
+            model="fake/model",
+            sdk_version="1.0.0",
+            prompt_digest=PROJECTION_DIGEST,
+            schema_digest=PROJECTION_DIGEST,
+            policy_digest=PROJECTION_DIGEST,
+            privacy_policy_digest=PROJECTION_DIGEST,
+            sampling_params=SamplingParams(128),
+            latency_ms=1,
+            semantic_attempt_id=protocol_id("att_", 1490),
+            dispatch_kind=SemanticDispatchKind.EXTERNAL,
+            privacy_receipt_id=protocol_id("egr_", 1491),
+            status=SemanticStatus.SUCCEEDED,
+            reason=SemanticReason.SEMANTIC_COMPLETED,
+            provider_request_id="fake-1",
+            egress_authorization_id=protocol_id("aut_", 1492),
+            request_commitment="hmac-sha256:" + "b" * 64,
+        ),
+    )
+
+
+def request_base(request_id: str) -> dict[str, JsonValue]:
+    """Build the common MCP request envelope a cooperative agent sends."""
+
+    return {
+        "protocol_version": "0.1",
+        "schema_version": "1.0.0",
+        "request_id": request_id,
+        "actor": {
+            "actor_id": "projection-sweep",
+            "actor_type": "logical_agent",
+            "display_name": "Codex",
+        },
+        "client": {
+            "kind": "cooperative_agent",
+            "version": "1.0",
+            "integration": "cooperative_mcp",
+        },
+    }
+
+
+def frontier_json(value: Frontier | FrontierModel) -> JsonValue:
+    """Normalize domain and wire frontiers to JSON."""
+
+    if isinstance(value, Frontier):
+        return cast(JsonValue, dict(value.as_wire().items()))
+    return cast(JsonValue, value.model_dump(mode="json"))
+
+
+async def build_projection_application(
+    semantic: Literal["disabled", "optional"] = "disabled",
+    *,
+    seed: int = 1400,
+    max_findings: int = 3,
+) -> tuple[Application, PrivacyPolicy]:
+    """A ready application whose disclosure boundary is the real coordinator and default policy."""
+
+    start_app, start_runtime, clock, catalog = start_composition()
+    ids = start_runtime.ids
+    privacy_state = MemoryPrivacyCatalogState()
+    policies = MemoryPrivacyPolicyStore(privacy_state, clock)
+    policy = _denied_policy(
+        installation_id=_INSTALLATION,
+        policy_id=protocol_id("pvy_", seed),
+        policy_digest=PROJECTION_DIGEST,
+        created_at=_NOW,
+    )
+    await policies.seed_if_absent(policy)
+    audit = MemoryPrivacyAudit(
+        privacy_state, cast(ObjectStorePort, MemoryObjects(ids)), StartTestLookup(), clock
+    )
+    coordinator = PrivacyCoordinator(
+        policies,
+        LocalPrivacyEnforcer(),
+        audit,
+        _Gateway(),  # type: ignore[arg-type]
+        clock,
+        ids,
+    )
+    runtime = _ProjectionRuntime(clock, ids)
+    app = Application(
+        start_catalog=catalog.delegate,
+        publish_responses=cast(PublishResponseCatalogPort, catalog.delegate),
+        runtime=cast(BundleRuntimePort, runtime),
+        clock=clock,
+        ids=ids,
+        verification_policy=VerificationPolicy(semantic=semantic, max_findings=max_findings),
+        privacy=coordinator,
+        status_cursor_key=b"projection-workflow-cursor-key",
+        waiver_policy_digest=PROJECTION_DIGEST,
+        semantic_evaluator=_semantic_never if semantic == "disabled" else _semantic_succeeds,
+        disclosure_scope_for=_scope,
+        receipt_version_resolver=lambda _: _versions(),
+        waiver_authorizer=lambda _: False,
+        import_publication_authorizer=lambda _: False,
+        profile=RuntimeProfile.TEST_FAKE,
+        policy_packs=("research-evidence/0.1.0", "work-integrity/0.1.0"),
+        version_manifest=start_app.version_manifest,
+        connected_provider_ids=() if semantic == "disabled" else ("fake",),
+        provider_credential_connected=semantic != "disabled",
+        semantic_ready=semantic != "disabled",
+    )
+    return app, policy
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionCase:
+    """One internal result and the request body its projection binding derives from.
+
+    ``label`` distinguishes cases that share a method — the ten status views all carry
+    ``ControlMethod.STATUS`` — and is what a failing sweep names.
+    """
+
+    label: str
+    method: ControlMethod
+    request_body: Mapping[str, JsonValue]
+    internal: UnprojectedControlBody
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionWorkflow:
+    """The application that ran the workflow, plus one case per public result model."""
+
+    app: Application
+    policy: PrivacyPolicy
+    cases: tuple[ProjectionCase, ...]
+
+    def case(self, label: str) -> ProjectionCase:
+        """Return the single case carrying *label*."""
+
+        for item in self.cases:
+            if item.label == label:
+                return item
+        raise KeyError(label)
+
+
+async def project_case(
+    app: Application, case: ProjectionCase, seed: int
+) -> Mapping[str, JsonValue]:
+    """Run the daemon's exact post-commit projection for an MCP bridge client."""
+
+    facts = await app.projection_binding_facts(case.method, case.request_body, case.internal)
+    rpc_id = protocol_id("rpc_", seed)
+    service_instance_id = protocol_id("svc_", seed + 1)
+    binding = ControlProjectionBinding(
+        rpc_id,
+        case.method,
+        service_instance_id,
+        1,
+        facts.original_request_id,
+        facts.route_identity_digest,
+        canonical_encode(
+            {
+                "rpc_id": rpc_id,
+                "method": case.method.value,
+                "service_instance_id": service_instance_id,
+                "service_generation": "1",
+            }
+        ),
+    )
+    projected = await app.project_result_for_client(
+        ClientProjectionContext(
+            ControlClientKind.MCP_BRIDGE, ProjectionRenderMode.MACHINE_READABLE, False
+        ),
+        binding,
+        case.internal,
+    )
+    return public_model_to_wire(projected)
+
+
+def _event_drafts(seed: int, obligation_event_id: str, obligation_id: str) -> list[JsonValue]:
+    """A batch that populates every nested status collection the sweep walks.
+
+    An obligation with an unmet requested item, an assignment that owns it, and an
+    action/result/evidence/claim chain whose claim rests on the obligation alone — so the
+    deterministic policies have real material and ``check`` produces real findings.
+    """
+
+    action_id = protocol_id("act_", seed + 10)
+    result_id = protocol_id("res_", seed + 11)
+    evidence_id = protocol_id("evd_", seed + 12)
+    action_event_id = protocol_id("evt_", seed + 13)
+    result_event_id = protocol_id("evt_", seed + 14)
+    evidence_event_id = protocol_id("evt_", seed + 15)
+    return [
+        {
+            "event_id": obligation_event_id,
+            "schema": {"name": "obligation_published", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:00.000Z",
+            "causal_parents": [],
+            "payload": {
+                "obligation_id": obligation_id,
+                "description": "Publish a result for the projection sweep.",
+                "acceptance_criteria": "A result is recorded in the task ledger.",
+                "evidence_expectation": "A linked immutable result record.",
+                "requested_items": [
+                    {"item_kind": "change", "value": "sweep-result"},
+                    {"item_kind": "change", "value": "sweep-unattempted"},
+                ],
+                "status": "open",
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+        {
+            "event_id": protocol_id("evt_", seed + 16),
+            "schema": {"name": "assignment_recorded", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:01.000Z",
+            "causal_parents": [obligation_event_id],
+            "payload": {
+                "assignee_actor_id": "projection-sweep",
+                "obligation_ids": [obligation_id],
+                "scope_description": "Owns the projection sweep obligation.",
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+        {
+            "event_id": action_event_id,
+            "schema": {"name": "action_recorded", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:02.000Z",
+            "causal_parents": [obligation_event_id],
+            "payload": {
+                "action_id": action_id,
+                "action_kind": "edit",
+                "description": "Edited the projection sweep fixture.",
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+        {
+            "event_id": result_event_id,
+            "schema": {"name": "result_recorded", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:03.000Z",
+            "causal_parents": [action_event_id],
+            "payload": {
+                "result_id": result_id,
+                "action_id": action_id,
+                "outcome": "success",
+                "summary": "The projection sweep fixture was edited.",
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+        {
+            "event_id": evidence_event_id,
+            "schema": {"name": "evidence_recorded", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:04.000Z",
+            "causal_parents": [result_event_id],
+            "payload": {
+                "evidence_id": evidence_id,
+                "evidence_kind": "test_result",
+                "strength": "metadata_only",
+                "observed_at": "2026-07-28T12:00:04.000Z",
+                "reference": "the projection sweep fixture",
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+        {
+            "event_id": protocol_id("evt_", seed + 17),
+            "schema": {"name": "claim_recorded", "version": "1.0.0"},
+            "occurred_at": "2026-07-28T12:00:05.000Z",
+            "causal_parents": [evidence_event_id],
+            "payload": {
+                "claim_id": protocol_id("clm_", seed + 18),
+                "claim_kind": "completion",
+                "statement": "The projection sweep work is complete.",
+                "supporting_refs": [obligation_id],
+                "obligation_refs": [obligation_id],
+            },
+            "artifact_refs": [],
+            "evidence_refs": [],
+        },
+    ]
+
+
+async def run_projection_workflow(
+    semantic: Literal["disabled", "optional"] = "disabled",
+    *,
+    seed: int = 1400,
+    max_findings: int = 3,
+) -> ProjectionWorkflow:
+    """Run one workflow and collect a case for every public result model and status view."""
+
+    app, policy = await build_projection_application(semantic, seed=seed, max_findings=max_findings)
+    cases: list[ProjectionCase] = []
+
+    start_body = start_request(seed + 1, title="Projection sweep")
+    started = await app.start(start_body)
+    cases.append(
+        ProjectionCase("start", ControlMethod.START, start_body.model_dump(mode="json"), started)
+    )
+
+    obligation_id = protocol_id("obl_", seed + 2)
+    obligation_event_id = protocol_id("evt_", seed + 3)
+    publish_body: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 4)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": frontier_json(started.frontier),
+        "event_drafts": _event_drafts(seed, obligation_event_id, obligation_id),
+    }
+    published = await app.publish_work(PublishWorkRequest.model_validate(publish_body))
+    # A first, non-replayed publish always yields the internal result; the replay branch returns a
+    # stored public result instead, and the sweep needs the unprojected body.
+    assert type(published) is PublishWorkInternalResult
+    cases.append(
+        ProjectionCase("publish_work", ControlMethod.PUBLISH_WORK, publish_body, published)
+    )
+
+    check_body: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 5)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": frontier_json(published.result_frontier),
+        "mode": "deterministic_only" if semantic == "disabled" else "semantic_required",
+        "max_findings": str(max_findings),
+    }
+    checked = await app.check(CheckRequest.model_validate(check_body))
+    assert checked.findings, "the sweep workflow must produce at least one finding"
+    cases.append(ProjectionCase("check", ControlMethod.CHECK, check_body, checked))
+
+    respond_body: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 6)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": frontier_json(checked.result_frontier),
+        "finding_id": checked.findings[0].finding_id,
+        "finding_frontier": frontier_json(checked.result_frontier),
+        "disposition": "acknowledged",
+        "reason": "The gap stays explicit until follow-up work is published.",
+        "evidence_refs": [protocol_id("evd_", seed + 12)],
+    }
+    responded = await app.respond(RespondRequest.model_validate(respond_body))
+    cases.append(ProjectionCase("respond", ControlMethod.RESPOND, respond_body, responded))
+
+    for offset, view in enumerate(STATUS_VIEWS):
+        status_body: dict[str, JsonValue] = {
+            **request_base(protocol_id("req_", seed + 20 + offset)),
+            "session_id": started.session_id,
+            "writer_id": started.writer_id,
+            "view": view,
+            "limit": "10",
+            "at_frontier": str(responded.result_frontier.sequence),
+        }
+        if view == "operation":
+            # The only view whose filter the frozen request schema makes mandatory. Point it at
+            # the publish, the one operation kind whose recovery page carries a nested
+            # ``accepted_events`` collection rather than an empty one.
+            status_body["filter"] = {"operation_request_id": cast(str, publish_body["request_id"])}
+        status = await app.status(StatusRequest.model_validate(status_body))
+        cases.append(ProjectionCase(f"status/{view}", ControlMethod.STATUS, status_body, status))
+
+    receipt_body: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 40)),
+        "task_id": started.task_id,
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": frontier_json(responded.result_frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+    receipt = await app.receipt(ReceiptRequest.model_validate(receipt_body))
+    cases.append(ProjectionCase("receipt", ControlMethod.RECEIPT, receipt_body, receipt))
+
+    return ProjectionWorkflow(app, policy, tuple(cases))

--- a/tests/integration/application/test_check_findings_projection.py
+++ b/tests/integration/application/test_check_findings_projection.py
@@ -1,0 +1,315 @@
+"""A ``check`` that produced a finding must project to a complete ``CheckSuccessModel``.
+
+2026-07-28 run 4 dogfood: every ``check`` that produced at least one finding committed durably
+(``check_recorded`` and ``finding_recorded`` landed, the frontier advanced) and then failed to
+project, so the caller received ``INTERNAL_ERROR`` / ``response_projection_failed`` and never
+learned the verdict, the finding, or the semantic outcome. ``findings[]`` is the delivery channel
+for a check's entire answer, and it had never worked in any mode; the only reason this stayed
+hidden through three dogfoods is that no check had ever produced a finding.
+
+Two defects of one class stacked here. The internal check body carries each finding as a
+``JsonObject`` — a real ``Mapping``, but not a built-in ``dict`` — and the public result models are
+configured ``strict=True``, where only a ``dict`` (or an instance of the target model) is admitted
+for a nested model field; the scalar top-level fields sailed through while every nested entry was
+rejected. Behind that, the check result's ``projected_finding`` requires ``provenance`` to be
+present and nullable, while the ``findings/finding-1.0.0`` encoding events and receipts share
+leaves it absent on a deterministic finding — a second rejection the first one had masked.
+
+These cases run the real ready composition — real vault objects, the real privacy coordinator and
+shipped default policy, the real closed-model validation the daemon runs for an MCP bridge client —
+and pin a complete response carrying the finding, in all three check modes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Literal, cast
+
+import pytest
+
+import yoetz.application.service as service_module
+from builders.projection_workflow import (
+    build_projection_application,
+    frontier_json,
+    request_base,
+)
+from builders.start_application import protocol_id, start_request
+from yoetz.application.service import (
+    Application,
+    ClientProjectionContext,
+    ControlProjectionBinding,
+    ProjectedControlBody,
+    ProjectionRenderMode,
+)
+from yoetz.domain.privacy import PrivacyPolicy
+from yoetz.domain.values import JsonObject
+from yoetz.ports.control import ControlClientKind, ControlMethod
+from yoetz.ports.ledger import CheckCommitResult
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.models import (
+    MAX_FINDINGS_LIMIT,
+    CheckRequest,
+    DataCategory,
+    PublishWorkRequest,
+    public_model_to_wire,
+)
+
+pytestmark = pytest.mark.anyio
+
+# The projection boundary itself, exercised directly where a test needs a body the workflow cannot
+# produce — a deliberately malformed one.
+_public_model = cast(
+    "Callable[[ControlMethod, Mapping[str, JsonValue]], ProjectedControlBody]",
+    getattr(service_module, "_public_model"),
+)
+
+_MODES: tuple[tuple[Literal["disabled", "optional"], str], ...] = (
+    ("disabled", "deterministic_only"),
+    ("optional", "semantic_if_configured"),
+    ("optional", "semantic_required"),
+)
+
+
+async def _binding(
+    app: Application,
+    request_body: Mapping[str, JsonValue],
+    internal: CheckCommitResult,
+    seed: int,
+) -> ControlProjectionBinding:
+    """Build the daemon-equivalent projection binding for a check."""
+
+    facts = await app.projection_binding_facts(ControlMethod.CHECK, request_body, internal)
+    rpc_id = protocol_id("rpc_", seed)
+    service_instance_id = protocol_id("svc_", seed + 1)
+    return ControlProjectionBinding(
+        rpc_id,
+        ControlMethod.CHECK,
+        service_instance_id,
+        1,
+        facts.original_request_id,
+        facts.route_identity_digest,
+        canonical_encode(
+            {
+                "rpc_id": rpc_id,
+                "method": "check",
+                "service_instance_id": service_instance_id,
+                "service_generation": "1",
+            }
+        ),
+    )
+
+
+async def _project(
+    app: Application,
+    request_body: Mapping[str, JsonValue],
+    internal: CheckCommitResult,
+    seed: int,
+) -> Mapping[str, JsonValue]:
+    """Run the daemon's exact post-commit projection sequence for an MCP bridge client."""
+
+    projected = await app.project_result_for_client(
+        ClientProjectionContext(
+            ControlClientKind.MCP_BRIDGE, ProjectionRenderMode.MACHINE_READABLE, False
+        ),
+        await _binding(app, request_body, internal, seed),
+        internal,
+    )
+    return public_model_to_wire(projected)
+
+
+def _unsupported_claim(seed: int, obligation_id: str, parent: str, index: int) -> JsonValue:
+    """One completion claim resting on an obligation alone — no admissible evidence."""
+
+    return {
+        "event_id": protocol_id("evt_", seed + 100 + index),
+        "schema": {"name": "claim_recorded", "version": "1.0.0"},
+        "occurred_at": f"2026-07-28T12:00:{index + 1:02d}.000Z",
+        "causal_parents": [parent],
+        "payload": {
+            "claim_id": protocol_id("clm_", seed + 200 + index),
+            "claim_kind": "completion",
+            "statement": f"Unsupported completion claim {index}.",
+            "supporting_refs": [obligation_id],
+            "obligation_refs": [obligation_id],
+        },
+        "artifact_refs": [],
+        "evidence_refs": [],
+    }
+
+
+async def _work_with_unsupported_claims(
+    app: Application, seed: int, count: int
+) -> tuple[str, str, JsonValue]:
+    """Publish *count* claims whose only support is an obligation, so findings fire."""
+
+    started = await app.start(start_request(seed, title="Check findings projection"))
+    obligation_id = protocol_id("obl_", seed + 1)
+    obligation_event_id = protocol_id("evt_", seed + 2)
+    publish_wire: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 3)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": frontier_json(started.frontier),
+        "event_drafts": [
+            {
+                "event_id": obligation_event_id,
+                "schema": {"name": "obligation_published", "version": "1.0.0"},
+                "occurred_at": "2026-07-28T12:00:00.000Z",
+                "causal_parents": [],
+                "payload": {
+                    "obligation_id": obligation_id,
+                    "description": "Publish a result for the check-findings exercise.",
+                    "acceptance_criteria": "A result is recorded in the task ledger.",
+                    "evidence_expectation": "A linked immutable result record.",
+                    "requested_items": [{"item_kind": "change", "value": "workflow-result"}],
+                    "status": "open",
+                },
+                "artifact_refs": [],
+                "evidence_refs": [],
+            },
+            *(
+                _unsupported_claim(seed, obligation_id, obligation_event_id, index)
+                for index in range(count)
+            ),
+        ],
+    }
+    published = await app.publish_work(PublishWorkRequest.model_validate(publish_wire))
+    return started.session_id, started.writer_id, frontier_json(published.result_frontier)
+
+
+async def _checked(
+    semantic: Literal["disabled", "optional"],
+    mode: str,
+    seed: int,
+    *,
+    claims: int = 1,
+    max_findings: int = 3,
+) -> tuple[Application, Mapping[str, JsonValue], CheckCommitResult, PrivacyPolicy]:
+    """Run one real check that produces findings, and hand back everything needed to project it."""
+
+    app, policy = await build_projection_application(semantic, seed=seed, max_findings=max_findings)
+    session, writer, frontier = await _work_with_unsupported_claims(app, seed, claims)
+    check_wire: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 6)),
+        "session_id": session,
+        "writer_id": writer,
+        "expected_frontier": frontier,
+        "mode": mode,
+        "max_findings": str(max_findings),
+    }
+    checked = await app.check(CheckRequest.model_validate(check_wire))
+    assert checked.findings
+    return app, check_wire, checked, policy
+
+
+@pytest.mark.parametrize(("semantic", "mode"), _MODES)
+async def test_check_with_a_finding_projects_a_complete_success(
+    semantic: Literal["disabled", "optional"], mode: str
+) -> None:
+    """The finding reaches the caller intact — and the mode it was produced under is irrelevant."""
+
+    seed = 1310 + 20 * _MODES.index((semantic, mode))
+    app, check_wire, checked, policy = await _checked(semantic, mode, seed)
+    # The disclosure boundary must not be what silences the answer: the shipped default really does
+    # include the finding summary for the agent context, so the text below is text, not a marker.
+    assert DataCategory.FINDING_SUMMARY in policy.agent_context_categories
+
+    projected = await _project(app, check_wire, checked, seed + 7)
+
+    assert projected["ok"] is True
+    assert projected["verdict"] == "action_required"
+    assert projected["semantic_status"] == (
+        "not_requested" if semantic == "disabled" else "succeeded"
+    )
+    findings = cast(list[Mapping[str, JsonValue]], projected["findings"])
+    assert len(findings) == len(checked.findings)
+    expected = checked.findings[0]
+    finding = findings[0]
+    assert finding["finding_id"] == expected.finding_id
+    assert finding["kind"] == expected.kind.value
+    assert finding["origin"] == expected.origin.value
+    assert finding["priority"] == expected.priority
+    # The shipped default includes the finding summary for the agent context, so the text the check
+    # exists to deliver arrives as text — not as an omission marker.
+    assert finding["summary"] == expected.summary
+    assert finding["detail"] == expected.detail
+    assert finding["subject_refs"] == list(expected.subject_refs)
+    assert finding["policy_id"] == expected.policy_id
+    assert finding["policy_version"] == expected.policy_version
+    assert isinstance(finding["subject_frontier"], Mapping)
+    assert isinstance(finding["coverage"], Mapping)
+    # A deterministic finding has no semantic provenance; the check result's projected finding
+    # requires the key all the same, as an explicit null.
+    assert "provenance" in finding
+    executions = cast(list[Mapping[str, JsonValue]], projected["policy_executions"])
+    assert [item["policy_id"] for item in executions] == ["research-evidence", "work-integrity"]
+
+
+async def test_the_maximum_permitted_finding_count_projects() -> None:
+    """The ceiling case projects too — the defect was per-element, so the count must be pinned."""
+
+    seed = 1420
+    app, check_wire, checked, _policy = await _checked(
+        "disabled",
+        "deterministic_only",
+        seed,
+        claims=MAX_FINDINGS_LIMIT + 2,
+        max_findings=MAX_FINDINGS_LIMIT,
+    )
+    assert len(checked.findings) == MAX_FINDINGS_LIMIT
+
+    projected = await _project(app, check_wire, checked, seed + 7)
+
+    assert projected["ok"] is True
+    findings = cast(list[Mapping[str, JsonValue]], projected["findings"])
+    assert len(findings) == MAX_FINDINGS_LIMIT
+    assert len({cast(str, item["finding_id"]) for item in findings}) == MAX_FINDINGS_LIMIT
+    # More findings existed than the request admitted, and the caller is told so rather than the
+    # remainder vanishing silently.
+    assert projected["suppressed_count"] != "0"
+
+
+async def test_a_malformed_nested_finding_is_still_rejected() -> None:
+    """Normalization is structural. It must not become a shape-laundering step.
+
+    The same body, in the same internal container type, with one nested leaf made genuinely
+    invalid: projection must still fail, and fail *at that leaf* — not be quietly repaired into
+    something the closed model accepts.
+    """
+
+    seed = 1450
+    app, check_wire, checked, _policy = await _checked("disabled", "deterministic_only", seed)
+    projected = await _project(app, check_wire, checked, seed + 7)
+
+    findings = cast(list[Mapping[str, JsonValue]], projected["findings"])
+    corrupted = {**findings[0], "priority": "1"}
+    body = {
+        **projected,
+        # Re-freeze into the container the internal result actually uses, so the malformed entry
+        # travels the normalization path rather than side-stepping it.
+        "findings": tuple(
+            JsonObject(corrupted if index == 0 else item) for index, item in enumerate(findings)
+        ),
+    }
+
+    with pytest.raises(Exception) as raised:  # noqa: PT011 - the pointer is the assertion
+        _public_model(ControlMethod.CHECK, body)
+    message = str(raised.value)
+    assert "findings.0.priority" in message, message
+    assert "findings.0\n" not in message, message
+
+
+async def test_a_well_formed_body_in_the_internal_container_projects() -> None:
+    """The control for the case above: same route, nothing corrupted, and it validates."""
+
+    seed = 1480
+    app, check_wire, checked, _policy = await _checked("disabled", "deterministic_only", seed)
+    projected = await _project(app, check_wire, checked, seed + 7)
+
+    body = {
+        **projected,
+        "findings": tuple(
+            JsonObject(item) for item in cast(list[Mapping[str, JsonValue]], projected["findings"])
+        ),
+    }
+    assert public_model_to_wire(_public_model(ControlMethod.CHECK, body))["ok"] is True

--- a/tests/integration/application/test_check_findings_projection.py
+++ b/tests/integration/application/test_check_findings_projection.py
@@ -45,7 +45,8 @@ from yoetz.domain.privacy import PrivacyPolicy
 from yoetz.domain.values import JsonObject
 from yoetz.ports.control import ControlClientKind, ControlMethod
 from yoetz.ports.ledger import CheckCommitResult
-from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.canonical import MAX_JSON_DEPTH, JsonValue, canonical_encode
+from yoetz.protocol.errors import ProtocolValueError
 from yoetz.protocol.models import (
     MAX_FINDINGS_LIMIT,
     CheckRequest,
@@ -57,10 +58,14 @@ from yoetz.protocol.models import (
 pytestmark = pytest.mark.anyio
 
 # The projection boundary itself, exercised directly where a test needs a body the workflow cannot
-# produce — a deliberately malformed one.
+# produce — a deliberately malformed or pathologically nested one.
 _public_model = cast(
     "Callable[[ControlMethod, Mapping[str, JsonValue]], ProjectedControlBody]",
     getattr(service_module, "_public_model"),
+)
+_plain_nested_mappings = cast(
+    "Callable[[JsonValue], JsonValue]",
+    getattr(service_module, "_plain_nested_mappings"),
 )
 
 _MODES: tuple[tuple[Literal["disabled", "optional"], str], ...] = (
@@ -313,3 +318,60 @@ async def test_a_well_formed_body_in_the_internal_container_projects() -> None:
         ),
     }
     assert public_model_to_wire(_public_model(ControlMethod.CHECK, body))["ok"] is True
+
+
+def _nested(containers: int, *, terminal: str = "empty") -> JsonValue:
+    """A chain of exactly *containers* nested objects, outermost at depth zero.
+
+    ``terminal="empty"`` ends the chain with an empty object, so the deepest *container* sits at
+    ``containers - 1`` and nothing lives below it. That is the shape that separates the two
+    depth-counting conventions: a guard that only rejects a node *below* the limit never sees one
+    here, while a guard that rejects the container itself does. A scalar terminal hides the
+    difference — the leaf beneath the deepest container trips the looser guard by accident — so the
+    boundary case deliberately does not use one.
+    """
+
+    value: JsonValue = "leaf" if terminal == "scalar" else {}
+    for _ in range(containers - 1):
+        value = {"next": value}
+    return value
+
+
+def test_the_depth_bound_is_exactly_the_canonical_one() -> None:
+    """Normalization must not admit a structure canonicalization would reject.
+
+    The bound is not decorative: everything reaching this boundary was already built under
+    ``MAX_JSON_DEPTH``, so a looser guard here would let the projection window accept a shape the
+    rest of the protocol treats as too deep. Pinned against ``canonical_encode`` rather than a
+    hand-copied constant, so the two cannot drift apart again.
+    """
+
+    deepest = _nested(MAX_JSON_DEPTH)
+    too_deep = _nested(MAX_JSON_DEPTH + 1)
+
+    # The reference: what the protocol itself admits at each of the two depths.
+    canonical_encode(deepest)
+    with pytest.raises(ProtocolValueError, match="nesting_too_deep"):
+        canonical_encode(too_deep)
+
+    # The boundary agrees, in both directions.
+    assert _plain_nested_mappings(deepest) == deepest
+    with pytest.raises(ValueError, match="projection_value_too_deep"):
+        _plain_nested_mappings(too_deep)
+
+
+@pytest.mark.parametrize("container", [list, tuple])
+def test_the_depth_bound_counts_sequences_too(
+    container: Callable[[list[JsonValue]], JsonValue],
+) -> None:
+    """Arrays nest as readily as objects, and the canonical limit counts them the same way."""
+
+    def chain(depth: int) -> JsonValue:
+        value: JsonValue = container([])
+        for _ in range(depth - 1):
+            value = container([value])
+        return value
+
+    assert _plain_nested_mappings(chain(MAX_JSON_DEPTH)) == chain(MAX_JSON_DEPTH)
+    with pytest.raises(ValueError, match="projection_value_too_deep"):
+        _plain_nested_mappings(chain(MAX_JSON_DEPTH + 1))

--- a/tests/integration/application/test_result_model_projection_sweep.py
+++ b/tests/integration/application/test_result_model_projection_sweep.py
@@ -1,0 +1,134 @@
+"""Every public result model with a nested collection must project from a real internal result.
+
+Two projection defects of the same class shipped in a row. PR #50 fixed a phantom null on
+``publish_work``'s accepted events; the class survived and reappeared as nested findings that the
+strict closed models could not accept at all, on ``check``. Each fix was verified against the one
+operation that had been observed failing, so nothing ever asked whether the *rest* of the public
+surface projected.
+
+This sweep asks. It runs one realistic workflow through the real ready composition and projects
+every public result model — and every status view — asserting that each nested collection the
+models declare is present and populated in the response the caller receives. A vacuous pass is the
+failure mode that let this class live, so an expectation that names a collection also requires it
+to be non-empty.
+
+The sweep deliberately states its invariant structurally: *nested collections project*. It never
+names the internal container type that happened to break, because the next instance of this class
+will arrive wearing a different type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+import pytest
+
+from builders.projection_workflow import (
+    STATUS_VIEWS,
+    ProjectionWorkflow,
+    project_case,
+    run_projection_workflow,
+)
+from yoetz.protocol.canonical import JsonValue
+
+pytestmark = pytest.mark.anyio
+
+
+# Every nested collection the public result models declare, as a JSON pointer into the projected
+# wire body. ``populated`` says whether this workflow must produce at least one element: where it
+# is True an empty collection is a sweep failure, because an empty collection proves nothing about
+# nested projection.
+_EXPECTATIONS: tuple[tuple[str, str, bool], ...] = (
+    ("start", "/compact", True),
+    ("publish_work", "/accepted_events", True),
+    ("check", "/findings", True),
+    ("check", "/policy_executions", True),
+    ("respond", "/accepted_event", True),
+    ("respond", "/response/evidence", True),
+    ("receipt", "/document", True),
+    ("receipt", "/versions/policy_versions", True),
+    ("receipt", "/versions/schema_versions", True),
+    # The compact view carries two collections nested one level inside its single page item; both
+    # are populated by the sweep workflow (an open obligation, and the finding ``check`` raised).
+    ("status/compact", "/page/items", True),
+    ("status/compact", "/page/items/0/open_obligations", True),
+    ("status/compact", "/page/items/0/unresolved_findings", True),
+    ("status/assignment", "/page/items", True),
+    ("status/evidence", "/page/items", True),
+    ("status/findings", "/page/items", True),
+    ("status/history", "/page/items", True),
+    ("status/obligations", "/page/items", True),
+    # The operation view is the one page that is a single recovery record rather than a list; its
+    # nested collection is the accepted events of the operation being recovered.
+    ("status/operation", "/page/accepted_events", True),
+    ("status/versions", "/page/items", True),
+    # Advice and candidate findings are populated by the observation pipeline, which a
+    # provider-free workflow never runs. Their pages must still project — an empty page is a
+    # nested collection too, and it is the shape the daemon returns today.
+    ("status/advice", "/page/items", False),
+    ("status/candidate_findings", "/page/items", False),
+)
+
+
+def _resolve(body: Mapping[str, JsonValue], pointer: str) -> JsonValue:
+    """Resolve one RFC 6901 pointer against a projected wire body."""
+
+    current: JsonValue = body
+    for segment in pointer.removeprefix("/").split("/"):
+        if isinstance(current, Mapping):
+            source = cast(Mapping[str, JsonValue], current)
+            assert segment in source, f"{pointer}: {segment!r} missing"
+            current = source[segment]
+            continue
+        assert isinstance(current, Sequence) and not isinstance(current, str), (
+            f"{pointer}: {segment!r} does not address a mapping or an array"
+        )
+        items = cast(Sequence[JsonValue], current)
+        assert segment.isdecimal() and int(segment) < len(items), f"{pointer}: {segment!r} missing"
+        current = items[int(segment)]
+    return current
+
+
+@pytest.fixture(scope="module")
+async def workflow() -> ProjectionWorkflow:
+    """Run the shared workflow once for the whole sweep."""
+
+    return await run_projection_workflow()
+
+
+async def test_the_sweep_covers_every_status_view() -> None:
+    """A new status view must arrive with an expectation, not silently unswept."""
+
+    swept = {label.removeprefix("status/") for label, _, _ in _EXPECTATIONS if "/" in label}
+    assert swept >= set(STATUS_VIEWS)
+
+
+@pytest.mark.parametrize(("label", "pointer", "populated"), _EXPECTATIONS)
+async def test_nested_collections_project(
+    workflow: ProjectionWorkflow, label: str, pointer: str, populated: bool
+) -> None:
+    """The named nested collection survives the public result model, for real material."""
+
+    seed = 1600 + 4 * _EXPECTATIONS.index((label, pointer, populated))
+    projected = await project_case(workflow.app, workflow.case(label), seed)
+
+    assert projected["ok"] is True
+    value = _resolve(projected, pointer)
+    assert value is not None, f"{label}{pointer} projected as null"
+    if isinstance(value, Mapping):
+        assert cast(Mapping[str, JsonValue], value), f"{label}{pointer} projected empty"
+        return
+    assert isinstance(value, Sequence) and not isinstance(value, str), (
+        f"{label}{pointer} is neither a nested object nor an array"
+    )
+    if populated:
+        assert cast(Sequence[JsonValue], value), f"{label}{pointer} projected empty"
+
+
+async def test_every_case_the_workflow_builds_projects(workflow: ProjectionWorkflow) -> None:
+    """No public result model may fail to project — including any the table has not reached yet."""
+
+    for offset, case in enumerate(workflow.cases):
+        projected = await project_case(workflow.app, case, 1800 + 4 * offset)
+        assert projected["ok"] is True, case.label


### PR DESCRIPTION
Closes #51.

## The defect

`check` could not return any response that contained a finding. Not one. In any mode.

The check committed durably — `check_recorded` and `finding_recorded` landed in the ledger and the frontier advanced — and then the response failed to project, so the caller received `INTERNAL_ERROR` / `response_projection_failed` and never learned the verdict, the finding, or the semantic outcome. `findings[]` is the delivery channel for a check's entire answer, and it had never worked. No check had ever produced a finding, which is why three dogfoods missed it.

Two defects of one class were stacked here, the first masking the second:

1. `_ClosedModel` is configured `strict=True`. Strict pydantic accepts only a real `dict` (or an instance of the target model) for a nested model field, and the internal result carries nested entries as `JsonObject` — a genuine `Mapping`, but not a `dict`. Top-level fields survived because they are scalars; every nested element was rejected.
2. The check result's `projected_finding` requires `provenance` to be *present* and nullable, while the `findings/finding-1.0.0` encoding that events and receipt documents share leaves it simply absent on a deterministic finding. Once (1) was fixed, this rejected the same responses.

## The fix

**`_public_model` normalizes nested mappings.** One place, above every result model, so no individual serializer has to remember. The conversion is structural only — scalars are returned untouched, key order is preserved, no key is added or dropped, and sequence containers keep their own type so the closed models' established list-to-tuple adaptation sees exactly what it saw before. `strict=True` is untouched: relaxing it would start accepting int-for-string and other coercions across the whole public contract. Depth is bounded by the same `MAX_JSON_DEPTH` the internal results are already built under, so a pathological structure degrades to a named rejection inside the projection window rather than recursing without limit.

**`check_internal_json` presents an absent provenance as an explicit null**, mirroring the top-level `semantic_provenance` immediately beside it, which the same result already emits that way. `finding_to_json` is left alone — the events and receipts it serves genuinely admit an absent provenance.

## Closing the class

PR #50 fixed one instance of a projection defect and the class survived to reappear. This PR adds the seam that was missing: `tests/builders/projection_workflow.py` runs one realistic workflow through the real ready composition — real vault objects, the real privacy coordinator seeded with the shipped default policy, the real closed-model validation the daemon runs for an MCP bridge client — and hands back the internal result of `start`, `publish_work`, `check`, `respond`, `status` (all ten views) and `receipt`.

`test_result_model_projection_sweep.py` walks that surface and asserts every nested collection the public models declare projects and is populated: `check`'s findings and policy executions, `publish_work`'s accepted events, `respond`'s accepted event and evidence, `receipt`'s document and version slices, `start`'s compact view, every status view's page, and the `open_obligations` / `unresolved_findings` nested one level inside a compact item. An expectation that names a collection also requires it to be non-empty — a vacuous pass is the failure mode that let this class live. A guard test fails if a status view is ever added without a case. The builder is written to be extended; the null-optional sweep planned next reuses it rather than rebuilding it.

Verified the sweep is not decorative: with the normalization reverted it fails on `check`, and the other twenty cases pass — which is the honest result, since only `check` carried nested entries in the rejected container.

## Tests

`test_check_findings_projection.py`:

- A `check` returning a finding projects to a complete `CheckSuccessModel` under `deterministic_only`, `semantic_if_configured` and `semantic_required` — the defect is mode-independent and the test says so. Asserts the verdict, finding id, kind, origin, priority, `summary`, `detail`, `subject_refs`, policy identity, nested frontier and coverage all survive, and that the shipped default really does disclose the finding summary to the agent context, so the text the check exists to deliver arrives as text rather than an omission marker.
- A check at `MAX_FINDINGS_LIMIT` projects, with the suppressed remainder reported rather than silently dropped.
- A genuinely malformed nested entry, in the same internal container type, is still rejected — and rejected *at that leaf* (`findings.0.priority`), not laundered into something the closed model accepts. A control case pins the same route validating when nothing is corrupted.
- No test asserts on `JsonObject`. The invariant is "nested mappings project", not "this one internal type is handled" — the next instance of this class will arrive wearing a different type.

Full suite green locally: 2155 passed, 17 skipped, 4 xfailed. `ruff format --check`, `ruff check`, `pyright` (strict), `generate_schemas --check`, `verify_resource_manifest --check` and `scan_public_boundary` all pass.

## Out of scope

Why a check produces the findings it produces. Semantic delivery and non-dispatch reporting. The durable projection of check state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJSyJi3nMAN7d3N4e3TcVs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed check results that contain findings being incorrectly reported as internal errors.
  * Improved handling of nested result data while preserving validation and rejecting malformed responses.
  * Ensured deterministic findings include complete provenance information.
  * Added coverage across check, status, start, publish, respond, and receipt result projections.

* **Documentation**
  * Added release notes and planning documentation covering projection reliability, semantic findings, status views, optional fields, and diagnostic correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->