### PR TITLE
Recovery must not mask a known authoring error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ released versions.
 
 ### Fixed
 
+- **Publish recovery must not mask a known authoring error.** When MCP `publish_work` body
+  validation fails, envelope-first operation lookup still runs so a committed same-`request_id`
+  operation can be recovered. A failed recovery read (for example nested `read_projection_failed`)
+  no longer replaces the field-pointed `INVALID_REQUEST` with a false “no durable state changed /
+  use a new request_id” message. Lookup is a closed tri-state: found recovery results retain
+  precedence; authoritative absence returns the original authoring pointer; unavailable recovery
+  returns retryable `OPERATION_PENDING` / `operation_recovery_unavailable` with the original
+  publish `request_id` and the safe field that will apply once recovery can answer.
+
 - **`check` can return a finding.** A check that raised even one finding committed durably and then
   failed to project, so the caller received `INTERNAL_ERROR` / `response_projection_failed` and
   never learned the verdict, the finding, or the semantic outcome — in every mode. The public

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -121,8 +121,26 @@ without requiring a reconstructed publish body. Stored result detail is state-co
 ids/digests; `pending`/`quarantined` report kind without those fields; `absent` reports none of
 them; non-publish completions report kind without append-shaped event detail. Lookups are scoped
 to the caller writer; another writer's `request_id` is reported as absent.
-`read_projection_failed` is the read-only counterpart: nothing was appended, so the remedy is
-repeating the request rather than a same-`request_id` replay that has no operation record to load.
+MCP `publish_work` performs the same envelope-first operation lookup when the supplied body fails
+schema validation (so a malformed retry body can still recover a committed operation). Recovery
+result selection is a closed tri-state:
+- **found** (`pending` / `complete` / `quarantined`) replaces the body-validation result with the
+  bounded recovery meaning for that state;
+- **authoritative absent** returns the original field-pointed `INVALID_REQUEST` (including for a
+  fresh `dry_run: true` with a malformed field — dry-run creates no operation record);
+- **lookup unavailable** (connection, timeout, projection, or unexpected recovery failure,
+  including a nested `read_projection_failed` on the internal status read) returns retryable
+  `OPERATION_PENDING` with `reason_code: operation_recovery_unavailable`, the original publish
+  `request_id`, and the safe authoring field pointer that will apply if the operation is later
+  authoritatively absent. The remedy is: (1) retry with the **same** `request_id`; (2) if recovery
+  reports absent, correct the named field and use the intended request identity; (3) if recovery
+  reports complete, recover the stored result. An unavailable recovery oracle must never claim
+  that durable state did or did not change, must never tell the caller to mint a new `request_id`,
+  and must never promote a nested status request id or nested read-only durability message as the
+  outer publish result.
+`read_projection_failed` is the read-only counterpart for direct status/receipt reads: nothing
+was appended, so the remedy is repeating the request rather than a same-`request_id` replay that
+has no operation record to load.
 When a non-publish write surfaces `response_projection_failed` and the committed frontier is known,
 the control error also carries `sequence`, `head_digest`, and `count` in `accepted_state` /
 `safe_details`.

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from enum import Enum
 from types import MappingProxyType
 from typing import Final, cast
 
@@ -118,6 +119,14 @@ _READ_PROJECTION_FAILED_MESSAGE: Final = (
     "the authoritative frontier."
 )
 _READ_PROJECTION_FAILED_DETAILS: Final = {"reason_code": "read_projection_failed"}
