### PR TITLE
A check must not erase the record that it happened (run-4 residuals plan 03)

### DIFF
--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -159,7 +159,7 @@ from yoetz.protocol.models import (
     StatusVersionSliceModel,
 )
 
-__all__ = ["MemoryLedgerAdapter", "MemoryLedgerState"]
+__all__ = ["MemoryLedgerAdapter", "MemoryLedgerState", "compact_status_coverage"]
 
 _GENESIS: Final = Frontier.genesis()
 type _SummaryCode = Literal[
@@ -663,7 +663,7 @@ def _status_gap_codes(markers: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(sorted({marker.split(":", 1)[0] for marker in markers}, key=str.encode))
 
 
-def _compact_status_coverage(
+def compact_status_coverage(
     records: tuple[LedgerRecord, ...], projection: ProjectionState
 ) -> Coverage:
     """Fold the applicable check's coverage into the compact-status baseline.
@@ -672,6 +672,9 @@ def _compact_status_coverage(
     ``check_types=(none,)`` even immediately after a rich check; the check's real coverage
     lives in its payload. The receipt applicability rule decides whether the projected latest
     check still covers this state: it does unless material work was appended after it.
+
+    Shared by the memory status view and the durable SQLite ``p1_projection_state`` mirror so
+    a restart cannot disagree with the in-process projection about what was checked.
     """
 
     baseline = records[-1].coverage
@@ -954,7 +957,7 @@ def _projection_items(
                 unresolved_findings=unresolved_findings[:10],
                 freshness=projection.freshness.value,
                 coverage=CoverageModel.model_validate(
-                    coverage_to_json(_compact_status_coverage(records, projection))
+                    coverage_to_json(compact_status_coverage(records, projection))
                 ),
                 gaps=_status_gap_codes(projection.coverage_gaps),
             ),

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -15,6 +15,7 @@ from yoetz.adapters.memory.ledger import (
     MemoryLedgerAdapter,
     MemoryLedgerState,
     build_append_operation_record,
+    compact_status_coverage,
     load_frozen_case_from_resume,
 )
 from yoetz.adapters.sqlite.observation import SqliteObservationStore
@@ -969,6 +970,8 @@ class SqliteLedger:
             "WHERE projection_name='work'",
             (projection.frontier, projection_digest(projection)),
         )
+        # Status coverage is the applicable-check fold, not the last event's envelope
+        # (engine-derived check/receipt envelopes hardcode check_types=none).
         self._db.execute(
             "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
             "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
@@ -983,7 +986,9 @@ class SqliteLedger:
                 projection.freshness.value,
                 projection.unknown_event_count,
                 records[0].event_id,
-                canonical_encode(coverage_to_json(records[-1].coverage)),
+                canonical_encode(
+                    coverage_to_json(compact_status_coverage(self._state.records, projection))
+                ),
                 canonical_encode(projection.coverage_gaps),
             ),
         )
@@ -1087,22 +1092,62 @@ class SqliteLedger:
             "WHERE projection_name='work'",
             (projection.frontier, projection_digest(projection)),
         )
