### PR TITLE
fix: deliver semantic advice or record why not

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -568,6 +568,23 @@ review was not run; they must not reuse blocked-by-policy wording. The not-reque
 deterministic-only check and forces coverage incompleteness without changing the deterministic
 verdict.
 
+Ready check composition resolves the configured external provider against the live
+generation-fenced registry for every semantic check. A provider binding activated after ready
+composition can therefore serve a later check without a service restart; a binding removed after
+composition cannot be used from the stale readiness snapshot. Exact credential-record presence is
+checked structurally without reading the secret; minting secret material remains dispatch-time only.
+
+A semantic check also appends one bounded diagnostic record when no provider endpoint is bound, its
+task route is inactive, the exact configured binding is absent from the live registry, or the outer
+check coordinator catches an evaluator exception. A missing exact credential record shares the
+credential-unavailable path. These paths use exactly one operation token:
+`semantic_not_dispatched_provider_unbound`, `semantic_not_dispatched_route_inactive`,
+`semantic_not_dispatched_credential_unavailable`, or
+`semantic_not_dispatched_coordinator_failure`. The reason is a closed structural token; provider
+identity, exception text, payload, and paths remain forbidden from this sink. Exceptions contained
+inside the production composition evaluator retain the existing `semantic_evaluation_failed`
+operation.
+
 The check-applicability gap family follows the same material-state rule: `check_not_applicable`
 means material work was appended after the recorded check and superseded its verdict, never that
 the frontier merely advanced.
@@ -1216,6 +1233,8 @@ storage or handle minting. `ProviderAttemptAuthBinding` freezes those same field
 final request-body SHA-256 digest, service
 generation, and deadline. Minting a credential handle requires every shared field to match the
 stored credential binding; a scoped credential cannot authorize another model, scope, or purpose.
+`VaultService.has_provider_credential(binding)` reads only the exact structural record-generation
+index and returns presence; it neither decrypts the record nor creates a credential handle.
 `ProviderCredentialHandle.authorize_attempt(binding, inject_and_start)` is single-use: after exact
 binding/body/deadline validation it exposes a protected view only inside the injected custom HTTP
 transport callback for authentication-header injection and one request start, then releases it
@@ -1392,6 +1411,8 @@ external/local consume share one generation CAS: tightening-first means no I/O; 
 one admitted attempt may send, is best-effort closed/nonselectable, and receives its actual receipt.
 `OutboundGatewayPort.reconcile_policy(policy, human_authority: HumanAuthorityCapability)` binds both
 policy and human-authority generations; unavailable authority yields an empty external registry.
+`PolicyEnforcingOutboundGateway.has_connected_provider_binding(binding)` is the composition-only
+exact-binding liveness query over that registry; it never probes or mints a credential.
 `OutboundGatewayPort.close()` is an idempotent terminal operation: it installs a deny fence before
 awaiting transport closure, after which reconciliation/dispatch/revocation admit no new work, mint
 no credential, render no content-bearing request, and perform no new adapter I/O. Unconsumed work is

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -295,6 +295,19 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             connected.add(registry.local_model[0].provider_id)
         return tuple(sorted(connected, key=str.encode))
 
