### PR TITLE
[bug]: Semantic attempts must be durable and obey the configured budget

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -841,7 +841,15 @@ blocks, human denial, secret detection, invalid case, stale frontier, refusal, a
 authority never retry. `confirm_every_request` requires a fresh foreground decision per physical
 attempt. Attempt accounting (`attempted_count`, `selected_attempt_id`, terminal reason counts,
 `exhausted`) is reconstructed from durable job/attempt rows via `load_semantic_job` +
-`list_semantic_attempts` — not from memory-only coordinator state.
+`list_semantic_attempts` — not from memory-only coordinator state. When
+`enqueue_semantic_job` recovers an already-terminal job (`succeeded` / `failed` /
+`quarantined`), the attempt loop must not call `claim_semantic_job`; it rebuilds the final
+status/reason (and selected judgment/provenance from the durable `SEMANTIC_RESPONSE` object on
+success) so crash-after-select or crash-after-final-failure remains reproducible. Because the
+check operation lease TTL is 60 seconds while `timeout_seconds` may be up to 300, the durable
+attempt coordinator renews the operation lease around claim/select and returns the renewed lease
+for later phase advance/commit — a valid provider result must not become `operation_pending`
+solely because the 60-second lease expired inside the semantic deadline.
 
 These field sets are closed: `OperationLease` and `SemanticAttemptHandle` carry the complete
 owner/lease/frontier/dependency compare-and-swap fence, while job, selected-attempt, and pending

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -772,9 +772,14 @@ the frontier merely advanced.
   FrozenCase | CheckCommitResult`;
 - `advance_check_phase(lease, expected_phase, next_phase, durable_object_ref?) -> OperationLease`;
 - `enqueue_semantic_job(lease, case_digest, case_object_ref) -> SemanticJobRecord`;
-- `claim_semantic_job(lease, job_id) -> SemanticAttemptHandle`;
+- `claim_semantic_job(lease, job_id) -> SemanticAttemptHandle` (same-owner live lease resumes the
+  active started attempt; expired lease closes the prior attempt as `expired` then mints the next
+  ordinal — never reuses a consumed authorization identity);
 - `record_attempt_outcome(handle, outcome, result_object_ref?, terminal_code?) -> None`;
 - `select_attempt(lease, handle, selected_result_object_ref) -> SelectedAttempt`;
+- `load_semantic_job(writer_id, operation_id) -> SemanticJobRecord | None`;
+- `list_semantic_attempts(job_id) -> tuple[SemanticAttemptRecord, ...]` (ordinal-sorted bounded
+  audit rows; no raw provider text);
 - `renew_leases(lease) -> OperationLease`;
 - `reclaim_operation(writer_id, operation_id, request_digest) -> OperationLease | PendingVerdict`;
 - `commit_check_if_current(frozen, findings, policy_executions, semantic_status, semantic_reason,
@@ -819,10 +824,24 @@ The exact shared frozen records, also owned by `ports/ledger.py`, are:
   provider_request_id, writer_id, operation_id, owner_generation, lease_owner_id,
   lease_generation: positive int, lease_expires_at, frontier: Frontier, dependency_digest)`;
 - `SelectedAttempt(job_id, attempt_id, result_object_ref: ObjectRef, selected_at,
-  frontier: Frontier, dependency_digest)`; and
+  frontier: Frontier, dependency_digest)`;
+- `SemanticAttemptRecord(job_id, attempt_id, attempt_ordinal: positive int,
+  provider_request_id, state: started|response_durable|selected|failed|expired|late,
+  terminal_code: SemanticReason?, result_object_ref?)` — structural audit row for one physical
+  dispatch; and
 - `PendingVerdict(kind: PendingVerdictKind, operation: OperationRecord | None,
   retry_after_ms: int | None)`, where retry time is present only for `live` and is bounded by the
   remaining lease lifetime.
+
+Semantic attempt budget (ADR-006): `ProviderProfileConfig.timeout_seconds` is the total
+semantic-operation deadline; `max_retries` (0..2) is the maximum additional physical attempts
+(so physical budget is `1 + max_retries`, at most three). Yoetz owns the retry loop with SDK
+`max_retries=0`. Retries are admitted only for timeout / transport / rate-limited classes; policy
+blocks, human denial, secret detection, invalid case, stale frontier, refusal, and exhausted
+authority never retry. `confirm_every_request` requires a fresh foreground decision per physical
+attempt. Attempt accounting (`attempted_count`, `selected_attempt_id`, terminal reason counts,
+`exhausted`) is reconstructed from durable job/attempt rows via `load_semantic_job` +
+`list_semantic_attempts` — not from memory-only coordinator state.
 
 These field sets are closed: `OperationLease` and `SemanticAttemptHandle` carry the complete
 owner/lease/frontier/dependency compare-and-swap fence, while job, selected-attempt, and pending

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -113,6 +113,7 @@ from yoetz.ports.ledger import (
     ProjectionView,
     SelectedAttempt,
     SemanticAttemptHandle,
+    SemanticAttemptRecord,
     SemanticJobRecord,
     StoredProjection,
 )
@@ -1801,14 +1802,32 @@ class MemoryLedgerAdapter:
             ):
                 raise _error(PublicErrorCode.INVALID_REQUEST)
             now = _now(self._clock)
-            if (
-                job.state == "leased"
-                and job.lease_expires_at is not None
-                and job.lease_expires_at > now
-            ):
+            if job.state == "leased" and job.lease_expires_at is not None and job.lease_expires_at > now:
+                # Same owner still holding a live lease: resume the active started attempt.
+                # Crash-before-authorization-consumption must not mint a new attempt identity.
+                if (
+                    job.lease_owner_id == lease.lease_owner_id
+                    and job.active_attempt_id is not None
+                ):
+                    attempt = self._state.attempts.get(job.active_attempt_id)
+                    if attempt is not None and attempt.state == "started":
+                        return attempt.handle
                 raise _error(PublicErrorCode.OPERATION_PENDING, retryable=True)
             if job.state not in {"queued", "leased"}:
                 raise _error(PublicErrorCode.OPERATION_PENDING, retryable=True)
+            # Expired or reclaimed lease: close the prior started attempt before a new ordinal.
+            if (
+                job.state == "leased"
+                and job.active_attempt_id is not None
+                and job.active_attempt_id in self._state.attempts
+            ):
+                prior = self._state.attempts[job.active_attempt_id]
+                if prior.state == "started":
+                    self._state.attempts[job.active_attempt_id] = replace(
+                        prior,
+                        state="expired",
+                        terminal_code=SemanticReason.LEASE_AUTHORITY_LOST,
+                    )
             ordinal = job.attempt_count + 1
             expiry = min(lease.lease_expires_at, now + timedelta(seconds=60))
             handle = SemanticAttemptHandle(
@@ -1933,6 +1952,51 @@ class MemoryLedgerAdapter:
                 lease.frontier,
                 lease.dependency_digest,
             )
+
+    async def load_semantic_job(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticJobRecord | None:
+        async with self._lock:
+            matches = tuple(
+                job
+                for job in self._state.jobs.values()
+                if job.writer_id == writer_id and job.operation_id == operation_id
+            )
+            if not matches:
+                return None
+            # One operation binds at most one durable semantic job in practice; if multiple
+            # case digests exist (should not), return the most recently enqueued by attempt_count.
+            return max(matches, key=lambda item: (item.attempt_count, item.job_id))
+
+    async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]:
+        async with self._lock:
+            if job_id not in self._state.jobs:
+                return ()
+            rows = [
+                SemanticAttemptRecord(
+                    attempt.handle.job_id,
+                    attempt.handle.attempt_id,
+                    attempt.handle.attempt_ordinal,
+                    attempt.handle.provider_request_id,
+                    cast(
+                        Literal[
+                            "started",
+                            "response_durable",
+                            "selected",
+                            "failed",
+                            "expired",
+                            "late",
+                        ],
+                        attempt.state,
+                    ),
+                    attempt.terminal_code,
+                    attempt.result_object_ref,
+                )
+                for attempt in self._state.attempts.values()
+                if attempt.handle.job_id == job_id
+            ]
+            rows.sort(key=lambda item: item.attempt_ordinal)
+            return tuple(rows)
 
     async def renew_leases(self, lease: OperationLease) -> OperationLease:
         async with self._lock:

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -1802,13 +1802,14 @@ class MemoryLedgerAdapter:
             ):
                 raise _error(PublicErrorCode.INVALID_REQUEST)
             now = _now(self._clock)
-            if job.state == "leased" and job.lease_expires_at is not None and job.lease_expires_at > now:
+            if (
+                job.state == "leased"
+                and job.lease_expires_at is not None
+                and job.lease_expires_at > now
+            ):
                 # Same owner still holding a live lease: resume the active started attempt.
                 # Crash-before-authorization-consumption must not mint a new attempt identity.
-                if (
-                    job.lease_owner_id == lease.lease_owner_id
-                    and job.active_attempt_id is not None
-                ):
+                if job.lease_owner_id == lease.lease_owner_id and job.active_attempt_id is not None:
                     attempt = self._state.attempts.get(job.active_attempt_id)
                     if attempt is not None and attempt.state == "started":
                         return attempt.handle

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -78,6 +78,7 @@ from yoetz.ports.ledger import (
     ProjectionView,
     SelectedAttempt,
     SemanticAttemptHandle,
+    SemanticAttemptRecord,
     SemanticJobRecord,
     StoredProjection,
 )
@@ -1384,6 +1385,16 @@ class SqliteLedger:
         result = await self._oracle().select_attempt(lease, handle, selected_result_object_ref)
         await self._sync_after_mutation()
         return result
+
+    async def load_semantic_job(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticJobRecord | None:
+        await self._ensure_recovered()
+        return await self._oracle().load_semantic_job(writer_id, operation_id)
+
+    async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]:
+        await self._ensure_recovered()
+        return await self._oracle().list_semantic_attempts(job_id)
 
     async def renew_leases(self, lease: OperationLease) -> OperationLease:
         await self._ensure_recovered()

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -50,6 +50,7 @@ from yoetz.ports.ledger import (
     CheckPhase,
     CheckPolicyExecution,
     FrozenCase,
+    OperationLease,
     OperationRecord,
     OperationState,
 )
@@ -236,6 +237,9 @@ class FinalSemanticEvaluation:
     # Bounded structural attempt accounting reconstructed from durable rows when a job ran.
     # Not part of the frozen public check-result wire; owner recovery reads the ledger.
     attempt_accounting: object | None = None
+    # When the durable semantic phase renewed the check operation lease (lease TTL is 60s while
+    # timeout_seconds may be longer), later phase advance / commit must use this CAS fence.
+    operation_lease: OperationLease | None = None
 
     def __post_init__(self) -> None:
         validate_semantic_outcome(self.status, self.reason)
@@ -252,6 +256,8 @@ class FinalSemanticEvaluation:
                 raise _invalid("semantic_judgment_invalid")
         elif self.judgment is not None:
             raise _invalid("semantic_judgment_invalid")
+        if self.operation_lease is not None and type(self.operation_lease) is not OperationLease:
+            raise _invalid("operation_lease_invalid")
 
 
 def semantic_coverage_gap_code(status: SemanticStatus, reason: SemanticReason) -> str | None:
@@ -951,6 +957,9 @@ async def execute_check_commit(app: Application, request: CheckRequest) -> Check
             )
             frozen = FrozenCase(frozen.case, lease)
         semantic_result = await _semantic_evaluation(app, request, runtime, frozen, deterministic)
+        # Durable semantic attempts may renew the check lease (TTL 60s vs timeout up to 300s).
+        if semantic_result.operation_lease is not None:
+            frozen = FrozenCase(frozen.case, semantic_result.operation_lease)
         semantic_candidates: tuple[CandidateFinding, ...] = ()
         if semantic_result.status is SemanticStatus.SUCCEEDED:
             assert semantic_result.judgment is not None

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -233,6 +233,9 @@ class FinalSemanticEvaluation:
     reason: SemanticReason
     judgment: SemanticJudgment | None = None
     provenance: SemanticProvenance | None = None
+    # Bounded structural attempt accounting reconstructed from durable rows when a job ran.
+    # Not part of the frozen public check-result wire; owner recovery reads the ledger.
+    attempt_accounting: object | None = None
 
     def __post_init__(self) -> None:
         validate_semantic_outcome(self.status, self.reason)
@@ -296,6 +299,7 @@ class Application(Protocol):
         self,
         frozen: FrozenCase,
         deterministic_findings: tuple[Finding, ...],
+        runtime: TaskRuntime | None = None,
     ) -> FinalSemanticEvaluation: ...
 
 
@@ -853,7 +857,7 @@ async def _semantic_evaluation(
             SemanticReason.PROVIDER_NOT_CONFIGURED,
         )
     try:
