### PR TITLE
Send the reviewer the real frozen, privacy-selected case

### DIFF
--- a/src/yoetz/adapters/privacy/local_enforcer.py
+++ b/src/yoetz/adapters/privacy/local_enforcer.py
@@ -7,6 +7,10 @@ import hashlib
 from dataclasses import dataclass
 from typing import Protocol, cast
 
+from yoetz.application.semantic_case import (
+    REVIEW_PACKET_ITEM_ID,
+    assemble_filtered_review_packet,
+)
 from yoetz.domain.privacy import (
     CandidateContext,
     CandidateContextItem,
@@ -103,7 +107,6 @@ def scan_exact_bytes(data: bytes) -> tuple[ForbiddenDataKind, ...]:
     return tuple(sorted(mapped, key=lambda value: value.value.encode()))
 
 
-_REVIEW_PACKET_ITEM_ID = "review-packet"
 _SEMANTIC_PACKET_SCHEMA = "yoetz.review-packet-case/1"
 
 
@@ -113,13 +116,14 @@ def _assemble_semantic_review_payload(
 ) -> bytes:
     """Assemble the versioned review-packet document from privacy-approved case items.
 
-    The pre-egress builder supplies one structural ``review-packet`` envelope plus separate
-    categorized content items. This keeps classification/minimization item-identity exact while
-    still delivering a readable packet to the provider.
+    The pre-egress builder supplies one structural ``review-packet`` envelope (with item catalog
+    and packet metadata) plus separate categorized content items. Projection reuses the shared
+    builder filter so section/source_kind/subject_ref are never reverse-engineered from origin_ref.
     """
 
+    del classified  # catalog on the envelope is the authority; classified only supplied included.
     included_by_id = {item.candidate.item_id: item for item in included}
-    envelope_item = included_by_id.get(_REVIEW_PACKET_ITEM_ID)
+    envelope_item = included_by_id.get(REVIEW_PACKET_ITEM_ID)
     if envelope_item is None:
         # Structural envelope withheld or missing: fail closed to empty authorized payload shape
         # recognized by the coordinator as insufficient approved context when ids are empty.
@@ -150,107 +154,16 @@ def _assemble_semantic_review_payload(
         return canonical_encode(
             cast(JsonValue, {"items": [], "omissions": [], "schema": _SEMANTIC_PACKET_SCHEMA})
         )
-    document = cast(dict[str, JsonValue], dict(cast(dict[object, object], envelope)))
-    included_ids = set(included_by_id)
-    content_rows: list[dict[str, JsonValue]] = []
-    for item in classified.items:
-        candidate = item.candidate
-        if candidate.item_id == _REVIEW_PACKET_ITEM_ID:
-            continue
-        if candidate.item_id not in included_ids:
-            continue
-        try:
-            text = candidate.plaintext.decode("utf-8")
-        except UnicodeDecodeError:
-            continue
-        # Section/source metadata is carried on the origin pointer when present.
-        origin = candidate.origin_ref
-        section = "timeline"
-        if origin.startswith("/case/"):
-            parts = origin.split("/")
-            if len(parts) >= 3 and parts[2]:
-                section = parts[2]
-        content_rows.append(
-            {
-                "category": candidate.category.value,
-                "content": text,
-                "content_bytes": len(candidate.plaintext),
-                "content_digest": f"sha256:{hashlib.sha256(candidate.plaintext).hexdigest()}",
-                "item_id": candidate.item_id,
-                "section": section,
-            }
-        )
-    content_rows.sort(key=lambda row: cast(str, row["item_id"]).encode("ascii"))
-
-    packet = document.get("review_packet")
-    if isinstance(packet, dict):
-        packet_obj = cast(dict[str, JsonValue], dict(cast(dict[object, object], packet)))
-        for key in (
-            "goal_item_ids",
-            "obligation_item_ids",
-            "claim_item_ids",
-            "decision_item_ids",
-            "timeline_item_ids",
-        ):
-            raw_ids = packet_obj.get(key)
-            if type(raw_ids) is list:
-                packet_obj[key] = [
-                    item_id
-                    for item_id in cast(list[object], raw_ids)
-                    if type(item_id) is str and item_id in included_ids
-                ]
-        excerpts = packet_obj.get("targeted_excerpts")
-        if type(excerpts) is list:
-            packet_obj["targeted_excerpts"] = [
-                row
-                for row in cast(list[object], excerpts)
-                if isinstance(row, dict)
-                and cast(dict[str, object], row).get("excerpt_item_id") in included_ids
-            ]
-        assessments = packet_obj.get("deterministic_assessments")
-        if type(assessments) is list:
-            filtered_assessments: list[JsonValue] = []
-            for raw in cast(list[object], assessments):
-                if not isinstance(raw, dict):
-                    continue
-                row = dict(cast(dict[str, JsonValue], cast(dict[object, object], raw)))
-                summary = row.get("summary_item_id")
-                detail = row.get("detail_item_id")
-                if type(summary) is str and type(detail) is str:
-                    if summary not in included_ids or detail not in included_ids:
-                        row.pop("summary_item_id", None)
-                        row.pop("detail_item_id", None)
-                filtered_assessments.append(row)
-            packet_obj["deterministic_assessments"] = filtered_assessments
-        omissions = packet_obj.get("omissions")
-        omission_rows: list[JsonValue] = (
-            list(cast(list[JsonValue], omissions)) if type(omissions) is list else []
-        )
-        for item in classified.items:
-            candidate = item.candidate
-            if candidate.item_id == _REVIEW_PACKET_ITEM_ID or candidate.item_id in included_ids:
-                continue
-            # Withheld content is represented exactly; subject identity stays structural.
-            origin = candidate.origin_ref
-            subject_ref = candidate.item_id
-            if origin.startswith("/case/") and len(origin.split("/")) >= 4:
-                subject_ref = origin.split("/", 3)[3]
-            omission_rows.append(
-                {
-                    "category": candidate.category.value,
-                    "reason": "withheld_by_policy",
-                    "source_kind": "finding"
-                    if candidate.category is DataCategory.FINDING_SUMMARY
-                    else "task",
-                    "subject_ref": subject_ref,
-                }
-            )
-        packet_obj["omissions"] = omission_rows
-        document["review_packet"] = packet_obj
-
-    document["items"] = cast(JsonValue, content_rows)
-    document["schema"] = _SEMANTIC_PACKET_SCHEMA
-    return canonical_encode(cast(JsonValue, document))
+    content_by_id = {
+        item_id: item.candidate.plaintext
+        for item_id, item in included_by_id.items()
+        if item_id != REVIEW_PACKET_ITEM_ID
+    }
+    return assemble_filtered_review_packet(
+        cast(dict[str, object], envelope),
+        content_by_id=content_by_id,
+        included_item_ids=set(included_by_id),
+    )
 
 
 class LocalPrivacyEnforcer:

--- a/src/yoetz/adapters/privacy/local_enforcer.py
+++ b/src/yoetz/adapters/privacy/local_enforcer.py
@@ -21,7 +21,7 @@ from yoetz.domain.privacy import (
 )
 from yoetz.observability.privacy import scan_for_sensitive_content
 from yoetz.ports.privacy import EffectivePrivacyPolicy, MinimizedDisclosure
-from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 from yoetz.protocol.models import DataCategory
 
 __all__ = [
@@ -101,6 +101,156 @@ def scan_exact_bytes(data: bytes) -> tuple[ForbiddenDataKind, ...]:
         for finding in findings
     }
     return tuple(sorted(mapped, key=lambda value: value.value.encode()))
+
+
+_REVIEW_PACKET_ITEM_ID = "review-packet"
+_SEMANTIC_PACKET_SCHEMA = "yoetz.review-packet-case/1"
+
+
+def _assemble_semantic_review_payload(
+    classified: ClassifiedContext,
+    included: tuple[ClassifiedContextItem, ...],
+) -> bytes:
+    """Assemble the versioned review-packet document from privacy-approved case items.
+
+    The pre-egress builder supplies one structural ``review-packet`` envelope plus separate
+    categorized content items. This keeps classification/minimization item-identity exact while
+    still delivering a readable packet to the provider.
+    """
+
+    included_by_id = {item.candidate.item_id: item for item in included}
+    envelope_item = included_by_id.get(_REVIEW_PACKET_ITEM_ID)
+    if envelope_item is None:
+        # Structural envelope withheld or missing: fail closed to empty authorized payload shape
+        # recognized by the coordinator as insufficient approved context when ids are empty.
+        return canonical_encode(
+            cast(
+                JsonValue,
+                {
+                    "items": [],
+                    "omissions": [],
+                    "schema": _SEMANTIC_PACKET_SCHEMA,
+                },
+            )
+        )
+    try:
+        envelope = strict_json_parse(envelope_item.candidate.plaintext)
+    except Exception:
+        return canonical_encode(
+            cast(
+                JsonValue,
+                {
+                    "items": [],
+                    "omissions": [],
+                    "schema": _SEMANTIC_PACKET_SCHEMA,
+                },
+            )
+        )
+    if not isinstance(envelope, dict):
+        return canonical_encode(
+            cast(JsonValue, {"items": [], "omissions": [], "schema": _SEMANTIC_PACKET_SCHEMA})
+        )
+    document = cast(dict[str, JsonValue], dict(cast(dict[object, object], envelope)))
+    included_ids = set(included_by_id)
+    content_rows: list[dict[str, JsonValue]] = []
+    for item in classified.items:
+        candidate = item.candidate
+        if candidate.item_id == _REVIEW_PACKET_ITEM_ID:
+            continue
+        if candidate.item_id not in included_ids:
+            continue
+        try:
+            text = candidate.plaintext.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        # Section/source metadata is carried on the origin pointer when present.
+        origin = candidate.origin_ref
+        section = "timeline"
+        if origin.startswith("/case/"):
+            parts = origin.split("/")
+            if len(parts) >= 3 and parts[2]:
+                section = parts[2]
+        content_rows.append(
+            {
+                "category": candidate.category.value,
+                "content": text,
+                "content_bytes": len(candidate.plaintext),
+                "content_digest": f"sha256:{hashlib.sha256(candidate.plaintext).hexdigest()}",
+                "item_id": candidate.item_id,
+                "section": section,
+            }
+        )
+    content_rows.sort(key=lambda row: cast(str, row["item_id"]).encode("ascii"))
+
+    packet = document.get("review_packet")
+    if isinstance(packet, dict):
+        packet_obj = cast(dict[str, JsonValue], dict(cast(dict[object, object], packet)))
+        for key in (
+            "goal_item_ids",
+            "obligation_item_ids",
+            "claim_item_ids",
+            "decision_item_ids",
+            "timeline_item_ids",
+        ):
+            raw_ids = packet_obj.get(key)
+            if type(raw_ids) is list:
+                packet_obj[key] = [
+                    item_id
+                    for item_id in cast(list[object], raw_ids)
+                    if type(item_id) is str and item_id in included_ids
+                ]
+        excerpts = packet_obj.get("targeted_excerpts")
+        if type(excerpts) is list:
+            packet_obj["targeted_excerpts"] = [
+                row
+                for row in cast(list[object], excerpts)
+                if isinstance(row, dict)
+                and cast(dict[str, object], row).get("excerpt_item_id") in included_ids
+            ]
+        assessments = packet_obj.get("deterministic_assessments")
+        if type(assessments) is list:
+            filtered_assessments: list[JsonValue] = []
+            for raw in cast(list[object], assessments):
+                if not isinstance(raw, dict):
+                    continue
+                row = dict(cast(dict[str, JsonValue], cast(dict[object, object], raw)))
+                summary = row.get("summary_item_id")
+                detail = row.get("detail_item_id")
+                if type(summary) is str and type(detail) is str:
+                    if summary not in included_ids or detail not in included_ids:
+                        row.pop("summary_item_id", None)
+                        row.pop("detail_item_id", None)
+                filtered_assessments.append(row)
+            packet_obj["deterministic_assessments"] = filtered_assessments
+        omissions = packet_obj.get("omissions")
+        omission_rows: list[JsonValue] = (
+            list(cast(list[JsonValue], omissions)) if type(omissions) is list else []
+        )
+        for item in classified.items:
+            candidate = item.candidate
+            if candidate.item_id == _REVIEW_PACKET_ITEM_ID or candidate.item_id in included_ids:
+                continue
+            # Withheld content is represented exactly; subject identity stays structural.
+            origin = candidate.origin_ref
+            subject_ref = candidate.item_id
+            if origin.startswith("/case/") and len(origin.split("/")) >= 4:
+                subject_ref = origin.split("/", 3)[3]
+            omission_rows.append(
+                {
+                    "category": candidate.category.value,
+                    "reason": "withheld_by_policy",
+                    "source_kind": "finding"
+                    if candidate.category is DataCategory.FINDING_SUMMARY
+                    else "task",
+                    "subject_ref": subject_ref,
+                }
+            )
+        packet_obj["omissions"] = omission_rows
+        document["review_packet"] = packet_obj
+
+    document["items"] = cast(JsonValue, content_rows)
+    document["schema"] = _SEMANTIC_PACKET_SCHEMA
+    return canonical_encode(cast(JsonValue, document))
 
 
 class LocalPrivacyEnforcer:
@@ -191,17 +341,20 @@ class LocalPrivacyEnforcer:
             and not item.forbidden_findings
             and item.data_class is not DataClass.SECRET_OR_CRYPTOGRAPHIC
         )
-        rows = [
-            {
-                "category": item.candidate.category.value,
-                "content_base64": base64.b64encode(item.candidate.plaintext).decode("ascii"),
-                "item_id": item.candidate.item_id,
-            }
-            for item in included
-        ]
-        prepared = canonical_encode(
-            cast(JsonValue, {"items": rows, "schema": "yoetz.minimized-disclosure/1"})
-        )
+        if classified.candidate.purpose == "semantic-review":
+            prepared = _assemble_semantic_review_payload(classified, included)
+        else:
+            rows = [
+                {
+                    "category": item.candidate.category.value,
+                    "content_base64": base64.b64encode(item.candidate.plaintext).decode("ascii"),
+                    "item_id": item.candidate.item_id,
+                }
+                for item in included
+            ]
+            prepared = canonical_encode(
+                cast(JsonValue, {"items": rows, "schema": "yoetz.minimized-disclosure/1"})
+            )
         findings = scan_exact_bytes(prepared)
         source_digests = tuple(
             sorted(

--- a/src/yoetz/application/semantic_case.py
+++ b/src/yoetz/application/semantic_case.py
@@ -1,0 +1,1323 @@
+"""Pure frozen-authority builder for privacy-selected semantic review cases.
+
+Constructs ``SemanticCase`` / ``ReviewPacket`` from the already-frozen check case,
+pinned deterministic findings/bases, and the active ``ReviewSelectionPolicy``.
+
+This module is deliberately capability-free: no Git, filesystem, network, transcript,
+environment, database, or provider access. Missing material becomes an omission.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Final, Literal, cast
+
+from yoetz.application.check import (
+    CheckScope,
+    case_coverage,
+    run_deterministic_policies,
+)
+from yoetz.domain.events import (
+    ActionKind,
+    ClaimRecordedPayload,
+    DecisionRecordedPayload,
+    EvidenceKind,
+    EvidenceRecordedPayload,
+    ObligationPublishedPayload,
+    ResultOutcome,
+)
+from yoetz.domain.findings import Finding, FindingKind
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    CandidateContext,
+    CandidateContextItem,
+    EgressChannel,
+    ProviderBinding,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
+from yoetz.domain.values import SubjectStateRelation
+from yoetz.kernel.deterministic_checks import DeterministicAssessment, DeterministicCase
+from yoetz.ports.semantic import (
+    ChangeObservation,
+    ReviewAssessment,
+    ReviewAssessmentSkipped,
+    ReviewOmission,
+    ReviewPacket,
+    SemanticCase,
+    SemanticCaseItem,
+    TargetedExcerptRef,
+    project_review_assessment,
+)
+from yoetz.protocol.canonical import JsonValue, canonical_digest, canonical_encode
+from yoetz.protocol.coverage import coverage_to_json
+from yoetz.protocol.models import (
+    MAX_REVIEW_TEXT_BYTES,
+    MAX_SEMANTIC_ITEM_BYTES,
+    DataCategory,
+)
+
+__all__ = [
+    "REVIEW_PACKET_ITEM_ID",
+    "SEMANTIC_REVIEW_PURPOSE",
+    "build_semantic_case",
+    "review_selection_digest",
+    "semantic_case_to_candidate_context",
+    "semantic_case_to_prepared_payload",
+]
+
+SEMANTIC_REVIEW_PURPOSE: Final = "semantic-review"
+REVIEW_PACKET_ITEM_ID: Final = "review-packet"
+_PACKET_SCHEMA: Final = "yoetz.review-packet-case/1"
+_CANONICAL_PACKS: Final = ("research-evidence/0.1.0", "work-integrity/0.1.0")
+_QUESTION_SET: Final = (
+    "Does the supplied packet contain a material discrepancy against the goal and obligations?",
+    "If so, which case-bound refs support the discrepancy?",
+    "What is the smallest next step the main agent should take?",
+)
+
+type _Section = Literal[
+    "goal",
+    "obligation",
+    "claim",
+    "decision",
+    "timeline",
+    "deterministic_summary",
+    "deterministic_detail",
+    "excerpt",
+]
+type _SourceKind = Literal[
+    "task",
+    "obligation",
+    "claim",
+    "decision",
+    "action",
+    "result",
+    "evidence",
+    "finding",
+    "test",
+    "failure",
+    "diff",
+    "command",
+    "repository",
+]
+type _ExcerptKind = Literal["evidence", "test", "failure", "diff", "command", "repository"]
+type _OmissionReason = Literal[
+    "not_recorded", "not_selected", "withheld_by_policy", "redacted_never_send"
+]
+
+_EVIDENCE_EXCERPT_KIND: Final[Mapping[EvidenceKind, _ExcerptKind]] = {
+    EvidenceKind.ARTIFACT: "evidence",
+    EvidenceKind.COMMAND_OUTPUT: "command",
+    EvidenceKind.TEST_RESULT: "test",
+    EvidenceKind.RESEARCH_SOURCE: "repository",
+    EvidenceKind.IMPORT_REPORT: "evidence",
+    EvidenceKind.OTHER: "evidence",
+}
+
+
+def review_selection_digest(selection: ReviewSelectionPolicy) -> str:
+    """Digest the closed review-selection value for case/provenance binding."""
+
+    if type(selection) is not ReviewSelectionPolicy:
+        raise TypeError("review_selection_invalid")
+    return canonical_digest(
+        cast(
+            JsonValue,
+            {
+                "excerpt_kinds": list(selection.excerpt_kinds),
+                "include_exact_command_text": selection.include_exact_command_text,
+                "include_finding_prose": selection.include_finding_prose,
+                "max_assessments": selection.max_assessments,
+                "max_change_observations": selection.max_change_observations,
+                "max_excerpt_bytes": selection.max_excerpt_bytes,
+                "max_excerpts": selection.max_excerpts,
+                "max_omissions": selection.max_omissions,
+                "max_timeline_items": selection.max_timeline_items,
+                "max_total_excerpt_bytes": selection.max_total_excerpt_bytes,
+                "relevance": selection.relevance,
+                "schema": "yoetz.review-selection/1",
+                "sections": list(selection.sections),
+            },
+        )
+    )
+
+
+def _utf8(text: str, *, maximum: int = MAX_SEMANTIC_ITEM_BYTES) -> bytes:
+    encoded = text.encode("utf-8")
+    if not 1 <= len(encoded) <= maximum:
+        raise ValueError("semantic_case_content_invalid")
+    return encoded
+
+
+def _content_item(
+    *,
+    item_id: str,
+    section: _Section,
+    category: DataCategory,
+    source_kind: _SourceKind,
+    source_ref: str,
+    linked_subject_refs: tuple[str, ...],
+    occurred_order: int,
+    text: str,
+) -> SemanticCaseItem:
+    content = _utf8(
+        text[:MAX_REVIEW_TEXT_BYTES] if len(text.encode("utf-8")) > MAX_REVIEW_TEXT_BYTES else text
+    )
+    if len(content) > MAX_SEMANTIC_ITEM_BYTES:
+        content = content[:MAX_SEMANTIC_ITEM_BYTES]
+        # Keep valid UTF-8 after truncation.
+        content = content.decode("utf-8", errors="ignore").encode("utf-8")
+        if not content:
+            raise ValueError("semantic_case_content_invalid")
+    digest = "sha256:" + hashlib.sha256(content).hexdigest()
+    return SemanticCaseItem(
+        item_id=item_id,
+        section=section,
+        category=category,
+        source_kind=source_kind,
+        source_ref=source_ref,
+        linked_subject_refs=linked_subject_refs,
+        occurred_order=occurred_order,
+        content=content,
+        content_bytes=len(content),
+        content_digest=digest,
+    )
+
+
+def _structural_json(value: Mapping[str, JsonValue]) -> str:
+    return canonical_encode(cast(JsonValue, dict(value))).decode("ascii")
+
+
+def _omit(
+    subject_ref: str,
+    category: DataCategory,
+    source_kind: _SourceKind,
+    reason: _OmissionReason,
+) -> ReviewOmission:
+    return ReviewOmission(
+        subject_ref=subject_ref,
+        category=category,
+        source_kind=source_kind,
+        reason=reason,
+    )
+
+
+def _match_assessments(
+    case: DeterministicCase,
+    findings: Sequence[Finding],
+) -> tuple[tuple[Finding, DeterministicAssessment], ...]:
+    assessments, _executions = run_deterministic_policies(
+        case,
+        CheckScope((), ()),
+        _CANONICAL_PACKS,
+    )
+    by_key: dict[tuple[object, tuple[str, ...]], DeterministicAssessment] = {}
+    for assessment in assessments:
+        key = (
+            assessment.candidate.kind,
+            tuple(str(ref) for ref in assessment.candidate.subject_refs),
+        )
+        by_key[key] = assessment
+    matched: list[tuple[Finding, DeterministicAssessment]] = []
+    for finding in findings:
+        key = (finding.kind, tuple(str(ref) for ref in finding.subject_refs))
+        assessment = by_key.get(key)
+        if assessment is not None:
+            matched.append((finding, assessment))
+    return tuple(matched)
+
+
+def build_semantic_case(
+    *,
+    case_id: str,
+    frozen_case: DeterministicCase,
+    dependency_digest: str,
+    findings: Sequence[Finding],
+    review_context_profile: ReviewContextProfile,
+    review_selection: ReviewSelectionPolicy,
+    policy_id: str,
+    policy_version: str,
+) -> SemanticCase:
+    """Build one pre-egress semantic case from frozen authority only."""
+
+    if type(frozen_case) is not DeterministicCase:
+        raise TypeError("deterministic_case_invalid")
+    if type(review_context_profile) is not ReviewContextProfile:
+        raise TypeError("review_context_profile_invalid")
+    if type(review_selection) is not ReviewSelectionPolicy:
+        raise TypeError("review_selection_invalid")
+    if review_context_profile is not ReviewContextProfile.CUSTOM:
+        expected = ReviewSelectionPolicy.for_profile(review_context_profile)
+        if review_selection != expected:
+            # Custom overlays may meet() narrower; allow any selection that is a meet of profile.
+            meet = expected.meet(review_selection)
+            if meet != review_selection:
+                raise ValueError("review_selection_profile_mismatch")
+
+    selection = review_selection
+    sections = frozenset(selection.sections)
+    frontier_refs = frozenset(str(ref) for ref in frozen_case.allowed_ids)
+    local_check_refs = frozenset(str(item.finding_id) for item in findings)
+    if frontier_refs & local_check_refs:
+        # Local check IDs must not collide with frontier material.
+        local_check_refs = frozenset(ref for ref in local_check_refs if ref not in frontier_refs)
+    allowed = frontier_refs | local_check_refs
+    projection = frozen_case.projection
+
+    items: list[SemanticCaseItem] = []
+    omissions: list[ReviewOmission] = []
+    goal_ids: list[str] = []
+    obligation_ids: list[str] = []
+    claim_ids: list[str] = []
+    decision_ids: list[str] = []
+    timeline_ids: list[str] = []
+    targeted: list[TargetedExcerptRef] = []
+    changes: list[ChangeObservation] = []
+
+    # --- Goal (latest plan summary) ---
+    if projection.plans:
+        latest_version = max(projection.plans)
+        plan = projection.plans[latest_version]
+        plan_ref = str(plan.source_event_id)
+        if "goal" in sections and plan.payload is not None and not plan.redacted:
+            text = plan.payload.summary
+            item = _content_item(
+                item_id=f"goal-{latest_version}",
+                section="goal",
+                category=DataCategory.TASK_DESCRIPTION,
+                source_kind="task",
+                source_ref=plan_ref,
+                linked_subject_refs=(plan_ref,) if plan_ref in allowed else (),
+                occurred_order=plan.source_frontier,
+                text=text,
+            )
+            items.append(item)
+            goal_ids.append(item.item_id)
+        elif "goal" not in sections:
+            omissions.append(_omit(plan_ref, DataCategory.TASK_DESCRIPTION, "task", "not_selected"))
+        elif plan.redacted:
+            omissions.append(
+                _omit(plan_ref, DataCategory.TASK_DESCRIPTION, "task", "redacted_never_send")
+            )
+        else:
+            omissions.append(_omit(plan_ref, DataCategory.TASK_DESCRIPTION, "task", "not_recorded"))
+
+    # --- Obligations ---
+    for obligation_id, record in sorted(
+        projection.obligations.items(), key=lambda pair: str(pair[0])
+    ):
+        ref = str(obligation_id)
+        if ref not in allowed and str(record.source_event_id) not in allowed:
+            continue
+        source_ref = ref if ref in allowed else str(record.source_event_id)
+        if "obligations" not in sections:
+            omissions.append(
+                _omit(source_ref, DataCategory.OBLIGATION_TEXT, "obligation", "not_selected")
+            )
+            continue
+        payload = record.payload
+        if record.redacted or payload is None:
+            omissions.append(
+                _omit(
+                    source_ref,
+                    DataCategory.OBLIGATION_TEXT,
+                    "obligation",
+                    "redacted_never_send" if record.redacted else "not_recorded",
+                )
+            )
+            continue
+        assert type(payload) is ObligationPublishedPayload
+        linked = tuple(
+            sorted(
+                {
+                    source_ref,
+                    *(str(item) for item in payload.source_refs if str(item) in allowed),
+                },
+                key=str.encode,
+            )
+        )[:16]
+        item = _content_item(
+            item_id=f"obligation-{ref}",
+            section="obligation",
+            category=DataCategory.OBLIGATION_TEXT,
+            source_kind="obligation",
+            source_ref=source_ref,
+            linked_subject_refs=linked if linked else (source_ref,),
+            occurred_order=record.source_frontier,
+            text=payload.description,
+        )
+        items.append(item)
+        obligation_ids.append(item.item_id)
+
+    # --- Claims ---
+    for claim_id, record in sorted(projection.claims.items(), key=lambda pair: str(pair[0])):
+        ref = str(claim_id)
+        if ref not in allowed:
+            continue
+        if "claims" not in sections:
+            omissions.append(_omit(ref, DataCategory.CLAIM_TEXT, "claim", "not_selected"))
+            continue
+        payload = record.payload
+        if record.redacted or payload is None:
+            omissions.append(
+                _omit(
+                    ref,
+                    DataCategory.CLAIM_TEXT,
+                    "claim",
+                    "redacted_never_send" if record.redacted else "not_recorded",
+                )
+            )
+            continue
+        assert type(payload) is ClaimRecordedPayload
+        item = _content_item(
+            item_id=f"claim-{ref}",
+            section="claim",
+            category=DataCategory.CLAIM_TEXT,
+            source_kind="claim",
+            source_ref=ref,
+            linked_subject_refs=(ref,),
+            occurred_order=record.source_frontier,
+            text=payload.statement,
+        )
+        items.append(item)
+        claim_ids.append(item.item_id)
+
+        if "change_observations" in sections and payload.subject_state is not None:
+            changes.append(
+                ChangeObservation(
+                    subject_refs=(ref,),
+                    claimed_change=True,
+                    subject_state_relation=SubjectStateRelation.UNKNOWN,
+                    content_visibility=(
+                        "available" if "targeted_excerpts" in sections else "not_selected"
+                    ),
+                )
+            )
+
+    # --- Decisions ---
+    for event_id, record in sorted(projection.decisions.items(), key=lambda pair: str(pair[0])):
+        ref = str(event_id)
+        if ref not in allowed:
+            continue
+        if "decisions" not in sections:
+            omissions.append(_omit(ref, DataCategory.DECISION_EXCERPT, "decision", "not_selected"))
+            continue
+        payload = record.payload
+        if record.redacted or payload is None:
+            omissions.append(
+                _omit(
+                    ref,
+                    DataCategory.DECISION_EXCERPT,
+                    "decision",
+                    "redacted_never_send" if record.redacted else "not_recorded",
+                )
+            )
+            continue
+        assert type(payload) is DecisionRecordedPayload
+        item = _content_item(
+            item_id=f"decision-{ref}",
+            section="decision",
+            category=DataCategory.DECISION_EXCERPT,
+            source_kind="decision",
+            source_ref=ref,
+            linked_subject_refs=(ref,),
+            occurred_order=record.source_frontier,
+            text=payload.statement,
+        )
+        items.append(item)
+        decision_ids.append(item.item_id)
+
+    # --- Material timeline (structural facts; no user prose) ---
+    if "timeline" in sections:
+        timeline_candidates: list[tuple[int, str, _SourceKind, str, Mapping[str, JsonValue]]] = []
+        for obligation_id, record in projection.obligations.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "obligation",
+                    str(obligation_id)
+                    if str(obligation_id) in allowed
+                    else str(record.source_event_id),
+                    {
+                        "kind": "obligation_published",
+                        "obligation_id": str(obligation_id),
+                        "source_event_id": str(record.source_event_id),
+                        "status": (
+                            record.payload.status.value
+                            if record.payload is not None
+                            else "unavailable"
+                        ),
+                    },
+                )
+            )
+        for claim_id, record in projection.claims.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "claim",
+                    str(claim_id),
+                    {
+                        "kind": "claim_recorded",
+                        "claim_id": str(claim_id),
+                        "source_event_id": str(record.source_event_id),
+                        "claim_kind": (
+                            record.payload.claim_kind.value
+                            if record.payload is not None
+                            else "unavailable"
+                        ),
+                    },
+                )
+            )
+        for action_id, record in projection.actions.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "action",
+                    str(action_id) if str(action_id) in allowed else str(record.source_event_id),
+                    {
+                        "kind": "action_recorded",
+                        "action_id": str(action_id),
+                        "source_event_id": str(record.source_event_id),
+                        "action_kind": (
+                            record.payload.action_kind.value
+                            if record.payload is not None
+                            else "unavailable"
+                        ),
+                    },
+                )
+            )
+        for result_id, record in projection.results.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "result",
+                    str(result_id) if str(result_id) in allowed else str(record.source_event_id),
+                    {
+                        "kind": "result_recorded",
+                        "result_id": str(result_id),
+                        "source_event_id": str(record.source_event_id),
+                        "outcome": (
+                            record.payload.outcome.value
+                            if record.payload is not None
+                            else "unavailable"
+                        ),
+                    },
+                )
+            )
+        for evidence_id, record in projection.evidence.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "evidence",
+                    str(evidence_id)
+                    if str(evidence_id) in allowed
+                    else str(record.source_event_id),
+                    {
+                        "kind": "evidence_recorded",
+                        "evidence_id": str(evidence_id),
+                        "source_event_id": str(record.source_event_id),
+                        "evidence_kind": (
+                            record.payload.evidence_kind.value
+                            if record.payload is not None
+                            else "unavailable"
+                        ),
+                    },
+                )
+            )
+        for event_id, record in projection.decisions.items():
+            timeline_candidates.append(
+                (
+                    record.source_frontier,
+                    str(record.source_event_id),
+                    "decision",
+                    str(event_id),
+                    {
+                        "kind": "decision_recorded",
+                        "source_event_id": str(event_id),
+                    },
+                )
+            )
+        # Always record the frozen frontier as a structural anchor.
+        timeline_candidates.append(
+            (
+                frozen_case.frontier.sequence,
+                f"frontier-{frozen_case.frontier.sequence}",
+                "task",
+                f"frontier-{frozen_case.frontier.sequence}",
+                {
+                    "kind": "frontier",
+                    "sequence": frozen_case.frontier.sequence,
+                    "head_digest": frozen_case.frontier.head_digest,
+                    "dependency_digest": dependency_digest,
+                },
+            )
+        )
+        timeline_candidates.sort(
+            key=lambda row: (row[0], row[1].encode("ascii"), row[3].encode("ascii"))
+        )
+        for order, _event, source_kind, source_ref, body in timeline_candidates[
+            : selection.max_timeline_items
+        ]:
+            linked = (source_ref,) if source_ref in allowed else ()
+            item = _content_item(
+                item_id=f"timeline-{source_ref}",
+                section="timeline",
+                category=DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                source_kind=source_kind,
+                source_ref=source_ref,
+                linked_subject_refs=linked,
+                occurred_order=order,
+                text=_structural_json(body),
+            )
+            items.append(item)
+            timeline_ids.append(item.item_id)
+
+    # --- Deterministic assessments + optional finding prose ---
+    review_assessments: list[ReviewAssessment] = []
+    if "deterministic_assessments" in sections:
+        matched = _match_assessments(frozen_case, findings)
+        for finding, assessment in matched[: selection.max_assessments]:
+            summary_id: str | None = None
+            detail_id: str | None = None
+            if selection.include_finding_prose:
+                finding_ref = str(finding.finding_id)
+                linked = tuple(str(ref) for ref in finding.subject_refs)
+                if not set(linked) <= allowed:
+                    linked = tuple(ref for ref in linked if ref in allowed)
+                if not linked:
+                    continue
+                summary_id = f"finding-summary-{finding_ref}"
+                detail_id = f"finding-detail-{finding_ref}"
+                items.append(
+                    _content_item(
+                        item_id=summary_id,
+                        section="deterministic_summary",
+                        category=DataCategory.FINDING_SUMMARY,
+                        source_kind="finding",
+                        source_ref=finding_ref,
+                        linked_subject_refs=linked,
+                        occurred_order=finding.subject_frontier.sequence,
+                        text=finding.summary,
+                    )
+                )
+                items.append(
+                    _content_item(
+                        item_id=detail_id,
+                        section="deterministic_detail",
+                        category=DataCategory.FINDING_SUMMARY,
+                        source_kind="finding",
+                        source_ref=finding_ref,
+                        linked_subject_refs=linked,
+                        occurred_order=finding.subject_frontier.sequence,
+                        text=finding.detail,
+                    )
+                )
+            projected = project_review_assessment(
+                assessment,
+                str(finding.finding_id),
+                summary_item_id=summary_id,
+                detail_item_id=detail_id,
+            )
+            if type(projected) is ReviewAssessment:
+                review_assessments.append(projected)
+            elif type(projected) is ReviewAssessmentSkipped:
+                omissions.append(projected.omission)
+
+    # --- Targeted excerpts (recorded text only; never fetch objects) ---
+    excerpt_bytes_used = 0
+    if "targeted_excerpts" in sections and selection.max_excerpts > 0:
+        linked_subjects: set[str] = set()
+        for finding in findings:
+            linked_subjects.update(str(ref) for ref in finding.subject_refs)
+        for claim_id in projection.claims:
+            linked_subjects.add(str(claim_id))
+        for obligation_id in projection.obligations:
+            linked_subjects.add(str(obligation_id))
+        # Assessment supporting refs are case-bound links the reviewer may need as excerpts.
+        for assessment in review_assessments:
+            linked_subjects.update(str(ref) for ref in assessment.supporting_refs)
+            for fact in (*assessment.observed_facts, *assessment.required_but_missing_facts):
+                linked_subjects.update(str(ref) for ref in fact.subject_refs)
+        for claim_record in projection.claims.values():
+            if claim_record.payload is None:
+                continue
+            linked_subjects.update(str(ref) for ref in claim_record.payload.supporting_refs)
+
+        evidence_rows = sorted(projection.evidence.items(), key=lambda pair: str(pair[0]))
+        for evidence_id, record in evidence_rows:
+            if len(targeted) >= selection.max_excerpts:
+                break
+            ref = str(evidence_id)
+            if ref not in allowed:
+                continue
+            payload = record.payload
+            if payload is None or record.redacted:
+                omissions.append(
+                    _omit(
+                        ref,
+                        DataCategory.EVIDENCE_EXCERPT,
+                        "evidence",
+                        "redacted_never_send" if record.redacted else "not_recorded",
+                    )
+                )
+                continue
+            assert type(payload) is EvidenceRecordedPayload
+            excerpt_kind = _EVIDENCE_EXCERPT_KIND.get(payload.evidence_kind, "evidence")
+            if excerpt_kind not in selection.excerpt_kinds:
+                omissions.append(
+                    _omit(ref, DataCategory.EVIDENCE_EXCERPT, excerpt_kind, "not_selected")
+                )
+                continue
+            if selection.relevance == "linked_subjects_only":
+                source_event = str(record.source_event_id)
+                if ref not in linked_subjects and source_event not in linked_subjects:
+                    omissions.append(
+                        _omit(ref, DataCategory.EVIDENCE_EXCERPT, excerpt_kind, "not_selected")
+                    )
+                    continue
+            text = payload.description or payload.reference
+            if text is None or not text:
+                omissions.append(
+                    _omit(ref, DataCategory.EVIDENCE_EXCERPT, excerpt_kind, "not_recorded")
+                )
+                continue
+            encoded = text.encode("utf-8")
+            if len(encoded) > selection.max_excerpt_bytes:
+                text = encoded[: selection.max_excerpt_bytes].decode("utf-8", errors="ignore")
+                encoded = text.encode("utf-8")
+            if excerpt_bytes_used + len(encoded) > selection.max_total_excerpt_bytes:
+                omissions.append(
+                    _omit(ref, DataCategory.EVIDENCE_EXCERPT, excerpt_kind, "not_selected")
+                )
+                continue
+            linked = tuple(
+                sorted(
+                    {
+                        ref,
+                        str(record.source_event_id),
+                        *(
+                            str(claim_id)
+                            for claim_id, claim_record in projection.claims.items()
+                            if claim_record.payload is not None
+                            and any(
+                                str(support) == ref
+                                for support in claim_record.payload.supporting_refs
+                            )
+                        ),
+                    }
+                    & allowed,
+                    key=str.encode,
+                )
+            )[:16]
+            if not linked:
+                omissions.append(
+                    _omit(ref, DataCategory.EVIDENCE_EXCERPT, excerpt_kind, "not_selected")
+                )
+                continue
+            item_id = f"excerpt-{ref}"
+            item = _content_item(
+                item_id=item_id,
+                section="excerpt",
+                category=DataCategory.EVIDENCE_EXCERPT,
+                source_kind=excerpt_kind,
+                source_ref=ref,
+                linked_subject_refs=linked,
+                occurred_order=record.source_frontier,
+                text=text,
+            )
+            items.append(item)
+            targeted.append(
+                TargetedExcerptRef(
+                    excerpt_item_id=item_id,
+                    source_kind=excerpt_kind,
+                    linked_subject_refs=linked,
+                    subject_state_relation=SubjectStateRelation.UNKNOWN,
+                    content_visibility="available",
+                    content_digest=item.content_digest,
+                    content_bytes=item.content_bytes,
+                )
+            )
+            excerpt_bytes_used += item.content_bytes
+
+        # Optional command excerpts from actions when expanded selection allows exact commands.
+        if selection.include_exact_command_text and "command" in selection.excerpt_kinds:
+            for action_id, record in sorted(
+                projection.actions.items(), key=lambda pair: str(pair[0])
+            ):
+                if len(targeted) >= selection.max_excerpts:
+                    break
+                ref = str(action_id)
+                if ref not in allowed or record.payload is None or record.redacted:
+                    continue
+                if record.payload.action_kind is not ActionKind.COMMAND:
+                    continue
+                command = record.payload.command
+                if command is None:
+                    omissions.append(
+                        _omit(ref, DataCategory.COMMAND_METADATA, "command", "not_recorded")
+                    )
+                    continue
+                encoded = command.encode("utf-8")
+                if len(encoded) > selection.max_excerpt_bytes:
+                    command = encoded[: selection.max_excerpt_bytes].decode(
+                        "utf-8", errors="ignore"
+                    )
+                    encoded = command.encode("utf-8")
+                if excerpt_bytes_used + len(encoded) > selection.max_total_excerpt_bytes:
+                    break
+                linked = (ref,) if ref in allowed else (str(record.source_event_id),)
+                linked = tuple(item for item in linked if item in allowed)
+                if not linked:
+                    continue
+                item_id = f"excerpt-cmd-{ref}"
+                item = _content_item(
+                    item_id=item_id,
+                    section="excerpt",
+                    category=DataCategory.COMMAND_METADATA,
+                    source_kind="command",
+                    source_ref=ref,
+                    linked_subject_refs=linked,
+                    occurred_order=record.source_frontier,
+                    text=command,
+                )
+                items.append(item)
+                targeted.append(
+                    TargetedExcerptRef(
+                        excerpt_item_id=item_id,
+                        source_kind="command",
+                        linked_subject_refs=linked,
+                        subject_state_relation=SubjectStateRelation.UNKNOWN,
+                        content_visibility="available",
+                        content_digest=item.content_digest,
+                        content_bytes=item.content_bytes,
+                    )
+                )
+                excerpt_bytes_used += item.content_bytes
+
+        # Failed results as failure excerpts when description-like summary exists.
+        if "failure" in selection.excerpt_kinds:
+            for result_id, record in sorted(
+                projection.results.items(), key=lambda pair: str(pair[0])
+            ):
+                if len(targeted) >= selection.max_excerpts:
+                    break
+                ref = str(result_id)
+                if ref not in allowed or record.payload is None or record.redacted:
+                    continue
+                if record.payload.outcome is not ResultOutcome.FAILURE:
+                    continue
+                summary = record.payload.summary
+                if summary is None or not summary:
+                    omissions.append(
+                        _omit(ref, DataCategory.EVIDENCE_EXCERPT, "failure", "not_recorded")
+                    )
+                    continue
+                linked = tuple(
+                    item
+                    for item in (ref, str(record.payload.action_id), str(record.source_event_id))
+                    if item in allowed
+                )[:16]
+                if not linked:
+                    continue
+                item_id = f"excerpt-fail-{ref}"
+                item = _content_item(
+                    item_id=item_id,
+                    section="excerpt",
+                    category=DataCategory.EVIDENCE_EXCERPT,
+                    source_kind="failure",
+                    source_ref=ref,
+                    linked_subject_refs=linked,
+                    occurred_order=record.source_frontier,
+                    text=summary,
+                )
+                items.append(item)
+                targeted.append(
+                    TargetedExcerptRef(
+                        excerpt_item_id=item_id,
+                        source_kind="failure",
+                        linked_subject_refs=linked,
+                        subject_state_relation=SubjectStateRelation.UNKNOWN,
+                        content_visibility="available",
+                        content_digest=item.content_digest,
+                        content_bytes=item.content_bytes,
+                    )
+                )
+
+    # Cap lists per selection.
+    goal_ids = goal_ids[:4]
+    obligation_ids = obligation_ids[:32]
+    claim_ids = claim_ids[:32]
+    decision_ids = decision_ids[:16]
+    timeline_ids = timeline_ids[: selection.max_timeline_items]
+    review_assessments = review_assessments[: selection.max_assessments]
+    changes = changes[: selection.max_change_observations]
+    targeted = targeted[: selection.max_excerpts]
+    omissions = omissions[: selection.max_omissions]
+
+    kind_order = {
+        kind: ordinal
+        for ordinal, kind in enumerate(
+            (
+                FindingKind.COMPLETION_WITH_OPEN_OBLIGATIONS,
+                FindingKind.REQUESTED_ITEM_NEVER_ATTEMPTED,
+                FindingKind.FAILED_WORK_OMITTED,
+                FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+                FindingKind.RESULT_WITHOUT_ACTION,
+                FindingKind.ACTION_WITHOUT_RESULT,
+                FindingKind.STALE_EVIDENCE_FOR_CHANGED_STATE,
+                FindingKind.CONTRADICTORY_CLAIMS_UNRESOLVED,
+                FindingKind.LEDGER_STALE_OR_INCOMPLETE,
+                FindingKind.WEAK_OR_STALE_RESPONSE,
+                FindingKind.EVIDENCE_DOES_NOT_SUPPORT_CLAIM,
+                FindingKind.DIFF_DOES_NOT_MATCH_ACCOUNT,
+                FindingKind.MATERIAL_LIMITATION_OMITTED,
+                FindingKind.QUESTIONABLE_FINDING_REJECTION,
+            )
+        )
+    }
+    review_assessments.sort(
+        key=lambda item: (
+            kind_order[item.finding_kind],
+            tuple(ref.encode("ascii") for ref in item.subject_refs),
+        )
+    )
+    changes.sort(key=lambda item: tuple(ref.encode("ascii") for ref in item.subject_refs))
+    omissions.sort(
+        key=lambda item: (
+            item.subject_ref.encode("ascii"),
+            item.category.value.encode("ascii"),
+            item.reason.encode("ascii"),
+        )
+    )
+
+    # Keep only items that remain referenced after caps.
+    keep_ids = (
+        set(goal_ids) | set(obligation_ids) | set(claim_ids) | set(decision_ids) | set(timeline_ids)
+    )
+    for assessment in review_assessments:
+        if assessment.summary_item_id is not None and assessment.detail_item_id is not None:
+            keep_ids.add(assessment.summary_item_id)
+            keep_ids.add(assessment.detail_item_id)
+    for excerpt in targeted:
+        keep_ids.add(excerpt.excerpt_item_id)
+
+    items = [item for item in items if item.item_id in keep_ids]
+    # Sort items per SemanticCase order.
+    _SECTION_ORDINAL = {
+        "goal": 0,
+        "obligation": 1,
+        "claim": 2,
+        "decision": 3,
+        "timeline": 4,
+        "deterministic_summary": 5,
+        "deterministic_detail": 6,
+        "excerpt": 7,
+    }
+    items.sort(
+        key=lambda item: (
+            _SECTION_ORDINAL[item.section],
+            item.occurred_order,
+            item.source_ref.encode("ascii"),
+            item.item_id.encode("ascii"),
+        )
+    )
+
+    if not items:
+        # Empty frozen case: still emit a frontier structural item so the case is valid.
+        body = {
+            "kind": "frontier",
+            "sequence": frozen_case.frontier.sequence,
+            "head_digest": frozen_case.frontier.head_digest,
+            "dependency_digest": dependency_digest,
+        }
+        item = _content_item(
+            item_id="timeline-frontier",
+            section="timeline",
+            category=DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            source_kind="task",
+            source_ref=f"frontier-{frozen_case.frontier.sequence}",
+            linked_subject_refs=(),
+            occurred_order=frozen_case.frontier.sequence,
+            text=_structural_json(body),
+        )
+        items = [item]
+        timeline_ids = [item.item_id]
+
+    coverage = case_coverage(frozen_case, semantic=True)
+    packet = ReviewPacket(
+        goal_item_ids=tuple(goal_ids),
+        obligation_item_ids=tuple(obligation_ids),
+        claim_item_ids=tuple(claim_ids),
+        decision_item_ids=tuple(decision_ids),
+        timeline_item_ids=tuple(timeline_ids),
+        deterministic_assessments=tuple(review_assessments),
+        change_observations=tuple(changes),
+        coverage=coverage,
+        targeted_excerpts=tuple(targeted),
+        omissions=tuple(omissions),
+    )
+
+    selection_digest = review_selection_digest(selection)
+    case_digest = canonical_digest(
+        cast(
+            JsonValue,
+            {
+                "dependency_digest": dependency_digest,
+                "frontier_refs": sorted(frontier_refs),
+                "items": [
+                    {
+                        "content_digest": item.content_digest,
+                        "item_id": item.item_id,
+                        "section": item.section,
+                    }
+                    for item in items
+                ],
+                "local_check_refs": sorted(local_check_refs),
+                "policy_id": policy_id,
+                "policy_version": policy_version,
+                "question_set": list(_QUESTION_SET),
+                "review_context_profile": review_context_profile.value,
+                "review_selection_digest": selection_digest,
+                "schema": "yoetz.semantic-case/1",
+                "subject_frontier": dict(frozen_case.frontier.as_wire()),
+            },
+        )
+    )
+
+    return SemanticCase(
+        case_id=case_id,
+        subject_frontier=frozen_case.frontier,
+        dependency_digest=dependency_digest,
+        frontier_refs=frontier_refs,
+        local_check_refs=local_check_refs,
+        review_context_profile=review_context_profile,
+        review_selection=selection,
+        policy_id=policy_id,
+        policy_version=policy_version,
+        packet=packet,
+        items=tuple(items),
+        question_set=_QUESTION_SET,
+        case_digest=case_digest,
+    )
+
+
+def _assessment_to_json(assessment: ReviewAssessment) -> dict[str, JsonValue]:
+    body: dict[str, JsonValue] = {
+        "coverage_gaps": list(assessment.coverage_gaps),
+        "finding_kind": assessment.finding_kind.value,
+        "finding_ref": str(assessment.finding_ref),
+        "observed_facts": [
+            {"fact_code": fact.fact_code, "subject_refs": list(fact.subject_refs)}
+            for fact in assessment.observed_facts
+        ],
+        "priority": assessment.priority,
+        "required_but_missing_facts": [
+            {"fact_code": fact.fact_code, "subject_refs": list(fact.subject_refs)}
+            for fact in assessment.required_but_missing_facts
+        ],
+        "rule_id": assessment.rule_id,
+        "source_availability": assessment.source_availability.value,
+        "subject_refs": list(assessment.subject_refs),
+        "subject_state_relation": assessment.subject_state_relation.value,
+        "supporting_refs": list(assessment.supporting_refs),
+    }
+    if assessment.summary_item_id is not None and assessment.detail_item_id is not None:
+        body["summary_item_id"] = assessment.summary_item_id
+        body["detail_item_id"] = assessment.detail_item_id
+    return body
+
+
+def _packet_to_json(packet: ReviewPacket) -> dict[str, JsonValue]:
+    return cast(
+        dict[str, JsonValue],
+        {
+            "change_observations": [
+                {
+                    "claimed_change": item.claimed_change,
+                    "content_visibility": item.content_visibility,
+                    "subject_refs": list(item.subject_refs),
+                    "subject_state_relation": item.subject_state_relation.value,
+                    **(
+                        {
+                            "after_state_digest": item.after_state_digest,
+                            "before_state_digest": item.before_state_digest,
+                        }
+                        if item.before_state_digest is not None
+                        else {}
+                    ),
+                }
+                for item in packet.change_observations
+            ],
+            "claim_item_ids": list(packet.claim_item_ids),
+            "coverage": coverage_to_json(packet.coverage),
+            "decision_item_ids": list(packet.decision_item_ids),
+            "deterministic_assessments": [
+                _assessment_to_json(item) for item in packet.deterministic_assessments
+            ],
+            "goal_item_ids": list(packet.goal_item_ids),
+            "obligation_item_ids": list(packet.obligation_item_ids),
+            "omissions": [
+                {
+                    "category": item.category.value,
+                    "reason": item.reason,
+                    "source_kind": item.source_kind,
+                    "subject_ref": item.subject_ref,
+                }
+                for item in packet.omissions
+            ],
+            "targeted_excerpts": [
+                {
+                    "content_bytes": item.content_bytes,
+                    "content_digest": item.content_digest,
+                    "content_visibility": item.content_visibility,
+                    "excerpt_item_id": item.excerpt_item_id,
+                    "linked_subject_refs": list(item.linked_subject_refs),
+                    "source_kind": item.source_kind,
+                    "subject_state_relation": item.subject_state_relation.value,
+                }
+                for item in packet.targeted_excerpts
+            ],
+            "timeline_item_ids": list(packet.timeline_item_ids),
+        },
+    )
+
+
+def _case_envelope_json(case: SemanticCase) -> dict[str, JsonValue]:
+    return cast(
+        dict[str, JsonValue],
+        {
+            "case_digest": case.case_digest,
+            "case_id": case.case_id,
+            "dependency_digest": case.dependency_digest,
+            "frontier_refs": sorted(case.frontier_refs),
+            "local_check_refs": sorted(case.local_check_refs),
+            "policy_id": case.policy_id,
+            "policy_version": case.policy_version,
+            "question_set": list(case.question_set),
+            "review_context_profile": case.review_context_profile.value,
+            "review_packet": _packet_to_json(case.packet),
+            "review_selection_digest": review_selection_digest(case.review_selection),
+            "schema": _PACKET_SCHEMA,
+            "subject_frontier": dict(case.subject_frontier.as_wire()),
+        },
+    )
+
+
+def semantic_case_to_candidate_context(
+    case: SemanticCase,
+    *,
+    request_id: str,
+    scope: AuthorizationScope,
+    provider_binding: ProviderBinding,
+) -> CandidateContext:
+    """Project a semantic case into separate privacy-classified candidate items."""
+
+    if type(case) is not SemanticCase:
+        raise TypeError("semantic_case_invalid")
+    envelope = canonical_encode(cast(JsonValue, _case_envelope_json(case)))
+    if len(envelope) > MAX_SEMANTIC_ITEM_BYTES:
+        # Packet envelope must remain structural and bounded: drop prose-bearing assessment links
+        # already live as separate items; keep assessments without item id references if needed.
+        compact = _case_envelope_json(case)
+        packet = cast(dict[str, JsonValue], compact["review_packet"])
+        assessments = cast(list[JsonValue], packet["deterministic_assessments"])
+        stripped: list[JsonValue] = []
+        for raw in assessments:
+            row = dict(cast(dict[str, JsonValue], raw))
+            row.pop("summary_item_id", None)
+            row.pop("detail_item_id", None)
+            stripped.append(row)
+        packet["deterministic_assessments"] = stripped
+        envelope = canonical_encode(cast(JsonValue, compact))
+        if len(envelope) > MAX_SEMANTIC_ITEM_BYTES:
+            # Last resort: assessments truncated in envelope; content items still carry prose.
+            packet["deterministic_assessments"] = stripped[:8]
+            packet["omissions"] = cast(list[JsonValue], packet["omissions"])[:16]
+            envelope = canonical_encode(cast(JsonValue, compact))
+
+    items: list[CandidateContextItem] = [
+        CandidateContextItem(
+            REVIEW_PACKET_ITEM_ID,
+            DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            scope,
+            "/case/review-packet",
+            envelope,
+        )
+    ]
+    for item in case.items:
+        items.append(
+            CandidateContextItem(
+                item.item_id,
+                item.category,
+                scope,
+                f"/case/{item.section}/{item.item_id}",
+                item.content,
+            )
+        )
+    return CandidateContext(
+        request_id=request_id,
+        channel=EgressChannel.LLM_INFERENCE,
+        local_sink=None,
+        purpose=SEMANTIC_REVIEW_PURPOSE,
+        scope=scope,
+        subject_digest=case.case_digest,
+        provider_binding=provider_binding,
+        items=tuple(items),
+    )
+
+
+def semantic_case_to_prepared_payload(
+    case: SemanticCase,
+    included_item_ids: frozenset[str] | set[str],
+) -> bytes:
+    """Assemble the provider-facing review-packet document from privacy-approved items."""
+
+    included = set(included_item_ids)
+    content_items = [item for item in case.items if item.item_id in included]
+    # Update packet lists to only reference included content.
+    packet = case.packet
+    omitted_extra: list[dict[str, JsonValue]] = []
+    for item in case.items:
+        if item.item_id in included:
+            continue
+        subject = (
+            item.source_ref
+            if item.source_ref in (case.frontier_refs | case.local_check_refs)
+            else next(iter(item.linked_subject_refs), item.source_ref)
+        )
+        omitted_extra.append(
+            cast(
+                dict[str, JsonValue],
+                {
+                    "category": item.category.value,
+                    "reason": "withheld_by_policy",
+                    "source_kind": item.source_kind,
+                    "subject_ref": subject,
+                },
+            )
+        )
+
+    def _filter_ids(ids: tuple[str, ...]) -> list[str]:
+        return [item_id for item_id in ids if item_id in included]
+
+    assessments: list[dict[str, JsonValue]] = []
+    for assessment in packet.deterministic_assessments:
+        body = _assessment_to_json(assessment)
+        if assessment.summary_item_id is not None and assessment.detail_item_id is not None:
+            if (
+                assessment.summary_item_id not in included
+                or assessment.detail_item_id not in included
+            ):
+                body.pop("summary_item_id", None)
+                body.pop("detail_item_id", None)
+        assessments.append(body)
+
+    excerpts = [
+        {
+            "content_bytes": item.content_bytes,
+            "content_digest": item.content_digest,
+            "content_visibility": item.content_visibility,
+            "excerpt_item_id": item.excerpt_item_id,
+            "linked_subject_refs": list(item.linked_subject_refs),
+            "source_kind": item.source_kind,
+            "subject_state_relation": item.subject_state_relation.value,
+        }
+        for item in packet.targeted_excerpts
+        if item.excerpt_item_id in included
+    ]
+
+    base_omissions: list[dict[str, JsonValue]] = [
+        cast(
+            dict[str, JsonValue],
+            {
+                "category": item.category.value,
+                "reason": item.reason,
+                "source_kind": item.source_kind,
+                "subject_ref": item.subject_ref,
+            },
+        )
+        for item in packet.omissions
+    ]
+    # Dedup omissions by (subject_ref, category, reason).
+    seen: set[tuple[str, str, str]] = set()
+    omissions: list[dict[str, JsonValue]] = []
+    for row in [*base_omissions, *omitted_extra]:
+        key = (
+            cast(str, row["subject_ref"]),
+            cast(str, row["category"]),
+            cast(str, row["reason"]),
+        )
+        if key in seen:
+            continue
+        # subject_ref must be allowlisted; skip invalid withheld markers.
+        if key[0] not in (case.frontier_refs | case.local_check_refs):
+            continue
+        seen.add(key)
+        omissions.append(row)
+    omissions.sort(
+        key=lambda row: (
+            cast(str, row["subject_ref"]).encode("ascii"),
+            cast(str, row["category"]).encode("ascii"),
+            cast(str, row["reason"]).encode("ascii"),
+        )
+    )
+
+    document = cast(
+        dict[str, JsonValue],
+        {
+            "case_digest": case.case_digest,
+            "case_id": case.case_id,
+            "dependency_digest": case.dependency_digest,
+            "frontier_refs": sorted(case.frontier_refs),
+            "items": [
+                {
+                    "category": item.category.value,
+                    "content": item.content.decode("utf-8"),
+                    "content_bytes": item.content_bytes,
+                    "content_digest": item.content_digest,
+                    "item_id": item.item_id,
+                    "linked_subject_refs": list(item.linked_subject_refs),
+                    "section": item.section,
+                    "source_kind": item.source_kind,
+                    "source_ref": item.source_ref,
+                }
+                for item in content_items
+            ],
+            "local_check_refs": sorted(case.local_check_refs),
+            "policy_id": case.policy_id,
+            "policy_version": case.policy_version,
+            "question_set": list(case.question_set),
+            "review_context_profile": case.review_context_profile.value,
+            "review_packet": {
+                "change_observations": [
+                    {
+                        "claimed_change": item.claimed_change,
+                        "content_visibility": item.content_visibility,
+                        "subject_refs": list(item.subject_refs),
+                        "subject_state_relation": item.subject_state_relation.value,
+                    }
+                    for item in packet.change_observations
+                ],
+                "claim_item_ids": _filter_ids(packet.claim_item_ids),
+                "coverage": coverage_to_json(packet.coverage),
+                "decision_item_ids": _filter_ids(packet.decision_item_ids),
+                "deterministic_assessments": assessments,
+                "goal_item_ids": _filter_ids(packet.goal_item_ids),
+                "obligation_item_ids": _filter_ids(packet.obligation_item_ids),
+                "omissions": omissions,
+                "targeted_excerpts": excerpts,
+                "timeline_item_ids": _filter_ids(packet.timeline_item_ids),
+            },
+            "review_selection_digest": review_selection_digest(case.review_selection),
+            "schema": _PACKET_SCHEMA,
+            "subject_frontier": dict(case.subject_frontier.as_wire()),
+        },
+    )
+    return canonical_encode(cast(JsonValue, document))

--- a/src/yoetz/application/semantic_case.py
+++ b/src/yoetz/application/semantic_case.py
@@ -61,6 +61,7 @@ from yoetz.protocol.models import (
 __all__ = [
     "REVIEW_PACKET_ITEM_ID",
     "SEMANTIC_REVIEW_PURPOSE",
+    "assemble_filtered_review_packet",
     "build_semantic_case",
     "review_selection_digest",
     "semantic_case_to_candidate_context",
@@ -162,15 +163,14 @@ def _content_item(
     occurred_order: int,
     text: str,
 ) -> SemanticCaseItem:
-    content = _utf8(
-        text[:MAX_REVIEW_TEXT_BYTES] if len(text.encode("utf-8")) > MAX_REVIEW_TEXT_BYTES else text
-    )
-    if len(content) > MAX_SEMANTIC_ITEM_BYTES:
-        content = content[:MAX_SEMANTIC_ITEM_BYTES]
-        # Keep valid UTF-8 after truncation.
-        content = content.decode("utf-8", errors="ignore").encode("utf-8")
-        if not content:
-            raise ValueError("semantic_case_content_invalid")
+    # Bound by UTF-8 bytes, not characters — multi-byte prose must not raise.
+    limit = min(MAX_REVIEW_TEXT_BYTES, MAX_SEMANTIC_ITEM_BYTES)
+    raw = text.encode("utf-8")
+    if len(raw) > limit:
+        raw = raw[:limit].decode("utf-8", errors="ignore").encode("utf-8")
+    if not raw:
+        raise ValueError("semantic_case_content_invalid")
+    content = _utf8(raw.decode("utf-8"), maximum=limit)
     digest = "sha256:" + hashlib.sha256(content).hexdigest()
     return SemanticCaseItem(
         item_id=item_id,
@@ -562,7 +562,16 @@ def build_semantic_case(
         timeline_candidates.sort(
             key=lambda row: (row[0], row[1].encode("ascii"), row[3].encode("ascii"))
         )
-        for order, _event, source_kind, source_ref, body in timeline_candidates[
+        # item_id is timeline-{source_ref}; duplicate source_ref would invalidate the case.
+        seen_timeline_refs: set[str] = set()
+        deduped_timeline: list[tuple[int, str, _SourceKind, str, Mapping[str, JsonValue]]] = []
+        for row in timeline_candidates:
+            source_ref = row[3]
+            if source_ref in seen_timeline_refs:
+                continue
+            seen_timeline_refs.add(source_ref)
+            deduped_timeline.append(row)
+        for order, _event, source_kind, source_ref, body in deduped_timeline[
             : selection.max_timeline_items
         ]:
             linked = (source_ref,) if source_ref in allowed else ()
@@ -589,36 +598,35 @@ def build_semantic_case(
             if selection.include_finding_prose:
                 finding_ref = str(finding.finding_id)
                 linked = tuple(str(ref) for ref in finding.subject_refs)
-                if not set(linked) <= allowed:
-                    linked = tuple(ref for ref in linked if ref in allowed)
-                if not linked:
-                    continue
-                summary_id = f"finding-summary-{finding_ref}"
-                detail_id = f"finding-detail-{finding_ref}"
-                items.append(
-                    _content_item(
-                        item_id=summary_id,
-                        section="deterministic_summary",
-                        category=DataCategory.FINDING_SUMMARY,
-                        source_kind="finding",
-                        source_ref=finding_ref,
-                        linked_subject_refs=linked,
-                        occurred_order=finding.subject_frontier.sequence,
-                        text=finding.summary,
+                # Prose requires exact-match allowlist on every subject_ref; otherwise keep the
+                # deterministic assessment without summary/detail content items.
+                if linked and set(linked) <= allowed:
+                    summary_id = f"finding-summary-{finding_ref}"
+                    detail_id = f"finding-detail-{finding_ref}"
+                    items.append(
+                        _content_item(
+                            item_id=summary_id,
+                            section="deterministic_summary",
+                            category=DataCategory.FINDING_SUMMARY,
+                            source_kind="finding",
+                            source_ref=finding_ref,
+                            linked_subject_refs=linked,
+                            occurred_order=finding.subject_frontier.sequence,
+                            text=finding.summary,
+                        )
                     )
-                )
-                items.append(
-                    _content_item(
-                        item_id=detail_id,
-                        section="deterministic_detail",
-                        category=DataCategory.FINDING_SUMMARY,
-                        source_kind="finding",
-                        source_ref=finding_ref,
-                        linked_subject_refs=linked,
-                        occurred_order=finding.subject_frontier.sequence,
-                        text=finding.detail,
+                    items.append(
+                        _content_item(
+                            item_id=detail_id,
+                            section="deterministic_detail",
+                            category=DataCategory.FINDING_SUMMARY,
+                            source_kind="finding",
+                            source_ref=finding_ref,
+                            linked_subject_refs=linked,
+                            occurred_order=finding.subject_frontier.sequence,
+                            text=finding.detail,
+                        )
                     )
-                )
             projected = project_review_assessment(
                 assessment,
                 str(finding.finding_id),
@@ -819,6 +827,17 @@ def build_semantic_case(
                         _omit(ref, DataCategory.EVIDENCE_EXCERPT, "failure", "not_recorded")
                     )
                     continue
+                encoded = summary.encode("utf-8")
+                if len(encoded) > selection.max_excerpt_bytes:
+                    summary = encoded[: selection.max_excerpt_bytes].decode(
+                        "utf-8", errors="ignore"
+                    )
+                    encoded = summary.encode("utf-8")
+                if excerpt_bytes_used + len(encoded) > selection.max_total_excerpt_bytes:
+                    omissions.append(
+                        _omit(ref, DataCategory.EVIDENCE_EXCERPT, "failure", "not_selected")
+                    )
+                    continue
                 linked = tuple(
                     item
                     for item in (ref, str(record.payload.action_id), str(record.source_event_id))
@@ -849,6 +868,7 @@ def build_semantic_case(
                         content_bytes=item.content_bytes,
                     )
                 )
+                excerpt_bytes_used += item.content_bytes
 
     # Cap lists per selection.
     goal_ids = goal_ids[:4]
@@ -965,6 +985,7 @@ def build_semantic_case(
     )
 
     selection_digest = review_selection_digest(selection)
+    # Bind assessments/omissions/packet lists into the digest so provenance covers the full case.
     case_digest = canonical_digest(
         cast(
             JsonValue,
@@ -984,6 +1005,7 @@ def build_semantic_case(
                 "policy_version": policy_version,
                 "question_set": list(_QUESTION_SET),
                 "review_context_profile": review_context_profile.value,
+                "review_packet": _packet_to_json(packet),
                 "review_selection_digest": selection_digest,
                 "schema": "yoetz.semantic-case/1",
                 "subject_frontier": dict(frozen_case.frontier.as_wire()),
@@ -1089,6 +1111,27 @@ def _packet_to_json(packet: ReviewPacket) -> dict[str, JsonValue]:
     )
 
 
+def _item_catalog_json(items: Sequence[SemanticCaseItem]) -> list[dict[str, JsonValue]]:
+    """Metadata-only catalog so egress can project without reverse-engineering origin_ref."""
+
+    return [
+        cast(
+            dict[str, JsonValue],
+            {
+                "category": item.category.value,
+                "content_bytes": item.content_bytes,
+                "content_digest": item.content_digest,
+                "item_id": item.item_id,
+                "linked_subject_refs": list(item.linked_subject_refs),
+                "section": item.section,
+                "source_kind": item.source_kind,
+                "source_ref": item.source_ref,
+            },
+        )
+        for item in items
+    ]
+
+
 def _case_envelope_json(case: SemanticCase) -> dict[str, JsonValue]:
     return cast(
         dict[str, JsonValue],
@@ -1097,6 +1140,7 @@ def _case_envelope_json(case: SemanticCase) -> dict[str, JsonValue]:
             "case_id": case.case_id,
             "dependency_digest": case.dependency_digest,
             "frontier_refs": sorted(case.frontier_refs),
+            "item_catalog": _item_catalog_json(case.items),
             "local_check_refs": sorted(case.local_check_refs),
             "policy_id": case.policy_id,
             "policy_version": case.policy_version,
@@ -1108,6 +1152,230 @@ def _case_envelope_json(case: SemanticCase) -> dict[str, JsonValue]:
             "subject_frontier": dict(case.subject_frontier.as_wire()),
         },
     )
+
+
+def assemble_filtered_review_packet(
+    envelope: Mapping[str, object],
+    *,
+    content_by_id: Mapping[str, bytes],
+    included_item_ids: frozenset[str] | set[str],
+) -> bytes:
+    """Assemble ``yoetz.review-packet-case/1`` from a builder envelope + approved content.
+
+    Single shared projection used by the application prepared-payload path and the privacy
+    enforcer. Filters by approved item id only; never re-derives section/source metadata from
+    origin pointers.
+    """
+
+    included = set(included_item_ids)
+    frontier_raw = envelope.get("frontier_refs")
+    local_raw = envelope.get("local_check_refs")
+    frontier_refs: set[str] = (
+        {item for item in cast(list[object], frontier_raw) if type(item) is str}
+        if type(frontier_raw) is list
+        else set()
+    )
+    local_check_refs: set[str] = (
+        {item for item in cast(list[object], local_raw) if type(item) is str}
+        if type(local_raw) is list
+        else set()
+    )
+    allowed: set[str] = frontier_refs | local_check_refs
+
+    catalog_raw = envelope.get("item_catalog")
+    catalog: list[dict[str, object]] = []
+    if type(catalog_raw) is list:
+        for row in cast(list[object], catalog_raw):
+            if isinstance(row, dict):
+                catalog.append(cast(dict[str, object], row))
+
+    content_rows: list[dict[str, JsonValue]] = []
+    omitted_extra: list[dict[str, JsonValue]] = []
+    for meta in catalog:
+        item_id = meta.get("item_id")
+        if type(item_id) is not str or item_id == REVIEW_PACKET_ITEM_ID:
+            continue
+        category = meta.get("category")
+        source_kind = meta.get("source_kind")
+        source_ref = meta.get("source_ref")
+        section = meta.get("section")
+        linked_raw = meta.get("linked_subject_refs")
+        linked = (
+            [ref for ref in cast(list[object], linked_raw) if type(ref) is str]
+            if type(linked_raw) is list
+            else []
+        )
+        if item_id in included and item_id in content_by_id:
+            plaintext = content_by_id[item_id]
+            try:
+                text = plaintext.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            content_rows.append(
+                cast(
+                    dict[str, JsonValue],
+                    {
+                        "category": category if type(category) is str else "",
+                        "content": text,
+                        "content_bytes": len(plaintext),
+                        "content_digest": "sha256:" + hashlib.sha256(plaintext).hexdigest(),
+                        "item_id": item_id,
+                        "linked_subject_refs": linked,
+                        "section": section if type(section) is str else "timeline",
+                        "source_kind": source_kind if type(source_kind) is str else "task",
+                        "source_ref": source_ref if type(source_ref) is str else item_id,
+                    },
+                )
+            )
+            continue
+        if item_id in included:
+            continue
+        # Prefer allowlisted source_ref, then any allowlisted linked ref; skip only if none.
+        subject: str | None = None
+        if type(source_ref) is str and source_ref in allowed:
+            subject = source_ref
+        else:
+            for ref in linked:
+                if ref in allowed:
+                    subject = ref
+                    break
+        if subject is None:
+            continue
+        omitted_extra.append(
+            cast(
+                dict[str, JsonValue],
+                {
+                    "category": category if type(category) is str else "",
+                    "reason": "withheld_by_policy",
+                    "source_kind": source_kind if type(source_kind) is str else "task",
+                    "subject_ref": subject,
+                },
+            )
+        )
+    content_rows.sort(key=lambda row: cast(str, row["item_id"]).encode("ascii"))
+
+    packet_raw = envelope.get("review_packet")
+    packet_obj: dict[str, JsonValue] = (
+        cast(dict[str, JsonValue], dict(cast(dict[object, object], packet_raw)))
+        if isinstance(packet_raw, dict)
+        else {}
+    )
+
+    def _filter_ids(raw: object) -> list[JsonValue]:
+        if type(raw) is not list:
+            return []
+        return [
+            item_id
+            for item_id in cast(list[object], raw)
+            if type(item_id) is str and item_id in included
+        ]
+
+    for key in (
+        "goal_item_ids",
+        "obligation_item_ids",
+        "claim_item_ids",
+        "decision_item_ids",
+        "timeline_item_ids",
+    ):
+        packet_obj[key] = _filter_ids(packet_obj.get(key))
+
+    excerpts_raw = packet_obj.get("targeted_excerpts")
+    if type(excerpts_raw) is list:
+        packet_obj["targeted_excerpts"] = cast(
+            JsonValue,
+            [
+                row
+                for row in cast(list[object], excerpts_raw)
+                if isinstance(row, dict)
+                and cast(dict[str, object], row).get("excerpt_item_id") in included
+            ],
+        )
+    else:
+        packet_obj["targeted_excerpts"] = cast(JsonValue, [])
+
+    assessments_raw = packet_obj.get("deterministic_assessments")
+    filtered_assessments: list[JsonValue] = []
+    if type(assessments_raw) is list:
+        for raw in cast(list[object], assessments_raw):
+            if not isinstance(raw, dict):
+                continue
+            row = dict(cast(dict[str, JsonValue], cast(dict[object, object], raw)))
+            summary = row.get("summary_item_id")
+            detail = row.get("detail_item_id")
+            if type(summary) is str and type(detail) is str:
+                if summary not in included or detail not in included:
+                    row.pop("summary_item_id", None)
+                    row.pop("detail_item_id", None)
+            filtered_assessments.append(row)
+    packet_obj["deterministic_assessments"] = filtered_assessments
+
+    base_omissions: list[dict[str, JsonValue]] = []
+    omissions_raw = packet_obj.get("omissions")
+    if type(omissions_raw) is list:
+        for raw in cast(list[object], omissions_raw):
+            if isinstance(raw, dict):
+                base_omissions.append(
+                    cast(dict[str, JsonValue], dict(cast(dict[object, object], raw)))
+                )
+
+    seen: set[tuple[str, str, str]] = set()
+    omissions: list[JsonValue] = []
+    for row in [*base_omissions, *omitted_extra]:
+        subject_ref = row.get("subject_ref")
+        category = row.get("category")
+        reason = row.get("reason")
+        if type(subject_ref) is not str or type(category) is not str or type(reason) is not str:
+            continue
+        key = (subject_ref, category, reason)
+        if key in seen:
+            continue
+        if subject_ref not in allowed:
+            continue
+        seen.add(key)
+        omissions.append(row)
+    omissions.sort(
+        key=lambda row: (
+            cast(str, cast(dict[str, JsonValue], row)["subject_ref"]).encode("ascii"),
+            cast(str, cast(dict[str, JsonValue], row)["category"]).encode("ascii"),
+            cast(str, cast(dict[str, JsonValue], row)["reason"]).encode("ascii"),
+        )
+    )
+    packet_obj["omissions"] = omissions
+
+    # Preserve change_observations / coverage as supplied by the builder envelope.
+    if "change_observations" not in packet_obj:
+        packet_obj["change_observations"] = cast(JsonValue, [])
+    if "coverage" not in packet_obj:
+        packet_obj["coverage"] = cast(JsonValue, {})
+
+    document = cast(
+        dict[str, JsonValue],
+        {
+            "case_digest": envelope.get("case_digest", ""),
+            "case_id": envelope.get("case_id", ""),
+            "dependency_digest": envelope.get("dependency_digest", ""),
+            "frontier_refs": sorted(frontier_refs),
+            "items": content_rows,
+            "local_check_refs": sorted(local_check_refs),
+            "policy_id": envelope.get("policy_id", ""),
+            "policy_version": envelope.get("policy_version", ""),
+            "question_set": (
+                list(cast(list[object], envelope["question_set"]))
+                if type(envelope.get("question_set")) is list
+                else []
+            ),
+            "review_context_profile": envelope.get("review_context_profile", ""),
+            "review_packet": packet_obj,
+            "review_selection_digest": envelope.get("review_selection_digest", ""),
+            "schema": _PACKET_SCHEMA,
+            "subject_frontier": (
+                dict(cast(dict[object, object], envelope["subject_frontier"]))
+                if isinstance(envelope.get("subject_frontier"), dict)
+                else {}
+            ),
+        },
+    )
+    return canonical_encode(cast(JsonValue, document))
 
 
 def semantic_case_to_candidate_context(
@@ -1140,7 +1408,11 @@ def semantic_case_to_candidate_context(
             # Last resort: assessments truncated in envelope; content items still carry prose.
             packet["deterministic_assessments"] = stripped[:8]
             packet["omissions"] = cast(list[JsonValue], packet["omissions"])[:16]
+            catalog = cast(list[JsonValue], compact.get("item_catalog", []))
+            compact["item_catalog"] = catalog[:64]
             envelope = canonical_encode(cast(JsonValue, compact))
+        if len(envelope) > MAX_SEMANTIC_ITEM_BYTES:
+            raise ValueError("semantic_case_envelope_too_large")
 
     items: list[CandidateContextItem] = [
         CandidateContextItem(
@@ -1179,145 +1451,11 @@ def semantic_case_to_prepared_payload(
 ) -> bytes:
     """Assemble the provider-facing review-packet document from privacy-approved items."""
 
-    included = set(included_item_ids)
-    content_items = [item for item in case.items if item.item_id in included]
-    # Update packet lists to only reference included content.
-    packet = case.packet
-    omitted_extra: list[dict[str, JsonValue]] = []
-    for item in case.items:
-        if item.item_id in included:
-            continue
-        subject = (
-            item.source_ref
-            if item.source_ref in (case.frontier_refs | case.local_check_refs)
-            else next(iter(item.linked_subject_refs), item.source_ref)
-        )
-        omitted_extra.append(
-            cast(
-                dict[str, JsonValue],
-                {
-                    "category": item.category.value,
-                    "reason": "withheld_by_policy",
-                    "source_kind": item.source_kind,
-                    "subject_ref": subject,
-                },
-            )
-        )
-
-    def _filter_ids(ids: tuple[str, ...]) -> list[str]:
-        return [item_id for item_id in ids if item_id in included]
-
-    assessments: list[dict[str, JsonValue]] = []
-    for assessment in packet.deterministic_assessments:
-        body = _assessment_to_json(assessment)
-        if assessment.summary_item_id is not None and assessment.detail_item_id is not None:
-            if (
-                assessment.summary_item_id not in included
-                or assessment.detail_item_id not in included
-            ):
-                body.pop("summary_item_id", None)
-                body.pop("detail_item_id", None)
-        assessments.append(body)
-
-    excerpts = [
-        {
-            "content_bytes": item.content_bytes,
-            "content_digest": item.content_digest,
-            "content_visibility": item.content_visibility,
-            "excerpt_item_id": item.excerpt_item_id,
-            "linked_subject_refs": list(item.linked_subject_refs),
-            "source_kind": item.source_kind,
-            "subject_state_relation": item.subject_state_relation.value,
-        }
-        for item in packet.targeted_excerpts
-        if item.excerpt_item_id in included
-    ]
-
-    base_omissions: list[dict[str, JsonValue]] = [
-        cast(
-            dict[str, JsonValue],
-            {
-                "category": item.category.value,
-                "reason": item.reason,
-                "source_kind": item.source_kind,
-                "subject_ref": item.subject_ref,
-            },
-        )
-        for item in packet.omissions
-    ]
-    # Dedup omissions by (subject_ref, category, reason).
-    seen: set[tuple[str, str, str]] = set()
-    omissions: list[dict[str, JsonValue]] = []
-    for row in [*base_omissions, *omitted_extra]:
-        key = (
-            cast(str, row["subject_ref"]),
-            cast(str, row["category"]),
-            cast(str, row["reason"]),
-        )
-        if key in seen:
-            continue
-        # subject_ref must be allowlisted; skip invalid withheld markers.
-        if key[0] not in (case.frontier_refs | case.local_check_refs):
-            continue
-        seen.add(key)
-        omissions.append(row)
-    omissions.sort(
-        key=lambda row: (
-            cast(str, row["subject_ref"]).encode("ascii"),
-            cast(str, row["category"]).encode("ascii"),
-            cast(str, row["reason"]).encode("ascii"),
-        )
+    if type(case) is not SemanticCase:
+        raise TypeError("semantic_case_invalid")
+    content_by_id = {item.item_id: item.content for item in case.items}
+    return assemble_filtered_review_packet(
+        _case_envelope_json(case),
+        content_by_id=content_by_id,
+        included_item_ids=included_item_ids,
     )
-
-    document = cast(
-        dict[str, JsonValue],
-        {
-            "case_digest": case.case_digest,
-            "case_id": case.case_id,
-            "dependency_digest": case.dependency_digest,
-            "frontier_refs": sorted(case.frontier_refs),
-            "items": [
-                {
-                    "category": item.category.value,
-                    "content": item.content.decode("utf-8"),
-                    "content_bytes": item.content_bytes,
-                    "content_digest": item.content_digest,
-                    "item_id": item.item_id,
-                    "linked_subject_refs": list(item.linked_subject_refs),
-                    "section": item.section,
-                    "source_kind": item.source_kind,
-                    "source_ref": item.source_ref,
-                }
-                for item in content_items
-            ],
-            "local_check_refs": sorted(case.local_check_refs),
-            "policy_id": case.policy_id,
-            "policy_version": case.policy_version,
-            "question_set": list(case.question_set),
-            "review_context_profile": case.review_context_profile.value,
-            "review_packet": {
-                "change_observations": [
-                    {
-                        "claimed_change": item.claimed_change,
-                        "content_visibility": item.content_visibility,
-                        "subject_refs": list(item.subject_refs),
-                        "subject_state_relation": item.subject_state_relation.value,
-                    }
-                    for item in packet.change_observations
-                ],
-                "claim_item_ids": _filter_ids(packet.claim_item_ids),
-                "coverage": coverage_to_json(packet.coverage),
-                "decision_item_ids": _filter_ids(packet.decision_item_ids),
-                "deterministic_assessments": assessments,
-                "goal_item_ids": _filter_ids(packet.goal_item_ids),
-                "obligation_item_ids": _filter_ids(packet.obligation_item_ids),
-                "omissions": omissions,
-                "targeted_excerpts": excerpts,
-                "timeline_item_ids": _filter_ids(packet.timeline_item_ids),
-            },
-            "review_selection_digest": review_selection_digest(case.review_selection),
-            "schema": _PACKET_SCHEMA,
-            "subject_frontier": dict(case.subject_frontier.as_wire()),
-        },
-    )
-    return canonical_encode(cast(JsonValue, document))

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -52,6 +52,10 @@ from yoetz.application.observation_coordinator import ObservationCoordinator
 from yoetz.application.observation_verification import ObservationVerificationSupervisor
 from yoetz.application.privacy_control import build_privacy_support_handlers
 from yoetz.application.privacy_policy import PrivacyPolicyApplication
+from yoetz.application.semantic_case import (
+    build_semantic_case,
+    semantic_case_to_candidate_context,
+)
 from yoetz.application.service import (
     ControlProjectionBinding,
     ReadyApplicationFactory,
@@ -62,7 +66,12 @@ from yoetz.config.models import YoetzConfig
 from yoetz.config.paths import ensure_owner_only_dir, verify_private_local_bundle
 from yoetz.config.privacy import safe_privacy_bootstrap, seed_policy_if_absent
 from yoetz.domain.events import RuntimeProfile
-from yoetz.domain.findings import SemanticDispatchKind, SemanticFailureClass, SemanticProvenance
+from yoetz.domain.findings import (
+    Finding,
+    SemanticDispatchKind,
+    SemanticFailureClass,
+    SemanticProvenance,
+)
 from yoetz.domain.privacy import (
     AuthorizationScope,
     AuthorizationScopeKind,
@@ -1469,54 +1478,37 @@ def _privacy_gated_semantic_evaluator(
                 workspace,
                 route.task_id,
             )
-            finding_ids: list[str] = []
-            for finding in findings:
-                finding_id = getattr(finding, "finding_id", None)
-                if type(finding_id) is str:
-                    finding_ids.append(finding_id)
-            case = frozen.case
-            payload = canonical_encode(
-                cast(
-                    CanonicalJsonValue,
-                    {
-                        "dependency_digest": frozen.lease.dependency_digest,
-                        "findings": finding_ids,
-                        "frontier": {
-                            "head_digest": case.frontier.head_digest,
-                            "sequence": case.frontier.sequence,
-                        },
-                        "schema": "yoetz.semantic-check-candidate/1",
-                    },
-                )
+            typed_findings = tuple(item for item in findings if type(item) is Finding)
+            # Live effective policy owns review selection; selection narrows candidates only.
+            # Composition test doubles may omit the policy application: fall back to structural.
+            policy_app = getattr(privacy, "policy_application", None)
+            if policy_app is not None:
+                effective = await policy_app.policy_store.effective_policy(scope)
+                policy = effective.policy
+                review_profile = policy.review_context_profile
+                review_selection = policy.review_selection
+                policy_id = policy.policy_id
+                policy_version = str(policy.version)
+            else:
+                review_profile = ReviewContextProfile.STRUCTURAL
+                review_selection = ReviewSelectionPolicy.for_profile(review_profile)
+                policy_id = ids.new(IdKind.PRIVACY_POLICY)
+                policy_version = "1"
+            semantic_case = build_semantic_case(
+                case_id=ids.new(IdKind.OUTBOUND_CASE),
+                frozen_case=frozen.case,
+                dependency_digest=frozen.lease.dependency_digest,
+                findings=typed_findings,
+                review_context_profile=review_profile,
+                review_selection=review_selection,
+                policy_id=policy_id,
+                policy_version=policy_version,
             )
-            candidate = CandidateContext(
+            candidate = semantic_case_to_candidate_context(
+                semantic_case,
                 request_id=frozen.lease.operation_id,
-                channel=EgressChannel.LLM_INFERENCE,
-                local_sink=None,
-                purpose="semantic-review",
                 scope=scope,
-                subject_digest=canonical_digest(
-                    cast(
-                        CanonicalJsonValue,
-                        {
-                            "frontier": {
-                                "head_digest": case.frontier.head_digest,
-                                "sequence": case.frontier.sequence,
-                            },
-                            "schema": "yoetz.semantic-check-subject/1",
-                        },
-                    )
-                ),
                 provider_binding=provider,
-                items=(
-                    CandidateContextItem(
-                        "case-packet",
-                        DataCategory.BOUNDED_STRUCTURAL_METADATA,
-                        scope,
-                        "/case",
-                        payload,
-                    ),
-                ),
             )
             deadline = Deadline(clock.now_utc(), clock.monotonic_seconds() + 60.0)
             result = await privacy.evaluate_semantic(candidate, deadline)

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1479,21 +1479,24 @@ def _privacy_gated_semantic_evaluator(
                 route.task_id,
             )
             typed_findings = tuple(item for item in findings if type(item) is Finding)
-            # Live effective policy owns review selection; selection narrows candidates only.
-            # Composition test doubles may omit the policy application: fall back to structural.
+            # Live effective policy owns review selection; never mint a synthetic policy identity.
             policy_app = getattr(privacy, "policy_application", None)
-            if policy_app is not None:
-                effective = await policy_app.policy_store.effective_policy(scope)
-                policy = effective.policy
-                review_profile = policy.review_context_profile
-                review_selection = policy.review_selection
-                policy_id = policy.policy_id
-                policy_version = str(policy.version)
-            else:
-                review_profile = ReviewContextProfile.STRUCTURAL
-                review_selection = ReviewSelectionPolicy.for_profile(review_profile)
-                policy_id = ids.new(IdKind.PRIVACY_POLICY)
-                policy_version = "1"
+            if policy_app is None:
+                record_bounded_event_without_raising(
+                    component="semantic_composition",
+                    operation="semantic_not_dispatched_policy_unavailable",
+                    reason=SemanticReason.COORDINATOR_FAILURE.value,
+                    request_id=frozen.lease.operation_id,
+                )
+                return FinalSemanticEvaluation(
+                    SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE
+                )
+            effective = await policy_app.policy_store.effective_policy(scope)
+            policy = effective.policy
+            review_profile = policy.review_context_profile
+            review_selection = policy.review_selection
+            policy_id = policy.policy_id
+            policy_version = str(policy.version)
             semantic_case = build_semantic_case(
                 case_id=ids.new(IdKind.OUTBOUND_CASE),
                 frozen_case=frozen.case,

--- a/tests/integration/service/test_semantic_non_dispatch.py
+++ b/tests/integration/service/test_semantic_non_dispatch.py
@@ -14,16 +14,28 @@ from builders.ledger_adapters import FixedClock
 from builders.policy_cases import FRONTIER, make_case
 from yoetz.application.check import FinalSemanticEvaluation, semantic_coverage_gap_code
 from yoetz.application.egress import PrivacyCoordinator, SemanticEgressAwaitingHuman
-from yoetz.domain.privacy import ProviderBinding
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ChannelPolicy,
+    DataClass,
+    EgressChannel,
+    PrivacyPolicy,
+    PrivacyProfile,
+    ProviderBinding,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
 from yoetz.domain.receipts import (
     SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP,
     SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
 )
 from yoetz.ports.keys import MacKeyHandle
 from yoetz.ports.ledger import CheckPhase, FrozenCase, OperationLease
+from yoetz.ports.privacy import EffectivePrivacyPolicy
 from yoetz.ports.start_catalog import StartCatalogPort, TaskRoute, TaskRouteState
 from yoetz.protocol.canonical import canonical_digest
-from yoetz.protocol.models import SemanticReason, SemanticStatus
+from yoetz.protocol.models import DataCategory, SemanticReason, SemanticStatus
 
 _TASK = "tsk_53000000-0000-4000-8000-000000000001"
 _SESSION = "ses_53000000-0000-4000-8000-000000000001"
@@ -43,9 +55,77 @@ type _SemanticEvaluator = Callable[
 ]
 
 
+def _test_effective_policy() -> EffectivePrivacyPolicy:
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        "hmac-sha256:" + "b" * 64,
+        _TASK,
+    )
+
+    def _disabled(channel: EgressChannel) -> ChannelPolicy:
+        return ChannelPolicy(
+            channel,
+            False,
+            (),
+            (),
+            None,
+            (),
+            AuthorizationScopeKind.MACHINE,
+            False,
+            0,
+            0,
+            0,
+        )
+
+    policy = PrivacyPolicy(
+        policy_id="pvy_53000000-0000-4000-8000-000000000001",
+        version=1,
+        policy_digest="sha256:" + "c" * 64,
+        profile=PrivacyProfile.LOCAL_ONLY,
+        review_context_profile=ReviewContextProfile.STRUCTURAL,
+        review_selection=ReviewSelectionPolicy.for_profile(ReviewContextProfile.STRUCTURAL),
+        require_current_provider_data_use_evidence=False,
+        network_egress_permitted=False,
+        effective_scope=scope,
+        channel_policies=tuple(
+            _disabled(channel) for channel in sorted(EgressChannel, key=lambda c: c.value)
+        ),
+        local_model_enabled=False,
+        local_model_binding=None,
+        local_model_categories=(),
+        local_model_data_classes=(),
+        agent_context_categories=(DataCategory.FINDING_SUMMARY,),
+        agent_context_data_classes=(DataClass.ORDINARY_USER_CONTENT, DataClass.PUBLIC_STRUCTURAL),
+        trusted_human_control_categories=tuple(DataCategory),
+        trusted_human_control_data_classes=(
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+        ),
+        created_at=datetime(2030, 1, 1, tzinfo=UTC),
+    )
+    return EffectivePrivacyPolicy(policy, 1, policy.policy_digest)
+
+
+class _PolicyStore:
+    def __init__(self, effective: EffectivePrivacyPolicy) -> None:
+        self._effective = effective
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return self._effective
+
+
+class _PolicyApplication:
+    def __init__(self, effective: EffectivePrivacyPolicy) -> None:
+        self.policy_store = _PolicyStore(effective)
+
+
 class _Privacy:
     def __init__(self) -> None:
         self.calls = 0
+        # Real policy path is required for dispatch; never mint synthetic policy identity.
+        self.policy_application = _PolicyApplication(_test_effective_policy())
 
     async def evaluate_semantic(self, candidate: object, deadline: object) -> object:
         del deadline

--- a/tests/unit/application/test_semantic_case.py
+++ b/tests/unit/application/test_semantic_case.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Sequence
 
 from builders.policy_cases import (
     clm,
@@ -31,6 +32,7 @@ from yoetz.domain.events import (
     ObligationStatus,
     PlanPublishedPayload,
 )
+from yoetz.domain.findings import Finding
 from yoetz.domain.privacy import (
     AuthorizationScope,
     AuthorizationScopeKind,
@@ -38,7 +40,11 @@ from yoetz.domain.privacy import (
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
-from yoetz.domain.values import timestamp_from_string
+from yoetz.domain.values import EvidenceId, timestamp_from_string
+from yoetz.kernel.deterministic_checks import DeterministicCase
+from yoetz.kernel.projections import EvidenceProjectionRecord
+from yoetz.ports.semantic import SemanticCase
+from yoetz.protocol.canonical import strict_json_parse
 from yoetz.protocol.coverage import EvidenceImmutability
 from yoetz.protocol.ids import IdKind, new_id
 from yoetz.protocol.models import DataCategory
@@ -49,7 +55,7 @@ class _Ids:
         return new_id(kind)
 
 
-def _case_with_material(*, with_evidence: bool = True):
+def _case_with_material(*, with_evidence: bool = True) -> DeterministicCase:
     plan = plan_record(PlanPublishedPayload(1, "Ship the review packet", (obl(1),)), 1)
     obligation = obligation_record(
         ObligationPublishedPayload(
@@ -68,7 +74,7 @@ def _case_with_material(*, with_evidence: bool = True):
         ),
         3,
     )
-    evidence = {}
+    evidence: dict[EvidenceId, EvidenceProjectionRecord] = {}
     extra = (clm(1), obl(1))
     if with_evidence:
         evidence[evd(1)] = evidence_record(
@@ -91,7 +97,7 @@ def _case_with_material(*, with_evidence: bool = True):
     )
 
 
-def _findings_for(case):
+def _findings_for(case: DeterministicCase) -> tuple[Finding, ...]:
     assessments, _ = run_deterministic_policies(
         case,
         CheckScope((), ()),
@@ -101,12 +107,12 @@ def _findings_for(case):
 
 
 def _build(
-    case,
+    case: DeterministicCase,
     profile: ReviewContextProfile,
     *,
-    findings=(),
+    findings: Sequence[Finding] = (),
     dependency: str = "sha256:" + "b" * 64,
-):
+) -> SemanticCase:
     return build_semantic_case(
         case_id="cas_10000000-0000-4000-8000-000000000001",
         frozen_case=case,
@@ -281,7 +287,28 @@ def test_prepared_payload_binds_selected_packet_and_withheld_omissions() -> None
     }
     payload = semantic_case_to_prepared_payload(semantic, included)
     assert b"yoetz.review-packet-case/1" in payload
-    assert b"withheld_by_policy" in payload or b"timeline" in payload
+    document = strict_json_parse(payload)
+    assert isinstance(document, dict)
+    packet = document.get("review_packet")
+    assert isinstance(packet, dict)
+    omissions = packet.get("omissions")
+    assert isinstance(omissions, list)
+    reasons: set[str] = set()
+    for row in omissions:
+        if isinstance(row, dict):
+            reason = row.get("reason")
+            if type(reason) is str:
+                reasons.add(reason)
+    assert "withheld_by_policy" in reasons
+    raw_items = document.get("items")
+    assert isinstance(raw_items, list)
+    item_ids: set[str] = set()
+    for row in raw_items:
+        if isinstance(row, dict):
+            item_id = row.get("item_id")
+            if type(item_id) is str:
+                item_ids.add(item_id)
+    assert item_ids == included
     assert semantic.case_digest.encode("ascii") in payload
 
 

--- a/tests/unit/application/test_semantic_case.py
+++ b/tests/unit/application/test_semantic_case.py
@@ -1,0 +1,310 @@
+"""Frozen privacy-selected semantic case construction (plan 03 / issue #69)."""
+
+from __future__ import annotations
+
+import inspect
+
+from builders.policy_cases import (
+    clm,
+    evd,
+    evidence_record,
+    make_case,
+    obl,
+    obligation_record,
+    plan_record,
+    record,
+)
+from yoetz.application.check import CheckScope, allocate_findings, run_deterministic_policies
+from yoetz.application.semantic_case import (
+    REVIEW_PACKET_ITEM_ID,
+    build_semantic_case,
+    review_selection_digest,
+    semantic_case_to_candidate_context,
+    semantic_case_to_prepared_payload,
+)
+from yoetz.domain.events import (
+    ClaimKind,
+    ClaimRecordedPayload,
+    EvidenceKind,
+    EvidenceRecordedPayload,
+    ObligationPublishedPayload,
+    ObligationStatus,
+    PlanPublishedPayload,
+)
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ProviderBinding,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
+from yoetz.domain.values import timestamp_from_string
+from yoetz.protocol.coverage import EvidenceImmutability
+from yoetz.protocol.ids import IdKind, new_id
+from yoetz.protocol.models import DataCategory
+
+
+class _Ids:
+    def new(self, kind: IdKind) -> str:
+        return new_id(kind)
+
+
+def _case_with_material(*, with_evidence: bool = True):
+    plan = plan_record(PlanPublishedPayload(1, "Ship the review packet", (obl(1),)), 1)
+    obligation = obligation_record(
+        ObligationPublishedPayload(
+            obl(1), "Build the real packet", "tests pass", ObligationStatus.OPEN
+        ),
+        2,
+    )
+    supports = (evd(1),) if with_evidence else ()
+    claim = record(
+        ClaimRecordedPayload(
+            clm(1),
+            ClaimKind.COMPLETION,
+            "Work is complete",
+            supports,
+            obligation_refs=(obl(1),),
+        ),
+        3,
+    )
+    evidence = {}
+    extra = (clm(1), obl(1))
+    if with_evidence:
+        evidence[evd(1)] = evidence_record(
+            EvidenceRecordedPayload(
+                evd(1),
+                EvidenceKind.TEST_RESULT,
+                EvidenceImmutability.METADATA_ONLY,
+                timestamp_from_string("2026-07-01T00:00:00.000Z"),
+                description="test output: 1 failed assertion",
+            ),
+            4,
+        )
+        extra = (*extra, evd(1))
+    return make_case(
+        plans={1: plan},
+        obligations={obl(1): obligation},
+        claims={clm(1): claim},
+        evidence=evidence,
+        extra_refs=extra,
+    )
+
+
+def _findings_for(case):
+    assessments, _ = run_deterministic_policies(
+        case,
+        CheckScope((), ()),
+        ("research-evidence/0.1.0", "work-integrity/0.1.0"),
+    )
+    return allocate_findings(_Ids(), tuple(item.candidate for item in assessments))
+
+
+def _build(
+    case,
+    profile: ReviewContextProfile,
+    *,
+    findings=(),
+    dependency: str = "sha256:" + "b" * 64,
+):
+    return build_semantic_case(
+        case_id="cas_10000000-0000-4000-8000-000000000001",
+        frozen_case=case,
+        dependency_digest=dependency,
+        findings=findings,
+        review_context_profile=profile,
+        review_selection=ReviewSelectionPolicy.for_profile(profile),
+        policy_id="pvy_10000000-0000-4000-8000-000000000001",
+        policy_version="1",
+    )
+
+
+def test_structural_profile_sends_no_prose_and_declares_omitted_sections() -> None:
+    case = _case_with_material()
+    semantic = _build(case, ReviewContextProfile.STRUCTURAL)
+
+    assert {item.category for item in semantic.items} == {DataCategory.BOUNDED_STRUCTURAL_METADATA}
+    assert semantic.packet.goal_item_ids == ()
+    assert semantic.packet.obligation_item_ids == ()
+    assert semantic.packet.claim_item_ids == ()
+    assert semantic.packet.targeted_excerpts == ()
+    reasons = {item.reason for item in semantic.packet.omissions}
+    assert "not_selected" in reasons
+    # Timeline / frontier structural facts remain present.
+    assert semantic.packet.timeline_item_ids
+    assert all(item.section == "timeline" for item in semantic.items)
+
+
+def test_goal_aware_profile_includes_bounded_goal_obligation_claim_with_categories() -> None:
+    case = _case_with_material()
+    semantic = _build(case, ReviewContextProfile.GOAL_AWARE)
+
+    categories = {item.category for item in semantic.items}
+    assert DataCategory.TASK_DESCRIPTION in categories
+    assert DataCategory.OBLIGATION_TEXT in categories
+    assert DataCategory.CLAIM_TEXT in categories
+    assert semantic.packet.goal_item_ids
+    assert semantic.packet.obligation_item_ids
+    assert semantic.packet.claim_item_ids
+    goal = next(item for item in semantic.items if item.section == "goal")
+    assert b"Ship the review packet" in goal.content
+    # Goal-aware still excludes targeted excerpts.
+    assert semantic.packet.targeted_excerpts == ()
+
+
+def test_assisted_profile_includes_only_linked_recorded_capped_excerpts() -> None:
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+
+    assert semantic.packet.targeted_excerpts
+    excerpt = semantic.packet.targeted_excerpts[0]
+    assert excerpt.source_kind == "test"
+    assert excerpt.content_visibility == "available"
+    body = next(item for item in semantic.items if item.item_id == excerpt.excerpt_item_id)
+    assert body.content == b"test output: 1 failed assertion"
+    assert set(excerpt.linked_subject_refs) <= (semantic.frontier_refs | semantic.local_check_refs)
+
+
+def test_withheld_and_not_selected_material_use_correct_omission_reasons() -> None:
+    case = _case_with_material()
+    structural = _build(case, ReviewContextProfile.STRUCTURAL)
+    omitted = {
+        (item.source_kind, item.reason, item.category) for item in structural.packet.omissions
+    }
+    assert ("task", "not_selected", DataCategory.TASK_DESCRIPTION) in omitted
+    assert ("obligation", "not_selected", DataCategory.OBLIGATION_TEXT) in omitted
+    assert ("claim", "not_selected", DataCategory.CLAIM_TEXT) in omitted
+
+    # No recorded decision → no decision prose under goal-aware, no invented content.
+    goal_aware = _build(case, ReviewContextProfile.GOAL_AWARE)
+    assert goal_aware.packet.decision_item_ids == ()
+    assert not any(item.section == "decision" for item in goal_aware.items)
+
+
+def test_every_supplied_ref_belongs_to_frozen_allowlist() -> None:
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+    allowed = semantic.frontier_refs | semantic.local_check_refs
+
+    for item in semantic.items:
+        assert set(item.linked_subject_refs) <= allowed
+    for assessment in semantic.packet.deterministic_assessments:
+        assert assessment.finding_ref in semantic.local_check_refs
+        assert set(assessment.subject_refs) <= semantic.frontier_refs
+        assert set(assessment.supporting_refs) <= allowed
+    for omission in semantic.packet.omissions:
+        assert omission.subject_ref in allowed
+
+
+def test_deterministic_finding_basis_and_evidence_produce_projected_assessment() -> None:
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    assert findings
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+
+    assert semantic.packet.deterministic_assessments
+    assessment = semantic.packet.deterministic_assessments[0]
+    assert assessment.observed_facts
+    assert assessment.summary_item_id is not None
+    assert assessment.detail_item_id is not None
+    summary = next(item for item in semantic.items if item.item_id == assessment.summary_item_id)
+    assert summary.category is DataCategory.FINDING_SUMMARY
+    assert summary.source_ref == str(assessment.finding_ref)
+
+
+def test_case_and_dependency_changes_invalidate_case_digest() -> None:
+    case = _case_with_material()
+    left = _build(case, ReviewContextProfile.GOAL_AWARE, dependency="sha256:" + "b" * 64)
+    right = _build(case, ReviewContextProfile.GOAL_AWARE, dependency="sha256:" + "c" * 64)
+    assert left.case_digest != right.case_digest
+
+    other = _case_with_material(with_evidence=False)
+    third = _build(other, ReviewContextProfile.GOAL_AWARE, dependency="sha256:" + "b" * 64)
+    assert left.case_digest != third.case_digest
+
+
+def test_case_builder_performs_no_ambient_state_access() -> None:
+    source = inspect.getsource(build_semantic_case)
+    # Capability-free contract: no ambient import or runner symbols in the builder body.
+    for forbidden in (
+        "subprocess",
+        "Path(",
+        "open(",
+        "os.environ",
+        "socket",
+        "Git",
+        "filesystem",
+        "transcript",
+        "httpx",
+        "aiohttp",
+    ):
+        assert forbidden not in source
+
+
+def test_candidate_context_preserves_item_categories_and_packet_envelope() -> None:
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        "ins_10000000-0000-4000-8000-000000000001",
+        "hmac-sha256:" + "a" * 64,
+        "tsk_10000000-0000-4000-8000-000000000001",
+    )
+    binding = ProviderBinding("fake", "model", "profile", "1.0.0", "external")
+    candidate = semantic_case_to_candidate_context(
+        semantic,
+        request_id="req_10000000-0000-4000-8000-000000000001",
+        scope=scope,
+        provider_binding=binding,
+    )
+    assert candidate.purpose == "semantic-review"
+    assert candidate.subject_digest == semantic.case_digest
+    assert candidate.items[0].item_id == REVIEW_PACKET_ITEM_ID
+    assert candidate.items[0].category is DataCategory.BOUNDED_STRUCTURAL_METADATA
+    categories = {item.category for item in candidate.items[1:]}
+    assert DataCategory.TASK_DESCRIPTION in categories
+    assert DataCategory.EVIDENCE_EXCERPT in categories or DataCategory.FINDING_SUMMARY in categories
+
+
+def test_prepared_payload_binds_selected_packet_and_withheld_omissions() -> None:
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+    # Approve only structural timeline + envelope-equivalent content subset.
+    included = {
+        item.item_id
+        for item in semantic.items
+        if item.category is DataCategory.BOUNDED_STRUCTURAL_METADATA
+    }
+    payload = semantic_case_to_prepared_payload(semantic, included)
+    assert b"yoetz.review-packet-case/1" in payload
+    assert b"withheld_by_policy" in payload or b"timeline" in payload
+    assert semantic.case_digest.encode("ascii") in payload
+
+
+def test_review_selection_digest_is_stable() -> None:
+    left = review_selection_digest(ReviewSelectionPolicy.for_profile(ReviewContextProfile.ASSISTED))
+    right = review_selection_digest(
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.ASSISTED)
+    )
+    assert left == right
+    structural = review_selection_digest(
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.STRUCTURAL)
+    )
+    assert left != structural
+
+
+def test_structural_assessments_have_no_finding_prose_items() -> None:
+    case = _case_with_material()
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.STRUCTURAL, findings=findings)
+    assert all(
+        assessment.summary_item_id is None and assessment.detail_item_id is None
+        for assessment in semantic.packet.deterministic_assessments
+    )
+    assert not any(
+        item.section in {"deterministic_summary", "deterministic_detail"} for item in semantic.items
+    )