+# Envelope-first publish recovery could not learn whether request_id already names a write.
+# Never claim durability either way, and never hand the nested status request_id to the caller.
+_OPERATION_RECOVERY_UNAVAILABLE_MESSAGE: Final = (
+    "Operation recovery could not determine whether this request_id already names a committed "
+    "operation. Retry with the same request_id. If recovery later reports the operation absent, "
+    "correct the named authoring fields and resubmit with the intended request identity."
+)
+_OPERATION_RECOVERY_UNAVAILABLE_DETAILS: Final = {"reason_code": "operation_recovery_unavailable"}
 _PUBLICATION_GUIDANCE_URI: Final = "yoetz://guidance/publication-policy.md"
 _WORKFLOW_GUIDANCE_URI: Final = "yoetz://guidance/workflow.md"
 _GUIDANCE_BY_OPERATION: Final = MappingProxyType(
@@ -578,16 +587,70 @@ def _publish_envelope_fields(
     )
 
 
+class _PublishRecoveryKind(Enum):
+    """Closed tri-state for envelope-first publish recovery lookup."""
+
+    FOUND = "found"
+    ABSENT = "absent"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class _PublishRecoveryOutcome:
+    """Result of looking up a request_id after body validation failed.
+
+    Only FOUND replaces the authoring diagnostic. ABSENT yields the original field-pointed
+    validation result. UNAVAILABLE is ambiguity-safe: same request_id, no durability claim.
+    """
+
+    kind: _PublishRecoveryKind
+    result: types.CallToolResult | None = None
+
+
+def _publish_recovery_unavailable_result(
+    request_id: str | None,
+    locations: Sequence[Mapping[str, str]] = (),
+) -> types.CallToolResult:
+    """Retryable same-ID remedy when the recovery oracle cannot answer."""
+
+    details: dict[str, object] = dict(_OPERATION_RECOVERY_UNAVAILABLE_DETAILS)
+    # Surface the first safe authoring pointer so the caller knows what to fix if recovery is
+    # later authoritatively absent — never hostile payload text, only structural locations.
+    if locations:
+        first = locations[0]
+        field = first.get("field")
+        if type(field) is str:
+            details["field"] = field
+    message = _OPERATION_RECOVERY_UNAVAILABLE_MESSAGE
+    if locations:
+        hint = _authoring_hint_for("publish_work", locations)
+        if hint:
+            message = message + hint
+    return structured_error_result(
+        PublicErrorCode.OPERATION_PENDING,
+        message,
+        retryable=True,
+        request_id=request_id,
+        safe_details=details,
+    )
+
+
 async def _publish_recovery_from_envelope(
     arguments: Mapping[str, object],
     runtime: BridgeRuntime,
     request_id: str | None,
-) -> types.CallToolResult | None:
-    """If the envelope names a known operation, surface recovery without body validation."""
+) -> _PublishRecoveryOutcome:
+    """Look up the envelope request_id without body validation.
+
+    Returns a closed tri-state: FOUND (pending/complete/quarantined), ABSENT (lookup succeeded
+    and no operation exists), or UNAVAILABLE (connection, timeout, projection, or unexpected
+    recovery failure). Incomplete envelopes that cannot form a recovery read are ABSENT so the
+    original field-pointed validation result surfaces.
+    """
 
     envelope = _publish_envelope_fields(arguments)
     if envelope is None:
-        return None
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.ABSENT)
     op_request_id, session_id, writer_id, actor, client = envelope
     recovery_request_id = request_id if request_id is not None else op_request_id
     status_request_id = new_id(IdKind.REQUEST)
@@ -608,20 +671,16 @@ async def _publish_recovery_from_envelope(
         )
     except ValidationError:
         # Envelope fields are not a valid status request; fall through to body validation error.
-        return None
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.ABSENT)
     except Exception as exc:
-        correlation_id = record_unexpected_exception_without_raising(
+        record_unexpected_exception_without_raising(
             exc,
             component="mcp.bridge",
             operation="publish_work_recovery_request_internal_error",
             request_id=recovery_request_id,
         )
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            "The bridge could not complete the operation.",
-            request_id=recovery_request_id,
-            correlation_id=correlation_id,
-        )
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
+
     try:
         await ensure_service_client(runtime)
         status_result = await _invoke_with_reconnect(
@@ -630,69 +689,57 @@ async def _publish_recovery_from_envelope(
             lambda service, request: service.status(request),
         )
     except PublicOperationError as exc:
-        # Writer ownership, session conflicts, and other public codes must not collapse into
-        # INVALID_REQUEST from the outer body-validation path.
-        try:
-            bound = (
-                exc
-                if exc.correlation_id is not None
-                else exc.bind_correlation_id(new_id(IdKind.CORRELATION))
-            )
-            return _result_from_wire(tool_error_envelope(bound, request_id=recovery_request_id))
-        except Exception as mapping_exc:
-            correlation_id = record_unexpected_exception_without_raising(
-                mapping_exc,
-                component="mcp.bridge",
-                operation="publish_work_recovery_public_error_internal_error",
-                request_id=recovery_request_id,
-            )
-            return structured_error_result(
-                PublicErrorCode.INTERNAL_ERROR,
-                "The bridge could not complete the operation.",
-                request_id=recovery_request_id,
-                correlation_id=correlation_id,
-            )
+        # A nested public failure (session conflict, projection, etc.) does not prove the
+        # operation is absent or found. Do not promote it over the outer authoring diagnostic,
+        # and do not forward nested "no durable state changed" remedies for a write path.
+        del exc
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
     except ControlError as exc:
-        return _control_error_result(exc, recovery_request_id, "publish_work_recovery")
+        # Including read_projection_failed: a failed recovery oracle must not become the outer
+        # publish result with a read-only durability claim and a new-request_id remedy.
+        del exc
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
     except Exception as exc:
-        correlation_id = record_unexpected_exception_without_raising(
+        record_unexpected_exception_without_raising(
             exc,
             component="mcp.bridge",
             operation="publish_work_recovery_status_internal_error",
             request_id=recovery_request_id,
         )
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            "The bridge could not complete the operation.",
-            request_id=recovery_request_id,
-            correlation_id=correlation_id,
-        )
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
+
     try:
         wire = public_model_to_wire(status_result)
         if wire.get("ok") is not True:
-            return None
+            return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
         page = wire.get("page")
         if type(page) is not dict:
-            return None
+            return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
         page_map = cast(dict[str, object], page)
         state = page_map.get("state")
         if state == "absent":
-            return None
+            return _PublishRecoveryOutcome(_PublishRecoveryKind.ABSENT)
         if state == "pending":
-            return structured_error_result(
-                PublicErrorCode.OPERATION_PENDING,
-                "The operation is still pending.",
-                retryable=True,
-                request_id=recovery_request_id,
+            return _PublishRecoveryOutcome(
+                _PublishRecoveryKind.FOUND,
+                structured_error_result(
+                    PublicErrorCode.OPERATION_PENDING,
+                    "The operation is still pending.",
+                    retryable=True,
+                    request_id=recovery_request_id,
+                ),
             )
         if state == "quarantined":
-            return structured_error_result(
-                PublicErrorCode.STORAGE_CORRUPT,
-                "The stored operation is quarantined.",
-                request_id=recovery_request_id,
+            return _PublishRecoveryOutcome(
+                _PublishRecoveryKind.FOUND,
+                structured_error_result(
+                    PublicErrorCode.STORAGE_CORRUPT,
+                    "The stored operation is quarantined.",
+                    request_id=recovery_request_id,
+                ),
             )
         if state != "complete":
-            return None
+            return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
         result_frontier = page_map.get("result_frontier")
         accepted = page_map.get("accepted_events")
         count = len(cast(Sequence[object], accepted)) if isinstance(accepted, Sequence) else 0
@@ -705,28 +752,26 @@ async def _publish_recovery_from_envelope(
                 details["sequence"] = int(sequence)
             if type(head_digest) is str:
                 details["head_digest"] = head_digest
-        return structured_error_result(
-            PublicErrorCode.REQUEST_IDENTITY_CONFLICT,
-            (
-                "The request ID was already used with a different request body. "
-                "Read status view=operation for the stored result of that request_id."
+        return _PublishRecoveryOutcome(
+            _PublishRecoveryKind.FOUND,
+            structured_error_result(
+                PublicErrorCode.REQUEST_IDENTITY_CONFLICT,
+                (
+                    "The request ID was already used with a different request body. "
+                    "Read status view=operation for the stored result of that request_id."
+                ),
+                request_id=recovery_request_id,
+                safe_details=details,
             ),
-            request_id=recovery_request_id,
-            safe_details=details,
         )
     except Exception as exc:
-        correlation_id = record_unexpected_exception_without_raising(
+        record_unexpected_exception_without_raising(
             exc,
             component="mcp.bridge",
             operation="publish_work_recovery_response_internal_error",
             request_id=recovery_request_id,
         )
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            "The bridge could not complete the operation.",
-            request_id=recovery_request_id,
-            correlation_id=correlation_id,
-        )
+        return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
 
 
 async def dispatch_publish_work(
@@ -737,11 +782,14 @@ async def dispatch_publish_work(
         PublishWorkRequest.model_validate(arguments)
     except ValidationError as exc:
         # Envelope-first recovery: when the body fails schema validation, still look up the
-        # request_id so run-3-style replays never die as bare INVALID_REQUEST.
-        recovery = await _publish_recovery_from_envelope(arguments, runtime, request_id)
-        if recovery is not None:
-            return recovery
+        # request_id so run-3-style replays never die as bare INVALID_REQUEST. Only an
+        # authoritative found operation replaces the authoring diagnostic.
         locations = safe_validation_locations(exc)
+        recovery = await _publish_recovery_from_envelope(arguments, runtime, request_id)
+        if recovery.kind is _PublishRecoveryKind.FOUND and recovery.result is not None:
+            return recovery.result
+        if recovery.kind is _PublishRecoveryKind.UNAVAILABLE:
+            return _publish_recovery_unavailable_result(request_id, locations)
         return structured_error_result(
             PublicErrorCode.INVALID_REQUEST,
             invalid_request_message("publish_work", locations),

--- a/src/yoetz/protocol/errors.py
+++ b/src/yoetz/protocol/errors.py
@@ -138,6 +138,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "object_key_not_string",
     "obligation_change_invalid",
     "obligation_resolution_invalid",
+    "operation_recovery_unavailable",
     "payload_redaction_mismatch",
     "plan_version_conflict",
     "privacy_projection_unavailable",
@@ -189,7 +190,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
 )
 
 _REASON_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$", re.ASCII)
-assert len(_PROTOCOL_REASON_CODE_VALUES) == 136
+assert len(_PROTOCOL_REASON_CODE_VALUES) == 137
 assert len(_PROTOCOL_REASON_CODE_VALUES) == len(set(_PROTOCOL_REASON_CODE_VALUES))
 assert _PROTOCOL_REASON_CODE_VALUES == tuple(sorted(_PROTOCOL_REASON_CODE_VALUES, key=str.encode))
 assert all(_REASON_CODE_PATTERN.fullmatch(value) for value in _PROTOCOL_REASON_CODE_VALUES)

--- a/tests/unit/mcp/test_publish_recovery_precedence.py
+++ b/tests/unit/mcp/test_publish_recovery_precedence.py
@@ -1,0 +1,357 @@
+"""Envelope-first publish recovery must not mask a known authoring error (issue #65).
+
+When body validation fails, the bridge still looks up the request_id so a committed operation can
+be recovered. Only an authoritative found state replaces the field-pointed INVALID_REQUEST. An
+unavailable recovery oracle returns an ambiguity-safe same-ID remedy — never the nested status
+read's "no durable state changed / new request_id" message.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import cast
+
+import pytest
+from mcp import types
+
+import yoetz.mcp.server as bridge
+from yoetz.ports.control import ControlError
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+
+_REQUEST = "req_00000000-0000-4000-8000-000000000065"
+_SESSION = "ses_00000000-0000-4000-8000-000000000001"
+_WRITER = "wri_00000000-0000-4000-8000-000000000001"
+_EVENT = "evt_00000000-0000-4000-8000-000000000001"
+_DIGEST = "sha256:" + "a" * 64
+# Dogfood-shaped authority: fails the actor_id pattern (whitespace), not a non-string type that
+# confuses the event-schema oneOf into pointing at /event_drafts/0/schema/name.
+_MALFORMED_AUTHORITY = "bad authority"
+_HOSTILE_PAYLOAD = "SECRET_MUST_NOT_LEAK"
+
+
+def _malformed_decision_arguments(
+    *,
+    request_id: str = _REQUEST,
+    dry_run: bool | None = None,
+    authority: object = _MALFORMED_AUTHORITY,
+) -> dict[str, object]:
+    arguments: dict[str, object] = {
+        "protocol_version": "0.1",
+        "schema_version": "1.0.0",
+        "request_id": request_id,
+        "session_id": _SESSION,
+        "writer_id": _WRITER,
+        "expected_frontier": {"sequence": "0", "head_digest": "genesis"},
+        "actor": {"actor_id": "harness:mcp", "actor_type": "harness"},
+        "client": {
+            "kind": "cooperative_agent",
+            "version": "0.1.0",
+            "integration": "cooperative_mcp",
+        },
+        "event_drafts": [
+            {
+                "event_id": _EVENT,
+                "schema": {"name": "decision_recorded", "version": "1.0.0"},
+                "occurred_at": "2026-01-01T00:00:00.000Z",
+                "causal_parents": [],
+                "payload": {
+                    "statement": "ship it",
+                    "rationale": "because",
+                    "authority": authority,
+                },
+                "artifact_refs": [],
+                "evidence_refs": [],
+            }
+        ],
+    }
+    if dry_run is not None:
+        arguments["dry_run"] = dry_run
+    return arguments
+
+
+def _operation_wire(state: str) -> dict[str, object]:
+    page: dict[str, object] = {
+        "operation_request_id": _REQUEST,
+        "found": state != "absent",
+        "state": state,
+    }
+    if state != "absent":
+        page["operation_kind"] = "publish_work"
+    if state == "complete":
+        page["outcome"] = "accepted"
+        page["subject_frontier"] = {"sequence": "1", "head_digest": _DIGEST}
+        page["result_frontier"] = {"sequence": "1", "head_digest": _DIGEST}
+        page["accepted_events"] = [
+            {
+                "event_id": _EVENT,
+                "entry_digest": _DIGEST,
+                "ingestion_sequence": "1",
+                "writer_sequence": "1",
+                "projection_status": "projected",
+            }
+        ]
+    return {"ok": True, "page": page}
+
+
+def _install_recovery_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    status_wire: Mapping[str, object] | None = None,
+    raise_on_status: BaseException | None = None,
+) -> list[object]:
+    """Drive the recovery status path without a live service client."""
+
+    seen: list[object] = []
+
+    async def ensure(_runtime: object = bridge.BRIDGE_RUNTIME) -> object:
+        return object()
+
+    async def invoke(
+        _runtime: object,
+        request: object,
+        _call: Callable[[object, object], Awaitable[object]],
+    ) -> object:
+        seen.append(request)
+        if raise_on_status is not None:
+            raise raise_on_status
+        return object()
+
+    def wire(model: object) -> dict[str, object]:
+        del model
+        if status_wire is None:
+            raise AssertionError("public_model_to_wire should not run without a status wire")
+        return dict(status_wire)
+
+    monkeypatch.setattr(bridge, "ensure_service_client", ensure)
+    monkeypatch.setattr(bridge, "_invoke_with_reconnect", invoke)
+    if status_wire is not None:
+        monkeypatch.setattr(bridge, "public_model_to_wire", wire)
+    return seen
+
+
+def _error(result: types.CallToolResult) -> dict[str, object]:
+    structured = cast(dict[str, object], result.structuredContent)
+    return cast(dict[str, object], structured["error"])
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_malformed_authority_absent_returns_field_pointer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authoritative absence yields the original dogfood field pointer, not recovery noise."""
+
+    _install_recovery_oracle(monkeypatch, status_wire=_operation_wire("absent"))
+    runtime = bridge.build_bridge_runtime()
+    arguments = _malformed_decision_arguments()
+
+    result = await bridge.dispatch_publish_work(arguments, runtime)
+
+    assert result.isError is True
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.INVALID_REQUEST.value
+    assert error["retryable"] is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["fields"] == ["/event_drafts/0/payload/authority"]
+    assert details["reasons"] == ["invalid_type_or_value"]
+    assert _HOSTILE_PAYLOAD not in str(result.structuredContent)
+    assert _MALFORMED_AUTHORITY not in str(result.structuredContent)
+    assert "No durable state changed" not in cast(str, error["message"])
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_completed_operation_wins_over_invalid_retry_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR #47 guarantee: a committed request_id recovers even when the retry body is malformed."""
+
+    _install_recovery_oracle(monkeypatch, status_wire=_operation_wire("complete"))
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    assert result.isError is True
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.REQUEST_IDENTITY_CONFLICT.value
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["reason_code"] == "request_identity_conflict"
+    assert details["count"] == 1
+    assert details["sequence"] == 1
+    assert details["head_digest"] == _DIGEST
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_pending_operation_retains_bounded_pending_meaning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_recovery_oracle(monkeypatch, status_wire=_operation_wire("pending"))
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.OPERATION_PENDING.value
+    assert error["retryable"] is True
+    assert "still pending" in cast(str, error["message"])
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    # Must not be the recovery-unavailable shape.
+    assert error.get("safe_details") is None or "operation_recovery_unavailable" not in str(
+        error.get("safe_details")
+    )
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_quarantined_operation_retains_storage_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_recovery_oracle(monkeypatch, status_wire=_operation_wire("quarantined"))
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.STORAGE_CORRUPT.value
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_read_projection_failed_returns_operation_recovery_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dogfood defect: nested status read failure must not become the outer publish result."""
+
+    _install_recovery_oracle(
+        monkeypatch,
+        raise_on_status=ControlError(
+            "read_projection_failed",
+            retryable=True,
+            correlation_id="err_00000000-0000-4000-8000-000000000096",
+        ),
+    )
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    assert result.isError is True
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.OPERATION_PENDING.value
+    assert error["retryable"] is True
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["reason_code"] == "operation_recovery_unavailable"
+    assert details["field"] == "/event_drafts/0/payload/authority"
+    message = cast(str, error["message"])
+    assert "same request_id" in message
+    assert "No durable state changed" not in message
+    assert "new request_id" not in message
+    assert "read_projection_failed" not in message
+    assert _MALFORMED_AUTHORITY not in message
+    assert _HOSTILE_PAYLOAD not in str(result.structuredContent)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_public_operation_error_during_recovery_is_unavailable_not_nested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_recovery_oracle(
+        monkeypatch,
+        raise_on_status=PublicOperationError(
+            PublicErrorCode.INTERNAL_ERROR,
+            "Nested internal failure must not become outer durability advice.",
+            True,
+            safe_details={"reason_code": "read_projection_failed"},
+        ),
+    )
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.OPERATION_PENDING.value
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["reason_code"] == "operation_recovery_unavailable"
+    assert "Nested internal failure" not in cast(str, error["message"])
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_connection_failure_during_recovery_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_recovery_oracle(
+        monkeypatch,
+        raise_on_status=ControlError("service_unavailable", retryable=True),
+    )
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_publish_work(_malformed_decision_arguments(), runtime)
+
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.OPERATION_PENDING.value
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["reason_code"] == "operation_recovery_unavailable"
+    assert result.structuredContent is not None
+    assert result.structuredContent["request_id"] == _REQUEST
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_malformed_dry_run_absent_returns_validation_not_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dry_run creates no operation record; absent lookup returns the authoring pointer."""
+
+    seen = _install_recovery_oracle(monkeypatch, status_wire=_operation_wire("absent"))
+    runtime = bridge.build_bridge_runtime()
+    arguments = _malformed_decision_arguments(dry_run=True)
+
+    result = await bridge.dispatch_publish_work(arguments, runtime)
+
+    assert len(seen) == 1  # recovery still consults operation identity; does not special-case
+    error = _error(result)
+    assert error["code"] == PublicErrorCode.INVALID_REQUEST.value
+    details = cast(dict[str, object], error["safe_details"])
+    assert details["fields"] == ["/event_drafts/0/payload/authority"]
+    # No claim about durable append / frontier / request-id consumption.
+    message = cast(str, error["message"])
+    assert "No durable state changed" not in message
+    assert "accepted" not in message.lower() or "invalid" in message.lower()
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_hostile_authority_text_never_appears_in_unavailable_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_recovery_oracle(
+        monkeypatch,
+        raise_on_status=ControlError("read_projection_failed", retryable=True),
+    )
+    runtime = bridge.build_bridge_runtime()
+    arguments = _malformed_decision_arguments(authority=f"x {_HOSTILE_PAYLOAD} y")
+
+    result = await bridge.dispatch_publish_work(arguments, runtime)
+
+    blob = str(result.structuredContent)
+    assert _HOSTILE_PAYLOAD not in blob
+    error = _error(result)
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == (
+        "operation_recovery_unavailable"
+    )
+    await bridge.close_bridge_runtime(runtime)

--- a/tests/unit/protocol/test_errors.py
+++ b/tests/unit/protocol/test_errors.py
@@ -117,6 +117,7 @@ nul_byte_forbidden
 object_key_not_string
 obligation_change_invalid
 obligation_resolution_invalid
+operation_recovery_unavailable
 payload_redaction_mismatch
 plan_version_conflict
 privacy_projection_unavailable
@@ -333,7 +334,7 @@ def test_public_error_code_membership() -> None:
 def test_protocol_reason_registry_is_exact_and_import_order_independent() -> None:
     source_values = cast(tuple[str, ...], getattr(errors_module, "_PROTOCOL_REASON_CODE_VALUES"))
     assert source_values == _EXPECTED_REASON_CODES
-    assert len(source_values) == 136
+    assert len(source_values) == 137
     assert source_values == tuple(sorted(source_values, key=str.encode))
     assert len(source_values) == len(set(source_values))
     assert PROTOCOL_REASON_CODES == frozenset(_EXPECTED_REASON_CODES)


### PR DESCRIPTION
## Summary

MCP `publish_work` envelope recovery is now a closed tri-state (`found` / `absent` / `unavailable`) so a failed secondary `status view=operation` read cannot replace a field-pointed `INVALID_REQUEST` with a false read-only durability claim.

- **Found** (pending/complete/quarantined): authoritative recovery still wins over authoring diagnostics (PR #47).
- **Absent**: returns the original field-pointed `INVALID_REQUEST`.
- **Unavailable**: returns `OPERATION_PENDING` with reason `operation_recovery_unavailable`, the original `request_id`, and the safe authoring field — never nested status request IDs or “use a new request_id”.

Also registers the reason code and updates INTERFACES/CHANGELOG.

## Plan

- Issue: https://github.com/TheGaySupreme123/yoetz/issues/65
- Plan: `docs/plans/2026-07-28-run5-residuals/01-recovery-must-not-mask-authoring-errors.md`

## Test plan

```text
uv run pytest tests/unit/mcp/test_publish_recovery_precedence.py tests/unit/protocol/test_errors.py tests/unit/mcp/test_control_error_correlation.py tests/subprocess/test_mcp_service_bridge.py -q
```

- 35 passed
- ruff + pyright clean on touched files

Fixes #65