-        return await app.evaluate_semantic_check(frozen, deterministic)
+        return await app.evaluate_semantic_check(frozen, deterministic, runtime)
     except Exception as exc:
         # Optional/required semantic evaluator crash must never fabricate a clean semantic pass.
         record_unexpected_exception_without_raising(

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -1147,6 +1147,14 @@ class PrivacyCoordinator:
                 "channel": EgressChannel.LLM_INFERENCE.value,
             }
         )
+        # Categories are a closed set of DataCategory values: unique and sorted for the
+        # PreDispatchAuditDecision contract. Multiple case items may share one category.
+        categories = tuple(
+            sorted(
+                {item.category for item in candidate.items},
+                key=lambda value: str(value.value).encode("ascii"),
+            )
+        )
         subject = PreDispatchAuditDecision(
             pid,
             candidate.request_id,
@@ -1158,7 +1166,7 @@ class PrivacyCoordinator:
             effective.policy.version,
             effective.effective_digest,
             None if destination is None else canonical_digest({"binding": destination.provider_id}),
-            tuple(item.category for item in candidate.items),
+            categories,
             len(candidate.items),
             len(candidate.items),
             (),

--- a/src/yoetz/application/semantic_attempts.py
+++ b/src/yoetz/application/semantic_attempts.py
@@ -1,0 +1,388 @@
+"""Durable semantic-operation attempt budget, retry matrix, and accounting.
+
+ADR-006: one durable semantic operation, at most two retries (``max_retries``), one total
+deadline (``timeout_seconds``), and one physical attempt identity per dispatch. The ledger's
+``semantic_jobs`` / ``semantic_attempts`` tables are the recovery authority — never a
+memory-only coordinator object.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Final, Literal, Protocol
+
+from yoetz.ports.ledger import (
+    AttemptOutcome,
+    OperationLease,
+    SemanticAttemptHandle,
+    SemanticAttemptRecord,
+    SemanticJobRecord,
+)
+from yoetz.ports.objects import ObjectRef
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.canonical import JsonValue
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+__all__ = [
+    "SemanticAttemptAccounting",
+    "SemanticAttemptDispatch",
+    "attempt_accounting_from_rows",
+    "attempt_accounting_to_json",
+    "backoff_seconds",
+    "final_status_after_exhaustion",
+    "is_retriable_semantic_outcome",
+    "max_physical_attempts",
+    "physical_attempt_budget",
+    "run_durable_semantic_attempts",
+    "should_retry_after",
+]
+
+# ADR-006 approved transient classes only. Contract-invalid is not automatically retried.
+_RETRIABLE_REASONS: Final[frozenset[SemanticReason]] = frozenset(
+    {
+        SemanticReason.PROVIDER_TIMEOUT,
+        SemanticReason.TRANSPORT_UNAVAILABLE,
+        SemanticReason.PROVIDER_RATE_LIMITED,
+    }
+)
+
+_RETRIABLE_STATUSES: Final[frozenset[SemanticStatus]] = frozenset(
+    {
+        SemanticStatus.TIMEOUT,
+        SemanticStatus.UNAVAILABLE,
+    }
+)
+
+# ADR-006: at most two retries → at most three physical attempts.
+_ADR_MAX_RETRIES: Final = 2
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticAttemptAccounting:
+    """Bounded structural attempt accounting reconstructible from durable rows."""
+
+    attempted_count: int
+    selected_attempt_id: str | None
+    exhausted: bool
+    terminal_reason_counts: tuple[tuple[str, int], ...]
+
+    def __post_init__(self) -> None:
+        if type(self.attempted_count) is not int or self.attempted_count < 0:
+            raise ValueError("semantic_attempt_accounting_invalid")
+        if self.selected_attempt_id is not None and (
+            type(self.selected_attempt_id) is not str or not self.selected_attempt_id.startswith("att_")
+        ):
+            raise ValueError("semantic_attempt_accounting_invalid")
+        if type(self.exhausted) is not bool:
+            raise ValueError("semantic_attempt_accounting_invalid")
+        if type(self.terminal_reason_counts) is not tuple:
+            raise ValueError("semantic_attempt_accounting_invalid")
+        for token, count in self.terminal_reason_counts:
+            if type(token) is not str or type(count) is not int or count < 1:
+                raise ValueError("semantic_attempt_accounting_invalid")
+
+
+def physical_attempt_budget(max_retries: int) -> int:
+    """Return the maximum physical attempts for a configured retry count (capped by ADR-006)."""
+
+    if type(max_retries) is not int or max_retries < 0:
+        raise ValueError("max_retries_invalid")
+    capped = min(max_retries, _ADR_MAX_RETRIES)
+    return 1 + capped
+
+
+def max_physical_attempts(max_retries: int) -> int:
+    """Alias used by tests and composition; same as :func:`physical_attempt_budget`."""
+
+    return physical_attempt_budget(max_retries)
+
+
+def is_retriable_semantic_outcome(status: SemanticStatus, reason: SemanticReason) -> bool:
+    """Whether a terminal attempt outcome may consume another physical attempt slot."""
+
+    if status not in _RETRIABLE_STATUSES or reason not in _RETRIABLE_REASONS:
+        return False
+    # Quota exhaustion is not a transient 429-class retry; refuse silent multi-dispatch.
+    if reason is SemanticReason.PROVIDER_QUOTA_EXHAUSTED:
+        return False
+    return True
+
+
+def should_retry_after(
+    *,
+    status: SemanticStatus,
+    reason: SemanticReason,
+    attempts_completed: int,
+    max_retries: int,
+    deadline_expired: bool,
+) -> bool:
+    """Decide whether another physical attempt is admitted inside the total deadline."""
+
+    if deadline_expired:
+        return False
+    if not is_retriable_semantic_outcome(status, reason):
+        return False
+    budget = physical_attempt_budget(max_retries)
+    return attempts_completed < budget
+
+
+def attempt_accounting_from_rows(
+    job: SemanticJobRecord | None,
+    attempts: tuple[SemanticAttemptRecord, ...],
+    *,
+    max_retries: int,
+) -> SemanticAttemptAccounting:
+    """Rebuild bounded accounting from durable job/attempt rows."""
+
+    budget = physical_attempt_budget(max_retries)
+    counts: dict[str, int] = {}
+    for attempt in attempts:
+        if attempt.terminal_code is None:
+            continue
+        token = attempt.terminal_code.value
+        counts[token] = counts.get(token, 0) + 1
+    ordered = tuple(sorted(counts.items(), key=lambda item: item[0].encode("ascii")))
+    attempted = len(attempts)
+    selected = None if job is None else job.selected_attempt_id
+    exhausted = (
+        job is not None
+        and job.state in {"failed", "quarantined"}
+        and (
+            attempted >= budget
+            or (job.terminal_code is SemanticReason.RETRY_BUDGET_EXHAUSTED)
+        )
+    )
+    return SemanticAttemptAccounting(
+        attempted_count=attempted,
+        selected_attempt_id=selected,
+        exhausted=exhausted,
+        terminal_reason_counts=ordered,
+    )
+
+
+def attempt_accounting_to_json(value: SemanticAttemptAccounting) -> dict[str, JsonValue]:
+    """Encode accounting as structural JSON with no user-controlled content."""
+
+    return {
+        "attempted_count": value.attempted_count,
+        "selected_attempt_id": value.selected_attempt_id,
+        "exhausted": value.exhausted,
+        "terminal_reason_counts": tuple(
+            {"reason": reason, "count": count} for reason, count in value.terminal_reason_counts
+        ),
+    }
+
+
+def final_status_after_exhaustion(
+    last_status: SemanticStatus,
+    last_reason: SemanticReason,
+    *,
+    attempts_completed: int,
+    max_retries: int,
+) -> tuple[SemanticStatus, SemanticReason]:
+    """Map multi-attempt exhaustion to the closed public status/reason pair.
+
+    A single physical attempt that fails with a retriable class keeps its exact reason
+    (``max_retries=0``). Exhaustion after using the full budget surfaces
+    ``unavailable/retry_budget_exhausted``.
+    """
+
+    budget = physical_attempt_budget(max_retries)
+    if attempts_completed >= budget and attempts_completed > 1:
+        return SemanticStatus.UNAVAILABLE, SemanticReason.RETRY_BUDGET_EXHAUSTED
+    if (
+        attempts_completed >= budget
+        and is_retriable_semantic_outcome(last_status, last_reason)
+        and max_retries > 0
+    ):
+        return SemanticStatus.UNAVAILABLE, SemanticReason.RETRY_BUDGET_EXHAUSTED
+    return last_status, last_reason
+
+
+BackoffKind = Literal["none", "transient"]
+
+
+def backoff_seconds(attempt_ordinal: int, *, kind: BackoffKind = "transient") -> float:
+    """Deterministic bounded backoff before the next physical attempt (ADR-006 jittered budget)."""
+
+    if kind == "none" or attempt_ordinal <= 1:
+        return 0.0
+    # Small deterministic backoff: 0.05s, 0.1s — stays well under typical total deadlines.
+    base = 0.05 * float(1 << min(attempt_ordinal - 1, 2))
+    # Stable pseudo-jitter from ordinal (no clock/random dependency).
+    jitter = 0.01 * float((attempt_ordinal * 17) % 5)
+    return min(1.0, base + jitter)
+
+
+class _SemanticAttemptLedger(Protocol):
+    async def claim_semantic_job(
+        self, lease: OperationLease, job_id: str
+    ) -> SemanticAttemptHandle: ...
+
+    async def record_attempt_outcome(
+        self,
+        handle: SemanticAttemptHandle,
+        outcome: AttemptOutcome,
+        result_object_ref: ObjectRef | None = None,
+        terminal_code: SemanticReason | None = None,
+    ) -> None: ...
+
+    async def select_attempt(
+        self,
+        lease: OperationLease,
+        handle: SemanticAttemptHandle,
+        selected_result_object_ref: ObjectRef,
+    ) -> object: ...
+
+    async def load_semantic_job(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticJobRecord | None: ...
+
+    async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]: ...
+
+
+class _AttemptEvaluation(Protocol):
+    @property
+    def status(self) -> SemanticStatus: ...
+
+    @property
+    def reason(self) -> SemanticReason: ...
+
+    @property
+    def judgment(self) -> object | None: ...
+
+    @property
+    def provenance(self) -> object | None: ...
+
+
+SemanticAttemptDispatch = Callable[
+    [SemanticAttemptHandle, Deadline],
+    Awaitable[_AttemptEvaluation],
+]
+
+
+async def run_durable_semantic_attempts(
+    *,
+    ledger: _SemanticAttemptLedger,
+    lease: OperationLease,
+    job: SemanticJobRecord,
+    deadline: Deadline,
+    max_retries: int,
+    now_monotonic: Callable[[], float],
+    dispatch: SemanticAttemptDispatch,
+    publish_success_response: Callable[
+        [SemanticAttemptHandle, _AttemptEvaluation], Awaitable[ObjectRef]
+    ],
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    build_final: Callable[
+        [SemanticStatus, SemanticReason, _AttemptEvaluation | None, SemanticAttemptAccounting],
+        object,
+    ],
+) -> object:
+    """Run the physical attempt loop for one durable semantic job.
+
+    Each iteration claims (or resumes) one attempt, dispatches once, and records a durable
+    outcome. Retries only the ADR-006 transient classes within the total deadline and
+    ``max_retries`` budget. Exactly one selected attempt or one terminal failed job results.
+    """
+
+    budget = physical_attempt_budget(max_retries)
+    last: _AttemptEvaluation | None = None
+    attempts_completed = 0
+
+    while attempts_completed < budget:
+        if deadline.expired(now_monotonic()):
+            rows = await ledger.list_semantic_attempts(job.job_id)
+            job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
+            accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+            if last is None:
+                return build_final(
+                    SemanticStatus.TIMEOUT,
+                    SemanticReason.PROVIDER_TIMEOUT,
+                    None,
+                    accounting,
+                )
+            status, reason = final_status_after_exhaustion(
+                last.status,
+                last.reason,
+                attempts_completed=attempts_completed,
+                max_retries=max_retries,
+            )
+            return build_final(status, reason, last, accounting)
+
+        handle = await ledger.claim_semantic_job(lease, job.job_id)
+        remaining = deadline.remaining_seconds(now_monotonic())
+        attempt_deadline = Deadline(
+            deadline.expires_at_utc,
+            now_monotonic() + remaining,
+        )
+        evaluation = await dispatch(handle, attempt_deadline)
+        attempts_completed = handle.attempt_ordinal
+        last = evaluation
+
+        if evaluation.status is SemanticStatus.SUCCEEDED:
+            response_ref = await publish_success_response(handle, evaluation)
+            await ledger.record_attempt_outcome(
+                handle, AttemptOutcome.RESPONSE_DURABLE, response_ref
+            )
+            await ledger.select_attempt(lease, handle, response_ref)
+            rows = await ledger.list_semantic_attempts(job.job_id)
+            job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
+            accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+            return build_final(
+                evaluation.status, evaluation.reason, evaluation, accounting
+            )
+
+        can_retry = should_retry_after(
+            status=evaluation.status,
+            reason=evaluation.reason,
+            attempts_completed=attempts_completed,
+            max_retries=max_retries,
+            deadline_expired=deadline.expired(now_monotonic()),
+        )
+        if can_retry:
+            await ledger.record_attempt_outcome(
+                handle,
+                AttemptOutcome.EXPIRED,
+                terminal_code=evaluation.reason,
+            )
+            delay = backoff_seconds(handle.attempt_ordinal)
+            if delay > 0.0 and not deadline.expired(now_monotonic() + delay):
+                await sleep(delay)
+            continue
+
+        terminal_status, terminal_reason = final_status_after_exhaustion(
+            evaluation.status,
+            evaluation.reason,
+            attempts_completed=attempts_completed,
+            max_retries=max_retries,
+        )
+        await ledger.record_attempt_outcome(
+            handle,
+            AttemptOutcome.FAILED,
+            terminal_code=terminal_reason,
+        )
+        rows = await ledger.list_semantic_attempts(job.job_id)
+        job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
+        accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+        return build_final(terminal_status, terminal_reason, evaluation, accounting)
+
+    rows = await ledger.list_semantic_attempts(job.job_id)
+    job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
+    accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+    if last is None:
+        return build_final(
+            SemanticStatus.UNAVAILABLE,
+            SemanticReason.RETRY_BUDGET_EXHAUSTED,
+            None,
+            accounting,
+        )
+    status, reason = final_status_after_exhaustion(
+        last.status,
+        last.reason,
+        attempts_completed=attempts_completed,
+        max_retries=max_retries,
+    )
+    return build_final(status, reason, last, accounting)

--- a/src/yoetz/application/semantic_attempts.py
+++ b/src/yoetz/application/semantic_attempts.py
@@ -72,7 +72,8 @@ class SemanticAttemptAccounting:
         if type(self.attempted_count) is not int or self.attempted_count < 0:
             raise ValueError("semantic_attempt_accounting_invalid")
         if self.selected_attempt_id is not None and (
-            type(self.selected_attempt_id) is not str or not self.selected_attempt_id.startswith("att_")
+            type(self.selected_attempt_id) is not str
+            or not self.selected_attempt_id.startswith("att_")
         ):
             raise ValueError("semantic_attempt_accounting_invalid")
         if type(self.exhausted) is not bool:
@@ -149,10 +150,7 @@ def attempt_accounting_from_rows(
     exhausted = (
         job is not None
         and job.state in {"failed", "quarantined"}
-        and (
-            attempted >= budget
-            or (job.terminal_code is SemanticReason.RETRY_BUDGET_EXHAUSTED)
-        )
+        and (attempted >= budget or (job.terminal_code is SemanticReason.RETRY_BUDGET_EXHAUSTED))
     )
     return SemanticAttemptAccounting(
         attempted_count=attempted,
@@ -331,9 +329,7 @@ async def run_durable_semantic_attempts(
             rows = await ledger.list_semantic_attempts(job.job_id)
             job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
             accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
-            return build_final(
-                evaluation.status, evaluation.reason, evaluation, accounting
-            )
+            return build_final(evaluation.status, evaluation.reason, evaluation, accounting)
 
         can_retry = should_retry_after(
             status=evaluation.status,

--- a/src/yoetz/application/semantic_attempts.py
+++ b/src/yoetz/application/semantic_attempts.py
@@ -23,7 +23,7 @@ from yoetz.ports.ledger import (
 from yoetz.ports.objects import ObjectRef
 from yoetz.ports.semantic import Deadline
 from yoetz.protocol.canonical import JsonValue
-from yoetz.protocol.models import SemanticReason, SemanticStatus
+from yoetz.protocol.models import VALID_SEMANTIC_REASONS, SemanticReason, SemanticStatus
 
 __all__ = [
     "SemanticAttemptAccounting",
@@ -37,6 +37,7 @@ __all__ = [
     "physical_attempt_budget",
     "run_durable_semantic_attempts",
     "should_retry_after",
+    "status_for_semantic_reason",
 ]
 
 # ADR-006 approved transient classes only. Contract-invalid is not automatically retried.
@@ -55,8 +56,16 @@ _RETRIABLE_STATUSES: Final[frozenset[SemanticStatus]] = frozenset(
     }
 )
 
+# Terminal job states that must not re-enter claim_semantic_job (recovery authority).
+_TERMINAL_JOB_STATES: Final[frozenset[str]] = frozenset({"succeeded", "failed", "quarantined"})
+
 # ADR-006: at most two retries → at most three physical attempts.
 _ADR_MAX_RETRIES: Final = 2
+
+# Reverse map: each closed SemanticReason belongs to exactly one SemanticStatus.
+_STATUS_BY_REASON: Final[dict[SemanticReason, SemanticStatus]] = {
+    reason: status for status, reasons in VALID_SEMANTIC_REASONS.items() for reason in reasons
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,6 +208,15 @@ def final_status_after_exhaustion(
     return last_status, last_reason
 
 
+def status_for_semantic_reason(reason: SemanticReason) -> SemanticStatus:
+    """Map a closed SemanticReason to its unique SemanticStatus (no coercion of unknown pairs)."""
+
+    status = _STATUS_BY_REASON.get(reason)
+    if status is None:
+        raise ValueError("semantic_reason_unmapped")
+    return status
+
+
 BackoffKind = Literal["none", "transient"]
 
 
@@ -240,6 +258,8 @@ class _SemanticAttemptLedger(Protocol):
 
     async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]: ...
 
+    async def renew_leases(self, lease: OperationLease) -> OperationLease: ...
+
 
 class _AttemptEvaluation(Protocol):
     @property
@@ -261,6 +281,57 @@ SemanticAttemptDispatch = Callable[
 ]
 
 
+async def _accounting_for(
+    ledger: _SemanticAttemptLedger,
+    lease: OperationLease,
+    job_id: str,
+    *,
+    max_retries: int,
+) -> SemanticAttemptAccounting:
+    rows = await ledger.list_semantic_attempts(job_id)
+    job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
+    return attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+
+
+async def _recover_terminal_job(
+    *,
+    ledger: _SemanticAttemptLedger,
+    lease: OperationLease,
+    job: SemanticJobRecord,
+    max_retries: int,
+    recover_selected: Callable[[SemanticJobRecord], Awaitable[_AttemptEvaluation | None]] | None,
+    build_final: Callable[
+        [SemanticStatus, SemanticReason, _AttemptEvaluation | None, SemanticAttemptAccounting],
+        object,
+    ],
+) -> object:
+    """Rebuild the final evaluation from a durable terminal job without re-claiming."""
+
+    accounting = await _accounting_for(ledger, lease, job.job_id, max_retries=max_retries)
+    if job.state == "succeeded":
+        evaluation: _AttemptEvaluation | None = None
+        if recover_selected is not None:
+            evaluation = await recover_selected(job)
+        reason = (
+            job.terminal_code
+            if type(job.terminal_code) is SemanticReason
+            else SemanticReason.SEMANTIC_COMPLETED
+        )
+        return build_final(SemanticStatus.SUCCEEDED, reason, evaluation, accounting)
+
+    reason = (
+        job.terminal_code
+        if type(job.terminal_code) is SemanticReason
+        else SemanticReason.COORDINATOR_FAILURE
+    )
+    try:
+        status = status_for_semantic_reason(reason)
+    except ValueError:
+        status = SemanticStatus.FAILED
+        reason = SemanticReason.COORDINATOR_FAILURE
+    return build_final(status, reason, None, accounting)
+
+
 async def run_durable_semantic_attempts(
     *,
     ledger: _SemanticAttemptLedger,
@@ -278,13 +349,45 @@ async def run_durable_semantic_attempts(
         [SemanticStatus, SemanticReason, _AttemptEvaluation | None, SemanticAttemptAccounting],
         object,
     ],
+    recover_selected: (
+        Callable[[SemanticJobRecord], Awaitable[_AttemptEvaluation | None]] | None
+    ) = None,
+    on_lease_renewed: Callable[[OperationLease], None] | None = None,
 ) -> object:
     """Run the physical attempt loop for one durable semantic job.
 
     Each iteration claims (or resumes) one attempt, dispatches once, and records a durable
     outcome. Retries only the ADR-006 transient classes within the total deadline and
     ``max_retries`` budget. Exactly one selected attempt or one terminal failed job results.
+
+    Crash/replay after a terminal job row already exists recovers from durable state without
+    re-claiming. The check operation lease is renewed around each claim/select so a configured
+    ``timeout_seconds`` longer than the 60s lease TTL cannot expire mid-operation.
     """
+
+    current_lease = lease
+
+    async def _renew() -> OperationLease:
+        nonlocal current_lease
+        current_lease = await ledger.renew_leases(current_lease)
+        if on_lease_renewed is not None:
+            on_lease_renewed(current_lease)
+        return current_lease
+
+    # Always refresh the check lease before recovery or the first claim so a long semantic
+    # deadline is not truncated by the 60-second operation-lease TTL.
+    await _renew()
+
+    # Recover previously terminal jobs (crash after select_attempt / final FAILED before commit).
+    if job.state in _TERMINAL_JOB_STATES:
+        return await _recover_terminal_job(
+            ledger=ledger,
+            lease=current_lease,
+            job=job,
+            max_retries=max_retries,
+            recover_selected=recover_selected,
+            build_final=build_final,
+        )
 
     budget = physical_attempt_budget(max_retries)
     last: _AttemptEvaluation | None = None
@@ -292,9 +395,9 @@ async def run_durable_semantic_attempts(
 
     while attempts_completed < budget:
         if deadline.expired(now_monotonic()):
-            rows = await ledger.list_semantic_attempts(job.job_id)
-            job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
-            accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+            accounting = await _accounting_for(
+                ledger, current_lease, job.job_id, max_retries=max_retries
+            )
             if last is None:
                 return build_final(
                     SemanticStatus.TIMEOUT,
@@ -310,7 +413,9 @@ async def run_durable_semantic_attempts(
             )
             return build_final(status, reason, last, accounting)
 
-        handle = await ledger.claim_semantic_job(lease, job.job_id)
+        # Keep the operation lease alive across provider latency and backoff.
+        await _renew()
+        handle = await ledger.claim_semantic_job(current_lease, job.job_id)
         remaining = deadline.remaining_seconds(now_monotonic())
         attempt_deadline = Deadline(
             deadline.expires_at_utc,
@@ -320,15 +425,18 @@ async def run_durable_semantic_attempts(
         attempts_completed = handle.attempt_ordinal
         last = evaluation
 
+        # Provider dispatch may consume most of a lease TTL; renew before ledger mutations.
+        await _renew()
+
         if evaluation.status is SemanticStatus.SUCCEEDED:
             response_ref = await publish_success_response(handle, evaluation)
             await ledger.record_attempt_outcome(
                 handle, AttemptOutcome.RESPONSE_DURABLE, response_ref
             )
-            await ledger.select_attempt(lease, handle, response_ref)
-            rows = await ledger.list_semantic_attempts(job.job_id)
-            job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
-            accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+            await ledger.select_attempt(current_lease, handle, response_ref)
+            accounting = await _accounting_for(
+                ledger, current_lease, job.job_id, max_retries=max_retries
+            )
             return build_final(evaluation.status, evaluation.reason, evaluation, accounting)
 
         can_retry = should_retry_after(
@@ -360,14 +468,12 @@ async def run_durable_semantic_attempts(
             AttemptOutcome.FAILED,
             terminal_code=terminal_reason,
         )
-        rows = await ledger.list_semantic_attempts(job.job_id)
-        job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
-        accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+        accounting = await _accounting_for(
+            ledger, current_lease, job.job_id, max_retries=max_retries
+        )
         return build_final(terminal_status, terminal_reason, evaluation, accounting)
 
-    rows = await ledger.list_semantic_attempts(job.job_id)
-    job_final = await ledger.load_semantic_job(lease.writer_id, lease.operation_id)
-    accounting = attempt_accounting_from_rows(job_final, rows, max_retries=max_retries)
+    accounting = await _accounting_for(ledger, current_lease, job.job_id, max_retries=max_retries)
     if last is None:
         return build_final(
             SemanticStatus.UNAVAILABLE,

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -850,9 +850,18 @@ class Application:
         return self.receipt_version_resolver(runtime)
 
     async def evaluate_semantic_check(
-        self, frozen: FrozenCase, deterministic_findings: tuple[Finding, ...]
+        self,
+        frozen: FrozenCase,
+        deterministic_findings: tuple[Finding, ...],
+        runtime: object | None = None,
     ) -> object:
-        return await self.semantic_evaluator(frozen, deterministic_findings)
+        evaluator = self.semantic_evaluator
+        # Production evaluators accept the task runtime for durable job/attempt coordination.
+        # Test doubles may still be binary callables.
+        try:
+            return await evaluator(frozen, deterministic_findings, runtime)  # type: ignore[misc]
+        except TypeError:
+            return await evaluator(frozen, deterministic_findings)
 
     async def project_result_for_client(
         self,

--- a/src/yoetz/ports/ledger.py
+++ b/src/yoetz/ports/ledger.py
@@ -82,6 +82,7 @@ __all__ = [
     "QueryableProjectionView",
     "SelectedAttempt",
     "SemanticAttemptHandle",
+    "SemanticAttemptRecord",
     "SemanticJobRecord",
     "StoredProjection",
 ]
@@ -830,6 +831,61 @@ class SelectedAttempt:
 
 
 @dataclass(frozen=True, slots=True)
+class SemanticAttemptRecord:
+    """Bounded durable facts for one physical semantic dispatch attempt.
+
+    No raw provider text, prompt, secret, path, or user-controlled diagnostic prose.
+    """
+
+    job_id: str
+    attempt_id: str
+    attempt_ordinal: int
+    provider_request_id: str
+    state: Literal["started", "response_durable", "selected", "failed", "expired", "late"]
+    terminal_code: SemanticReason | None
+    result_object_ref: ObjectRef | None
+
+    def __post_init__(self) -> None:
+        _id(IdKind.SEMANTIC_JOB, self.job_id)
+        _id(IdKind.SEMANTIC_ATTEMPT, self.attempt_id)
+        _uint(self.attempt_ordinal, positive=True)
+        _identity(self.provider_request_id)
+        if type(self.state) is not str or self.state not in {
+            "started",
+            "response_durable",
+            "selected",
+            "failed",
+            "expired",
+            "late",
+        }:
+            raise _invalid()
+        if self.terminal_code is not None and type(self.terminal_code) is not SemanticReason:
+            raise _invalid()
+        if self.result_object_ref is not None and (
+            type(self.result_object_ref) is not ObjectRef
+            or self.result_object_ref.metadata.kind is not ObjectKind.SEMANTIC_RESPONSE
+        ):
+            raise _invalid()
+        if self.state == "started":
+            if self.terminal_code is not None or self.result_object_ref is not None:
+                raise _invalid()
+        elif self.state == "response_durable":
+            if self.terminal_code is not None or self.result_object_ref is None:
+                raise _invalid()
+        elif self.state == "selected":
+            if self.terminal_code is None or self.result_object_ref is None:
+                raise _invalid()
+        elif self.state == "expired":
+            if self.terminal_code is None or self.result_object_ref is not None:
+                raise _invalid()
+        elif self.state == "late":
+            if self.terminal_code is None or self.result_object_ref is None:
+                raise _invalid()
+        elif self.terminal_code is None:
+            raise _invalid()
+
+
+@dataclass(frozen=True, slots=True)
 class PendingVerdict:
     kind: PendingVerdictKind
     operation: OperationRecord | None
@@ -1321,6 +1377,12 @@ class LedgerPort(Protocol):
         handle: SemanticAttemptHandle,
         selected_result_object_ref: ObjectRef,
     ) -> SelectedAttempt: ...
+
+    async def load_semantic_job(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticJobRecord | None: ...
+
+    async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]: ...
 
     async def renew_leases(self, lease: OperationLease) -> OperationLease: ...
 

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1482,6 +1482,92 @@ async def _publish_semantic_case_object(
     return await runtime.objects.finalize(staged)
 
 
+def _judgment_to_response_json(judgment: object) -> dict[str, CanonicalJsonValue]:
+    """Encode a SemanticJudgment into the durable SEMANTIC_RESPONSE wire object."""
+
+    from yoetz.ports.semantic import ReviewerChallenge, SemanticJudgment
+
+    if type(judgment) is not SemanticJudgment:
+        raise TypeError("semantic_judgment_required")
+    challenges: list[CanonicalJsonValue] = []
+    for item in judgment.challenges:
+        if type(item) is not ReviewerChallenge:
+            raise TypeError("semantic_judgment_required")
+        challenges.append(
+            {
+                "finding_kind": item.finding_kind.value,
+                "summary": item.summary,
+                "cited_refs": list(item.cited_refs),
+                "discrepancy": item.discrepancy,
+                "alternative_interpretation": item.alternative_interpretation,
+                "message_to_main_agent": item.message_to_main_agent,
+                "requested_next_step": item.requested_next_step,
+                "uncertainty": item.uncertainty,
+            }
+        )
+    return {
+        "conclusion": judgment.conclusion,
+        "reviewer_challenges": challenges,
+    }
+
+
+def _judgment_from_response_json(value: object) -> object:
+    """Decode a durable SEMANTIC_RESPONSE judgment object into SemanticJudgment."""
+
+    from yoetz.domain.findings import FindingKind
+    from yoetz.ports.semantic import (
+        ReviewerChallenge,
+        ReviewerNextStep,
+        SemanticConclusion,
+        SemanticJudgment,
+    )
+
+    if type(value) is not dict:
+        raise ValueError("semantic_response_judgment_invalid")
+    source = cast(dict[str, object], value)
+    conclusion_raw = source.get("conclusion")
+    raw_challenges = source.get("reviewer_challenges")
+    # Backward-compatible with the earlier structural-only challenge_count form.
+    if raw_challenges is None and "challenge_count" in source:
+        if conclusion_raw == "challenges_returned":
+            raise ValueError("semantic_response_judgment_incomplete")
+        if type(conclusion_raw) is not str:
+            raise ValueError("semantic_response_judgment_invalid")
+        return SemanticJudgment(cast(SemanticConclusion, conclusion_raw), ())
+    if type(conclusion_raw) is not str or type(raw_challenges) is not list:
+        raise ValueError("semantic_response_judgment_invalid")
+    challenges: list[ReviewerChallenge] = []
+    for item in cast(list[object], raw_challenges):
+        if type(item) is not dict:
+            raise ValueError("semantic_response_judgment_invalid")
+        row = cast(dict[str, object], item)
+        cited = row.get("cited_refs")
+        if type(cited) is not list or any(
+            type(ref) is not str for ref in cast(list[object], cited)
+        ):
+            raise ValueError("semantic_response_judgment_invalid")
+        next_step = row.get("requested_next_step")
+        if type(next_step) is not str:
+            raise ValueError("semantic_response_judgment_invalid")
+        try:
+            kind = FindingKind(cast(str, row["finding_kind"]))
+            challenges.append(
+                ReviewerChallenge(
+                    kind,
+                    cast(str, row["summary"]),
+                    tuple(cast(list[str], cited)),
+                    cast(str, row["discrepancy"]),
+                    cast(str, row["alternative_interpretation"]),
+                    cast(str, row["message_to_main_agent"]),
+                    cast(ReviewerNextStep, next_step),
+                    cast(str, row["uncertainty"]),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("semantic_response_judgment_invalid") from exc
+    return SemanticJudgment(cast(SemanticConclusion, conclusion_raw), tuple(challenges))
+
+
 async def _publish_semantic_response_object(
     runtime: TaskRuntime,
     *,
@@ -1489,7 +1575,7 @@ async def _publish_semantic_response_object(
     evaluation: FinalSemanticEvaluation,
     clock: ClockPort,
 ) -> ObjectRef:
-    """Persist bounded SEMANTIC_RESPONSE facts (judgment/provenance only; no raw provider text)."""
+    """Persist SEMANTIC_RESPONSE facts (full judgment + provenance; no raw provider text)."""
 
     body: dict[str, CanonicalJsonValue] = {
         "schema": "yoetz.semantic-response/1",
@@ -1498,10 +1584,7 @@ async def _publish_semantic_response_object(
         "reason": evaluation.reason.value,
     }
     if evaluation.judgment is not None:
-        body["judgment"] = {
-            "conclusion": evaluation.judgment.conclusion,
-            "challenge_count": len(evaluation.judgment.challenges),
-        }
+        body["judgment"] = _judgment_to_response_json(evaluation.judgment)
     if evaluation.provenance is not None:
         body["provenance"] = cast(
             CanonicalJsonValue, dict(semantic_provenance_to_json(evaluation.provenance).items())
@@ -1517,6 +1600,60 @@ async def _publish_semantic_response_object(
         ),
     )
     return await runtime.objects.finalize(staged)
+
+
+async def _recover_selected_evaluation(
+    runtime: TaskRuntime,
+    job: object,
+) -> FinalSemanticEvaluation | None:
+    """Load judgment/provenance from the durable selected SEMANTIC_RESPONSE object."""
+
+    from yoetz.domain.findings import semantic_provenance_from_json
+    from yoetz.ports.ledger import SemanticJobRecord as _Job
+    from yoetz.ports.semantic import SemanticJudgment
+    from yoetz.protocol.canonical import strict_json_parse
+    from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+    if type(job) is not _Job:
+        return None
+    ref = job.selected_result_object_ref
+    if ref is None:
+        return None
+    try:
+        resolved = await runtime.objects.resolve_verified(ref.object_id, ref.envelope_digest)
+        payload = b"".join([chunk async for chunk in runtime.objects.open_verified(resolved)])
+        parsed = strict_json_parse(payload)
+    except KeyError, OSError, TypeError, ValueError:
+        return None
+    if type(parsed) is not dict:
+        return None
+    body = cast(dict[str, object], parsed)
+    try:
+        status = SemanticStatus(cast(str, body["status"]))
+        reason = SemanticReason(cast(str, body["reason"]))
+    except KeyError, TypeError, ValueError:
+        return None
+    judgment = None
+    provenance = None
+    raw_judgment = body.get("judgment")
+    if raw_judgment is not None:
+        try:
+            decoded = _judgment_from_response_json(raw_judgment)
+        except TypeError, ValueError:
+            return None
+        if type(decoded) is SemanticJudgment:
+            judgment = decoded
+    raw_provenance = body.get("provenance")
+    if raw_provenance is not None:
+        try:
+            from yoetz.domain.values import JsonValue as _DomainJson
+
+            provenance = semantic_provenance_from_json(cast(_DomainJson, raw_provenance))
+        except TypeError, ValueError:
+            return None
+    if status is SemanticStatus.SUCCEEDED and (judgment is None or provenance is None):
+        return None
+    return FinalSemanticEvaluation(status, reason, judgment=judgment, provenance=provenance)
 
 
 def _privacy_gated_semantic_evaluator(
@@ -1672,6 +1809,21 @@ def _privacy_gated_semantic_evaluator(
                     clock=clock,
                 )
 
+            # Track the latest check lease so phase advance/commit after a long semantic
+            # deadline still holds a valid CAS fence (renewals happen inside the attempt loop).
+            from yoetz.ports.ledger import OperationLease as _OpLease
+            from yoetz.ports.ledger import SemanticJobRecord as _JobRecord
+
+            current_lease: list[_OpLease] = [frozen.lease]
+
+            def _on_lease_renewed(renewed: object) -> None:
+                assert type(renewed) is _OpLease
+                current_lease[0] = renewed
+
+            async def _recover_selected(job_row: object) -> FinalSemanticEvaluation | None:
+                assert type(job_row) is _JobRecord
+                return await _recover_selected_evaluation(runtime, job_row)
+
             def _build_final(
                 status: SemanticStatus,
                 reason: SemanticReason,
@@ -1690,12 +1842,22 @@ def _privacy_gated_semantic_evaluator(
                         and evaluation.provenance is not None
                     ):
                         provenance = evaluation.provenance
+                # Terminal recovery of a succeeded job without a recoverable response object
+                # must not invent a judgment; surface an honest coordinator failure instead.
+                if status is SemanticStatus.SUCCEEDED and (judgment is None or provenance is None):
+                    return FinalSemanticEvaluation(
+                        SemanticStatus.FAILED,
+                        SemanticReason.COORDINATOR_FAILURE,
+                        attempt_accounting=accounting,
+                        operation_lease=current_lease[0],
+                    )
                 return FinalSemanticEvaluation(
                     status,
                     reason,
                     judgment=judgment,
                     provenance=provenance,
                     attempt_accounting=accounting,
+                    operation_lease=current_lease[0],
                 )
 
             return cast(
@@ -1710,6 +1872,8 @@ def _privacy_gated_semantic_evaluator(
                     dispatch=_dispatch,
                     publish_success_response=_publish_success,
                     build_final=_build_final,
+                    recover_selected=_recover_selected,
+                    on_lease_renewed=_on_lease_renewed,
                 ),
             )
         except Exception as exc:

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -1644,7 +1644,9 @@ def _privacy_gated_semantic_evaluator(
                 case_ref,
             )
 
-            async def _dispatch(handle: object, attempt_deadline: Deadline) -> FinalSemanticEvaluation:
+            async def _dispatch(
+                handle: object, attempt_deadline: Deadline
+            ) -> FinalSemanticEvaluation:
                 from yoetz.ports.ledger import SemanticAttemptHandle as _Handle
 
                 assert type(handle) is _Handle

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -7,7 +7,7 @@ import hashlib
 import os
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Final, Protocol, cast
 
@@ -52,6 +52,10 @@ from yoetz.application.observation_coordinator import ObservationCoordinator
 from yoetz.application.observation_verification import ObservationVerificationSupervisor
 from yoetz.application.privacy_control import build_privacy_support_handlers
 from yoetz.application.privacy_policy import PrivacyPolicyApplication
+from yoetz.application.semantic_attempts import (
+    SemanticAttemptAccounting,
+    run_durable_semantic_attempts,
+)
 from yoetz.application.semantic_case import (
     build_semantic_case,
     semantic_case_to_candidate_context,
@@ -71,6 +75,7 @@ from yoetz.domain.findings import (
     SemanticDispatchKind,
     SemanticFailureClass,
     SemanticProvenance,
+    semantic_provenance_to_json,
 )
 from yoetz.domain.privacy import (
     AuthorizationScope,
@@ -112,6 +117,7 @@ from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
 from yoetz.ports.keys import BundleKeys, MacKeyHandle, MacKeyPurpose
 from yoetz.ports.ledger import FrozenCase, LedgerPort
 from yoetz.ports.objects import (
+    ObjectKind,
     ObjectMetadata,
     ObjectRef,
     ObjectRootSnapshot,
@@ -1310,7 +1316,7 @@ def _provider_provenance(
     *,
     status: SemanticStatus,
     reason: SemanticReason,
-    ids: IdPort,
+    attempt_id: str,
 ) -> SemanticProvenance | None:
     """Bind a completed attempt to its dispatch-specific durable privacy authority."""
 
@@ -1343,7 +1349,7 @@ def _provider_provenance(
         privacy_policy_digest=attempt.privacy_policy_digest,
         sampling_params=attempt.sampling_params,
         latency_ms=attempt.latency_ms,
-        semantic_attempt_id=ids.new(IdKind.SEMANTIC_ATTEMPT),
+        semantic_attempt_id=attempt_id,
         dispatch_kind=result.dispatch_kind,
         privacy_receipt_id=result.privacy_receipt_id,
         status=status,
@@ -1359,8 +1365,8 @@ def _provider_provenance(
 
 
 def _map_provider_outcome(
-    result: SemanticEgressProviderOutcome, ids: IdPort
-) -> FinalSemanticEvaluation:
+    result: SemanticEgressProviderOutcome, *, attempt_id: str
+) -> FinalSemanticEvaluation:  # attempt_id is the durable semantic_attempts row identity
     provider = result.result
     status: SemanticStatus
     reason: SemanticReason
@@ -1379,10 +1385,17 @@ def _map_provider_outcome(
     elif type(provider) is SemanticResultLate:
         status, reason = SemanticStatus.LATE, SemanticReason.DEADLINE_AUTHORITY_LOST
     elif type(provider) is SemanticResultUnavailable:
-        status, reason = SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE
+        status = SemanticStatus.UNAVAILABLE
+        failure_class = provider.provenance.failure_class
+        if failure_class is SemanticFailureClass.RATE_LIMITED:
+            reason = SemanticReason.PROVIDER_RATE_LIMITED
+        elif failure_class is SemanticFailureClass.QUOTA_EXHAUSTED:
+            reason = SemanticReason.PROVIDER_QUOTA_EXHAUSTED
+        else:
+            reason = SemanticReason.TRANSPORT_UNAVAILABLE
     else:
         return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
-    provenance = _provider_provenance(result, status=status, reason=reason, ids=ids)
+    provenance = _provider_provenance(result, status=status, reason=reason, attempt_id=attempt_id)
     if provenance is None:
         return FinalSemanticEvaluation(
             SemanticStatus.UNAVAILABLE, SemanticReason.RECEIPT_PERSISTENCE_UNKNOWN
@@ -1390,15 +1403,30 @@ def _map_provider_outcome(
     return FinalSemanticEvaluation(status, reason, provenance=provenance)
 
 
-def _map_egress_to_final(result: object, ids: IdPort) -> FinalSemanticEvaluation:
-    """Map privacy egress outcomes to check FinalSemanticEvaluation without inventing findings."""
+def _map_egress_to_final(
+    result: object,
+    ids: IdPort | None = None,
+    *,
+    attempt_id: str | None = None,
+) -> FinalSemanticEvaluation:
+    """Map privacy egress outcomes to check FinalSemanticEvaluation without inventing findings.
+
+    Production passes the durable ``attempt_id``. Tests may pass only an ``IdPort`` to mint a
+    provisional attempt identity for mapping assertions.
+    """
+
+    resolved_attempt = attempt_id
+    if resolved_attempt is None:
+        if ids is None:
+            raise TypeError("semantic_attempt_id_required")
+        resolved_attempt = ids.new(IdKind.SEMANTIC_ATTEMPT)
 
     if type(result) is SemanticEgressSuccess:
         provenance = _provider_provenance(
             result,
             status=SemanticStatus.SUCCEEDED,
             reason=SemanticReason.SEMANTIC_COMPLETED,
-            ids=ids,
+            attempt_id=resolved_attempt,
         )
         if provenance is None:
             return FinalSemanticEvaluation(
@@ -1417,8 +1445,78 @@ def _map_egress_to_final(result: object, ids: IdPort) -> FinalSemanticEvaluation
     if type(result) is SemanticEgressBlocked:
         return _map_blocked(result.outcome, result.reason)
     if type(result) is SemanticEgressProviderOutcome:
-        return _map_provider_outcome(result, ids)
+        return _map_provider_outcome(result, attempt_id=resolved_attempt)
     return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
+
+
+async def _publish_semantic_case_object(
+    runtime: TaskRuntime,
+    *,
+    case_digest: str,
+    case_id: str,
+    dependency_digest: str,
+    clock: ClockPort,
+) -> ObjectRef:
+    """Persist a structural SEMANTIC_CASE object bound into the durable job row."""
+
+    payload = canonical_encode(
+        cast(
+            CanonicalJsonValue,
+            {
+                "schema": "yoetz.semantic-case/1",
+                "case_id": case_id,
+                "case_digest": case_digest,
+                "dependency_digest": dependency_digest,
+            },
+        )
+    )
+    staged = await runtime.objects.stage(
+        ObjectSource(data=payload, declared_size=len(payload)),
+        ObjectMetadata(
+            ObjectKind.SEMANTIC_CASE,
+            "application/json",
+            runtime.task_id,
+            clock.now_utc(),
+        ),
+    )
+    return await runtime.objects.finalize(staged)
+
+
+async def _publish_semantic_response_object(
+    runtime: TaskRuntime,
+    *,
+    attempt_id: str,
+    evaluation: FinalSemanticEvaluation,
+    clock: ClockPort,
+) -> ObjectRef:
+    """Persist bounded SEMANTIC_RESPONSE facts (judgment/provenance only; no raw provider text)."""
+
+    body: dict[str, CanonicalJsonValue] = {
+        "schema": "yoetz.semantic-response/1",
+        "attempt_id": attempt_id,
+        "status": evaluation.status.value,
+        "reason": evaluation.reason.value,
+    }
+    if evaluation.judgment is not None:
+        body["judgment"] = {
+            "conclusion": evaluation.judgment.conclusion,
+            "challenge_count": len(evaluation.judgment.challenges),
+        }
+    if evaluation.provenance is not None:
+        body["provenance"] = cast(
+            CanonicalJsonValue, dict(semantic_provenance_to_json(evaluation.provenance).items())
+        )
+    payload = canonical_encode(cast(CanonicalJsonValue, body))
+    staged = await runtime.objects.stage(
+        ObjectSource(data=payload, declared_size=len(payload)),
+        ObjectMetadata(
+            ObjectKind.SEMANTIC_RESPONSE,
+            "application/json",
+            runtime.task_id,
+            clock.now_utc(),
+        ),
+    )
+    return await runtime.objects.finalize(staged)
 
 
 def _privacy_gated_semantic_evaluator(
@@ -1429,9 +1527,16 @@ def _privacy_gated_semantic_evaluator(
     catalog: StartCatalogPort,
     lookup: MacKeyHandle,
     ids: IdPort,
+    *,
+    timeout_seconds: int = 60,
+    max_retries: int = 2,
 ):
+    total_timeout = float(max(1, min(int(timeout_seconds), 300)))
+
     async def _evaluate(
-        frozen: FrozenCase, findings: tuple[object, ...]
+        frozen: FrozenCase,
+        findings: tuple[object, ...],
+        runtime: TaskRuntime | None = None,
     ) -> FinalSemanticEvaluation:
         # Re-resolve against the live generation-fenced registry on every check: a binding
         # activated after composition must take effect without a service restart, and a revoked
@@ -1507,15 +1612,104 @@ def _privacy_gated_semantic_evaluator(
                 policy_id=policy_id,
                 policy_version=policy_version,
             )
-            candidate = semantic_case_to_candidate_context(
-                semantic_case,
-                request_id=frozen.lease.operation_id,
-                scope=scope,
-                provider_binding=provider,
+            # Total semantic-operation deadline from configured timeout_seconds (not a hard-coded 60).
+            deadline = Deadline(
+                clock.now_utc() + timedelta(seconds=total_timeout),
+                clock.monotonic_seconds() + total_timeout,
             )
-            deadline = Deadline(clock.now_utc(), clock.monotonic_seconds() + 60.0)
-            result = await privacy.evaluate_semantic(candidate, deadline)
-            return _map_egress_to_final(result, ids)
+            # Without a task runtime there is no durable ledger/object store: perform one
+            # physical attempt only (tests and pre-dispatch probes). Production check always
+            # supplies the runtime so the durable multi-attempt path below is authoritative.
+            if runtime is None:
+                candidate = semantic_case_to_candidate_context(
+                    semantic_case,
+                    request_id=frozen.lease.operation_id,
+                    scope=scope,
+                    provider_binding=provider,
+                )
+                result = await privacy.evaluate_semantic(candidate, deadline)
+                return _map_egress_to_final(result, ids)
+
+            # One durable semantic job per check: create/recover after freeze, before dispatch.
+            case_ref = await _publish_semantic_case_object(
+                runtime,
+                case_digest=semantic_case.case_digest,
+                case_id=semantic_case.case_id,
+                dependency_digest=semantic_case.dependency_digest,
+                clock=clock,
+            )
+            job = await runtime.ledger.enqueue_semantic_job(
+                frozen.lease,
+                semantic_case.case_digest,
+                case_ref,
+            )
+
+            async def _dispatch(handle: object, attempt_deadline: Deadline) -> FinalSemanticEvaluation:
+                from yoetz.ports.ledger import SemanticAttemptHandle as _Handle
+
+                assert type(handle) is _Handle
+                # Fresh request identity per physical attempt so authorization cannot be reused.
+                candidate = semantic_case_to_candidate_context(
+                    semantic_case,
+                    request_id=handle.provider_request_id,
+                    scope=scope,
+                    provider_binding=provider,
+                )
+                result = await privacy.evaluate_semantic(candidate, attempt_deadline)
+                return _map_egress_to_final(result, ids, attempt_id=handle.attempt_id)
+
+            async def _publish_success(handle: object, evaluation: object) -> ObjectRef:
+                from yoetz.ports.ledger import SemanticAttemptHandle as _Handle
+
+                assert type(handle) is _Handle
+                assert type(evaluation) is FinalSemanticEvaluation
+                return await _publish_semantic_response_object(
+                    runtime,
+                    attempt_id=handle.attempt_id,
+                    evaluation=evaluation,
+                    clock=clock,
+                )
+
+            def _build_final(
+                status: SemanticStatus,
+                reason: SemanticReason,
+                evaluation: object | None,
+                accounting: SemanticAttemptAccounting,
+            ) -> FinalSemanticEvaluation:
+                judgment = None
+                provenance = None
+                if type(evaluation) is FinalSemanticEvaluation:
+                    if status is SemanticStatus.SUCCEEDED:
+                        judgment = evaluation.judgment
+                        provenance = evaluation.provenance
+                    elif (
+                        status is evaluation.status
+                        and reason is evaluation.reason
+                        and evaluation.provenance is not None
+                    ):
+                        provenance = evaluation.provenance
+                return FinalSemanticEvaluation(
+                    status,
+                    reason,
+                    judgment=judgment,
+                    provenance=provenance,
+                    attempt_accounting=accounting,
+                )
+
+            return cast(
+                FinalSemanticEvaluation,
+                await run_durable_semantic_attempts(
+                    ledger=runtime.ledger,
+                    lease=frozen.lease,
+                    job=job,
+                    deadline=deadline,
+                    max_retries=max_retries,
+                    now_monotonic=clock.monotonic_seconds,
+                    dispatch=_dispatch,
+                    publish_success_response=_publish_success,
+                    build_final=_build_final,
+                ),
+            )
         except Exception as exc:
             record_unexpected_exception_without_raising(
                 exc,
@@ -1692,6 +1886,7 @@ async def provide_service_ready_context(
     elif not provider_endpoint_bound:
         semantic_evaluator = _semantic_provider_unbound
     else:
+        provider_cfg = config.provider
         semantic_evaluator = _privacy_gated_semantic_evaluator(
             cast(PrivacyCoordinator, privacy),
             clock,
@@ -1700,6 +1895,8 @@ async def provide_service_ready_context(
             catalog,
             lookup,
             ids,
+            timeout_seconds=60 if provider_cfg is None else int(provider_cfg.timeout_seconds),
+            max_retries=2 if provider_cfg is None else int(provider_cfg.max_retries),
         )
 
     async def _semantic_review(

--- a/tests/conformance/adapters/test_ledger_port.py
+++ b/tests/conformance/adapters/test_ledger_port.py
@@ -384,4 +384,46 @@ async def test_semantic_attempt_selection_contract() -> None:
         response_ref = await _object_ref(adapter, command, ObjectKind.SEMANTIC_RESPONSE)
         await adapter.record_attempt_outcome(handle, AttemptOutcome.RESPONSE_DURABLE, response_ref)
         selected.append(await adapter.select_attempt(lease, handle, response_ref))
+        loaded = await adapter.load_semantic_job(command.writer_id, frozen.lease.operation_id)
+        assert loaded is not None
+        assert loaded.selected_attempt_id == selected[-1].attempt_id
+        attempts = await adapter.list_semantic_attempts(loaded.job_id)
+        assert len(attempts) == 1
+        assert attempts[0].state == "selected"
+        assert attempts[0].attempt_id == selected[-1].attempt_id
     assert selected[0] == selected[1]
+
+
+@pytest.mark.anyio
+async def test_semantic_claim_resumes_same_started_attempt_for_owner() -> None:
+    """Crash before authorization consumption resumes the same attempt identity."""
+
+    command = ledger_command()
+    for adapter in (memory_ledger(command), sqlite_ledger(command)):
+        await adapter.append_batch(command)
+        frozen = await adapter.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            "req_00000000-0000-4000-8000-000000000018",
+            "sha256:" + "8" * 64,
+        )
+        assert type(frozen) is FrozenCase
+        lease = await adapter.advance_check_phase(
+            frozen.lease,
+            CheckPhase.RESERVED,
+            CheckPhase.LOCAL_READY,
+            await _local_result_ref(adapter, command),
+        )
+        lease = await adapter.advance_check_phase(
+            lease,
+            CheckPhase.LOCAL_READY,
+            CheckPhase.SEMANTIC_WAIT,
+        )
+        case_ref = await _object_ref(adapter, command, ObjectKind.SEMANTIC_CASE)
+        job = await adapter.enqueue_semantic_job(lease, "sha256:" + "7" * 64, case_ref)
+        first = await adapter.claim_semantic_job(lease, job.job_id)
+        second = await adapter.claim_semantic_job(lease, job.job_id)
+        assert first.attempt_id == second.attempt_id
+        assert first.provider_request_id == second.provider_request_id
+        assert first.attempt_ordinal == 1

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -257,8 +257,9 @@ class _App:
         self,
         frozen: FrozenCase,
         deterministic_findings: tuple[Finding, ...],
+        runtime: object | None = None,
     ) -> FinalSemanticEvaluation:
-        _ = (frozen, deterministic_findings)
+        _ = (frozen, deterministic_findings, runtime)
         if self.crash_semantic:
             raise RuntimeError("semantic_evaluator_crashed")
         return self.semantic_result

--- a/tests/unit/application/test_semantic_attempts.py
+++ b/tests/unit/application/test_semantic_attempts.py
@@ -1,0 +1,588 @@
+"""Unit tests for durable semantic attempt budget, retry matrix, and accounting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Literal
+
+import pytest
+
+from yoetz.application.semantic_attempts import (
+    SemanticAttemptAccounting,
+    attempt_accounting_from_rows,
+    attempt_accounting_to_json,
+    final_status_after_exhaustion,
+    is_retriable_semantic_outcome,
+    physical_attempt_budget,
+    run_durable_semantic_attempts,
+    should_retry_after,
+)
+from yoetz.domain.values import Frontier
+from yoetz.ports.ledger import (
+    AttemptOutcome,
+    CheckPhase,
+    OperationLease,
+    SemanticAttemptHandle,
+    SemanticAttemptRecord,
+    SemanticJobRecord,
+)
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+_JOB = "job_40000000-0000-4000-8000-000000000001"
+_ATT1 = "att_40000000-0000-4000-8000-000000000001"
+_ATT2 = "att_40000000-0000-4000-8000-000000000002"
+_ATT3 = "att_40000000-0000-4000-8000-000000000003"
+_WRITER = "wri_40000000-0000-4000-8000-000000000001"
+_OP = "req_40000000-0000-4000-8000-000000000001"
+_SESSION = "ses_40000000-0000-4000-8000-000000000001"
+_CASE = "sha256:" + "a" * 64
+_DEP = "sha256:" + "b" * 64
+_FRONTIER = Frontier(1, "sha256:" + "c" * 64)
+
+
+def _case_ref() -> ObjectRef:
+    return ObjectRef(
+        "obj_40000000-0000-4000-8000-000000000001",
+        2,
+        "hmac-sha256:" + "d" * 64,
+        "sha256:" + "e" * 64,
+        "yoetz-object/1",
+        "bmk-1",
+        ObjectMetadata(
+            ObjectKind.SEMANTIC_CASE,
+            "application/json",
+            "tsk_40000000-0000-4000-8000-000000000001",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def _response_ref() -> ObjectRef:
+    return ObjectRef(
+        "obj_40000000-0000-4000-8000-000000000002",
+        2,
+        "hmac-sha256:" + "f" * 64,
+        "sha256:" + "1" * 64,
+        "yoetz-object/1",
+        "bmk-1",
+        ObjectMetadata(
+            ObjectKind.SEMANTIC_RESPONSE,
+            "application/json",
+            "tsk_40000000-0000-4000-8000-000000000001",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def _lease() -> OperationLease:
+    return OperationLease(
+        _WRITER,
+        _OP,
+        _SESSION,
+        CheckPhase.SEMANTIC_WAIT,
+        "owner-generation-1",
+        "lease-owner-1",
+        1,
+        datetime(2030, 1, 1, tzinfo=UTC),
+        _FRONTIER,
+        _DEP,
+    )
+
+
+def test_physical_attempt_budget_caps_at_adr_006() -> None:
+    assert physical_attempt_budget(0) == 1
+    assert physical_attempt_budget(1) == 2
+    assert physical_attempt_budget(2) == 3
+    assert physical_attempt_budget(99) == 3
+
+
+def test_retry_matrix_admits_only_approved_transient_classes() -> None:
+    assert is_retriable_semantic_outcome(
+        SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT
+    )
+    assert is_retriable_semantic_outcome(
+        SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE
+    )
+    assert is_retriable_semantic_outcome(
+        SemanticStatus.UNAVAILABLE, SemanticReason.PROVIDER_RATE_LIMITED
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.INVALID, SemanticReason.RESPONSE_SCHEMA_INVALID
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.REFUSED, SemanticReason.PROVIDER_REFUSED
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.NETWORK_EGRESS_DENIED
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.HUMAN_DENIED, SemanticReason.HUMAN_DENIED
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.UNAVAILABLE, SemanticReason.PROVIDER_QUOTA_EXHAUSTED
+    )
+    assert not is_retriable_semantic_outcome(
+        SemanticStatus.STALE, SemanticReason.FRONTIER_CHANGED
+    )
+
+
+def test_should_retry_respects_budget_and_deadline() -> None:
+    assert should_retry_after(
+        status=SemanticStatus.TIMEOUT,
+        reason=SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=1,
+        max_retries=2,
+        deadline_expired=False,
+    )
+    assert not should_retry_after(
+        status=SemanticStatus.TIMEOUT,
+        reason=SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=1,
+        max_retries=0,
+        deadline_expired=False,
+    )
+    assert not should_retry_after(
+        status=SemanticStatus.TIMEOUT,
+        reason=SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=3,
+        max_retries=2,
+        deadline_expired=False,
+    )
+    assert not should_retry_after(
+        status=SemanticStatus.TIMEOUT,
+        reason=SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=1,
+        max_retries=2,
+        deadline_expired=True,
+    )
+
+
+def test_final_status_after_exhaustion() -> None:
+    status, reason = final_status_after_exhaustion(
+        SemanticStatus.TIMEOUT,
+        SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=1,
+        max_retries=0,
+    )
+    assert (status, reason) == (SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT)
+
+    status, reason = final_status_after_exhaustion(
+        SemanticStatus.TIMEOUT,
+        SemanticReason.PROVIDER_TIMEOUT,
+        attempts_completed=3,
+        max_retries=2,
+    )
+    assert (status, reason) == (
+        SemanticStatus.UNAVAILABLE,
+        SemanticReason.RETRY_BUDGET_EXHAUSTED,
+    )
+
+
+def test_attempt_accounting_from_rows_is_structural() -> None:
+    job = SemanticJobRecord(
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "failed",
+        2,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        SemanticReason.RETRY_BUDGET_EXHAUSTED,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    attempts = (
+        SemanticAttemptRecord(
+            _JOB,
+            _ATT1,
+            1,
+            "req_40000000-0000-4000-8000-0000000000aa",
+            "expired",
+            SemanticReason.PROVIDER_TIMEOUT,
+            None,
+        ),
+        SemanticAttemptRecord(
+            _JOB,
+            _ATT2,
+            2,
+            "req_40000000-0000-4000-8000-0000000000bb",
+            "failed",
+            SemanticReason.RETRY_BUDGET_EXHAUSTED,
+            None,
+        ),
+    )
+    accounting = attempt_accounting_from_rows(job, attempts, max_retries=1)
+    assert accounting.attempted_count == 2
+    assert accounting.selected_attempt_id is None
+    assert accounting.exhausted is True
+    encoded = attempt_accounting_to_json(accounting)
+    # No user-controlled content: only structural tokens and counts.
+    assert encoded["attempted_count"] == 2
+    assert encoded["exhausted"] is True
+    raw = str(encoded)
+    assert "timeout" in raw or "provider_timeout" in raw
+    assert "secret" not in raw
+    assert "prompt" not in raw
+
+
+@dataclass(frozen=True, slots=True)
+class _Eval:
+    status: SemanticStatus
+    reason: SemanticReason
+    judgment: object | None = None
+    provenance: object | None = None
+
+
+@dataclass
+class _FakeLedger:
+    job: SemanticJobRecord
+    lease: OperationLease
+    outcomes: list[tuple[str, AttemptOutcome, SemanticReason | None]] | None = None
+    dispatches: list[str] | None = None
+    mono: float = 0.0
+    attempt_ids: list[str] | None = None
+    provider_ids: list[str] | None = None
+    selected: str | None = None
+    attempts: dict[str, SemanticAttemptRecord] | None = None
+
+    def __post_init__(self) -> None:
+        self.outcomes = []
+        self.dispatches = []
+        self.attempt_ids = []
+        self.provider_ids = []
+        self.attempts = {}
+
+    async def claim_semantic_job(
+        self, lease: OperationLease, job_id: str
+    ) -> SemanticAttemptHandle:
+        assert lease == self.lease
+        assert job_id == self.job.job_id
+        ordinal = self.job.attempt_count + 1
+        att = f"att_40000000-0000-4000-8000-{ordinal:012x}"
+        req = f"req_40000000-0000-4000-8000-{ordinal:012x}"
+        handle = SemanticAttemptHandle(
+            job_id,
+            att,
+            ordinal,
+            req,
+            lease.writer_id,
+            lease.operation_id,
+            lease.owner_generation,
+            lease.lease_owner_id,
+            ordinal,
+            lease.lease_expires_at,
+            lease.frontier,
+            lease.dependency_digest,
+        )
+        self.job = replace(
+            self.job,
+            state="leased",
+            attempt_count=ordinal,
+            active_attempt_id=att,
+            lease_owner_id=lease.lease_owner_id,
+            lease_generation=ordinal,
+            lease_expires_at=lease.lease_expires_at,
+        )
+        assert self.attempt_ids is not None
+        assert self.provider_ids is not None
+        assert self.attempts is not None
+        self.attempt_ids.append(att)
+        self.provider_ids.append(req)
+        self.attempts[att] = SemanticAttemptRecord(
+            job_id, att, ordinal, req, "started", None, None
+        )
+        return handle
+
+    async def record_attempt_outcome(
+        self,
+        handle: SemanticAttemptHandle,
+        outcome: AttemptOutcome,
+        result_object_ref: ObjectRef | None = None,
+        terminal_code: SemanticReason | None = None,
+    ) -> None:
+        assert self.attempts is not None
+        assert self.outcomes is not None
+        self.outcomes.append((handle.attempt_id, outcome, terminal_code))
+        state: Literal[
+            "started", "response_durable", "selected", "failed", "expired", "late"
+        ]
+        if outcome is AttemptOutcome.RESPONSE_DURABLE:
+            state = "response_durable"
+        elif outcome is AttemptOutcome.EXPIRED:
+            state = "expired"
+        elif outcome is AttemptOutcome.FAILED:
+            state = "failed"
+        elif outcome is AttemptOutcome.LATE:
+            state = "late"
+        else:
+            state = "selected"
+        self.attempts[handle.attempt_id] = SemanticAttemptRecord(
+            handle.job_id,
+            handle.attempt_id,
+            handle.attempt_ordinal,
+            handle.provider_request_id,
+            state,
+            terminal_code,
+            result_object_ref,
+        )
+        if outcome is AttemptOutcome.EXPIRED:
+            self.job = replace(
+                self.job,
+                state="queued",
+                active_attempt_id=None,
+                lease_owner_id=None,
+                lease_generation=None,
+                lease_expires_at=None,
+            )
+        elif outcome is AttemptOutcome.FAILED:
+            self.job = replace(
+                self.job,
+                state="failed",
+                active_attempt_id=None,
+                lease_owner_id=None,
+                lease_generation=None,
+                lease_expires_at=None,
+                terminal_code=terminal_code,
+                terminal_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+
+    async def select_attempt(
+        self,
+        lease: OperationLease,
+        handle: SemanticAttemptHandle,
+        selected_result_object_ref: ObjectRef,
+    ) -> object:
+        self.selected = handle.attempt_id
+        self.job = replace(
+            self.job,
+            state="succeeded",
+            active_attempt_id=None,
+            selected_attempt_id=handle.attempt_id,
+            selected_result_object_ref=selected_result_object_ref,
+            terminal_code=SemanticReason.SEMANTIC_COMPLETED,
+            terminal_at=datetime(2026, 1, 1, tzinfo=UTC),
+            lease_owner_id=None,
+            lease_generation=None,
+            lease_expires_at=None,
+        )
+        return object()
+
+    async def load_semantic_job(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticJobRecord | None:
+        assert (writer_id, operation_id) == (_WRITER, _OP)
+        return self.job
+
+    async def list_semantic_attempts(self, job_id: str) -> tuple[SemanticAttemptRecord, ...]:
+        assert job_id == _JOB
+        assert self.attempts is not None
+        return tuple(sorted(self.attempts.values(), key=lambda item: item.attempt_ordinal))
+
+
+@pytest.mark.anyio
+async def test_zero_retry_performs_exactly_one_attempt() -> None:
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+    )
+    ledger = _FakeLedger(job, lease)
+    script = [
+        _Eval(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT),
+    ]
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        assert ledger.dispatches is not None
+        ledger.dispatches.append(handle.attempt_id)
+        assert not deadline.expired(0.0)
+        return script.pop(0)
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+        raise AssertionError("publish_not_expected")
+
+    finals: list[tuple[SemanticStatus, SemanticReason, int]] = []
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        finals.append((status, reason, accounting.attempted_count))
+        return (status, reason, accounting)
+
+    result = await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=lease,
+        job=job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+        max_retries=0,
+        now_monotonic=lambda: 0.0,
+        dispatch=dispatch,
+        publish_success_response=publish,
+        sleep=lambda _: _async_noop(),
+        build_final=build_final,
+    )
+    assert ledger.dispatches is not None and len(ledger.dispatches) == 1
+    assert ledger.outcomes is not None and ledger.outcomes[0][1] is AttemptOutcome.FAILED
+    assert finals[0] == (SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT, 1)
+    assert result[0] is SemanticStatus.TIMEOUT
+
+
+async def _async_noop() -> None:
+    return None
+
+
+@pytest.mark.anyio
+async def test_two_retries_perform_at_most_three_physical_attempts() -> None:
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+    )
+    ledger = _FakeLedger(job, lease)
+    script = [
+        _Eval(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT),
+        _Eval(SemanticStatus.UNAVAILABLE, SemanticReason.PROVIDER_RATE_LIMITED),
+        _Eval(SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE),
+        _Eval(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT),  # must not run
+    ]
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        assert ledger.dispatches is not None
+        ledger.dispatches.append(handle.provider_request_id)
+        return script.pop(0)
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+        raise AssertionError("publish_not_expected")
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, accounting)
+
+    result = await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=lease,
+        job=job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+        max_retries=2,
+        now_monotonic=lambda: 0.0,
+        dispatch=dispatch,
+        publish_success_response=publish,
+        sleep=lambda _: _async_noop(),
+        build_final=build_final,
+    )
+    assert ledger.dispatches is not None and len(ledger.dispatches) == 3
+    assert len(set(ledger.dispatches)) == 3  # unique provider request ids
+    assert ledger.attempt_ids is not None and len(set(ledger.attempt_ids)) == 3
+    assert result[0] is SemanticStatus.UNAVAILABLE
+    assert result[1] is SemanticReason.RETRY_BUDGET_EXHAUSTED
+    assert result[2].attempted_count == 3
+    assert result[2].exhausted is True
+    # Intermediate retriable outcomes used EXPIRED; final FAILED.
+    assert ledger.outcomes is not None
+    assert [item[1] for item in ledger.outcomes] == [
+        AttemptOutcome.EXPIRED,
+        AttemptOutcome.EXPIRED,
+        AttemptOutcome.FAILED,
+    ]
+
+
+@pytest.mark.anyio
+async def test_success_selects_first_valid_and_stops() -> None:
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+    )
+    ledger = _FakeLedger(job, lease)
+    script = [
+        _Eval(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT),
+        _Eval(SemanticStatus.SUCCEEDED, SemanticReason.SEMANTIC_COMPLETED),
+        _Eval(SemanticStatus.SUCCEEDED, SemanticReason.SEMANTIC_COMPLETED),
+    ]
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        assert ledger.dispatches is not None
+        ledger.dispatches.append(handle.attempt_id)
+        return script.pop(0)
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+        return _response_ref()
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, accounting)
+
+    result = await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=lease,
+        job=job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+        max_retries=2,
+        now_monotonic=lambda: 0.0,
+        dispatch=dispatch,
+        publish_success_response=publish,
+        sleep=lambda _: _async_noop(),
+        build_final=build_final,
+    )
+    assert ledger.dispatches is not None
+    assert len(ledger.dispatches) == 2
+    assert ledger.selected is not None
+    assert result[0] is SemanticStatus.SUCCEEDED
+    assert result[2].selected_attempt_id == ledger.selected
+    assert result[2].attempted_count == 2
+
+
+@pytest.mark.anyio
+async def test_policy_block_never_retries() -> None:
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+    )
+    ledger = _FakeLedger(job, lease)
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        assert ledger.dispatches is not None
+        ledger.dispatches.append(handle.attempt_id)
+        return _Eval(SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.NETWORK_EGRESS_DENIED)
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+        raise AssertionError("publish_not_expected")
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, accounting)
+
+    result = await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=lease,
+        job=job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+        max_retries=2,
+        now_monotonic=lambda: 0.0,
+        dispatch=dispatch,
+        publish_success_response=publish,
+        sleep=lambda _: _async_noop(),
+        build_final=build_final,
+    )
+    assert ledger.dispatches is not None and len(ledger.dispatches) == 1
+    assert result[0] is SemanticStatus.BLOCKED_BY_POLICY
+    assert ledger.outcomes is not None and ledger.outcomes[0][1] is AttemptOutcome.FAILED

