### PR TITLE
Status enrichment must degrade honestly, never silently or unboundedly

### DIFF
--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -20,6 +20,7 @@ from yoetz.kernel.deterministic_checks import (
     build_deterministic_case,
     finding_basis_to_status_json,
 )
+from yoetz.observability.logging import record_unexpected_exception_without_raising
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.ledger import (
     AssignmentProjectionFilter,
@@ -714,6 +715,7 @@ async def _closure_readiness(
     runtime: TaskRuntime,
     frontier: Frontier,
     compact_page: ProjectionPage | None = None,
+    request_id: str | None = None,
 ) -> StatusClosureReadinessModel:
     """Derive what currently bounds a completion conclusion, from the compact projection.
 
@@ -723,6 +725,12 @@ async def _closure_readiness(
 
     ``view=compact`` already loads exactly this page, so it passes it in rather than paying for a
     second identical query. Compact admits no filter or position, so the page is equivalent.
+
+    Because it runs on *every* view, it is also the one enrichment that can strand every view at
+    once. It is therefore total over the page it is handed: an unexpected page shape degrades to
+    ``readiness_unknown`` — the same honest answer a lagging projection already produces — and
+    leaves a bounded diagnostic, rather than raising into the daemon as an unbounded internal
+    error on a read that changed nothing.
     """
 
     if compact_page is not None:
@@ -744,14 +752,25 @@ async def _closure_readiness(
             # Secondary enrichment only: do not fail a structural status page because the
             # compact projection is lagging, rebuilding, or temporarily unreadable.
             return _readiness_unknown()
-    item = page.items[0] if page.items else None
-    if type(item) is not StatusCompactItemModel:
-        # Compact omits its singleton when the task title is unreadable. Counting that as zero
-        # open obligations would manufacture a clean record out of missing data.
+    try:
+        item = page.items[0] if page.items else None
+        if type(item) is not StatusCompactItemModel:
+            # Compact omits its singleton when the task title is unreadable. Counting that as
+            # zero open obligations would manufacture a clean record out of missing data.
+            return _readiness_unknown()
+        open_obligations = int(item.open_obligation_count)
+        unresolved_findings = int(item.unresolved_finding_count)
+        has_plan = item.current_plan_event_id is not None
+        stale = page.rebuild_state != "current" or bool(page.lag)
+        declared_gaps = bool(page.gaps)
+    except (AttributeError, IndexError, TypeError, ValueError) as exc:
+        record_unexpected_exception_without_raising(
+            exc,
+            component="application.status",
+            operation="status_closure_readiness_page_invalid",
+            request_id=request_id,
+        )
         return _readiness_unknown()
-    open_obligations = int(item.open_obligation_count)
-    unresolved_findings = int(item.unresolved_finding_count)
-    has_plan = item.current_plan_event_id is not None
     blocking: list[str] = []
     if open_obligations:
         blocking.append("obligations_open")
@@ -759,9 +778,9 @@ async def _closure_readiness(
         blocking.append("findings_unresolved")
     if not has_plan:
         blocking.append("no_plan_published")
-    if page.rebuild_state != "current" or page.lag:
+    if stale:
         blocking.append("projection_stale")
-    if page.gaps:
+    if declared_gaps:
         blocking.append("coverage_gaps_declared")
     return StatusClosureReadinessModel(
         open_obligation_count=str(open_obligations),
@@ -873,9 +892,18 @@ async def execute_status(app: Application, request: StatusRequest) -> StatusInte
                     next_lag = raw_page.lag
                     next_version = raw_page.projection_version
                     next_rebuild = raw_page.rebuild_state
-                except AttributeError:
-                    # Unexpected page shape: keep the structural defaults already bound above.
-                    pass
+                except AttributeError as exc:
+                    # Unexpected page shape. Recovery still succeeds on the structural defaults
+                    # already bound above — the operation page is authoritative and enrichment is
+                    # secondary — but degrading silently would discard the only signal that the
+                    # compact projection is returning something it should not. Record the bounded
+                    # reason so the next occurrence is diagnosable instead of invisible.
+                    record_unexpected_exception_without_raising(
+                        exc,
+                        component="application.status",
+                        operation="status_operation_compact_enrichment_invalid",
+                        request_id=request.request_id,
+                    )
                 else:
                     compact_page = raw_page
                     coverage = next_coverage
@@ -1019,7 +1047,9 @@ async def execute_status(app: Application, request: StatusRequest) -> StatusInte
             lag = raw_page.lag
             projection_version = raw_page.projection_version
             rebuild_state = raw_page.rebuild_state
-        closure_readiness = await _closure_readiness(runtime, frontier, compact_page)
+        closure_readiness = await _closure_readiness(
+            runtime, frontier, compact_page, request.request_id
+        )
         return StatusInternalResult(
             "0.1",
             "1.0.0",

--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -720,8 +720,9 @@ async def _closure_readiness(
     """Derive what currently bounds a completion conclusion, from the compact projection.
 
     Computed on every view so an agent never has to switch views — or spend a check and a receipt
-    — to learn that the record cannot yet support a completion claim. This reads only; it records
-    nothing and changes no coverage.
+    — to learn that the record cannot yet support a completion claim. This reads only: it creates
+    no task-ledger consequence and changes no coverage. Its one write is the owner-only bounded
+    diagnostic below, emitted when the page it is handed has an unexpected shape.
 
     ``view=compact`` already loads exactly this page, so it passes it in rather than paying for a
     second identical query. Compact admits no filter or position, so the page is equivalent.

--- a/tests/integration/application/test_status_operation_view.py
+++ b/tests/integration/application/test_status_operation_view.py
@@ -8,8 +8,10 @@ operation. Plus compact-projection lag and cursor rejection so no path raises un
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -590,26 +592,21 @@ async def test_status_view_operation_reports_pending_for_in_flight_check() -> No
     assert page.accepted_events == ()
 
 
-async def test_status_view_operation_survives_compact_projection_lag() -> None:
-    """Compact enrichment must not fail recovery when the projection is temporarily unreadable."""
+def _complete_check_record(writer_id: str, operation_id: str) -> OperationRecord:
+    """A terminal, non-publish operation seeded directly, without paying for a real check."""
 
-    app, runtime, _catalog = await _workflow_app()
-    started = await app.start(start_request(830, title="Compact lag recovery"))
-    check_req_id = protocol_id("req_", 831)
-    # Seed a complete non-publish operation without going through check (ledger inject).
-    ledger, _objects = runtime.resources[started.task_id]
     canonical = canonical_encode(
         {
             "finding_ids": (),
-            "request_id": check_req_id,
+            "request_id": operation_id,
             "result_frontier": Frontier.genesis().as_wire(),
             "subject_frontier": Frontier.genesis().as_wire(),
             "verdict": "clean",
         }
     )
-    complete = OperationRecord(
-        started.writer_id,
-        check_req_id,
+    return OperationRecord(
+        writer_id,
+        operation_id,
         OperationKind.CHECK,
         "sha256:" + "d" * 64,
         OperationState.COMPLETE,
@@ -625,8 +622,18 @@ async def test_status_view_operation_survives_compact_projection_lag() -> None:
         None,
         datetime(2026, 1, 1, tzinfo=UTC),
     )
+
+
+async def test_status_view_operation_survives_compact_projection_lag() -> None:
+    """Compact enrichment must not fail recovery when the projection is temporarily unreadable."""
+
+    app, runtime, _catalog = await _workflow_app()
+    started = await app.start(start_request(830, title="Compact lag recovery"))
+    check_req_id = protocol_id("req_", 831)
+    # Seed a complete non-publish operation without going through check (ledger inject).
+    ledger, _objects = runtime.resources[started.task_id]
     ledger._state.operations[(started.writer_id, check_req_id)] = (  # pyright: ignore[reportPrivateUsage]
-        complete,
+        _complete_check_record(started.writer_id, check_req_id),
         None,
     )
 
@@ -648,6 +655,75 @@ async def test_status_view_operation_survives_compact_projection_lag() -> None:
     assert page.state == "complete"
     assert page.operation_kind == "check"
     assert status.rebuild_state == "rebuild_required"
+
+
+async def test_status_view_operation_records_invalid_compact_enrichment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A compact page of the wrong shape degrades recovery, but never silently.
+
+    Enrichment is secondary, so the operation page still resolves on structural defaults. The
+    discarded ``AttributeError`` is the only evidence that the projection returned something it
+    should not, so it must leave a bounded, resolvable record rather than vanish.
+    """
+
+    import yoetz.observability.diagnostics as diagnostics
+
+    monkeypatch.setattr(diagnostics, "log_dir", lambda: tmp_path)
+    app, runtime, _catalog = await _workflow_app()
+    started = await app.start(start_request(870, title="Compact enrichment invalid"))
+    check_req_id = protocol_id("req_", 871)
+    ledger, _objects = runtime.resources[started.task_id]
+    ledger._state.operations[(started.writer_id, check_req_id)] = (  # pyright: ignore[reportPrivateUsage]
+        _complete_check_record(started.writer_id, check_req_id),
+        None,
+    )
+
+    class _ShapelessPage:
+        """A page missing every enrichment attribute the branch reads."""
+
+    async def shapeless(*_args: object, **_kwargs: object) -> object:
+        return _ShapelessPage()
+
+    ledger.query_projection = shapeless  # type: ignore[method-assign]
+
+    status = await app.status(
+        _status_operation_request(
+            session_id=started.session_id,
+            writer_id=started.writer_id,
+            operation_request_id=check_req_id,
+            request_tail=872,
+        )
+    )
+
+    page = cast(StatusOperationPageModel, status.page)
+    assert page.found is True
+    assert page.state == "complete"
+    assert page.operation_kind == "check"
+    assert status.rebuild_state == "rebuild_required"
+
+    raw = diagnostics.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    records = tuple(
+        cast(Mapping[str, object], json.loads(line)) for line in raw.splitlines() if line
+    )
+    # Both enrichments read the same bad page: the operation branch's own coverage/frontier
+    # reads, and closure readiness, which runs on every view. Each degrades and each records.
+    assert [item["operation"] for item in records] == [
+        "status_operation_compact_enrichment_invalid",
+        "status_closure_readiness_page_invalid",
+    ]
+    for item in records:
+        assert item == {
+            "timestamp": item["timestamp"],
+            "correlation_id": item["correlation_id"],
+            "component": "application.status",
+            "operation": item["operation"],
+            "reason": "exception_attribute_error",
+            "request_id": "req_00000000-0000-4000-8000-000000000872",
+        }
+    assert "traceback" not in raw
+    assert "_ShapelessPage" not in raw
+    assert str(tmp_path) not in raw
 
 
 async def test_status_view_operation_rejects_cursor_with_bounded_error() -> None:


### PR DESCRIPTION
## Issue

- Linked issue: `Refs #61`
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: no protocol, privacy/egress, storage, or packaging surface changes. The
  diagnostic sink and its field allowlist are reused unchanged.

## Documentation

- Behavior change? `yes`
- Docs updated: `n/a` for `docs/` — no public surface moves. `status view=operation` and every other
  view keep their wire shapes; the two changes are (a) a read that previously raised now returns
  `readiness_unknown`, which is an already-documented value of `closure_readiness`, and (b) two new
  owner-only diagnostic operation tokens, which are not a public interface. The behavior is
  documented at both call sites and in the `_closure_readiness` docstring.

## Verification

Commands run (paste):

```text
$ uv run --locked pytest -q
2214 passed, 17 skipped, 4 xfailed in 233.01s (0:03:53)

$ uv run --locked ruff format --check . && uv run --locked ruff check .
444 files already formatted
All checks passed!

$ npx --no-install pyright
0 errors, 0 warnings, 0 informations

$ uv run --locked pytest tests/integration/application/test_status_operation_view.py -q
9 passed in 1.00s

# Counterfactual: the new case against main, which must fail
$ git worktree add /tmp/wt-main main && cp tests/integration/application/test_status_operation_view.py /tmp/wt-main/tests/integration/application/
$ cd /tmp/wt-main && uv run --locked pytest tests/integration/application/test_status_operation_view.py -q -k enrichment
E   AttributeError: '_ShapelessPage' object has no attribute 'items'
src/yoetz/application/status.py:747: AttributeError
1 failed, 8 deselected in 2.97s
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Follow-up to #62 (run-4 residuals plan 06). Two holes remained in the class that plan was written to
close.

**`_closure_readiness` could raise unbounded, on every view.** It runs on every status view and read
`page.items`, `page.rebuild_state`, `page.lag`, and `page.gaps` with no guard, so an unexpected
compact page shape raised an `AttributeError` straight out of `execute_status`. Enrichment is
secondary by design — the operation branch's own comment says compact projection "must not fail
recovery when lagging, rebuilding, or missing" — but this one could fail *every* view at once, on a
read that changed nothing. It now degrades to `readiness_unknown`, the same honest answer a lagging
projection already produces.

**The operation branch degraded silently.** #62 added `except AttributeError: pass` around the
enrichment reads. Recovery still succeeded, but the only evidence that the projection returned
something it should not was discarded. Both paths now record a bounded diagnostic — component,
operation, reason token, `request_id`, nothing else — so the next occurrence resolves through
`yoetz service diagnostics --correlation-id`.

**What this does not do.** It does not identify the run-4 `item_40` `AttributeError`, and I want that
on the record rather than implied away. That cause remains unreproduced: the `operation` branch is
byte-identical between the run-4 baseline (`d3274a7`) and #62's parent, so the triggering state lived
in the store, not in the code. #62's own eight integration tests pass unmodified against its pre-fix
commit, so they do not reproduce it either. The plan's hypothesis is also ruled out — `head` is bound
in both arms of the cursor decode, and `operation_kind` cannot be `None` because
`OperationRecord.__post_init__` rejects it.

What has changed is containment: an unexpected read failure is now retryable with a resolvable
correlation id (#62), and both enrichment paths leave a durable record (this PR). The next occurrence
is diagnosable in one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