-        self._db.execute(
-            "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
-            "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
-            "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=? "
-            "WHERE projection_name='work'",
-            (
-                projection.frontier,
-                projection.head_digest,
-                len(projection.obligations),
-                len(projection.findings),
-                projection.freshness.value,
-                projection.unknown_event_count,
-                canonical_encode(coverage_to_json(records[-1].coverage)),
-                canonical_encode(projection.coverage_gaps),
-            ),
+        # Mirror the reducer's applicable-check coverage, never the last event envelope.
+        status_coverage = canonical_encode(
+            coverage_to_json(compact_status_coverage(self._state.records, projection))
         )
+        status_gaps = canonical_encode(projection.coverage_gaps)
+        has_check = any(record.schema.name == "check_recorded" for record in records)
+        if has_check:
+            latest = projection.latest_tested_state
+            if latest is None:
+                # check_recorded without a projected latest state would violate 0001.sql
+                # null/non-null consistency; fail closed rather than write a partial row.
+                raise _public_error(PublicErrorCode.STORAGE_CORRUPT)
+            self._db.execute(
+                "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
+                "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
+                "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=?,"
+                "latest_check_event_id=?,latest_subject_frontier_seq=?,"
+                "latest_subject_frontier_digest=?,latest_verdict=?,"
+                "latest_returned_finding_ids=?,latest_suppressed_count=?,"
+                "latest_coverage_canonical=? "
+                "WHERE projection_name='work'",
+                (
+                    projection.frontier,
+                    projection.head_digest,
+                    len(projection.obligations),
+                    len(projection.findings),
+                    projection.freshness.value,
+                    projection.unknown_event_count,
+                    status_coverage,
+                    status_gaps,
+                    latest.source_check_event_id,
+                    latest.subject_frontier.sequence,
+                    latest.subject_frontier.head_digest,
+                    latest.verdict.value,
+                    canonical_encode(latest.returned_finding_ids),
+                    latest.suppressed_count,
+                    canonical_encode(coverage_to_json(latest.coverage)),
+                ),
+            )
+        else:
+            self._db.execute(
+                "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
+                "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
+                "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=? "
+                "WHERE projection_name='work'",
+                (
+                    projection.frontier,
+                    projection.head_digest,
+                    len(projection.obligations),
+                    len(projection.findings),
+                    projection.freshness.value,
+                    projection.unknown_event_count,
+                    status_coverage,
+                    status_gaps,
+                ),
+            )
 
     async def append_batch(self, command: AppendCommand) -> AppendResult:
         await self._ensure_recovered()

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -187,6 +187,31 @@ def _operation_digest_row(
     return row[0], row[1]
 
 
+def _latest_check_column_values(
+    projection: ProjectionState,
+) -> tuple[str | None, int | None, str | None, str | None, bytes | None, int | None, bytes | None]:
+    """Bind params for the seven ``p1_projection_state`` latest-check columns.
+
+    Always all-null or all-non-null so the ``0001.sql`` consistency CHECK holds. When the
+    reducer has cleared ``latest_tested_state`` (for example redaction of the current
+    check), the durable mirror must clear with it — leaving prior values would advertise a
+    redacted verdict after restart.
+    """
+
+    latest = projection.latest_tested_state
+    if latest is None:
+        return (None, None, None, None, None, None, None)
+    return (
+        latest.source_check_event_id,
+        latest.subject_frontier.sequence,
+        latest.subject_frontier.head_digest,
+        latest.verdict.value,
+        canonical_encode(latest.returned_finding_ids),
+        latest.suppressed_count,
+        canonical_encode(coverage_to_json(latest.coverage)),
+    )
+
+
 def _import_reservation(db: apsw.Connection, command: AppendCommand) -> _Reservation:
     row = db.execute(
         "SELECT ipr.source_identity_digest, ipr.publication_ordinal, "
@@ -971,12 +996,17 @@ class SqliteLedger:
             (projection.frontier, projection_digest(projection)),
         )
         # Status coverage is the applicable-check fold, not the last event's envelope
-        # (engine-derived check/receipt envelopes hardcode check_types=none).
+        # (engine-derived check/receipt envelopes hardcode check_types=none). Always mirror
+        # latest_tested_state too — including clearing it when redaction drops the check.
         self._db.execute(
             "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
             "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
             "unknown_event_count=?,task_title_source_event_id=?,"
-            "status_coverage_canonical=?,status_gap_codes_canonical=? "
+            "status_coverage_canonical=?,status_gap_codes_canonical=?,"
+            "latest_check_event_id=?,latest_subject_frontier_seq=?,"
+            "latest_subject_frontier_digest=?,latest_verdict=?,"
+            "latest_returned_finding_ids=?,latest_suppressed_count=?,"
+            "latest_coverage_canonical=? "
             "WHERE projection_name='work'",
             (
                 projection.frontier,
@@ -990,6 +1020,7 @@ class SqliteLedger:
                     coverage_to_json(compact_status_coverage(self._state.records, projection))
                 ),
                 canonical_encode(projection.coverage_gaps),
+                *_latest_check_column_values(projection),
             ),
         )
 
@@ -1092,62 +1123,32 @@ class SqliteLedger:
             "WHERE projection_name='work'",
             (projection.frontier, projection_digest(projection)),
         )