--- a/tests/unit/application/test_semantic_attempts.py
+++ b/tests/unit/application/test_semantic_attempts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 
@@ -408,7 +408,7 @@ async def test_zero_retry_performs_exactly_one_attempt() -> None:
         assert not deadline.expired(0.0)
         return script.pop(0)
 
-    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
         raise AssertionError("publish_not_expected")
 
     finals: list[tuple[SemanticStatus, SemanticReason, int]] = []
@@ -422,17 +422,20 @@ async def test_zero_retry_performs_exactly_one_attempt() -> None:
         finals.append((status, reason, accounting.attempted_count))
         return (status, reason, accounting)
 
-    result = await run_durable_semantic_attempts(
-        ledger=ledger,
-        lease=lease,
-        job=job,
-        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
-        max_retries=0,
-        now_monotonic=lambda: 0.0,
-        dispatch=dispatch,
-        publish_success_response=publish,
-        sleep=lambda _: _async_noop(),
-        build_final=build_final,
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=0,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+        ),
     )
     assert ledger.dispatches is not None and len(ledger.dispatches) == 1
     assert ledger.outcomes is not None and ledger.outcomes[0][1] is AttemptOutcome.FAILED
@@ -477,7 +480,7 @@ async def test_two_retries_perform_at_most_three_physical_attempts() -> None:
         ledger.dispatches.append(handle.provider_request_id)
         return script.pop(0)
 