+    def has_connected_provider_binding(self, binding: ProviderBinding) -> bool:
+        """Return whether the exact configured binding is live in the current registry."""
+
+        if type(binding) is not ProviderBinding:
+            raise TypeError("privacy_gateway_provider_binding_invalid")
+        registry = self._current_registry()
+        if registry is None:
+            return False
+        return (
+            registry.resolve_external(binding) is not None
+            or registry.resolve_local(binding) is not None
+        )
+
     # -- reconciliation -----------------------------------------------------------------------
 
     async def reconcile_policy(

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -41,6 +41,7 @@ from yoetz.kernel.deterministic_checks import (
 from yoetz.kernel.policies.research_evidence import research_evidence_findings
 from yoetz.kernel.policies.work_integrity import work_integrity_findings
 from yoetz.kernel.ranking import CheckCompleteness, RankingContext, rank_findings
+from yoetz.observability.logging import record_unexpected_exception_without_raising
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.ids import IdPort
@@ -853,8 +854,14 @@ async def _semantic_evaluation(
         )
     try:
         return await app.evaluate_semantic_check(frozen, deterministic)
-    except Exception:
+    except Exception as exc:
         # Optional/required semantic evaluator crash must never fabricate a clean semantic pass.
+        record_unexpected_exception_without_raising(
+            exc,
+            component="check",
+            operation="semantic_not_dispatched_coordinator_failure",
+            request_id=request.request_id,
+        )
         return FinalSemanticEvaluation(
             SemanticStatus.FAILED,
             SemanticReason.COORDINATOR_FAILURE,

--- a/src/yoetz/observability/logging.py
+++ b/src/yoetz/observability/logging.py
@@ -27,6 +27,7 @@ __all__ = [
     "StructuredLogger",
     "configure_logging",
     "get_logger",
+    "record_bounded_event_without_raising",
     "record_fatal_exception_without_raising",
     "record_unexpected_exception_without_raising",
 ]
@@ -376,6 +377,49 @@ def record_unexpected_exception_without_raising(
             correlation_id=correlation_id,
             request_id=request_id,
             outcome="internal_error",
+            reason=reason,
+        )
+    except BaseException:
+        pass
+    try:
+        from yoetz.observability.diagnostics import append_diagnostic_record
+
+        append_diagnostic_record(
+            correlation_id=correlation_id,
+            component=component,
+            operation=operation,
+            reason=reason,
+            request_id=request_id,
+        )
+    except BaseException:
+        pass
+    return correlation_id
+
+
+def record_bounded_event_without_raising(
+    *,
+    component: str,
+    operation: str,
+    reason: str,
+    request_id: str | None = None,
+) -> str:
+    """Emit bounded structural identity for a reviewed non-exception event.
+
+    Semantic review declining to dispatch is an expected operating state, not an unexpected
+    exception, so it has no ``_exception_reason`` source; the caller passes the already-bounded
+    reason token it is simultaneously reporting on the operation's own result channel. Both
+    tokens are reviewed literals at the call site, and the sinks re-validate them against the
+    same field allowlists as an exception record. The durable owner-only line is what makes the
+    outcome resolvable when harnesses swallow process stderr.
+    """
+
+    correlation_id = _new_correlation()
+    try:
+        get_logger(component).warning(
+            operation,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            outcome="not_dispatched",
             reason=reason,
         )
     except BaseException:

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
@@ -92,7 +92,10 @@ from yoetz.kernel.policies.observation_advice import (
     ObservationAdviceCandidate,
     ObservationCompositionFact,
 )
-from yoetz.observability.logging import record_unexpected_exception_without_raising
+from yoetz.observability.logging import (
+    record_bounded_event_without_raising,
+    record_unexpected_exception_without_raising,
+)
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.control import ControlError
 from yoetz.ports.diagnostics import DiagnosticsPort, RuntimeCapability, StartupCheckResult
@@ -137,6 +140,7 @@ from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind, new_id, validate_id
 from yoetz.protocol.models import SemanticReason, SemanticStatus
+from yoetz.service.vault import ProviderCredentialBinding, provider_credential_profile_binding
 from yoetz.version import build_version_manifest, version_manifest_json
 
 __all__ = [
@@ -177,6 +181,8 @@ class _Vault(Protocol):
     async def provider_credential(
         self, binding: ProviderAttemptAuthBinding
     ) -> ProviderCredentialHandle: ...
+
+    async def has_provider_credential(self, binding: ProviderCredentialBinding) -> bool: ...
 
 
 class _Paths(Protocol):
@@ -1218,15 +1224,18 @@ async def _semantic_not_configured(
     )
 
 
-async def _semantic_credential_unavailable(
+async def _semantic_provider_unbound(
     frozen: FrozenCase, findings: tuple[object, ...]
 ) -> FinalSemanticEvaluation:
-    """Endpoint is bound but no provider credential is connected in this generation."""
+    """Semantic is enabled, but no external provider endpoint is configured."""
 
-    del frozen, findings
-    return FinalSemanticEvaluation(
-        SemanticStatus.UNAVAILABLE, SemanticReason.CREDENTIAL_UNAVAILABLE
+    record_bounded_event_without_raising(
+        component="semantic_composition",
+        operation="semantic_not_dispatched_provider_unbound",
+        reason=SemanticReason.PROVIDER_NOT_CONFIGURED.value,
+        request_id=frozen.lease.operation_id,
     )
+    return await _semantic_not_configured(frozen, findings)
 
 
 def _map_blocked(outcome: PrivacyOutcome, reason: object) -> FinalSemanticEvaluation:
@@ -1401,7 +1410,7 @@ def _privacy_gated_semantic_evaluator(
     privacy: PrivacyCoordinator,
     clock: ClockPort,
     installation_id: str,
-    provider: ProviderBinding | None,
+    resolve_provider: Callable[[], Awaitable[ProviderBinding | None]],
     catalog: StartCatalogPort,
     lookup: MacKeyHandle,
     ids: IdPort,
@@ -1409,11 +1418,29 @@ def _privacy_gated_semantic_evaluator(
     async def _evaluate(
         frozen: FrozenCase, findings: tuple[object, ...]
     ) -> FinalSemanticEvaluation:
+        # Re-resolve against the live generation-fenced registry on every check: a binding
+        # activated after composition must take effect without a service restart, and a revoked
+        # binding must not remain usable from the stale readiness snapshot.
+        provider = await resolve_provider()
         if provider is None:
-            return await _semantic_not_configured(frozen, findings)
+            record_bounded_event_without_raising(
+                component="semantic_composition",
+                operation="semantic_not_dispatched_credential_unavailable",
+                reason=SemanticReason.CREDENTIAL_UNAVAILABLE.value,
+                request_id=frozen.lease.operation_id,
+            )
+            return FinalSemanticEvaluation(
+                SemanticStatus.UNAVAILABLE, SemanticReason.CREDENTIAL_UNAVAILABLE
+            )
         try:
             route = await catalog.resolve_route(frozen.lease.session_id)
             if route is None or route.state is not TaskRouteState.ACTIVE:
+                record_bounded_event_without_raising(
+                    component="semantic_composition",
+                    operation="semantic_not_dispatched_route_inactive",
+                    reason=SemanticReason.PROVIDER_NOT_CONFIGURED.value,
+                    request_id=frozen.lease.operation_id,
+                )
                 return await _semantic_not_configured(frozen, findings)
             workspace = lookup.mac(
                 WORKSPACE_REF_DOMAIN,
@@ -1550,14 +1577,35 @@ async def provide_service_ready_context(
     )
     semantic_configured = config.verification.semantic != "disabled"
     provider_endpoint_bound = config.provider is not None
-    # Resolve the binding before readiness: a connected provider that is not the *configured* one
-    # leaves dispatch on the credential-unavailable path, so readiness must track the exact binding
-    # rather than "any provider connected".
-    provider_binding: ProviderBinding | None = None
+    # Preserve the composition-time snapshot for readiness/status, but resolve the configured
+    # binding again for every check so a later registry activation can take effect immediately.
+    candidate_binding: ProviderBinding | None = None
     if config.provider is not None:
         candidate_binding = provider_binding_from_config(config.provider)
-        if candidate_binding.provider_id in connected_provider_ids:
-            provider_binding = candidate_binding
+
+    def binding_not_connected(_binding: ProviderBinding) -> bool:
+        return False
+
+    async def resolve_provider_binding() -> ProviderBinding | None:
+        if candidate_binding is None:
+            return None
+        binding_connected = cast(
+            Callable[[ProviderBinding], bool],
+            getattr(gateway, "has_connected_provider_binding", binding_not_connected),
+        )
+        if binding_connected(candidate_binding) is not True:
+            return None
+        credential_binding = provider_credential_profile_binding(
+            candidate_binding.provider_id,
+            candidate_binding.model_id,
+            candidate_binding.endpoint_profile_id,
+            candidate_binding.endpoint_profile_version,
+        )
+        if not await vault.has_provider_credential(credential_binding):
+            return None
+        return candidate_binding
+
+    provider_binding = await resolve_provider_binding()
     provider_credential_connected = provider_binding is not None
     semantic_ready = (
         semantic_configured and provider_endpoint_bound and provider_credential_connected
@@ -1630,15 +1678,13 @@ async def provide_service_ready_context(
     if not semantic_configured:
         semantic_evaluator = _semantic_not_configured
     elif not provider_endpoint_bound:
-        semantic_evaluator = _semantic_not_configured
-    elif provider_binding is None:
-        semantic_evaluator = _semantic_credential_unavailable
+        semantic_evaluator = _semantic_provider_unbound
     else:
         semantic_evaluator = _privacy_gated_semantic_evaluator(
             cast(PrivacyCoordinator, privacy),
             clock,
             installation_id,
-            provider_binding,
+            resolve_provider_binding,
             catalog,
             lookup,
             ids,

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1421,7 +1421,18 @@ def _privacy_gated_semantic_evaluator(
         # Re-resolve against the live generation-fenced registry on every check: a binding
         # activated after composition must take effect without a service restart, and a revoked
         # binding must not remain usable from the stale readiness snapshot.
-        provider = await resolve_provider()
+        try:
+            provider = await resolve_provider()
+        except Exception as exc:
+            record_unexpected_exception_without_raising(
+                exc,
+                component="semantic_composition",
+                operation="semantic_evaluation_failed",
+                request_id=frozen.lease.operation_id,
+            )
+            return FinalSemanticEvaluation(
+                SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE
+            )
         if provider is None:
             record_bounded_event_without_raising(
                 component="semantic_composition",

--- a/src/yoetz/service/vault.py
+++ b/src/yoetz/service/vault.py
@@ -601,6 +601,23 @@ class VaultService:
                 reason = "record_missing" if exc.reason == "record_missing" else "vault_tampered"
                 raise VaultError(reason) from exc
 
+    async def has_provider_credential(self, binding: ProviderCredentialBinding) -> bool:
+        """Return structural presence for one exact provider profile without reading its secret."""
+
+        if type(binding) is not ProviderCredentialBinding:
+            raise TypeError("provider_credential_binding_invalid")
+        async with self._mutex:
+            store, _generation = self._ready_store()
+            try:
+                return (
+                    store.record_generation(
+                        VaultRecordKind.PROVIDER_CREDENTIAL, binding.record_binding()
+                    )
+                    is not None
+                )
+            except EncryptedVaultError as exc:
+                raise VaultError("vault_tampered") from exc
+
     async def provider_credential(
         self, binding: ProviderAttemptAuthBinding
     ) -> ProviderCredentialHandle:
@@ -618,23 +635,9 @@ class VaultService:
                 record = store.load_record(
                     VaultRecordKind.PROVIDER_CREDENTIAL, stored.record_binding()
                 )
-            except EncryptedVaultError:
-                # Backward-read support for pre-profile-binding development vaults.
-                legacy = ProviderCredentialBinding(
-                    binding.provider_id,
-                    binding.model_id,
-                    binding.endpoint_profile_id,
-                    binding.endpoint_profile_version,
-                    binding.purpose,
-                    binding.authorization_scope_digest,
-                    binding.purpose_digest,
-                )
-                try:
-                    record = store.load_record(
-                        VaultRecordKind.PROVIDER_CREDENTIAL, legacy.record_binding()
-                    )
-                except EncryptedVaultError as exc:
-                    raise VaultError("record_missing") from exc
+            except EncryptedVaultError as exc:
+                reason = "record_missing" if exc.reason == "record_missing" else "vault_tampered"
+                raise VaultError(reason) from exc
             plaintext = record.consume(SecretConsumer.VAULT_ROOT, lambda view: bytearray(view))
             credential = self._secret_memory.capture(SecretPurpose.PROVIDER_CREDENTIAL, plaintext)
             handle = _ProviderHandle(self, generation, binding, credential, self._clock)

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import replace
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import cast
 
 import pytest
 
+import yoetz.observability.diagnostics as diagnostics_module
 from builders.ledger_adapters import FixedClock, MemoryObjects
 from builders.policy_cases import FRONTIER, clm, make_case, record
 from yoetz.application.check import FinalSemanticEvaluation, execute_check, execute_check_commit
@@ -321,7 +324,9 @@ async def test_semantic_required_unavailable_preserves_deterministic_truth() -> 
 
 
 @pytest.mark.anyio
-async def test_semantic_evaluator_crash_degrades_to_not_run_without_false_clean() -> None:
+async def test_semantic_evaluator_crash_degrades_to_not_run_without_false_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Requirement: evaluator crash/timeout degrades to not-run disclosure, never false clean."""
 
     from yoetz.domain.receipts import (
@@ -329,6 +334,7 @@ async def test_semantic_evaluator_crash_degrades_to_not_run_without_false_clean(
         SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
     )
 
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
     crashed = _App(semantic=True, crash_semantic=True)
     crash_result = await execute_check_commit(crashed, _request("semantic_if_configured"))
     assert crash_result.findings
@@ -337,6 +343,16 @@ async def test_semantic_evaluator_crash_degrades_to_not_run_without_false_clean(
     assert crash_result.verdict.value != "no_issue_detected"
     assert SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP in crash_result.coverage.known_gaps
     assert SEMANTIC_REVIEW_NOT_CONFIGURED_GAP not in crash_result.coverage.known_gaps
+    raw = diagnostics_module.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    records = tuple(json.loads(line) for line in raw.splitlines() if line)
+    assert len(records) == 1
+    assert records[0]["component"] == "check"
+    assert records[0]["operation"] == "semantic_not_dispatched_coordinator_failure"
+    assert records[0]["reason"] == "exception_runtime_error"
+    assert records[0]["request_id"] == _REQUEST
+    assert "semantic_evaluator_crashed" not in raw
+    assert "payload" not in raw
+    assert str(tmp_path) not in raw
 
     timed_out = _App(semantic=True)
     timed_out.semantic_result = FinalSemanticEvaluation(

--- a/tests/integration/application/test_check_findings_projection.py
+++ b/tests/integration/application/test_check_findings_projection.py
@@ -23,6 +23,7 @@ and pin a complete response carrying the finding, in all three check modes.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import replace
 from typing import Literal, cast
 
 import pytest
@@ -34,6 +35,7 @@ from builders.projection_workflow import (
     request_base,
 )
 from builders.start_application import protocol_id, start_request
+from yoetz.application.check import FinalSemanticEvaluation
 from yoetz.application.service import (
     Application,
     ClientProjectionContext,
@@ -41,17 +43,22 @@ from yoetz.application.service import (
     ProjectedControlBody,
     ProjectionRenderMode,
 )
+from yoetz.domain.findings import Finding, FindingKind, SemanticDispatchKind, SemanticProvenance
 from yoetz.domain.privacy import PrivacyPolicy
 from yoetz.domain.values import JsonObject
 from yoetz.ports.control import ControlClientKind, ControlMethod
-from yoetz.ports.ledger import CheckCommitResult
+from yoetz.ports.ledger import CheckCommitResult, FrozenCase
+from yoetz.ports.semantic import ReviewerChallenge, SamplingParams, SemanticJudgment
 from yoetz.protocol.canonical import MAX_JSON_DEPTH, JsonValue, canonical_encode
 from yoetz.protocol.errors import ProtocolValueError
 from yoetz.protocol.models import (
     MAX_FINDINGS_LIMIT,
+    CheckProjectedFindingModel,
     CheckRequest,
     DataCategory,
     PublishWorkRequest,
+    SemanticReason,
+    SemanticStatus,
     public_model_to_wire,
 )
 
@@ -73,6 +80,63 @@ _MODES: tuple[tuple[Literal["disabled", "optional"], str], ...] = (
     ("optional", "semantic_if_configured"),
     ("optional", "semantic_required"),
 )
+_DIGEST = "sha256:" + "7" * 64
+
+
+async def _semantic_challenge(
+    frozen: FrozenCase, findings: tuple[Finding, ...]
+) -> FinalSemanticEvaluation:
+    """Hermetic second reviewer that challenges one real deterministic finding."""
+
+    del frozen
+    assert findings
+    provenance = SemanticProvenance(
+        provider="fake",
+        endpoint_profile_id="fake",
+        endpoint_profile_version="1.0.0",
+        model="fake/model",
+        sdk_version="1.0.0",
+        prompt_digest=_DIGEST,
+        schema_digest=_DIGEST,
+        policy_digest=_DIGEST,
+        privacy_policy_digest=_DIGEST,
+        sampling_params=SamplingParams(128),
+        latency_ms=1,
+        semantic_attempt_id=protocol_id("att_", 1510),
+        dispatch_kind=SemanticDispatchKind.EXTERNAL,
+        privacy_receipt_id=protocol_id("egr_", 1511),
+        status=SemanticStatus.SUCCEEDED,
+        reason=SemanticReason.SEMANTIC_COMPLETED,
+        provider_request_id="fake-semantic-request-1",
+        egress_authorization_id=protocol_id("aut_", 1512),
+        request_commitment="hmac-sha256:" + "b" * 64,
+    )
+    challenge = ReviewerChallenge(
+        FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+        "The completion claim overstates its evidence",
+        (str(findings[0].finding_id),),
+        "The cited material records an obligation but no admissible completion evidence.",
+        "The work may be complete, but the frozen case does not establish that conclusion.",
+        "Cite admissible evidence or narrow the completion claim.",
+        "provide_evidence",
+        "Additional evidence may exist outside the frozen case.",
+    )
+    return FinalSemanticEvaluation(
+        SemanticStatus.SUCCEEDED,
+        SemanticReason.SEMANTIC_COMPLETED,
+        judgment=SemanticJudgment("challenges_returned", (challenge,)),
+        provenance=provenance,
+    )
+
+
+async def _semantic_unavailable(
+    frozen: FrozenCase, findings: tuple[Finding, ...]
+) -> FinalSemanticEvaluation:
+    del frozen, findings
+    return FinalSemanticEvaluation(
+        SemanticStatus.UNAVAILABLE,
+        SemanticReason.CREDENTIAL_UNAVAILABLE,
+    )
 
 
 async def _binding(
@@ -207,6 +271,22 @@ async def _checked(
     return app, check_wire, checked, policy
 
 
+async def _semantic_projected(seed: int) -> Mapping[str, JsonValue]:
+    app, _policy = await build_projection_application("optional", seed=seed, max_findings=3)
+    app = replace(app, semantic_evaluator=_semantic_challenge)
+    session, writer, frontier = await _work_with_unsupported_claims(app, seed, 1)
+    check_wire: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 6)),
+        "session_id": session,
+        "writer_id": writer,
+        "expected_frontier": frontier,
+        "mode": "semantic_required",
+        "max_findings": "3",
+    }
+    checked = await app.check(CheckRequest.model_validate(check_wire))
+    return await _project(app, check_wire, checked, seed + 7)
+
+
 @pytest.mark.parametrize(("semantic", "mode"), _MODES)
 async def test_check_with_a_finding_projects_a_complete_success(
     semantic: Literal["disabled", "optional"], mode: str
@@ -248,6 +328,62 @@ async def test_check_with_a_finding_projects_a_complete_success(
     assert "provenance" in finding
     executions = cast(list[Mapping[str, JsonValue]], projected["policy_executions"])
     assert [item["policy_id"] for item in executions] == ["research-evidence", "work-integrity"]
+
+
+async def test_semantic_finding_projects_with_provenance_and_advice_text() -> None:
+    """A second reviewer's challenge reaches the agent with its explanation and provenance."""
+
+    projected = await _semantic_projected(1515)
+
+    assert projected["semantic_status"] == "succeeded"
+    assert projected["semantic_reason"] == "semantic_completed"
+    findings = cast(list[Mapping[str, JsonValue]], projected["findings"])
+    semantic = next(item for item in findings if item["origin"] == "semantic_model_derived")
+    assert semantic["summary"] == "The completion claim overstates its evidence"
+    assert semantic["detail"] == "Cite admissible evidence or narrow the completion claim."
+    provenance = cast(Mapping[str, JsonValue], semantic["provenance"])
+    assert provenance["provider_request_id"] == "fake-semantic-request-1"
+    assert provenance["status"] == "succeeded"
+    assert provenance["reason"] == "semantic_completed"
+
+
+async def test_projected_finding_origin_and_provenance_pairing_is_strict() -> None:
+    projected = await _semantic_projected(1545)
+    findings = cast(list[Mapping[str, JsonValue]], projected["findings"])
+    semantic = next(item for item in findings if item["origin"] == "semantic_model_derived")
+    deterministic = next(item for item in findings if item["origin"] == "deterministic")
+
+    with pytest.raises(ValueError, match="semantic_finding_provenance_missing"):
+        CheckProjectedFindingModel.model_validate({**semantic, "provenance": None})
+    with pytest.raises(ValueError, match="deterministic_finding_provenance_invalid"):
+        CheckProjectedFindingModel.model_validate(
+            {**deterministic, "provenance": semantic["provenance"]}
+        )
+
+
+async def test_semantic_required_non_dispatch_projects_the_exact_reason() -> None:
+    seed = 1575
+    app, _policy = await build_projection_application("optional", seed=seed, max_findings=3)
+    app = replace(app, semantic_evaluator=_semantic_unavailable)
+    session, writer, frontier = await _work_with_unsupported_claims(app, seed, 1)
+    check_wire: dict[str, JsonValue] = {
+        **request_base(protocol_id("req_", seed + 6)),
+        "session_id": session,
+        "writer_id": writer,
+        "expected_frontier": frontier,
+        "mode": "semantic_required",
+        "max_findings": "3",
+    }
+
+    checked = await app.check(CheckRequest.model_validate(check_wire))
+    projected = await _project(app, check_wire, checked, seed + 7)
+
+    assert projected["ok"] is True
+    assert projected["verdict"] == "incomplete_check"
+    assert projected["semantic_status"] == "unavailable"
+    assert projected["semantic_reason"] == "credential_unavailable"
+    coverage = cast(Mapping[str, JsonValue], projected["coverage"])
+    assert "semantic_relevance_review_not_run" in cast(list[str], coverage["known_gaps"])
 
 
 async def test_the_maximum_permitted_finding_count_projects() -> None:

--- a/tests/integration/privacy/test_egress_gateway.py
+++ b/tests/integration/privacy/test_egress_gateway.py
@@ -569,10 +569,18 @@ def test_reconcile_and_dispatch_external_semantic_succeeds() -> None:
     policy = _policy(external_enabled=True, local_enabled=False)
     effective = EffectivePrivacyPolicy(policy, 1, policy.policy_digest)
     human = _human_authority(available=True)
+    assert gateway.has_connected_provider_binding(_provider_binding()) is False
 
     async def run() -> tuple[SemanticResult, EgressAuthorization]:
         reconciliation = await gateway.reconcile_policy(effective, human)
         assert reconciliation == ProviderReconciliation(1, 1, 0, ())
+        assert gateway.has_connected_provider_binding(_provider_binding()) is True
+        assert (
+            gateway.has_connected_provider_binding(
+                replace(_provider_binding(), model_id="different-model-same-provider")
+            )
+            is False
+        )
 
         authorization = _authorization(
             authorization_id="aut_60000000-0000-4000-8000-000000000010",

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import hmac
 from collections.abc import Callable, Iterator
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol, cast
@@ -13,12 +14,15 @@ import pytest
 
 import yoetz.adapters.sqlite.connection as connection_module
 import yoetz.service.ready_composition as ready_composition_module
+from builders.privacy_policies import minimal_external_policy
 from yoetz.adapters.keys.encrypted_vault import EncryptedVaultStore
 from yoetz.adapters.keys.secret_memory import LocalSecretMemory
 from yoetz.adapters.sqlite.connection import open_catalog_writer
 from yoetz.adapters.sqlite.migrations import initialize_catalog
 from yoetz.application.service import ClientProjectionContext, ControlProjectionBinding
 from yoetz.config.models import YoetzConfig
+from yoetz.config.write import fireworks_provider
+from yoetz.domain.privacy import AuthorizationScope, AuthorizationScopeKind
 from yoetz.ports.control import (
     ControlCallRequest,
     ControlClientKind,
@@ -26,8 +30,13 @@ from yoetz.ports.control import (
     ServiceState,
 )
 from yoetz.ports.diagnostics import StartupCheckResult
-from yoetz.ports.secret_memory import SecretPurpose
-from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    HumanAuthorityCapability,
+    OutboundGatewayPort,
+)
+from yoetz.ports.secret_memory import HumanAuthorizationProof, SecretPurpose
+from yoetz.protocol.canonical import JsonValue, canonical_digest, canonical_encode
 from yoetz.protocol.ids import IdKind, new_id
 from yoetz.protocol.models import (
     CheckRequest,
@@ -44,7 +53,7 @@ from yoetz.service.ready_composition import (
     build_ready_application_factory,
     open_ready_catalog,
 )
-from yoetz.service.vault import VaultMode, VaultService
+from yoetz.service.vault import VaultMode, VaultService, provider_credential_profile_binding
 
 _INSTALLATION_ID = "ins_00000000-0000-4000-8000-000000000001"
 _INSTANCE_ID = "svc_00000000-0000-4000-8000-000000000002"
@@ -821,6 +830,168 @@ async def test_ready_factory_deterministic_check_records_semantic_not_requested_
         assert required.semantic_status.value == "not_configured"
         assert required.semantic_reason.value == "provider_not_configured"
         assert required.verdict.value == "incomplete_check"
+    finally:
+        if app is not None:
+            await app.close()
+        await vault.close()
+        memory.close()
+        await lifecycle.close()
+
+
+@pytest.mark.anyio
+async def test_ready_check_re_resolves_provider_activated_after_composition(
+    tmp_path: Path,
+) -> None:
+    """A live registry update revives semantic check dispatch without rebuilding the app."""
+
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "d" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    await lifecycle.acquire_singleton()
+    await lifecycle.transition(ServiceState.LOCKED)
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "e" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "f" * 64)
+    provider = fireworks_provider(model="accounts/fireworks/models/minimax-m3")
+    config = YoetzConfig(profile="local-openai", provider=provider)
+    app = None
+    try:
+        factory = build_ready_application_factory(
+            lifecycle=lifecycle,
+            vault=vault,
+            config=config,
+            paths=_Paths(tmp_path),
+            clock=clock,
+            secret_memory=memory,
+            diagnostics=_Diagnostics(),
+        )
+        app = await factory(1, vault.generation)
+        common = {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "actor": {"actor_id": "harness:pytest", "actor_type": "harness"},
+            "client": {
+                "kind": "cooperative_agent",
+                "version": "0.1.0",
+                "integration": "cooperative_mcp",
+            },
+        }
+        started = await app.start(
+            StartRequest.model_validate(
+                {
+                    **common,
+                    "request_id": "req_00000000-0000-4000-8000-000000000401",
+                    "mode": "create",
+                    "task_title": "Resolve provider binding after ready composition",
+                    "requested_view": "compact",
+                }
+            )
+        )
+        first = await app.check(
+            CheckRequest.model_validate(
+                {
+                    **common,
+                    "request_id": "req_00000000-0000-4000-8000-000000000402",
+                    "session_id": started.session_id,
+                    "writer_id": started.writer_id,
+                    "expected_frontier": {
+                        "sequence": str(started.frontier.sequence),
+                        "head_digest": started.frontier.head_digest,
+                    },
+                    "mode": "semantic_required",
+                    "max_findings": "3",
+                    "policy_packs": ["work-integrity/0.1.0"],
+                }
+            )
+        )
+        assert first.semantic_status.value == "unavailable"
+        assert first.semantic_reason.value == "credential_unavailable"
+
+        evaluator = app.semantic_evaluator
+        widened = replace(
+            minimal_external_policy(),
+            effective_scope=AuthorizationScope(AuthorizationScopeKind.MACHINE, _INSTALLATION_ID),
+            created_at=clock.now_utc(),
+        )
+        gateway = cast(OutboundGatewayPort, getattr(app.privacy, "_gateway"))
+        await gateway.reconcile_policy(
+            EffectivePrivacyPolicy(widened, 2, widened.policy_digest),
+            HumanAuthorityCapability(
+                "established_passphrase",
+                canonical_digest({"source": "test"}),
+                1,
+                str(getattr(vault.mode, "value", vault.mode)),
+                vault.generation,
+                True,
+            ),
+        )
+        assert "fireworks" in cast(
+            tuple[str, ...], tuple(getattr(gateway, "connected_provider_ids")())
+        )
+        credential_binding = provider_credential_profile_binding(
+            provider.provider_id,
+            provider.model,
+            provider.endpoint_profile_id,
+            provider.endpoint_profile_version,
+        )
+        assert await vault.has_provider_credential(credential_binding) is False
+        proof = HumanAuthorizationProof(
+            "provider-proof-after-composition",
+            "provider_credential_set",
+            credential_binding.target_digest("set"),
+            1,
+            vault.generation,
+            None,
+            1.0,
+            60.0,
+        )
+        credential = memory.capture(
+            SecretPurpose.PROVIDER_CREDENTIAL,
+            bytearray(b"test-provider-token-after-composition"),
+        )
+        await vault.store_provider_credential("set", credential_binding, credential, proof, 2.0)
+        assert await vault.has_provider_credential(credential_binding) is True
+
+        second = await app.check(
+            CheckRequest.model_validate(
+                {
+                    **common,
+                    "request_id": "req_00000000-0000-4000-8000-000000000403",
+                    "session_id": started.session_id,
+                    "writer_id": started.writer_id,
+                    "expected_frontier": {
+                        "sequence": str(first.result_frontier.sequence),
+                        "head_digest": first.result_frontier.head_digest,
+                    },
+                    "mode": "semantic_required",
+                    "max_findings": "3",
+                    "policy_packs": ["work-integrity/0.1.0"],
+                }
+            )
+        )
+
+        assert app.semantic_evaluator is evaluator
+        # The unchanged durable LOCAL_ONLY policy now supplies the next fence. Reaching this exact
+        # pair proves the same ready application crossed the refreshed provider-binding gate and
+        # entered privacy evaluation rather than repeating the stale credential result.
+        assert (second.semantic_status.value, second.semantic_reason.value) == (
+            "blocked_by_policy",
+            "provider_binding_not_authorized",
+        )
     finally:
         if app is not None:
             await app.close()

--- a/tests/integration/service/test_semantic_non_dispatch.py
+++ b/tests/integration/service/test_semantic_non_dispatch.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import yoetz.observability.diagnostics as diagnostics_module
+import yoetz.service.ready_composition as ready_composition_module
+from builders.ledger_adapters import FixedClock
+from builders.policy_cases import FRONTIER, make_case
+from yoetz.application.check import FinalSemanticEvaluation, semantic_coverage_gap_code
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressAwaitingHuman
+from yoetz.domain.privacy import ProviderBinding
+from yoetz.domain.receipts import (
+    SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP,
+    SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
+)
+from yoetz.ports.keys import MacKeyHandle
+from yoetz.ports.ledger import CheckPhase, FrozenCase, OperationLease
+from yoetz.ports.start_catalog import StartCatalogPort, TaskRoute, TaskRouteState
+from yoetz.protocol.canonical import canonical_digest
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+_TASK = "tsk_53000000-0000-4000-8000-000000000001"
+_SESSION = "ses_53000000-0000-4000-8000-000000000001"
+_WRITER = "wri_53000000-0000-4000-8000-000000000001"
+_REQUEST = "req_53000000-0000-4000-8000-000000000001"
+_INSTALLATION = "ins_53000000-0000-4000-8000-000000000001"
+_PROVIDER = ProviderBinding(
+    "sensitive-provider",
+    "model",
+    "endpoint-profile",
+    "1.0.0",
+    "external",
+)
+
+type _SemanticEvaluator = Callable[
+    [FrozenCase, tuple[object, ...]], Awaitable[FinalSemanticEvaluation]
+]
+
+
+class _Privacy:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def evaluate_semantic(self, candidate: object, deadline: object) -> object:
+        del deadline
+        self.calls += 1
+        request_id = cast(str, getattr(candidate, "request_id"))
+        return SemanticEgressAwaitingHuman(
+            request_id,
+            "pvp_53000000-0000-4000-8000-000000000001",
+            "sha256:" + "a" * 64,
+            datetime(2030, 1, 1, tzinfo=UTC),
+        )
+
+
+class _Catalog:
+    def __init__(self, route: TaskRoute | None) -> None:
+        self.route = route
+
+    async def resolve_route(self, session: str) -> TaskRoute | None:
+        assert session == _SESSION
+        return self.route
+
+
+class _Lookup:
+    def mac(self, domain: bytes, message: bytes) -> str:
+        del domain, message
+        return "hmac-sha256:" + "b" * 64
+
+
+def _route(state: TaskRouteState = TaskRouteState.ACTIVE) -> TaskRoute:
+    route_generation = 1
+    bundle_relpath = f"tasks/{_TASK}"
+    identity = canonical_digest(
+        {
+            "task_id": _TASK,
+            "bundle_relpath": bundle_relpath,
+            "route_generation": route_generation,
+        }
+    )
+    return TaskRoute(_TASK, _SESSION, bundle_relpath, route_generation, state, identity)
+
+
+def _frozen() -> FrozenCase:
+    return FrozenCase(
+        make_case(),
+        OperationLease(
+            _WRITER,
+            _REQUEST,
+            _SESSION,
+            CheckPhase.LOCAL_READY,
+            "owner-generation-1",
+            "lease-owner-1",
+            1,
+            datetime(2030, 1, 1, tzinfo=UTC),
+            FRONTIER,
+            "sha256:" + "d" * 64,
+        ),
+    )
+
+
+def _evaluator(
+    privacy: _Privacy,
+    resolver: Callable[[], ProviderBinding | None],
+    route: TaskRoute | None,
+) -> _SemanticEvaluator:
+    async def resolve_provider() -> ProviderBinding | None:
+        return resolver()
+
+    factory = cast(
+        "Callable[..., _SemanticEvaluator]",
+        getattr(ready_composition_module, "_privacy_gated_semantic_evaluator"),
+    )
+    return factory(
+        cast(PrivacyCoordinator, privacy),
+        FixedClock(),
+        _INSTALLATION,
+        resolve_provider,
+        cast(StartCatalogPort, _Catalog(route)),
+        cast(MacKeyHandle, _Lookup()),
+        ready_composition_module.IdPort(),
+    )
+
+
+def _records(tmp_path: Path) -> tuple[Mapping[str, object], ...]:
+    path = diagnostics_module.diagnostic_log_path(root=tmp_path)
+    return tuple(
+        cast(Mapping[str, object], json.loads(line))
+        for line in path.read_text(encoding="ascii").splitlines()
+        if line
+    )
+
+
+def _assert_record(tmp_path: Path, operation: str, reason: SemanticReason) -> None:
+    records = _records(tmp_path)
+    assert records == (
+        {
+            "timestamp": records[0]["timestamp"],
+            "correlation_id": records[0]["correlation_id"],
+            "component": "semantic_composition",
+            "operation": operation,
+            "reason": reason.value,
+            "request_id": _REQUEST,
+        },
+    )
+    raw = diagnostics_module.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    assert "sensitive-provider" not in raw
+    assert "payload" not in raw
+    assert "exception" not in raw
+    assert str(tmp_path) not in raw
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    (
+        "live_provider",
+        "route",
+        "status",
+        "reason",
+        "gap",
+        "operation",
+    ),
+    (
+        (
+            None,
+            _route(),
+            SemanticStatus.UNAVAILABLE,
+            SemanticReason.CREDENTIAL_UNAVAILABLE,
+            SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP,
+            "semantic_not_dispatched_credential_unavailable",
+        ),
+        (
+            _PROVIDER,
+            None,
+            SemanticStatus.NOT_CONFIGURED,
+            SemanticReason.PROVIDER_NOT_CONFIGURED,
+            SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
+            "semantic_not_dispatched_route_inactive",
+        ),
+        (
+            _PROVIDER,
+            _route(TaskRouteState.QUARANTINED),
+            SemanticStatus.NOT_CONFIGURED,
+            SemanticReason.PROVIDER_NOT_CONFIGURED,
+            SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
+            "semantic_not_dispatched_route_inactive",
+        ),
+    ),
+)
+async def test_semantic_non_dispatch_records_exact_bounded_reason(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    live_provider: ProviderBinding | None,
+    route: TaskRoute | None,
+    status: SemanticStatus,
+    reason: SemanticReason,
+    gap: str,
+    operation: str,
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+    privacy = _Privacy()
+    evaluator = _evaluator(privacy, lambda: live_provider, route)
+
+    result = await evaluator(_frozen(), ())
+
+    assert (result.status, result.reason) == (status, reason)
+    assert semantic_coverage_gap_code(result.status, result.reason) == gap
+    assert privacy.calls == 0
+    _assert_record(tmp_path, operation, reason)
+
+
+@pytest.mark.anyio
+async def test_provider_unbound_records_not_configured_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+    evaluator = cast(
+        _SemanticEvaluator,
+        getattr(ready_composition_module, "_semantic_provider_unbound"),
+    )
+
+    result = await evaluator(_frozen(), ())
+
+    assert (result.status, result.reason) == (
+        SemanticStatus.NOT_CONFIGURED,
+        SemanticReason.PROVIDER_NOT_CONFIGURED,
+    )
+    assert semantic_coverage_gap_code(result.status, result.reason) == (
+        SEMANTIC_REVIEW_NOT_CONFIGURED_GAP
+    )
+    _assert_record(
+        tmp_path,
+        "semantic_not_dispatched_provider_unbound",
+        SemanticReason.PROVIDER_NOT_CONFIGURED,
+    )
+
+
+@pytest.mark.anyio
+async def test_provider_binding_is_re_resolved_without_rebuilding_evaluator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+    privacy = _Privacy()
+    connected: ProviderBinding | None = None
+
+    def resolve() -> ProviderBinding | None:
+        return connected
+
+    evaluator = _evaluator(privacy, resolve, _route())
+    unavailable = await evaluator(_frozen(), ())
+    connected = _PROVIDER
+    dispatched = await evaluator(_frozen(), ())
+
+    assert (unavailable.status, unavailable.reason) == (
+        SemanticStatus.UNAVAILABLE,
+        SemanticReason.CREDENTIAL_UNAVAILABLE,
+    )
+    assert (dispatched.status, dispatched.reason) == (
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+    )
+    assert privacy.calls == 1
+    assert [record["operation"] for record in _records(tmp_path)] == [
+        "semantic_not_dispatched_credential_unavailable"
+    ]

--- a/tests/integration/service/test_semantic_non_dispatch.py
+++ b/tests/integration/service/test_semantic_non_dispatch.py
@@ -269,3 +269,34 @@ async def test_provider_binding_is_re_resolved_without_rebuilding_evaluator(
     assert [record["operation"] for record in _records(tmp_path)] == [
         "semantic_not_dispatched_credential_unavailable"
     ]
+
+
+@pytest.mark.anyio
+async def test_provider_resolution_failure_stays_inside_composition_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+    privacy = _Privacy()
+
+    def resolve() -> ProviderBinding | None:
+        raise RuntimeError("resolver-detail-must-not-leak")
+
+    evaluator = _evaluator(privacy, resolve, _route())
+
+    result = await evaluator(_frozen(), ())
+
+    assert (result.status, result.reason) == (
+        SemanticStatus.FAILED,
+        SemanticReason.COORDINATOR_FAILURE,
+    )
+    assert semantic_coverage_gap_code(result.status, result.reason) == (
+        SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP
+    )
+    records = _records(tmp_path)
+    assert len(records) == 1
+    assert records[0]["component"] == "semantic_composition"
+    assert records[0]["operation"] == "semantic_evaluation_failed"
+    assert records[0]["reason"] == "exception_runtime_error"
+    assert records[0]["request_id"] == _REQUEST
+    raw = diagnostics_module.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    assert "resolver-detail-must-not-leak" not in raw

--- a/tests/unit/service/test_vault_state.py
+++ b/tests/unit/service/test_vault_state.py
@@ -15,13 +15,12 @@ from yoetz.ports.secret_memory import (
     SecretMemoryError,
     SecretPurpose,
 )
-from yoetz.protocol.canonical import canonical_digest
 from yoetz.service.vault import (
-    ProviderCredentialBinding,
     VaultError,
     VaultMode,
     VaultService,
     VaultState,
+    provider_credential_profile_binding,
 )
 
 _INSTALLATION_ID = "ins_00000000-0000-4000-8000-000000000001"
@@ -130,16 +129,13 @@ async def test_provider_credential_is_exact_attempt_bound_and_one_use(tmp_path: 
     clock = _Clock()
     service = _service(tmp_path, memory, clock)
     await _initialize(service, memory)
-    purpose_digest = canonical_digest({"purpose": "semantic-review"})
-    binding = ProviderCredentialBinding(
+    binding = provider_credential_profile_binding(
         "openai",
         "gpt-5",
         "openai-responses",
         "1",
-        "semantic-review",
-        "sha256:" + "3" * 64,
-        purpose_digest,
     )
+    assert await service.has_provider_credential(binding) is False
     proof = HumanAuthorizationProof(
         "proof-test",
         "provider_credential_set",
@@ -154,6 +150,7 @@ async def test_provider_credential_is_exact_attempt_bound_and_one_use(tmp_path: 
         SecretPurpose.PROVIDER_CREDENTIAL, bytearray(b"sk-test-token-value")
     )
     await service.store_provider_credential("set", binding, credential, proof, 10.0)
+    assert await service.has_provider_credential(binding) is True
     replacement_proof = HumanAuthorizationProof(
         "proof-test-replacement",
         "provider_credential_set",


### PR DESCRIPTION
Closes #53.

Implements `docs/plans/2026-07-28-run4-residuals/02-semantic-advice-delivery.md` after the plan-01 delivery fix in #52.

## Issue

- duplicate search completed before coding; no open issue or PR covered plan 02
- tracking issue: #53
- design acknowledgment: the implementation follows the maintainer-committed plan under `docs/plans/2026-07-28-run4-residuals/` and the explicit request to implement it

## Summary

- prove a semantic challenge traverses judgment validation, finding allocation, ranking, persistence, and public projection with advice text and non-null provenance
- emit bounded durable diagnostics for provider-unbound, route-inactive, credential-unavailable, and outer coordinator-failure paths without exception text, payload, provider identity, or paths
- preserve exact semantic status/reason and coverage-gap pairings, including a projectable `semantic_required` non-dispatch response
- re-resolve the exact configured provider binding and exact structural credential record on every check, allowing post-composition activation without restart
- align gateway/vault readiness checks with exact bindings without decrypting or minting credentials

## Documentation

- updated `docs/INTERFACES.md` with live binding/credential resolution, bounded diagnostic operations, exact gateway liveness, and structural vault-presence contracts
- no schema, fixture, ADR, or generated artifact changes

## Boundaries

- depends on #52 for the finding delivery channel
- does not persist check state (plan 03)
- does not change semantic prompts, policy questions, or provider model behavior
- preserves fail-closed semantic outcomes and the existing privacy-authorized egress path

## Verification

- `uv run pytest`: 2167 passed, 17 skipped, 4 xfailed
- focused post-review suite: 51 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `npx --no-install pyright`: 0 errors
- independent local diff review: no remaining findings
- CodeRabbit finding fixed in `dfe383f`: resolver failures now remain inside the semantic composition exception boundary