### PR TITLE
status view=operation must work (run-4 residuals plan 06)

### DIFF
--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -409,7 +409,12 @@ def _operation_page_from_record(
     operation_request_id: str,
     operation: object | None,
 ) -> StatusOperationPageModel:
-    """Project one operation record into the recovery page, or a bounded not-found page."""
+    """Project one operation record into the recovery page, or a bounded not-found page.
+
+    Every exit is either a validated page or ``ValueError``. Attribute and type faults on a
+    stored record (corrupt shape, missing enum members) collapse to the same bounded error so
+    the operation status branch never raises an unbounded exception into the daemon.
+    """
 
     if operation is None:
         return StatusOperationPageModel.model_validate(
@@ -421,42 +426,42 @@ def _operation_page_from_record(
         )
     from yoetz.ports.ledger import OperationRecord as _OperationRecord
 
-    if type(operation) is not _OperationRecord:
-        raise ValueError("status_operation_result_invalid")
-    record = operation
-    kind = record.operation_kind.value
-    if record.state is OperationState.PENDING:
-        return StatusOperationPageModel.model_validate(
-            {
-                "operation_request_id": operation_request_id,
-                "found": True,
-                "state": "pending",
-                "operation_kind": kind,
-            }
-        )
-    if record.state is OperationState.QUARANTINED:
-        return StatusOperationPageModel.model_validate(
-            {
-                "operation_request_id": operation_request_id,
-                "found": True,
-                "state": "quarantined",
-                "operation_kind": kind,
-            }
-        )
-    if record.state is not OperationState.COMPLETE or record.result_canonical is None:
-        raise ValueError("status_operation_result_invalid")
-    # Only publish_work stores the AppendResult shape used here. Other complete kinds surface
-    # without accepted-event detail so recovery stays bounded and honest.
-    if record.operation_kind is not OperationKind.PUBLISH_WORK:
-        return StatusOperationPageModel.model_validate(
-            {
-                "operation_request_id": operation_request_id,
-                "found": True,
-                "state": "complete",
-                "operation_kind": kind,
-            }
-        )
     try:
+        if type(operation) is not _OperationRecord:
+            raise ValueError("status_operation_result_invalid")
+        record = operation
+        kind = record.operation_kind.value
+        if record.state is OperationState.PENDING:
+            return StatusOperationPageModel.model_validate(
+                {
+                    "operation_request_id": operation_request_id,
+                    "found": True,
+                    "state": "pending",
+                    "operation_kind": kind,
+                }
+            )
+        if record.state is OperationState.QUARANTINED:
+            return StatusOperationPageModel.model_validate(
+                {
+                    "operation_request_id": operation_request_id,
+                    "found": True,
+                    "state": "quarantined",
+                    "operation_kind": kind,
+                }
+            )
+        if record.state is not OperationState.COMPLETE or record.result_canonical is None:
+            raise ValueError("status_operation_result_invalid")
+        # Only publish_work stores the AppendResult shape used here. Other complete kinds surface
+        # without accepted-event detail so recovery stays bounded and honest.
+        if record.operation_kind is not OperationKind.PUBLISH_WORK:
+            return StatusOperationPageModel.model_validate(
+                {
+                    "operation_request_id": operation_request_id,
+                    "found": True,
+                    "state": "complete",
+                    "operation_kind": kind,
+                }
+            )
         source = _mapping(strict_json_parse(record.result_canonical))
         accepted_raw = source["accepted"]
         if type(accepted_raw) is not tuple and type(accepted_raw) is not list:
@@ -494,7 +499,7 @@ def _operation_page_from_record(
                 "accepted_events": accepted,
             }
         )
-    except (KeyError, TypeError, ValueError) as exc:
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
         raise ValueError("status_operation_result_invalid") from exc
 
 
@@ -821,13 +826,30 @@ async def execute_status(app: Application, request: StatusRequest) -> StatusInte
             )
             try:
                 page = _operation_page_from_record(request.filter.operation_request_id, operation)
-            except ValueError as exc:
+            except (AttributeError, TypeError, ValueError) as exc:
                 raise _error(
                     PublicErrorCode.STORAGE_CORRUPT, "The stored operation result is invalid."
                 ) from exc
             # Operation recovery is structural: the operation page is authoritative. Compact
             # projection only enriches coverage/closure/frontiers and must not fail recovery
             # when lagging, rebuilding, or missing.