-    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
         raise AssertionError("publish_not_expected")
 
     def build_final(
@@ -488,17 +491,20 @@ async def test_two_retries_perform_at_most_three_physical_attempts() -> None:
     ) -> object:
         return (status, reason, accounting)
 
-    result = await run_durable_semantic_attempts(
-        ledger=ledger,
-        lease=lease,
-        job=job,
-        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
-        max_retries=2,
-        now_monotonic=lambda: 0.0,
-        dispatch=dispatch,
-        publish_success_response=publish,
-        sleep=lambda _: _async_noop(),
-        build_final=build_final,
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=2,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+        ),
     )
     assert ledger.dispatches is not None and len(ledger.dispatches) == 3
     assert len(set(ledger.dispatches)) == 3  # unique provider request ids
@@ -548,7 +554,7 @@ async def test_success_selects_first_valid_and_stops() -> None:
         ledger.dispatches.append(handle.attempt_id)
         return script.pop(0)
 
-    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
         return _response_ref()
 
     def build_final(
@@ -559,17 +565,20 @@ async def test_success_selects_first_valid_and_stops() -> None:
     ) -> object:
         return (status, reason, accounting)
 
-    result = await run_durable_semantic_attempts(
-        ledger=ledger,
-        lease=lease,
-        job=job,
-        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
-        max_retries=2,
-        now_monotonic=lambda: 0.0,
-        dispatch=dispatch,
-        publish_success_response=publish,
-        sleep=lambda _: _async_noop(),
-        build_final=build_final,
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=2,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+        ),
     )
     assert ledger.dispatches is not None
     assert len(ledger.dispatches) == 2