-        # Mirror the reducer's applicable-check coverage, never the last event envelope.
-        status_coverage = canonical_encode(
-            coverage_to_json(compact_status_coverage(self._state.records, projection))
+        # Mirror the reducer's applicable-check coverage and latest-check aggregate, never
+        # the last event envelope. When latest_tested_state is absent, clear the seven
+        # latest_* columns atomically so a redacted check cannot survive restart.
+        self._db.execute(
+            "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
+            "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
+            "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=?,"
+            "latest_check_event_id=?,latest_subject_frontier_seq=?,"
+            "latest_subject_frontier_digest=?,latest_verdict=?,"
+            "latest_returned_finding_ids=?,latest_suppressed_count=?,"
+            "latest_coverage_canonical=? "
+            "WHERE projection_name='work'",
+            (
+                projection.frontier,
+                projection.head_digest,
+                len(projection.obligations),
+                len(projection.findings),
+                projection.freshness.value,
+                projection.unknown_event_count,
+                canonical_encode(
+                    coverage_to_json(compact_status_coverage(self._state.records, projection))
+                ),
+                canonical_encode(projection.coverage_gaps),
+                *_latest_check_column_values(projection),
+            ),
         )
-        status_gaps = canonical_encode(projection.coverage_gaps)
-        has_check = any(record.schema.name == "check_recorded" for record in records)
-        if has_check:
-            latest = projection.latest_tested_state
-            if latest is None:
-                # check_recorded without a projected latest state would violate 0001.sql
-                # null/non-null consistency; fail closed rather than write a partial row.
-                raise _public_error(PublicErrorCode.STORAGE_CORRUPT)
-            self._db.execute(
-                "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
-                "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
-                "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=?,"
-                "latest_check_event_id=?,latest_subject_frontier_seq=?,"
-                "latest_subject_frontier_digest=?,latest_verdict=?,"
-                "latest_returned_finding_ids=?,latest_suppressed_count=?,"
-                "latest_coverage_canonical=? "
-                "WHERE projection_name='work'",
-                (
-                    projection.frontier,
-                    projection.head_digest,
-                    len(projection.obligations),
-                    len(projection.findings),
-                    projection.freshness.value,
-                    projection.unknown_event_count,
-                    status_coverage,
-                    status_gaps,
-                    latest.source_check_event_id,
-                    latest.subject_frontier.sequence,
-                    latest.subject_frontier.head_digest,
-                    latest.verdict.value,
-                    canonical_encode(latest.returned_finding_ids),
-                    latest.suppressed_count,
-                    canonical_encode(coverage_to_json(latest.coverage)),
-                ),
-            )
-        else:
-            self._db.execute(
-                "UPDATE p1_projection_state SET frontier_seq=?,head_digest=?,"
-                "open_obligation_count=?,unresolved_finding_count=?,freshness=?,"
-                "unknown_event_count=?,status_coverage_canonical=?,status_gap_codes_canonical=? "
-                "WHERE projection_name='work'",
-                (
-                    projection.frontier,
-                    projection.head_digest,
-                    len(projection.obligations),
-                    len(projection.findings),
-                    projection.freshness.value,
-                    projection.unknown_event_count,
-                    status_coverage,
-                    status_gaps,
-                ),
-            )
 
     async def append_batch(self, command: AppendCommand) -> AppendResult:
         await self._ensure_recovered()

--- a/tests/integration/storage/test_check_projection_coverage.py
+++ b/tests/integration/storage/test_check_projection_coverage.py
@@ -370,9 +370,9 @@ async def test_redaction_of_latest_check_clears_durable_aggregate(tmp_path: Path
     assert _check_types(row["status_coverage_canonical"]) == ["none"]
     gaps = strict_json_parse(row["status_gap_codes_canonical"])
     assert type(gaps) is list
-    assert any(
-        type(marker) is str and marker.startswith("redacted_event:") for marker in gaps
-    ), gaps
+    assert any(type(marker) is str and marker.startswith("redacted_event:") for marker in gaps), (
+        gaps
+    )
     db.close()
 
     _reopened, reopened_db = file_sqlite_for(command, objects, path)

--- a/tests/integration/storage/test_check_projection_coverage.py
+++ b/tests/integration/storage/test_check_projection_coverage.py
@@ -1,0 +1,442 @@
+"""Durable check aggregate and status coverage must survive restart (issue #55 / plan 03).
+
+A successful check used to leave ``p1_projection_state`` with null latest-check columns and
+overwrite ``status_coverage_canonical`` with the engine-derived envelope's
+``check_types: ["none"]``. The in-memory projection held the truth, so the lie was invisible
+until the bundle was reopened or the durable row was read directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import apsw
+import pytest
+
+from builders.ledger_adapters import MemoryObjects
+from builders.replay import replay_records
+from integration.storage.test_append_and_replay import (
+    command_from_records,
+    file_sqlite_for,
+    uuid_id,
+)
+from yoetz.adapters.sqlite.repository import SqliteLedger
+from yoetz.domain.events import EventDraft, EventPayload, LedgerRecord, encode_payload
+from yoetz.domain.findings import CheckVerdict, RankedFindings
+from yoetz.domain.values import Frontier, event_id, object_id, parse_rfc3339_millis
+from yoetz.ports.ledger import (
+    AppendCommand,
+    AppendEntry,
+    CheckPhase,
+    CheckPolicyExecution,
+    FrozenCase,
+    OperationKind,
+)
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource
+from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
+from yoetz.protocol.coverage import CheckType, Coverage
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _projection_row(db: apsw.Connection) -> dict[str, Any]:
+    columns = (
+        "frontier_seq",
+        "status_coverage_canonical",
+        "status_gap_codes_canonical",
+        "latest_check_event_id",
+        "latest_subject_frontier_seq",
+        "latest_subject_frontier_digest",
+        "latest_verdict",
+        "latest_returned_finding_ids",
+        "latest_suppressed_count",
+        "latest_coverage_canonical",
+        "freshness",
+        "unknown_event_count",
+    )
+    row = db.execute(
+        "SELECT " + ",".join(columns) + " FROM p1_projection_state WHERE projection_name='work'"
+    ).fetchone()
+    assert row is not None
+    return dict(zip(columns, row, strict=True))
+
+
+def _decode_coverage(blob: bytes | None) -> dict[str, Any]:
+    assert blob is not None
+    parsed = strict_json_parse(blob)
+    assert type(parsed) is dict
+    return cast(dict[str, Any], parsed)
+
+
+def _check_types(blob: bytes | None) -> list[str]:
+    return list(cast(list[str], _decode_coverage(blob)["check_types"]))
+
+
+async def _local_result_ref(objects: MemoryObjects, command: AppendCommand) -> ObjectRef:
+    staged = await objects.stage(
+        ObjectSource(data=b"{}", declared_size=2),
+        ObjectMetadata(
+            ObjectKind.DETERMINISTIC_RESULT,
+            "application/vnd.yoetz.deterministic-result+json",
+            command.task_id,
+            command.entries[0].payload_object.metadata.created_at,
+        ),
+    )
+    return await objects.finalize(staged)
+
+
+def _checked_coverage(base: Coverage, *check_types: CheckType) -> Coverage:
+    types = tuple(check_types) if check_types else (CheckType.DETERMINISTIC,)
+    return replace(base, check_types=types)
+
+
+async def _commit_check(
+    ledger: SqliteLedger,
+    command: AppendCommand,
+    objects: MemoryObjects,
+    subject_frontier: Frontier,
+    *,
+    request_number: int,
+    coverage: Coverage,
+    verdict: CheckVerdict = CheckVerdict.NO_ISSUE_DETECTED,
+    suppressed_count: int = 0,
+    semantic_status: SemanticStatus = SemanticStatus.NOT_REQUESTED,
+    semantic_reason: SemanticReason = SemanticReason.DETERMINISTIC_MODE,
+) -> None:
+    check_request = uuid_id("req", request_number)
+    digest = "sha256:" + f"{request_number:064d}"[-64:]
+    frozen = await ledger.freeze_case(
+        command.session_id,
+        command.writer_id,
+        subject_frontier.sequence,
+        check_request,
+        digest,
+    )
+    assert type(frozen) is FrozenCase
+    lease = await ledger.advance_check_phase(
+        frozen.lease,
+        CheckPhase.RESERVED,
+        CheckPhase.LOCAL_READY,
+        await _local_result_ref(objects, command),
+    )
+    lease = await ledger.advance_check_phase(
+        lease,
+        CheckPhase.LOCAL_READY,
+        CheckPhase.READY_TO_FINALIZE,
+    )
+    ranked = RankedFindings((), suppressed_count, verdict, coverage)
+    result = await ledger.commit_check_if_current(
+        FrozenCase(frozen.case, lease),
+        ranked,
+        (CheckPolicyExecution("work-integrity", "0.1.0", "run", "completed"),),
+        semantic_status,
+        semantic_reason,
+        None,
+        check_request,
+    )
+    assert result.outcome == "committed"
+
+
+def _assert_check_aggregate_consistent(row: dict[str, Any], *, has_check: bool) -> None:
+    """Honour 0001.sql null/non-null consistency over the latest-check columns."""
+
+    fields = (
+        row["latest_check_event_id"],
+        row["latest_subject_frontier_seq"],
+        row["latest_subject_frontier_digest"],
+        row["latest_verdict"],
+        row["latest_returned_finding_ids"],
+        row["latest_suppressed_count"],
+        row["latest_coverage_canonical"],
+    )
+    if has_check:
+        assert all(value is not None for value in fields)
+        assert row["latest_subject_frontier_seq"] <= row["frontier_seq"]
+        assert row["latest_subject_frontier_seq"] > 0
+        assert row["latest_subject_frontier_digest"] != "genesis"
+    else:
+        assert all(value is None for value in fields)
+
+
+@pytest.mark.anyio
+async def test_never_checked_task_reports_none_coverage(tmp_path: Path) -> None:
+    records = replay_records("projection-rebuild")[:1]
+    command, objects = command_from_records(records)
+    path = tmp_path / "never-checked.sqlite3"
+    ledger, db = file_sqlite_for(command, objects, path)
+    await ledger.append_batch(command)
+
+    row = _projection_row(db)
+    assert _check_types(row["status_coverage_canonical"]) == ["none"]
+    _assert_check_aggregate_consistent(row, has_check=False)
+    db.close()
+
+    _reopened, reopened_db = file_sqlite_for(command, objects, path)
+    row = _projection_row(reopened_db)
+    assert _check_types(row["status_coverage_canonical"]) == ["none"]
+    _assert_check_aggregate_consistent(row, has_check=False)
+    reopened_db.close()
+
+
+@pytest.mark.anyio
+async def test_check_populates_durable_aggregate_and_status_coverage(tmp_path: Path) -> None:
+    records = replay_records("projection-rebuild")[:1]
+    command, objects = command_from_records(records)
+    path = tmp_path / "check-aggregate.sqlite3"
+    ledger, db = file_sqlite_for(command, objects, path)
+    accepted = await ledger.append_batch(command)
+    # Coverage on the check payload is what the durable mirror must retain; include both
+    # check types so the aggregate proves semantic-derived coverage is not collapsed to none.
+    check_coverage = _checked_coverage(
+        command.entries[0].coverage, CheckType.DETERMINISTIC, CheckType.SEMANTIC_MODEL_DERIVED
+    )
+    await _commit_check(
+        ledger,
+        command,
+        objects,
+        accepted.result_frontier,
+        request_number=91_001,
+        coverage=check_coverage,
+    )
+
+    row = _projection_row(db)
+    _assert_check_aggregate_consistent(row, has_check=True)
+    assert row["latest_verdict"] == CheckVerdict.NO_ISSUE_DETECTED.value
+    assert _check_types(row["latest_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    assert _check_types(row["status_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    assert "none" not in _check_types(row["status_coverage_canonical"])
+    assert row["latest_returned_finding_ids"] == canonical_encode(())
+    assert row["latest_suppressed_count"] == 0
+    check_event_id = row["latest_check_event_id"]
+    assert type(check_event_id) is str and check_event_id.startswith("evt_")
+    db.close()
+
+    _reopened, reopened_db = file_sqlite_for(command, objects, path)
+    durable = _projection_row(reopened_db)
+    _assert_check_aggregate_consistent(durable, has_check=True)
+    assert durable["latest_check_event_id"] == check_event_id
+    assert durable["latest_verdict"] == CheckVerdict.NO_ISSUE_DETECTED.value
+    assert _check_types(durable["latest_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    assert _check_types(durable["status_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    reopened_db.close()
+
+
+@pytest.mark.anyio
+async def test_ordinary_publish_after_check_does_not_resurrect_none(tmp_path: Path) -> None:
+    """Ordinary append must not wipe applicable-check coverage back to envelope none.
+
+    After a successful check the durable status coverage carries the check's types. A later
+    non-material session_resumed lands on the ordinary append path; that path used to write
+    ``records[-1].coverage`` (always none) and resurrect the lie.
+    """
+
+    seed = replay_records("projection-rebuild")[:1]
+    command, objects = command_from_records(seed)
+    path = tmp_path / "publish-after-check.sqlite3"
+    ledger, db = file_sqlite_for(command, objects, path)
+    accepted = await ledger.append_batch(command)
+    check_coverage = _checked_coverage(command.entries[0].coverage, CheckType.DETERMINISTIC)
+    await _commit_check(
+        ledger,
+        command,
+        objects,
+        accepted.result_frontier,
+        request_number=92_001,
+        coverage=check_coverage,
+    )
+    after_check = _projection_row(db)
+    assert _check_types(after_check["status_coverage_canonical"]) == ["deterministic"]
+    check_event_id = after_check["latest_check_event_id"]
+    assert check_event_id is not None
+
+    # session_resumed is non-material: the prior check remains applicable.
+    resume_template = next(
+        record
+        for record in replay_records("all-event-families")
+        if record.schema.name == "session_resumed"
+    )
+    resume_command, objects = _append_follow_on(
+        seed[0],
+        resume_template,
+        objects,
+        writer_id=command.writer_id,
+        session_id=command.session_id,
+        task_id=command.task_id,
+        expected_frontier=after_check["frontier_seq"],
+        request_number=92_010,
+        event_number=92_011,
+        object_number=92_012,
+    )
+    await ledger.append_batch(resume_command)
+
+    row = _projection_row(db)
+    assert row["latest_check_event_id"] == check_event_id
+    assert _check_types(row["latest_coverage_canonical"]) == ["deterministic"]
+    assert _check_types(row["status_coverage_canonical"]) == ["deterministic"]
+    assert "none" not in _check_types(row["status_coverage_canonical"])
+    _assert_check_aggregate_consistent(row, has_check=True)
+    db.close()
+
+    _reopened, reopened_db = file_sqlite_for(command, objects, path)
+    durable = _projection_row(reopened_db)
+    assert durable["latest_check_event_id"] == check_event_id
+    assert _check_types(durable["status_coverage_canonical"]) == ["deterministic"]
+    assert _check_types(durable["latest_coverage_canonical"]) == ["deterministic"]
+    _assert_check_aggregate_consistent(durable, has_check=True)
+    reopened_db.close()
+
+
+@pytest.mark.anyio
+async def test_two_checks_update_aggregate_and_keep_constraints(tmp_path: Path) -> None:
+    records = replay_records("projection-rebuild")[:1]
+    command, objects = command_from_records(records)
+    path = tmp_path / "two-checks.sqlite3"
+    ledger, db = file_sqlite_for(command, objects, path)
+    accepted = await ledger.append_batch(command)
+
+    first_coverage = _checked_coverage(command.entries[0].coverage, CheckType.DETERMINISTIC)
+    await _commit_check(
+        ledger,
+        command,
+        objects,
+        accepted.result_frontier,
+        request_number=93_001,
+        coverage=first_coverage,
+        verdict=CheckVerdict.NO_ISSUE_DETECTED,
+    )
+    first = _projection_row(db)
+    _assert_check_aggregate_consistent(first, has_check=True)
+    first_check_id = first["latest_check_event_id"]
+    head_row = db.execute(
+        "SELECT frontier_seq, head_digest FROM p1_projection_state WHERE projection_name='work'"
+    ).fetchone()
+    assert head_row is not None
+    second_subject = Frontier(int(head_row[0]), cast(str, head_row[1]))
+
+    second_coverage = _checked_coverage(
+        command.entries[0].coverage, CheckType.DETERMINISTIC, CheckType.SEMANTIC_MODEL_DERIVED
+    )
+    await _commit_check(
+        ledger,
+        command,
+        objects,
+        second_subject,
+        request_number=93_002,
+        coverage=second_coverage,
+        verdict=CheckVerdict.INSUFFICIENT_COVERAGE,
+        suppressed_count=2,
+    )
+    second = _projection_row(db)
+    _assert_check_aggregate_consistent(second, has_check=True)
+    assert second["latest_check_event_id"] != first_check_id
+    assert second["latest_verdict"] == CheckVerdict.INSUFFICIENT_COVERAGE.value
+    assert second["latest_suppressed_count"] == 2
+    assert _check_types(second["latest_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    assert _check_types(second["status_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    # Subject of the second check is the post-first-check head, not the original seed.
+    assert second["latest_subject_frontier_seq"] == first["frontier_seq"]
+    db.close()
+
+    _reopened, reopened_db = file_sqlite_for(command, objects, path)
+    durable = _projection_row(reopened_db)
+    _assert_check_aggregate_consistent(durable, has_check=True)
+    assert durable["latest_check_event_id"] == second["latest_check_event_id"]
+    assert durable["latest_verdict"] == CheckVerdict.INSUFFICIENT_COVERAGE.value
+    assert _check_types(durable["status_coverage_canonical"]) == [
+        "deterministic",
+        "semantic_model_derived",
+    ]
+    reopened_db.close()
+
+
+def _append_follow_on(
+    seed: LedgerRecord,
+    template: LedgerRecord,
+    objects: MemoryObjects,
+    *,
+    writer_id: str,
+    session_id: str,
+    task_id: str,
+    expected_frontier: int,
+    request_number: int,
+    event_number: int,
+    object_number: int,
+) -> tuple[AppendCommand, MemoryObjects]:
+    assert template.payload is not None
+    payload = cast(EventPayload, template.payload)
+    event = event_id(uuid_id("evt", event_number))
+    payload_object = object_id(uuid_id("obj", object_number))
+    draft = EventDraft(
+        event,
+        template.schema,
+        template.occurred_at,
+        (),
+        payload,
+        template.artifact_refs,
+        template.evidence_refs,
+    )
+    metadata = ObjectMetadata(
+        ObjectKind.EVENT_PAYLOAD,
+        template.payload_ref.media_type,
+        task_id,
+        parse_rfc3339_millis(template.ledger.accepted_at.wire),
+    )
+    ref = ObjectRef(
+        payload_object,
+        template.payload_ref.plaintext_size,
+        template.payload_ref.commitment,
+        "sha256:" + "c" * 64,
+        "yoetz-object/1",
+        "slot-1",
+        metadata,
+    )
+    objects._data[ref.object_id] = canonical_encode(  # pyright: ignore[reportPrivateUsage]
+        encode_payload(payload)
+    )
+    operation_id = uuid_id("req", request_number)
+    entry = AppendEntry(
+        draft,
+        seed.author if seed.author.actor_type.value != "yoetz_engine" else template.author,
+        ref,
+        ref.commitment,
+        metadata.media_type,
+        ref.plaintext_size,
+        template.publication_channel,
+        template.coverage,
+        "projected",
+    )
+    command = AppendCommand(
+        task_id,
+        session_id,
+        writer_id,
+        operation_id,
+        OperationKind.PUBLISH_WORK,
+        canonical_digest({"event_ids": (event,), "operation_id": operation_id}),
+        expected_frontier,
+        (entry,),
+    )
+    return command, objects

--- a/tests/integration/storage/test_check_projection_coverage.py
+++ b/tests/integration/storage/test_check_projection_coverage.py
@@ -23,7 +23,13 @@ from integration.storage.test_append_and_replay import (
     uuid_id,
 )
 from yoetz.adapters.sqlite.repository import SqliteLedger
-from yoetz.domain.events import EventDraft, EventPayload, LedgerRecord, encode_payload
+from yoetz.domain.events import (
+    EventDraft,
+    EventPayload,
+    LedgerRecord,
+    RedactionRecordedPayload,
+    encode_payload,
+)
 from yoetz.domain.findings import CheckVerdict, RankedFindings
 from yoetz.domain.values import Frontier, event_id, object_id, parse_rfc3339_millis
 from yoetz.ports.ledger import (
@@ -305,6 +311,78 @@ async def test_ordinary_publish_after_check_does_not_resurrect_none(tmp_path: Pa
 
 
 @pytest.mark.anyio
+async def test_redaction_of_latest_check_clears_durable_aggregate(tmp_path: Path) -> None:
+    """Redacting the current check must clear the durable latest-* columns.
+
+    The reducer sets ``latest_tested_state`` to None when ``redaction_recorded`` targets
+    that check. The ordinary append path used to refresh only status coverage/gaps and
+    leave the seven latest-check columns advertising the redacted verdict after restart.
+    """
+
+    seed = replay_records("projection-rebuild")[:1]
+    command, objects = command_from_records(seed)
+    path = tmp_path / "redact-check-aggregate.sqlite3"
+    ledger, db = file_sqlite_for(command, objects, path)
+    accepted = await ledger.append_batch(command)
+    check_coverage = _checked_coverage(command.entries[0].coverage, CheckType.DETERMINISTIC)
+    await _commit_check(
+        ledger,
+        command,
+        objects,
+        accepted.result_frontier,
+        request_number=94_001,
+        coverage=check_coverage,
+    )
+    after_check = _projection_row(db)
+    _assert_check_aggregate_consistent(after_check, has_check=True)
+    check_event_id = after_check["latest_check_event_id"]
+    assert type(check_event_id) is str
+
+    redaction_template = next(
+        record
+        for record in replay_records("all-event-families")
+        if record.schema.name == "redaction_recorded"
+    )
+    assert type(redaction_template.payload) is RedactionRecordedPayload
+    redaction_payload = replace(
+        redaction_template.payload,
+        target_event_ids=(event_id(check_event_id),),
+        target_object_ids=(),
+    )
+    redaction_command, objects = _append_follow_on(
+        seed[0],
+        redaction_template,
+        objects,
+        writer_id=command.writer_id,
+        session_id=command.session_id,
+        task_id=command.task_id,
+        expected_frontier=after_check["frontier_seq"],
+        request_number=94_010,
+        event_number=94_011,
+        object_number=94_012,
+        payload=redaction_payload,
+    )
+    await ledger.append_batch(redaction_command)
+
+    row = _projection_row(db)
+    _assert_check_aggregate_consistent(row, has_check=False)
+    # No applicable check remains; compact status falls back to the redaction envelope.
+    assert _check_types(row["status_coverage_canonical"]) == ["none"]
+    gaps = strict_json_parse(row["status_gap_codes_canonical"])
+    assert type(gaps) is list
+    assert any(
+        type(marker) is str and marker.startswith("redacted_event:") for marker in gaps
+    ), gaps
+    db.close()
+
+    _reopened, reopened_db = file_sqlite_for(command, objects, path)
+    durable = _projection_row(reopened_db)
+    _assert_check_aggregate_consistent(durable, has_check=False)
+    assert _check_types(durable["status_coverage_canonical"]) == ["none"]
+    reopened_db.close()
+
+
+@pytest.mark.anyio
 async def test_two_checks_update_aggregate_and_keep_constraints(tmp_path: Path) -> None:
     records = replay_records("projection-rebuild")[:1]
     command, objects = command_from_records(records)
@@ -385,9 +463,16 @@ def _append_follow_on(
     request_number: int,
     event_number: int,
     object_number: int,
+    payload: EventPayload | None = None,
 ) -> tuple[AppendCommand, MemoryObjects]:
-    assert template.payload is not None
-    payload = cast(EventPayload, template.payload)
+    assert template.payload is not None or payload is not None
+    typed_payload = cast(EventPayload, payload if payload is not None else template.payload)
+    # Redaction envelopes mirror target_object_ids in artifact_refs; rebuild when the
+    # payload is overridden so EventDraft ref-mirror validation stays honest.
+    if type(typed_payload) is RedactionRecordedPayload:
+        artifact_refs = typed_payload.target_object_ids
+    else:
+        artifact_refs = template.artifact_refs
     event = event_id(uuid_id("evt", event_number))
     payload_object = object_id(uuid_id("obj", object_number))
     draft = EventDraft(
@@ -395,8 +480,8 @@ def _append_follow_on(
         template.schema,
         template.occurred_at,
         (),
-        payload,
-        template.artifact_refs,
+        typed_payload,
+        artifact_refs,
         template.evidence_refs,
     )
     metadata = ObjectMetadata(
@@ -405,18 +490,17 @@ def _append_follow_on(
         task_id,
         parse_rfc3339_millis(template.ledger.accepted_at.wire),
     )
+    payload_bytes = canonical_encode(encode_payload(typed_payload))
     ref = ObjectRef(
         payload_object,
-        template.payload_ref.plaintext_size,
+        len(payload_bytes),
         template.payload_ref.commitment,
         "sha256:" + "c" * 64,
         "yoetz-object/1",
         "slot-1",
         metadata,
     )
-    objects._data[ref.object_id] = canonical_encode(  # pyright: ignore[reportPrivateUsage]
-        encode_payload(payload)
-    )
+    objects._data[ref.object_id] = payload_bytes  # pyright: ignore[reportPrivateUsage]
     operation_id = uuid_id("req", request_number)
     entry = AppendEntry(
         draft,


### PR DESCRIPTION
## Summary

Populate the durable check aggregate from reducer `latest_tested_state` and write applicable compact status coverage on both SQLite projection update paths so a check no longer erases itself as `check_types=["none"]`.

**Why:** After a successful check, restart/reload could leave the projection looking as if no check had occurred. Durable status and restart-proof coverage must retain that a check happened.

## Plan reference

- Issue: https://github.com/TheGaySupreme123/yoetz/issues/55
- Plan: run-4 residuals plan 03 — *A check must not erase the record that it happened*

## Changes

- Durable check aggregate filled from reducer `latest_tested_state`
- Applicable compact status coverage written on both SQLite projection update paths
- Restart-proof integration tests for 0 / 1 / 2 checks

## Test plan

```text
uv run pytest \
  tests/integration/storage/test_check_projection_coverage.py \
  tests/conformance/adapters/test_ledger_port.py \
  tests/conformance/adapters/test_memory_sqlite_parity.py \
  tests/integration/storage/test_append_and_replay.py \
  tests/integration/application/test_respond_status_receipt.py \
  -q
```

Result: **33 passed**

Fixes #55