+            #
+            # Totality: capture frontier/head-derived enrichment first, then optionally replace
+            # from a successful compact page. Every path that reaches StatusInternalResult has
+            # head, effective, lag, projection_version, and rebuild_state bound — the shape of
+            # the run-4 AttributeError was an unbound/stale local on a recovery path.
+            structural_head = head
+            structural_effective = frontier
+            structural_lag = structural_head.sequence - frontier.sequence
+            structural_version = runtime.projection_version
+            compact_page = None
+            coverage = _unknown_structural_coverage()
+            gaps: tuple[str, ...] = ()
+            head = structural_head
+            effective = structural_effective
+            lag = structural_lag
+            projection_version = structural_version
+            rebuild_state: Literal["current", "rebuild_required", "rebuilding"] = "rebuild_required"
             try:
                 raw_page = await runtime.ledger.query_projection(
                     ProjectionQuery(
@@ -841,22 +863,28 @@ async def execute_status(app: Application, request: StatusRequest) -> StatusInte
                     )
                 )
             except PublicOperationError:
-                compact_page = None
-                coverage = _unknown_structural_coverage()
-                gaps = ()
-                effective = frontier
-                lag = head.sequence - frontier.sequence
-                projection_version = runtime.projection_version
-                rebuild_state = "rebuild_required"
+                pass
             else:
-                compact_page = raw_page
-                coverage = raw_page.coverage
-                gaps = raw_page.gaps
-                head = raw_page.head_frontier
-                effective = raw_page.effective_frontier
-                lag = raw_page.lag
-                projection_version = raw_page.projection_version
-                rebuild_state = raw_page.rebuild_state
+                try:
+                    next_coverage = raw_page.coverage
+                    next_gaps = raw_page.gaps
+                    next_head = raw_page.head_frontier
+                    next_effective = raw_page.effective_frontier
+                    next_lag = raw_page.lag
+                    next_version = raw_page.projection_version
+                    next_rebuild = raw_page.rebuild_state
+                except AttributeError:
+                    # Unexpected page shape: keep the structural defaults already bound above.
+                    pass
+                else:
+                    compact_page = raw_page
+                    coverage = next_coverage
+                    gaps = next_gaps
+                    head = next_head
+                    effective = next_effective
+                    lag = next_lag
+                    projection_version = next_version
+                    rebuild_state = next_rebuild
         elif request.view == "advice":
             if position is not None:
                 raise _error(PublicErrorCode.INVALID_REQUEST, "The status cursor is invalid.")

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -697,11 +697,29 @@ class ServiceDaemon:
         except ControlProtocolError, TypeError, ValueError:
             return self._error_result(request, ControlError("frame_invalid"))
         except Exception as exc:
+            # Unexpected failure outside the post-commit projection window. A read never committed
+            # anything, so the remedy is repeating the request with a fresh request_id — the same
+            # classification used when projection itself fails for STATUS. Surfacing non-retryable
+            # internal_error for a pure status/privacy read is what stranded run-4's
+            # status view=operation recovery (AttributeError → retryable: false).
+            request_id = _safe_body_request_id(request)
+            if request.method in _READ_ONLY_METHODS:
+                reason = "read_projection_failed"
+                correlation_id = record_unexpected_exception_without_raising(
+                    exc,
+                    component="service.daemon",
+                    operation=f"{request.method.value}_{reason}",
+                    request_id=request_id,
+                )
+                return self._error_result(
+                    request,
+                    ControlError(reason, retryable=True, correlation_id=correlation_id),
+                )
             correlation_id = record_unexpected_exception_without_raising(
                 exc,
                 component="service.daemon",
                 operation=f"{request.method.value}_internal_error",
-                request_id=_safe_body_request_id(request),
+                request_id=request_id,
             )
             return self._error_result(
                 request, ControlError("internal_error", correlation_id=correlation_id)

--- a/tests/integration/application/test_status_operation_view.py
+++ b/tests/integration/application/test_status_operation_view.py
@@ -1,0 +1,711 @@
+"""Integration coverage for ``status view=operation`` recovery (run-4 residual plan 06 / #61).
+
+The five cases the recovery surface must be total over: completed publish_work, completed check
+(the run-4 failure), unknown request_id, other-writer request_id, and a pending in-flight
+operation. Plus compact-projection lag and cursor rejection so no path raises unbounded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+
+from builders.ledger_adapters import (
+    FixedClock,
+    MemoryObjects,
+    append_command,
+    memory_adapter,
+    ownership_fence,
+)
+from builders.start_application import (
+    MemoryStartRuntime,
+    protocol_id,
+    start_composition,
+    start_request,
+)
+from yoetz.adapters.memory.ledger import MemoryLedgerAdapter
+from yoetz.application.egress import PrivacyCoordinator
+from yoetz.application.publish_work import Application as PublishApplication
+from yoetz.application.publish_work import execute_publish_work
+from yoetz.application.service import Application, ControlProjectionBinding, VerificationPolicy
+from yoetz.application.status import Application as StatusApplication
+from yoetz.application.status import execute_status
+from yoetz.domain.events import RuntimeProfile
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    ConsentSource,
+    LocalDisclosureApproved,
+    LocalDisclosureReceipt,
+    PrivacyOutcome,
+    ReceiptCounts,
+    ReceiptPolicyBinding,
+    ReceiptSecretScan,
+    ReceiptTransformations,
+)
+from yoetz.domain.receipts import PolicyVersionEntry, ReceiptVersionSlice, SchemaVersionEntry
+from yoetz.domain.values import Frontier, session_id
+from yoetz.ports.diagnostics import RuntimeCapability
+from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
+from yoetz.ports.ledger import (
+    AppendCommand,
+    CheckPhase,
+    OperationKind,
+    OperationRecord,
+    OperationState,
+)
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectStorePort
+from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
+from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+from yoetz.protocol.models import (
+    CheckRequest,
+    FrontierModel,
+    PublishWorkRequest,
+    PublishWorkRequestModel,
+    StatusOperationPageModel,
+    StatusRequest,
+)
+
+pytestmark = pytest.mark.anyio
+
+_DIGEST = "sha256:" + "7" * 64
+_WORKSPACE = "hmac-sha256:" + "8" * 64
+
+
+class _IdleImporter:
+    async def status(self, session: str) -> ImportStatusSnapshot:
+        return ImportStatusSnapshot(session_id(session), 0, 0, (), ())
+
+
+class _PublishRuntime:
+    def __init__(self, task: TaskRuntime) -> None:
+        self.task = task
+
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        del command
+        return self.task
+
+    async def release(self, runtime: TaskRuntime) -> None:
+        assert runtime is self.task
+
+
+class _PublishApp:
+    def __init__(self, runtime: _PublishRuntime) -> None:
+        self.runtime = runtime
+        self.clock = FixedClock()
+        self.status_cursor_key = b"status-operation-view-cursor-key!!!"
+
+    def authorizes_import_publication(self, request: PublishWorkRequestModel) -> bool:
+        del request
+        return False
+
+
+class _WorkflowRuntime(MemoryStartRuntime):
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        assert command.writer_id is not None
+        task_id, resources = next(iter(self.resources.items()))
+        ledger, objects = resources
+        assert (command.session_id, command.writer_id) in self.owners
+        return TaskRuntime(
+            task_id,
+            command.session_id,
+            command.writer_id,
+            frozenset(
+                {
+                    RuntimeCapability.WRITE,
+                    RuntimeCapability.STRUCTURAL_READ,
+                    RuntimeCapability.PAYLOAD_READ,
+                }
+            ),
+            ledger,
+            objects,
+            cast(ImporterPort, _IdleImporter()),
+            "0.1.0",
+            "0.1.0",
+            "0.1",
+            "1.0.0",
+            ownership_fence(),
+        )
+
+
+class _ProjectionSpy:
+    async def prepare_local_disclosure(
+        self, candidate: CandidateContext
+    ) -> LocalDisclosureApproved:
+        sink = candidate.local_sink
+        assert sink is not None
+        proposal_id = protocol_id("ppr_", 801)
+        policy = ReceiptPolicyBinding(protocol_id("pvy_", 802), 1, _DIGEST, _DIGEST)
+        receipt = LocalDisclosureReceipt(
+            "1.0.0",
+            protocol_id("egr_", 803),
+            candidate.request_id,
+            proposal_id,
+            sink,
+            PrivacyOutcome.COMPLETED,
+            datetime(2026, 7, 19, 12, 0, tzinfo=UTC),
+            candidate.scope,
+            candidate.purpose,
+            policy,
+            ConsentSource.BASELINE_POLICY,
+            (),
+            (),
+            ReceiptCounts(0, 0, 0, 0, 0, 0, 0),
+            ReceiptTransformations(0, 0, 0),
+            ReceiptSecretScan("1.0.0", _DIGEST, 0, True),
+            None,
+            1,
+        )
+        return LocalDisclosureApproved(
+            proposal_id,
+            candidate.request_id,
+            sink,
+            candidate.purpose,
+            candidate.scope,
+            _DIGEST,
+            _WORKSPACE,
+            (),
+            (),
+            receipt,
+        )
+
+    async def close(self) -> None:
+        return None
+
+
+def _versions() -> ReceiptVersionSlice:
+    return ReceiptVersionSlice(
+        package_name="yoetz",
+        package_version="0.1.0",
+        protocol_version="0.1",
+        engine_version="0.1.0",
+        projection_version="0.1.0",
+        object_format_version="yoetz-object/1",
+        catalog_schema_version="1",
+        bundle_schema_version="1",
+        policy_versions=(
+            PolicyVersionEntry("research-evidence", "0.1.0"),
+            PolicyVersionEntry("work-integrity", "0.1.0"),
+        ),
+        schema_versions=(SchemaVersionEntry("receipts/receipt-document", "1.0.0"),),
+        resource_manifest_digest=_DIGEST,
+    )
+
+
+def _scope(_: ControlProjectionBinding, source: Mapping[str, JsonValue]) -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        protocol_id("ins_", 804),
+        _WORKSPACE,
+        cast(str, source["task_id"]),
+    )
+
+
+async def _semantic_disabled(frozen: object, findings: object) -> object:
+    del frozen, findings
+    raise AssertionError("semantic_evaluator_called_in_deterministic_mode")
+
+
+def _request_base(request_id: str) -> dict[str, object]:
+    return {
+        "protocol_version": "0.1",
+        "schema_version": "1.0.0",
+        "request_id": request_id,
+        "actor": {"actor_id": "harness:test", "actor_type": "harness"},
+        "client": {"kind": "test_client", "version": "0.1.0", "integration": "local_cli"},
+    }
+
+
+def _frontier(value: Frontier | FrontierModel) -> dict[str, object]:
+    if isinstance(value, Frontier):
+        return dict(value.as_wire().items())
+    return cast(dict[str, object], value.model_dump(mode="json"))
+
+
+def _publish_composition() -> tuple[_PublishApp, MemoryObjects, AppendCommand, MemoryLedgerAdapter]:
+    seed = append_command()
+    ledger = memory_adapter(seed)
+    objects = cast(MemoryObjects, ledger._objects)  # pyright: ignore[reportPrivateUsage]
+    task = TaskRuntime(
+        seed.task_id,
+        seed.session_id,
+        seed.writer_id,
+        frozenset(
+            {
+                RuntimeCapability.WRITE,
+                RuntimeCapability.STRUCTURAL_READ,
+                RuntimeCapability.PAYLOAD_READ,
+            }
+        ),
+        ledger,
+        cast(ObjectStorePort, objects),
+        cast(ImporterPort, _IdleImporter()),
+        "0.1.0",
+        "0.1.0",
+        "0.1",
+        "1.0.0",
+        ownership_fence(),
+    )
+    return _PublishApp(_PublishRuntime(task)), objects, seed, ledger
+
+
+def _status_operation_request(
+    *,
+    session_id: str,
+    writer_id: str,
+    operation_request_id: str,
+    request_tail: int,
+    cursor: str | None = None,
+) -> StatusRequest:
+    body: dict[str, object] = {
+        **_request_base(f"req_00000000-0000-4000-8000-{request_tail:012d}"),
+        "session_id": session_id,
+        "writer_id": writer_id,
+        "view": "operation",
+        "limit": "1",
+        "filter": {"operation_request_id": operation_request_id},
+    }
+    if cursor is not None:
+        body["cursor"] = cursor
+    return StatusRequest.model_validate(body)
+
+
+async def _workflow_app() -> tuple[Application, _WorkflowRuntime, object]:
+    start_app, start_runtime, clock, catalog = start_composition()
+    ids = start_runtime.ids
+    runtime = _WorkflowRuntime(clock, ids)
+    app = Application(
+        start_catalog=catalog.delegate,
+        publish_responses=cast(PublishResponseCatalogPort, catalog.delegate),
+        runtime=cast(BundleRuntimePort, runtime),
+        clock=clock,
+        ids=ids,
+        verification_policy=VerificationPolicy(semantic="disabled", max_findings=3),
+        privacy=cast(PrivacyCoordinator, _ProjectionSpy()),
+        status_cursor_key=b"status-operation-view-workflow-key!",
+        waiver_policy_digest=_DIGEST,
+        semantic_evaluator=_semantic_disabled,
+        disclosure_scope_for=_scope,
+        receipt_version_resolver=lambda _: _versions(),
+        waiver_authorizer=lambda _: False,
+        import_publication_authorizer=lambda _: False,
+        profile=RuntimeProfile.TEST_FAKE,
+        policy_packs=("research-evidence/0.1.0", "work-integrity/0.1.0"),
+        version_manifest=start_app.version_manifest,
+    )
+    return app, runtime, catalog
+
+
+async def test_status_view_operation_returns_completed_check_page() -> None:
+    """Run-4 sequence: a completed check looked up by request_id returns a bounded page."""
+
+    app, runtime, _catalog = await _workflow_app()
+    started = await app.start(start_request(810, title="Operation view check recovery"))
+    obligation_id = protocol_id("obl_", 811)
+    published = await app.publish_work(
+        PublishWorkRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 812)),
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(started.frontier),
+                "event_drafts": (
+                    {
+                        "event_id": protocol_id("evt_", 813),
+                        "schema": {"name": "obligation_published", "version": "1.0.0"},
+                        "occurred_at": "2026-07-19T12:00:00.000Z",
+                        "causal_parents": (),
+                        "payload": {
+                            "obligation_id": obligation_id,
+                            "description": "Publish a result for the operation-view check.",
+                            "acceptance_criteria": "A result is recorded in the task ledger.",
+                            "evidence_expectation": "A linked immutable result record.",
+                            "requested_items": (
+                                {"item_kind": "change", "value": "operation-view-result"},
+                            ),
+                            "status": "open",
+                        },
+                        "artifact_refs": (),
+                        "evidence_refs": (),
+                    },
+                ),
+            }
+        )
+    )
+    check_req_id = protocol_id("req_", 814)
+    await app.check(
+        CheckRequest.model_validate(
+            {
+                **_request_base(check_req_id),
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(published.result_frontier),
+                "mode": "deterministic_only",
+                "max_findings": "3",
+            }
+        )
+    )
+    ledger, _objects = runtime.resources[started.task_id]
+    durable = await ledger.lookup_operation(started.writer_id, check_req_id)
+    assert durable is not None
+    assert durable.operation_kind is OperationKind.CHECK
+    assert durable.state is OperationState.COMPLETE
+
+    status = await app.status(
+        _status_operation_request(
+            session_id=started.session_id,
+            writer_id=started.writer_id,
+            operation_request_id=check_req_id,
+            request_tail=901,
+        )
+    )
+    page = status.page
+    assert type(page) is StatusOperationPageModel
+    assert page.found is True
+    assert page.state == "complete"
+    assert page.operation_kind == "check"
+    assert page.outcome is None
+    assert page.accepted_events == ()
+    assert page.subject_frontier is None
+    assert page.result_frontier is None
+
+
+async def test_status_view_operation_returns_stored_publish_work_detail() -> None:
+    app, _objects, seed, _ledger = _publish_composition()
+    request = PublishWorkRequestModel.model_validate(
+        {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "request_id": "req_00000000-0000-4000-8000-000000000501",
+            "session_id": seed.session_id,
+            "writer_id": seed.writer_id,
+            "expected_frontier": None,
+            "event_drafts": (
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000502",
+                    "schema": {"name": "action_recorded", "version": "1.0.0"},
+                    "occurred_at": "2026-07-19T12:00:00.000Z",
+                    "causal_parents": (),
+                    "payload": {
+                        "action_id": "act_00000000-0000-4000-8000-000000000503",
+                        "action_kind": "other",
+                        "description": "Materialized one coherent slice",
+                    },
+                    "artifact_refs": (),
+                    "evidence_refs": (),
+                },
+            ),
+            "actor": {"actor_id": "harness:test", "actor_type": "harness"},
+            "client": {
+                "kind": "test_client",
+                "version": "0.1.0",
+                "integration": "local_cli",
+            },
+        }
+    )
+    first = await execute_publish_work(cast(PublishApplication, app), request)
+
+    status = await execute_status(
+        cast(StatusApplication, app),
+        _status_operation_request(
+            session_id=seed.session_id,
+            writer_id=seed.writer_id,
+            operation_request_id=request.request_id,
+            request_tail=510,
+        ),
+    )
+    page = status.page
+    assert type(page) is StatusOperationPageModel
+    assert page.found is True
+    assert page.state == "complete"
+    assert page.operation_kind == "publish_work"
+    assert page.outcome == "accepted"
+    assert page.result_frontier is not None
+    assert page.result_frontier.sequence == str(first.result_frontier.sequence)
+    assert tuple(item.event_id for item in page.accepted_events) == tuple(
+        item.event_id for item in first.accepted_events
+    )
+
+
+async def test_status_view_operation_absent_for_unknown_request_id() -> None:
+    app, _objects, seed, _ledger = _publish_composition()
+    status = await execute_status(
+        cast(StatusApplication, app),
+        _status_operation_request(
+            session_id=seed.session_id,
+            writer_id=seed.writer_id,
+            operation_request_id="req_00000000-0000-4000-8000-000000000599",
+            request_tail=522,
+        ),
+    )
+    page = cast(StatusOperationPageModel, status.page)
+    assert page.found is False
+    assert page.state == "absent"
+    assert page.operation_kind is None
+    assert page.accepted_events == ()
+
+
+async def test_status_view_operation_absent_for_other_writer_request_id() -> None:
+    """A request_id owned by another writer discloses nothing — same absent page."""
+
+    app, _objects, seed, ledger = _publish_composition()
+    request = PublishWorkRequestModel.model_validate(
+        {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "request_id": "req_00000000-0000-4000-8000-000000000521",
+            "session_id": seed.session_id,
+            "writer_id": seed.writer_id,
+            "expected_frontier": None,
+            "event_drafts": (
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000522",
+                    "schema": {"name": "action_recorded", "version": "1.0.0"},
+                    "occurred_at": "2026-07-19T12:00:00.000Z",
+                    "causal_parents": (),
+                    "payload": {
+                        "action_id": "act_00000000-0000-4000-8000-000000000523",
+                        "action_kind": "other",
+                        "description": "Owned by the original writer only.",
+                    },
+                    "artifact_refs": (),
+                    "evidence_refs": (),
+                },
+            ),
+            "actor": {"actor_id": "harness:test", "actor_type": "harness"},
+            "client": {
+                "kind": "test_client",
+                "version": "0.1.0",
+                "integration": "local_cli",
+            },
+        }
+    )
+    await execute_publish_work(cast(PublishApplication, app), request)
+    foreign_writer = "wri_00000000-0000-4000-8000-000000000599"
+    assert foreign_writer != seed.writer_id
+    assert (await ledger.lookup_operation(foreign_writer, request.request_id)) is None
+    assert (await ledger.lookup_operation(seed.writer_id, request.request_id)) is not None
+
+    # Route with the foreign writer_id on the same ledger so status does not SESSION_CONFLICT;
+    # lookup_operation is still keyed by (writer_id, request_id) and must report absent.
+    base = app.runtime.task
+
+    class _ForeignRuntime:
+        async def route(self, command: RouteCommand) -> TaskRuntime:
+            assert command.writer_id == foreign_writer
+            return TaskRuntime(
+                base.task_id,
+                command.session_id,
+                command.writer_id,
+                base.capabilities,
+                base.ledger,
+                base.objects,
+                base.importer,
+                base.projection_version,
+                base.engine_version,
+                base.protocol_version,
+                base.bundle_schema_version,
+                base.fence,
+            )
+
+        async def release(self, runtime: TaskRuntime) -> None:
+            del runtime
+
+    foreign_app = _PublishApp(cast(_PublishRuntime, _ForeignRuntime()))
+    status = await execute_status(
+        cast(StatusApplication, foreign_app),
+        _status_operation_request(
+            session_id=seed.session_id,
+            writer_id=foreign_writer,
+            operation_request_id=request.request_id,
+            request_tail=524,
+        ),
+    )
+    page = cast(StatusOperationPageModel, status.page)
+    assert page.found is False
+    assert page.state == "absent"
+    assert page.operation_kind is None
+
+
+async def test_status_view_operation_reports_pending_for_in_flight_check() -> None:
+    app, _objects, seed, ledger = _publish_composition()
+    op_id = "req_00000000-0000-4000-8000-000000000701"
+    resume = ObjectRef(
+        "obj_00000000-0000-4000-8000-00000000aaaa",
+        1,
+        "hmac-sha256:" + "a" * 64,
+        "sha256:" + "b" * 64,
+        "yoetz-object/1",
+        "bmk-1",
+        ObjectMetadata(
+            ObjectKind.CHECK_RESUME,
+            "application/vnd.yoetz.check-resume+json",
+            seed.task_id,
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+    pending = OperationRecord(
+        seed.writer_id,
+        op_id,
+        OperationKind.CHECK,
+        "sha256:" + "c" * 64,
+        OperationState.PENDING,
+        CheckPhase.RESERVED,
+        "owner-generation-1",
+        "lease-owner-1",
+        1,
+        datetime(2030, 1, 1, tzinfo=UTC),
+        resume,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    ledger._state.operations[(seed.writer_id, op_id)] = (  # pyright: ignore[reportPrivateUsage]
+        pending,
+        None,
+    )
+
+    status = await execute_status(
+        cast(StatusApplication, app),
+        _status_operation_request(
+            session_id=seed.session_id,
+            writer_id=seed.writer_id,
+            operation_request_id=op_id,
+            request_tail=702,
+        ),
+    )
+    page = cast(StatusOperationPageModel, status.page)
+    assert page.found is True
+    assert page.state == "pending"
+    assert page.operation_kind == "check"
+    assert page.accepted_events == ()
+
+
+async def test_status_view_operation_survives_compact_projection_lag() -> None:
+    """Compact enrichment must not fail recovery when the projection is temporarily unreadable."""
+
+    app, runtime, _catalog = await _workflow_app()
+    started = await app.start(start_request(830, title="Compact lag recovery"))
+    check_req_id = protocol_id("req_", 831)
+    # Seed a complete non-publish operation without going through check (ledger inject).
+    ledger, _objects = runtime.resources[started.task_id]
+    canonical = canonical_encode(
+        {
+            "finding_ids": (),
+            "request_id": check_req_id,
+            "result_frontier": Frontier.genesis().as_wire(),
+            "subject_frontier": Frontier.genesis().as_wire(),
+            "verdict": "clean",
+        }
+    )
+    complete = OperationRecord(
+        started.writer_id,
+        check_req_id,
+        OperationKind.CHECK,
+        "sha256:" + "d" * 64,
+        OperationState.COMPLETE,
+        CheckPhase.TERMINAL,
+        None,
+        None,
+        None,
+        None,
+        None,
+        canonical,
+        f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+        None,
+        None,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ledger._state.operations[(started.writer_id, check_req_id)] = (  # pyright: ignore[reportPrivateUsage]
+        complete,
+        None,
+    )
+
+    async def boom(*_args: object, **_kwargs: object) -> object:
+        raise PublicOperationError(PublicErrorCode.SERVICE_UNAVAILABLE, "projection lagging", True)
+
+    ledger.query_projection = boom  # type: ignore[method-assign]
+
+    status = await app.status(
+        _status_operation_request(
+            session_id=started.session_id,
+            writer_id=started.writer_id,
+            operation_request_id=check_req_id,
+            request_tail=832,
+        )
+    )
+    page = cast(StatusOperationPageModel, status.page)
+    assert page.found is True
+    assert page.state == "complete"
+    assert page.operation_kind == "check"
+    assert status.rebuild_state == "rebuild_required"
+
+
+async def test_status_view_operation_rejects_cursor_with_bounded_error() -> None:
+    """Cursor-bearing operation views are invalid input, never an unbounded exception."""
+
+    app, _objects, seed, _ledger = _publish_composition()
+    with pytest.raises(PublicOperationError) as caught:
+        await execute_status(
+            cast(StatusApplication, app),
+            _status_operation_request(
+                session_id=seed.session_id,
+                writer_id=seed.writer_id,
+                operation_request_id="req_00000000-0000-4000-8000-000000000599",
+                request_tail=840,
+                # Shape is irrelevant: the operation branch rejects any cursor before decode use.
+                cursor="not-a-valid-cursor-but-present",
+            ),
+        )
+    assert caught.value.code is PublicErrorCode.INVALID_REQUEST
+    assert caught.value.retryable is False
+
+
+async def test_status_view_operation_page_from_corrupt_record_is_storage_corrupt() -> None:
+    """A complete record whose stored bytes are not the expected shape stays bounded."""
+
+    app, _objects, seed, ledger = _publish_composition()
+    op_id = "req_00000000-0000-4000-8000-000000000850"
+    corrupt_bytes = b'{"not":"append-result"}'
+    corrupt = OperationRecord(
+        seed.writer_id,
+        op_id,
+        OperationKind.PUBLISH_WORK,
+        "sha256:" + "e" * 64,
+        OperationState.COMPLETE,
+        CheckPhase.TERMINAL,
+        None,
+        None,
+        None,
+        None,
+        None,
+        corrupt_bytes,
+        f"sha256:{hashlib.sha256(corrupt_bytes).hexdigest()}",
+        None,
+        None,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ledger._state.operations[(seed.writer_id, op_id)] = (  # pyright: ignore[reportPrivateUsage]
+        corrupt,
+        None,
+    )
+    with pytest.raises(PublicOperationError) as caught:
+        await execute_status(
+            cast(StatusApplication, app),
+            _status_operation_request(
+                session_id=seed.session_id,
+                writer_id=seed.writer_id,
+                operation_request_id=op_id,
+                request_tail=851,
+            ),
+        )
+    assert caught.value.code is PublicErrorCode.STORAGE_CORRUPT

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -673,6 +673,48 @@ async def test_status_read_projection_failure_correlation_resolves(
 
 
 @pytest.mark.anyio
+async def test_status_handler_attribute_error_is_retryable_read_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected failure during application.status is retryable, never terminal internal_error.
+
+    Run-4 item_40: AttributeError inside the operation branch escaped as status_internal_error
+    with retryable:false. A pure read that changed nothing must present as read_projection_failed.
+    """
+
+    import yoetz.observability.diagnostics as diagnostics
+
+    monkeypatch.setattr(diagnostics, "log_dir", lambda: tmp_path)
+    daemon, application, _vault, _listener = _daemon()
+    await daemon.start()
+
+    async def boom(request: object) -> object:
+        del request
+        raise AttributeError("'NoneType' object has no attribute 'sequence'")
+
+    application.status = boom  # type: ignore[method-assign]
+
+    result = await daemon.dispatch(
+        ControlClientKind.MCP_BRIDGE,
+        _request(daemon, ControlMethod.STATUS, _status_body()),
+    )
+
+    assert result.outcome == "error"
+    assert isinstance(result.body, ControlError)
+    assert result.body.reason == "read_projection_failed"
+    assert result.body.retryable is True
+    assert result.body.correlation_id is not None
+    found = lookup_diagnostic_records(result.body.correlation_id, root=tmp_path)
+    assert len(found) == 1
+    assert found[0]["operation"] == "status_read_projection_failed"
+    assert found[0]["component"] == "service.daemon"
+    assert found[0]["request_id"] == "req_00000000-0000-4000-8000-000000000040"
+    for forbidden in ("traceback", "exception", "payload", "path", "message", "sequence"):
+        assert forbidden not in found[0]
+    await daemon.close()
+
+
+@pytest.mark.anyio
 async def test_publish_one_shot_projection_failure_is_accepted_without_replay() -> None:
     """Projection failure after append still returns acceptance; replay is optional, not required."""
 


### PR DESCRIPTION
## Summary

Makes `status view=operation` total and correctly classified under read failures.

**What / why**
- Made status `view=operation` total over enrichment locals (no unbound `head` / `effective` / `lag` / `version` / `rebuild_state`).
- Collapsed operation-page `AttributeError`s to `STORAGE_CORRUPT`.
- Reclassified unexpected status-handler failures as retryable `read_projection_failed`.

This closes residual gaps from run-4 plan 06 so operation status is reliable for check/publish/unknown/foreign/pending/lag/cursor/corrupt paths and daemon AttributeError handling.

## Plan reference

- Issue: https://github.com/TheGaySupreme123/yoetz/issues/61
- Run-4 residuals plan 06

## Test plan

```text
uv run pytest \
  tests/integration/application/test_status_operation_view.py \
  tests/integration/service/test_daemon_clients.py::test_status_handler_attribute_error_is_retryable_read_failure \
  tests/integration/service/test_daemon_clients.py::test_status_read_projection_failure_correlation_resolves \
  tests/integration/application/test_publish_work.py::test_status_view_operation_returns_stored_publish_result \
  tests/integration/application/test_publish_work.py::test_status_view_operation_absent_for_unknown_request_id \
  -q
```

Result: 12 passed.

Coverage includes check/publish/unknown/foreign/pending/lag/cursor/corrupt and daemon AttributeError retryability.

Fixes #61