@@ -606,7 +615,7 @@ async def test_policy_block_never_retries() -> None:
         ledger.dispatches.append(handle.attempt_id)
         return _Eval(SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.NETWORK_EGRESS_DENIED)
 
-    async def publish(handle: SemanticAttemptHandle, evaluation: _Eval) -> ObjectRef:
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
         raise AssertionError("publish_not_expected")
 
     def build_final(
@@ -617,17 +626,20 @@ async def test_policy_block_never_retries() -> None:
     ) -> object:
         return (status, reason, accounting)
 
-    result = await run_durable_semantic_attempts(
-        ledger=ledger,
-        lease=lease,
-        job=job,
-        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
-        max_retries=2,
-        now_monotonic=lambda: 0.0,
-        dispatch=dispatch,
-        publish_success_response=publish,
-        sleep=lambda _: _async_noop(),
-        build_final=build_final,
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=2,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+        ),
     )
     assert ledger.dispatches is not None and len(ledger.dispatches) == 1
     assert result[0] is SemanticStatus.BLOCKED_BY_POLICY

--- a/tests/unit/application/test_semantic_attempts.py
+++ b/tests/unit/application/test_semantic_attempts.py
@@ -100,9 +100,7 @@ def test_physical_attempt_budget_caps_at_adr_006() -> None:
 
 
 def test_retry_matrix_admits_only_approved_transient_classes() -> None:
-    assert is_retriable_semantic_outcome(
-        SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT
-    )
+    assert is_retriable_semantic_outcome(SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT)
     assert is_retriable_semantic_outcome(
         SemanticStatus.UNAVAILABLE, SemanticReason.TRANSPORT_UNAVAILABLE
     )
@@ -124,9 +122,7 @@ def test_retry_matrix_admits_only_approved_transient_classes() -> None:
     assert not is_retriable_semantic_outcome(
         SemanticStatus.UNAVAILABLE, SemanticReason.PROVIDER_QUOTA_EXHAUSTED
     )
-    assert not is_retriable_semantic_outcome(
-        SemanticStatus.STALE, SemanticReason.FRONTIER_CHANGED
-    )
+    assert not is_retriable_semantic_outcome(SemanticStatus.STALE, SemanticReason.FRONTIER_CHANGED)
 
 
 def test_should_retry_respects_budget_and_deadline() -> None:
@@ -260,9 +256,7 @@ class _FakeLedger:
         self.provider_ids = []
         self.attempts = {}
 
-    async def claim_semantic_job(
-        self, lease: OperationLease, job_id: str
-    ) -> SemanticAttemptHandle:
+    async def claim_semantic_job(self, lease: OperationLease, job_id: str) -> SemanticAttemptHandle:
         assert lease == self.lease
         assert job_id == self.job.job_id
         ordinal = self.job.attempt_count + 1