### PR DESCRIPTION
## Summary

Closes the core defect in issue #69: the semantic review path was sending a stub candidate blob instead of a real frozen, privacy-selected case. Providers now receive a pure frozen `SemanticCase` / `ReviewPacket` built under the active `ReviewContextProfile` selection, with items classified into correct `DataCategory` values through the privacy gateway, and an omission manifest so challenges can cite real case-bound refs.

### What changed

- Build a frozen `SemanticCase` / `ReviewPacket` from frontier authority and the active `ReviewContextProfile` (structural / goal-aware / assisted).
- Emit selected content as separate categorized privacy items (goal, obligation, claim, timeline, assessments, excerpts as profile allows).
- Assemble a versioned review-packet provider payload with omission reasons.
- Wire selection through the local privacy enforcer and ready composition path.
- Tests cover structural/goal-aware/assisted profiles, allowlisted refs, case digests, and no ambient access.

### Why

Without a real privacy-selected case, the reviewer cannot challenge against authentic case-bound material. This replaces the stub with the frozen, profile-selected payload the protocol requires.

## Plan / issue

- Fixes #69
- https://github.com/TheGaySupreme123/yoetz/issues/69

## Test plan

```text
uv run pytest \
  tests/unit/application/test_semantic_case.py \
  tests/unit/application/test_semantic_post_validation.py \
  tests/unit/application/test_semantic_local_egress.py \
  tests/unit/privacy/test_local_enforcer.py \
  tests/integration/service/test_semantic_non_dispatch.py \
  tests/integration/providers/test_fake_provider_coordinator.py \
  -q
```

Result: **40 passed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added purpose-specific semantic review packaging with structured, versioned review packets.
  * Added privacy-aware review case generation with configurable profiles, selection limits, omissions, evidence excerpts, and deterministic integrity digests.
  * Improved review context composition to use policy-selected content and preserve references only to included items.

* **Bug Fixes**
  * Prevented invalid or incomplete review envelopes from being processed by failing closed.
  * Ensured withheld, omitted, and unselected content is accurately represented in review packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->