@@ -296,9 +290,7 @@ class _FakeLedger:
         assert self.attempts is not None
         self.attempt_ids.append(att)
         self.provider_ids.append(req)
-        self.attempts[att] = SemanticAttemptRecord(
-            job_id, att, ordinal, req, "started", None, None
-        )
+        self.attempts[att] = SemanticAttemptRecord(job_id, att, ordinal, req, "started", None, None)
         return handle
 
     async def record_attempt_outcome(
@@ -311,9 +303,7 @@ class _FakeLedger:
         assert self.attempts is not None
         assert self.outcomes is not None
         self.outcomes.append((handle.attempt_id, outcome, terminal_code))
-        state: Literal[
-            "started", "response_durable", "selected", "failed", "expired", "late"
-        ]
+        state: Literal["started", "response_durable", "selected", "failed", "expired", "late"]
         if outcome is AttemptOutcome.RESPONSE_DURABLE:
             state = "response_durable"
         elif outcome is AttemptOutcome.EXPIRED:
@@ -391,7 +381,21 @@ class _FakeLedger:
 async def test_zero_retry_performs_exactly_one_attempt() -> None:
     lease = _lease()
     job = SemanticJobRecord(
-        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "queued",
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     )
     ledger = _FakeLedger(job, lease)
     script = [
@@ -444,7 +448,21 @@ async def _async_noop() -> None:
 async def test_two_retries_perform_at_most_three_physical_attempts() -> None:
     lease = _lease()
     job = SemanticJobRecord(
-        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "queued",
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     )
     ledger = _FakeLedger(job, lease)
     script = [
@@ -502,7 +520,21 @@ async def test_two_retries_perform_at_most_three_physical_attempts() -> None:
 async def test_success_selects_first_valid_and_stops() -> None:
     lease = _lease()
     job = SemanticJobRecord(
-        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "queued",
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     )
     ledger = _FakeLedger(job, lease)
     script = [
@@ -551,7 +583,21 @@ async def test_success_selects_first_valid_and_stops() -> None:
 async def test_policy_block_never_retries() -> None:
     lease = _lease()
     job = SemanticJobRecord(
-        _JOB, _WRITER, _OP, _CASE, _case_ref(), "queued", 0, None, None, None, None, None, None, None, None
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "queued",
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
     )
     ledger = _FakeLedger(job, lease)
 

--- a/tests/unit/application/test_semantic_attempts.py
+++ b/tests/unit/application/test_semantic_attempts.py
@@ -248,6 +248,8 @@ class _FakeLedger:
     provider_ids: list[str] | None = None
     selected: str | None = None
     attempts: dict[str, SemanticAttemptRecord] | None = None
+    renew_count: int = 0
+    claim_calls: int = 0
 
     def __post_init__(self) -> None:
         self.outcomes = []
@@ -255,10 +257,27 @@ class _FakeLedger:
         self.attempt_ids = []
         self.provider_ids = []
         self.attempts = {}
+        self.renew_count = 0
+        self.claim_calls = 0
+
+    async def renew_leases(self, lease: OperationLease) -> OperationLease:
+        assert lease.writer_id == self.lease.writer_id
+        assert lease.operation_id == self.lease.operation_id
+        self.renew_count += 1
+        self.lease = replace(
+            self.lease,
+            lease_generation=self.lease.lease_generation + 1,
+            lease_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        )
+        return self.lease
 
     async def claim_semantic_job(self, lease: OperationLease, job_id: str) -> SemanticAttemptHandle:
+        # After terminal recovery, claim must not be invoked.
+        if self.job.state in {"succeeded", "failed", "quarantined"}:
+            raise AssertionError("claim_semantic_job_on_terminal_job")
         assert lease == self.lease
         assert job_id == self.job.job_id
+        self.claim_calls += 1
         ordinal = self.job.attempt_count + 1
         att = f"att_40000000-0000-4000-8000-{ordinal:012x}"
         req = f"req_40000000-0000-4000-8000-{ordinal:012x}"
@@ -644,3 +663,211 @@ async def test_policy_block_never_retries() -> None:
     assert ledger.dispatches is not None and len(ledger.dispatches) == 1
     assert result[0] is SemanticStatus.BLOCKED_BY_POLICY
     assert ledger.outcomes is not None and ledger.outcomes[0][1] is AttemptOutcome.FAILED
+
+
+@pytest.mark.anyio
+async def test_terminal_failed_job_recovers_without_claim() -> None:
+    """Crash after final FAILED, before check commit: replay must not re-claim."""
+
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "failed",
+        1,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        SemanticReason.PROVIDER_TIMEOUT,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ledger = _FakeLedger(job, lease)
+    ledger.attempts = {
+        _ATT1: SemanticAttemptRecord(
+            _JOB,
+            _ATT1,
+            1,
+            "req_40000000-0000-4000-8000-0000000000aa",
+            "failed",
+            SemanticReason.PROVIDER_TIMEOUT,
+            None,
+        )
+    }
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        raise AssertionError("dispatch_not_expected_on_terminal_recovery")
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
+        raise AssertionError("publish_not_expected")
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, accounting)
+
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=2,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+        ),
+    )
+    assert ledger.claim_calls == 0
+    assert result[0] is SemanticStatus.TIMEOUT
+    assert result[1] is SemanticReason.PROVIDER_TIMEOUT
+    assert result[2].attempted_count == 1
+    assert ledger.renew_count >= 1
+
+
+@pytest.mark.anyio
+async def test_terminal_succeeded_job_recovers_via_selected_callback() -> None:
+    """Crash after select_attempt: recover judgment/provenance without re-claim."""
+
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "succeeded",
+        1,
+        None,
+        _ATT1,
+        None,
+        None,
+        None,
+        _response_ref(),
+        SemanticReason.SEMANTIC_COMPLETED,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    ledger = _FakeLedger(job, lease)
+    ledger.attempts = {
+        _ATT1: SemanticAttemptRecord(
+            _JOB,
+            _ATT1,
+            1,
+            "req_40000000-0000-4000-8000-0000000000aa",
+            "selected",
+            SemanticReason.SEMANTIC_COMPLETED,
+            _response_ref(),
+        )
+    }
+    recovered = _Eval(SemanticStatus.SUCCEEDED, SemanticReason.SEMANTIC_COMPLETED, judgment="j")
+
+    async def recover_selected(row: SemanticJobRecord) -> _Eval | None:
+        assert row.state == "succeeded"
+        return recovered
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        raise AssertionError("dispatch_not_expected_on_terminal_recovery")
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
+        raise AssertionError("publish_not_expected")
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, evaluation, accounting)
+
+    result = cast(
+        tuple[SemanticStatus, SemanticReason, object | None, SemanticAttemptAccounting],
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=lease,
+            job=job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=2,
+            now_monotonic=lambda: 0.0,
+            dispatch=dispatch,
+            publish_success_response=publish,
+            sleep=lambda _: _async_noop(),
+            build_final=build_final,
+            recover_selected=recover_selected,
+        ),
+    )
+    assert ledger.claim_calls == 0
+    assert result[0] is SemanticStatus.SUCCEEDED
+    assert result[2] is recovered
+    assert result[3].selected_attempt_id == _ATT1
+
+
+@pytest.mark.anyio
+async def test_attempt_loop_renews_operation_lease() -> None:
+    """Lease is renewed around claim/select so timeout_seconds can exceed the 60s TTL."""
+
+    lease = _lease()
+    job = SemanticJobRecord(
+        _JOB,
+        _WRITER,
+        _OP,
+        _CASE,
+        _case_ref(),
+        "queued",
+        0,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    ledger = _FakeLedger(job, lease)
+    renewed: list[OperationLease] = []
+
+    async def dispatch(handle: SemanticAttemptHandle, deadline: Deadline) -> _Eval:
+        return _Eval(SemanticStatus.SUCCEEDED, SemanticReason.SEMANTIC_COMPLETED)
+
+    async def publish(handle: SemanticAttemptHandle, evaluation: object) -> ObjectRef:
+        return _response_ref()
+
+    def build_final(
+        status: SemanticStatus,
+        reason: SemanticReason,
+        evaluation: object | None,
+        accounting: SemanticAttemptAccounting,
+    ) -> object:
+        return (status, reason, accounting)
+
+    def on_lease(renewed_lease: OperationLease) -> None:
+        renewed.append(renewed_lease)
+
+    await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=lease,
+        job=job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+        max_retries=0,
+        now_monotonic=lambda: 0.0,
+        dispatch=dispatch,
+        publish_success_response=publish,
+        sleep=lambda _: _async_noop(),
+        build_final=build_final,
+        on_lease_renewed=on_lease,
+    )
+    # At least: initial renew + pre-claim renew + post-dispatch renew.
+    assert ledger.renew_count >= 3
+    assert len(renewed) >= 3
+    assert renewed[-1].lease_generation > lease.lease_generation


### PR DESCRIPTION
## Summary

Semantic checks now create durable `semantic_jobs` / `semantic_attempts`, honor configured `timeout_seconds` and `max_retries` (ADR-006 budget), retry only approved transient failure classes with unique per-attempt identities, resume same-owner started attempts, and reconstruct bounded attempt accounting from durable rows. Also fixes pre-dispatch category uniqueness for multi-item review packets.

**Why:** Production advertised ADR-006 retry/deadline behavior via `ProviderProfileConfig` but performed a single attempt with no durable job/attempt ledger, so timeouts and invalid responses disappeared and manual retries were unbounded. Configuration must match runtime.

## Plan reference

- Issue: #71
- Plan: [`docs/plans/2026-07-28-run5-residuals/04-durable-semantic-attempts-and-retry-budget.md`](docs/plans/2026-07-28-run5-residuals/04-durable-semantic-attempts-and-retry-budget.md)
- Run-5 index: [`docs/plans/2026-07-28-run5-residuals/00-INDEX.md`](docs/plans/2026-07-28-run5-residuals/00-INDEX.md)

## What changed

- Create/recover one semantic job after freeze, before external dispatch
- Claim unique attempt identity (dispatch/auth/receipt/credential handle) per physical try
- Retry only timeout/transport/rate-limit classes; never policy/human/stale/refusal
- Same-owner live lease resumes the started attempt; expired lease expires it first
- Reconstruct attempt accounting from durable rows; document ledger ports
- Fix pre-dispatch category uniqueness for multi-item review packets
- Wire ready composition / service paths so production uses the durable coordinator

## Test plan

```text
uv run pytest \
  tests/unit/application/test_semantic_attempts.py \
  tests/unit/application/test_semantic_local_egress.py \
  tests/integration/service/test_ready_composition.py::test_ready_check_re_resolves_provider_activated_after_composition \
  tests/integration/service/test_semantic_non_dispatch.py \
  tests/conformance/adapters/test_ledger_port.py::test_semantic_attempt_selection_contract \
  tests/conformance/adapters/test_ledger_port.py::test_semantic_claim_resumes_same_started_attempt_for_owner \
  tests/integration/application/test_check.py \
  tests/integration/privacy/test_egress_gateway.py \
  tests/integration/providers/test_fake_provider_coordinator.py \
  -q
```

Result: **45 passed**; Ruff clean; Pyright 0 errors.

## Fixes

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable semantic evaluation with bounded retries, recovery, and attempt history.
  * Semantic operations now resume safely after interruptions and renew leases during processing.
  * Added configurable semantic timeouts and retry limits.
  * Added provider-independent attempt tracking and accounting without exposing raw provider text.

* **Bug Fixes**
  * Prevented duplicate attempts when the same active lease resumes processing.
  * Improved handling of expired leases and deterministic category reporting.
  * Added recovery for completed semantic jobs without reprocessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->