### PR TITLE
Root-level request rules must name safe corrective fields

### DIFF
--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -125,7 +125,15 @@ _SAFE_VALIDATION_REASONS: Final[Mapping[str, str]] = MappingProxyType(
         "list_type": "invalid_type",
         "string_type": "invalid_type",
         "tuple_type": "invalid_type",
+        # Closed object-rule tokens projected from schema-side dependentRequired / if-then.
+        "paired_field_required": "paired_field_required",
+        "conditional_field_required": "conditional_field_required",
     }
+)
+# ValueError ctx tokens from `_validate_model_against_schema` object-rule projection. Only these
+# may replace the generic value_error reason; never trust free-form exception text.
+_SAFE_VALUE_ERROR_REASON_TOKENS: Final = frozenset(
+    {"paired_field_required", "conditional_field_required"}
 )
 _MAX_VALIDATION_LOCATIONS: Final = 8
 # Bounded so the hint stays a hint: a long enum dump would bury the field locations it explains.
@@ -167,6 +175,25 @@ def _pointer_for_location(
     return "/" + "/".join(segments)
 
 
+def _reason_from_validation_item(item: Mapping[str, object]) -> str:
+    """Map one Pydantic error item to a closed safe reason token."""
+
+    raw_reason = item.get("type")
+    if type(raw_reason) is not str:
+        return "invalid_type_or_value"
+    if raw_reason == "value_error":
+        # Object-rule projections stash a closed token on ValueError; do not trust other messages.
+        ctx = item.get("ctx")
+        if isinstance(ctx, Mapping):
+            error = cast(Mapping[object, object], ctx).get("error")
+            if isinstance(error, BaseException):
+                token = str(error)
+                if token in _SAFE_VALUE_ERROR_REASON_TOKENS:
+                    return token
+        return "invalid_type_or_value"
+    return _SAFE_VALIDATION_REASONS.get(raw_reason, "invalid_type_or_value")
+
+
 def safe_validation_locations(exc: object) -> tuple[dict[str, str], ...]:
     """Project Pydantic failures to allowlisted locations and bounded reason tokens."""
 
@@ -174,13 +201,11 @@ def safe_validation_locations(exc: object) -> tuple[dict[str, str], ...]:
         return ()
     projected: list[dict[str, str]] = []
     try:
-        errors = exc.errors(include_url=False, include_context=False, include_input=False)
+        # Context is required to recover closed object-rule reason tokens; inputs stay excluded.
+        errors = exc.errors(include_url=False, include_context=True, include_input=False)
     except BaseException:
         return ()
     for item in errors:
-        raw_reason = item.get("type")
-        if type(raw_reason) is not str:
-            continue
         pointer = _pointer_for_location(
             item.get("loc"),
             # Project to the nearest allowlisted parent so untrusted leaf keys (payload fields,
@@ -190,7 +215,7 @@ def safe_validation_locations(exc: object) -> tuple[dict[str, str], ...]:
         # Empty pointers (model-level failures with no path) are not actionable; omit them.
         if pointer is None or pointer == "":
             continue
-        reason = _SAFE_VALIDATION_REASONS.get(raw_reason, "invalid_type_or_value")
+        reason = _reason_from_validation_item(cast(Mapping[str, object], item))
         projected.append({"field": pointer, "reason": reason})
         if len(projected) == _MAX_VALIDATION_LOCATIONS:
             break
@@ -206,9 +231,12 @@ def authoring_hint(schema: object, locations: Sequence[Mapping[str, str]]) -> st
     the gap because they say where, not what. Nested `/event_drafts/N` failures need the same:
     walk local ``$defs`` so payload enums such as `action_kind` are named.
 
+    Root-level object rules (``dependentRequired``, attach ``if/then``) name the required peer or
+    safe alternative from schema metadata only — never from submitted values.
+
     Every character comes from the checked-in presentation schema — enum members, consts, bounded
-    patterns, and the worked example's own keys — so no caller-controlled text can reach the
-    message.
+    patterns, pairing maps, and the worked example's own keys — so no caller-controlled text can
+    reach the message.
     """
 
     if not isinstance(schema, Mapping):
@@ -221,20 +249,34 @@ def authoring_hint(schema: object, locations: Sequence[Mapping[str, str]]) -> st
     seen: set[tuple[str, str]] = set()
     example_families: list[str] = []
     try:
-        for location in locations:
-            pointer = location.get("field", "")
-            if type(pointer) is not str or not pointer.startswith("/"):
-                continue
-            label, admitted, family = _hint_for_pointer(document, pointer)
-            key = (label, admitted)
-            if not admitted or key in seen:
+        object_rule_parts = _object_rule_hint_parts(document, locations)
+        for text in object_rule_parts:
+            key = (text, "")
+            if key in seen:
                 continue
             seen.add(key)
-            parts.append(f"{label} admits {admitted}")
-            if family is not None and family not in example_families:
-                example_families.append(family)
+            parts.append(text)
             if len(parts) == _MAX_HINT_FIELDS:
                 break
+        if len(parts) < _MAX_HINT_FIELDS:
+            for location in locations:
+                pointer = location.get("field", "")
+                reason = location.get("reason", "")
+                if type(pointer) is not str or not pointer.startswith("/"):
+                    continue
+                # Object-rule locations already contributed schema-derived pairing text above.
+                if reason in _SAFE_VALUE_ERROR_REASON_TOKENS:
+                    continue
+                label, admitted, family = _hint_for_pointer(document, pointer)
+                key = (label, admitted)
+                if not admitted or key in seen:
+                    continue
+                seen.add(key)
+                parts.append(f"{label} admits {admitted}")
+                if family is not None and family not in example_families:
+                    example_families.append(family)
+                if len(parts) == _MAX_HINT_FIELDS:
+                    break
         if _has_example(document):
             if example_families:
                 named = ", ".join(example_families[:_MAX_HINT_FIELDS])
@@ -261,6 +303,179 @@ def authoring_hint(schema: object, locations: Sequence[Mapping[str, str]]) -> st
     if not parts:
         return ""
     return " Hint: " + "; ".join(parts) + "."
+
+
+def _object_rule_hint_parts(
+    document: Mapping[str, JsonValue], locations: Sequence[Mapping[str, str]]
+) -> list[str]:
+    """Build pairing / conditional hints from schema metadata for object-rule locations."""
+
+    paired_fields: list[str] = []
+    conditional_fields: list[str] = []
+    for location in locations:
+        pointer = location.get("field", "")
+        reason = location.get("reason", "")
+        if type(pointer) is not str or not pointer.startswith("/"):
+            continue
+        segments = pointer.removeprefix("/").split("/")
+        if len(segments) != 1 or not segments[0]:
+            continue
+        field = segments[0]
+        if field not in _SAFE_LOCATION_SEGMENTS:
+            continue
+        if reason == "paired_field_required":
+            if field not in paired_fields:
+                paired_fields.append(field)
+        elif reason == "conditional_field_required":
+            if field not in conditional_fields:
+                conditional_fields.append(field)
+    parts: list[str] = []
+    if paired_fields:
+        parts.extend(_paired_field_hint_parts(document, paired_fields))
+    if conditional_fields:
+        parts.extend(_conditional_field_hint_parts(document, conditional_fields))
+    return parts
+
+
+def _paired_field_hint_parts(document: Mapping[str, JsonValue], fields: Sequence[str]) -> list[str]:
+    """Name required peers from schema ``dependentRequired`` only."""
+
+    deps = document.get("dependentRequired")
+    if not isinstance(deps, Mapping):
+        return []
+    properties = document.get("properties")
+    if not isinstance(properties, Mapping):
+        return []
+    prop_names = cast(Mapping[str, JsonValue], properties)
+    field_set = set(fields)
+    parts: list[str] = []
+    seen: set[str] = set()
+    for key, peers in cast(Mapping[object, object], deps).items():
+        if type(key) is not str or key not in prop_names:
+            continue
+        if key not in field_set and not (
+            isinstance(peers, list)
+            and any(type(p) is str and p in field_set for p in cast(list[object], peers))
+        ):
+            continue
+        if not isinstance(peers, list):
+            continue
+        peer_names = [
+            peer for peer in cast(list[object], peers) if type(peer) is str and peer in prop_names
+        ]
+        if not peer_names:
+            continue
+        text = f"{key} requires {', '.join(peer_names)}"
+        if text in seen:
+            continue
+        seen.add(text)
+        parts.append(text)
+        if len(parts) == _MAX_HINT_FIELDS:
+            break
+    return parts
+
+
+def _conditional_field_hint_parts(
+    document: Mapping[str, JsonValue], fields: Sequence[str]
+) -> list[str]:
+    """Name safe required alternatives activated by a root-level ``if/then`` rule."""
+
+    del fields  # Field list confirms a conditional failure; alternatives come from the schema.
+    properties = document.get("properties")
+    if not isinstance(properties, Mapping):
+        return []
+    prop_names = cast(Mapping[str, JsonValue], properties)
+    all_of = document.get("allOf")
+    if not isinstance(all_of, list):
+        return []
+    for branch in cast(list[JsonValue], all_of):
+        if not isinstance(branch, Mapping):
+            continue
+        source = cast(Mapping[str, JsonValue], branch)
+        if_node = source.get("if")
+        then_node = source.get("then")
+        if not isinstance(if_node, Mapping) or not isinstance(then_node, Mapping):
+            continue
+        condition = _if_const_condition(cast(Mapping[str, JsonValue], if_node), prop_names)
+        alternatives = _required_alternatives(cast(Mapping[str, JsonValue], then_node), prop_names)
+        if not alternatives:
+            continue
+        alt_text = " or ".join(alternatives)
+        if condition is not None:
+            return [f"{condition} requires {alt_text}"]
+        return [f"requires {alt_text}"]
+    return []
+
+
+def _if_const_condition(
+    if_node: Mapping[str, JsonValue], prop_names: Mapping[str, JsonValue]
+) -> str | None:
+    """Return ``field value`` for a simple ``if.properties.X.const`` condition, else None."""
+
+    required = if_node.get("required")
+    props = if_node.get("properties")
+    if not isinstance(props, Mapping):
+        return None
+    if isinstance(required, list):
+        keys = [item for item in cast(list[object], required) if type(item) is str]
+    else:
+        keys = [key for key in cast(Mapping[object, object], props) if type(key) is str]
+    if len(keys) != 1:
+        return None
+    field = keys[0]
+    if field not in prop_names or field not in _SAFE_LOCATION_SEGMENTS:
+        return None
+    field_schema = cast(Mapping[str, JsonValue], props).get(field)
+    if not isinstance(field_schema, Mapping):
+        return None
+    const = cast(Mapping[str, JsonValue], field_schema).get("const")
+    if type(const) is not str or not const.isascii() or len(const) > 64:
+        return None
+    return f"{field} {const}"
+
+
+def _required_alternatives(
+    then_node: Mapping[str, JsonValue], prop_names: Mapping[str, JsonValue]
+) -> list[str]:
+    """Return human-readable required alternatives under then.anyOf|oneOf|required."""
+
+    options = then_node.get("anyOf")
+    if not isinstance(options, list):
+        options = then_node.get("oneOf")
+    if isinstance(options, list):
+        alts: list[str] = []
+        for branch in cast(list[JsonValue], options):
+            if not isinstance(branch, Mapping):
+                continue
+            required = cast(Mapping[str, JsonValue], branch).get("required")
+            text = _format_required_list(required, prop_names)
+            if text and text not in alts:
+                alts.append(text)
+            if len(alts) == _MAX_HINT_FIELDS:
+                break
+        return alts
+    return (
+        [_format_required_list(then_node.get("required"), prop_names)]
+        if then_node.get("required") is not None
+        else []
+    )
+
+
+def _format_required_list(required: object, prop_names: Mapping[str, JsonValue]) -> str:
+    if not isinstance(required, list):
+        return ""
+    names = [
+        item
+        for item in cast(list[object], required)
+        if type(item) is str and item in prop_names and item in _SAFE_LOCATION_SEGMENTS
+    ]
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + f", and {names[-1]}"
 
 
 def _hint_for_pointer(

--- a/src/yoetz/protocol/models.py
+++ b/src/yoetz/protocol/models.py
@@ -1004,7 +1004,22 @@ def _validate_model_against_schema(model: BaseModel, schema_name: str) -> None:
     try:
         validate_schema_instance(schema_name, "1.0.0", cast(JsonValue, dumped))
     except SchemaInstanceInvalid as exc:
-        # Re-raise with the JSON Schema absolute path so MCP safe_details can name the field.
+        # Re-raise with JSON Schema path(s) so MCP safe_details can name corrective fields.
+        # Root-level object rules (dependentRequired, if/then) arrive as location_reasons with
+        # closed reason tokens; nested field failures use absolute_path.
+        if exc.location_reasons:
+            raise PydanticValidationError.from_exception_data(
+                type(model).__name__,
+                [
+                    {
+                        "type": "value_error",
+                        "loc": tuple(path),
+                        "input": None,
+                        "ctx": {"error": ValueError(reason)},
+                    }
+                    for path, reason in exc.location_reasons
+                ],
+            ) from None
         if exc.absolute_path:
             raise PydanticValidationError.from_exception_data(
                 type(model).__name__,

--- a/src/yoetz/protocol/schemas.py
+++ b/src/yoetz/protocol/schemas.py
@@ -724,19 +724,50 @@ def event_schema_versions(catalog: SchemaCatalog) -> Mapping[str, str]:
     return catalog.event_schema_versions
 
 
-class SchemaInstanceInvalid(ProtocolValueError):
-    """Schema admission failure with an optional absolute JSON path for caller recovery."""
+# Closed reason tokens for root-level object rules (dependentRequired, if/then required).
+# These travel through Pydantic value_error ctx and MCP safe_details; never invent free-form text.
+_OBJECT_RULE_PAIRED: Final = "paired_field_required"
+_OBJECT_RULE_CONDITIONAL: Final = "conditional_field_required"
+_OBJECT_RULE_REASONS: Final = frozenset({_OBJECT_RULE_PAIRED, _OBJECT_RULE_CONDITIONAL})
+_MAX_PROJECTED_OBJECT_LOCATIONS: Final = 8
 
-    __slots__ = ("absolute_path",)
+
+class SchemaInstanceInvalid(ProtocolValueError):
+    """Schema admission failure with optional path(s) for caller recovery.
+
+    ``absolute_path`` names one nested field when jsonschema already points there.
+    ``location_reasons`` carries root-level object-rule projections (pairing / conditional
+    required) when the instance path is empty but the schema names safe corrective fields.
+    """
+
+    __slots__ = ("absolute_path", "location_reasons")
 
     absolute_path: tuple[str | int, ...]
+    location_reasons: tuple[tuple[tuple[str | int, ...], str], ...]
 
-    def __init__(self, absolute_path: tuple[str | int, ...] = ()) -> None:
+    def __init__(
+        self,
+        absolute_path: tuple[str | int, ...] = (),
+        location_reasons: tuple[tuple[tuple[str | int, ...], str], ...] = (),
+    ) -> None:
         if type(absolute_path) is not tuple:
             raise TypeError("schema_instance_path_invalid")
         if any(type(item) is not str and type(item) is not int for item in absolute_path):
             raise TypeError("schema_instance_path_invalid")
+        if type(location_reasons) is not tuple:
+            raise TypeError("schema_instance_locations_invalid")
+        for item in location_reasons:
+            if type(item) is not tuple or len(item) != 2:
+                raise TypeError("schema_instance_locations_invalid")
+            path, reason = item
+            if type(path) is not tuple:
+                raise TypeError("schema_instance_locations_invalid")
+            if any(type(segment) is not str and type(segment) is not int for segment in path):
+                raise TypeError("schema_instance_locations_invalid")
+            if type(reason) is not str or reason not in _OBJECT_RULE_REASONS:
+                raise TypeError("schema_instance_locations_invalid")
         self.absolute_path = absolute_path
+        self.location_reasons = location_reasons
         super().__init__("schema_instance_invalid")
 
 
@@ -756,7 +787,15 @@ def validate_schema_instance(name: str, version: str, value: JsonValue) -> None:
         validator_api = cast(_ValidatorProtocol, cast(object, validator))
         validator_api.validate(_plain_validation_value(value))
     except ValidationError as exc:
-        raise SchemaInstanceInvalid(_best_schema_instance_path(exc)) from None
+        path = _best_schema_instance_path(exc)
+        if path:
+            raise SchemaInstanceInvalid(path) from None
+        # Root-level object rules (dependentRequired, if/then anyOf required) report an empty
+        # instance path. Project only schema-named fields so MCP can name the corrective pair.
+        projected = _project_root_object_rule_locations(exc)
+        if projected:
+            raise SchemaInstanceInvalid((), projected) from None
+        raise SchemaInstanceInvalid() from None
     except BaseException:
         raise SchemaInstanceInvalid() from None
 
@@ -771,6 +810,151 @@ def _path_items_from(error: ValidationError) -> tuple[str | int, ...] | None:
         else:
             return None
     return tuple(path_items)
+
+
+def _schema_property_names(schema: object) -> frozenset[str] | None:
+    """Return checked-in property names from a schema object, or None when unusable."""
+
+    if not isinstance(schema, Mapping):
+        return None
+    properties = cast(Mapping[str, JsonValue], schema).get("properties")
+    if not isinstance(properties, Mapping):
+        return None
+    names = frozenset(key for key in cast(Mapping[object, object], properties) if type(key) is str)
+    return names or None
+
+
+def _safe_schema_field(name: object, property_names: frozenset[str] | None) -> str | None:
+    """Admit a field name only when it is a checked-in schema property."""
+
+    if type(name) is not str or property_names is None or name not in property_names:
+        return None
+    return name
+
+
+def _project_root_object_rule_locations(
+    exc: ValidationError,
+) -> tuple[tuple[tuple[str | int, ...], str], ...]:
+    """Project known root-level object rules into fixed safe (path, reason) pairs.
+
+    Inspects only validator kind and checked-in schema metadata. Never names a key that is not
+    declared on the schema. Failure to derive a safe projection returns empty so the caller
+    falls back to a generic invalid request.
+    """
+
+    try:
+        return _project_root_object_rule_locations_impl(exc)
+    except Exception:
+        return ()
+
+
+def _project_root_object_rule_locations_impl(
+    exc: ValidationError,
+) -> tuple[tuple[tuple[str | int, ...], str], ...]:
+    path = _path_items_from(exc)
+    if path is None or path != ():
+        return ()
+    validator = exc.validator
+    if validator == "dependentRequired":
+        return _project_dependent_required(exc)
+    if validator in {"anyOf", "oneOf"}:
+        return _project_conditional_required_alternatives(exc)
+    # allOf itself rarely fails at root; nested context may hold the object rule.
+    if validator == "allOf":
+        for nested in exc.context or ():
+            projected = _project_root_object_rule_locations_impl(nested)
+            if projected:
+                return projected
+    return ()
+
+
+def _project_dependent_required(
+    error: ValidationError,
+) -> tuple[tuple[tuple[str | int, ...], str], ...]:
+    """Name the present field and its required peer from schema ``dependentRequired`` only."""
+
+    deps = error.validator_value
+    instance = error.instance
+    if not isinstance(deps, Mapping) or not isinstance(instance, Mapping):
+        return ()
+    property_names = _schema_property_names(error.schema)
+    if property_names is None:
+        return ()
+    ordered: list[tuple[tuple[str | int, ...], str]] = []
+    seen: set[str] = set()
+    for prop, peers in cast(Mapping[object, object], deps).items():
+        present = _safe_schema_field(prop, property_names)
+        if present is None or present not in cast(Mapping[object, object], instance):
+            continue
+        if not isinstance(peers, list):
+            continue
+        for peer in cast(list[object], peers):
+            missing = _safe_schema_field(peer, property_names)
+            if missing is None or missing in cast(Mapping[object, object], instance):
+                continue
+            for name in (present, missing):
+                if name in seen:
+                    continue
+                seen.add(name)
+                ordered.append(((name,), _OBJECT_RULE_PAIRED))
+                if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
+                    return tuple(ordered)
+    return tuple(ordered)
+
+
+def _project_conditional_required_alternatives(
+    error: ValidationError,
+) -> tuple[tuple[tuple[str | int, ...], str], ...]:
+    """Name safe required fields under a selected ``if/then`` anyOf|oneOf branch.
+
+    Only when the schema path includes ``then`` (conditional branch) and context errors are
+    ``required`` failures whose field names are checked-in properties.
+    """
+
+    schema_path = tuple(error.absolute_schema_path)
+    if "then" not in schema_path and "if" not in schema_path:
+        # Closed discriminated unions without if/then still admit required-field projection when
+        # every context error is a schema-named required property.
+        if error.validator not in {"anyOf", "oneOf"}:
+            return ()
+    property_names = _schema_property_names(error.schema)
+    # Error.schema for anyOf is often the anyOf node (list of branches), not the root object.
+    # Fall back to walking context validator_value lists and the parent schema when needed.
+    ordered: list[tuple[tuple[str | int, ...], str]] = []
+    seen: set[str] = set()
+    for nested in error.context or ():
+        if nested.validator != "required":
+            continue
+        required_list = nested.validator_value
+        instance = nested.instance
+        if not isinstance(required_list, list) or not isinstance(instance, Mapping):
+            continue
+        # Prefer property names from the enclosing object schema when available.
+        nested_props = _schema_property_names(nested.schema)
+        admitted = property_names if property_names is not None else nested_props
+        # When the branch schema is only {"required": [...]}, admit names from the required list
+        # only if each is a plain string — still never use instance keys as the source of names.
+        for item in cast(list[object], required_list):
+            if type(item) is not str:
+                continue
+            if admitted is not None and item not in admitted:
+                # Branch-only required list: allow schema-authored required names even when the
+                # branch node has no properties map (common for anyOf required alternatives).
+                if nested_props is not None:
+                    continue
+            if item in cast(Mapping[object, object], instance):
+                continue
+            if item in seen:
+                continue
+            # Final gate: only emit names that look like schema identifiers already used as
+            # locations elsewhere — still never take them from the instance.
+            if not item or not item.isascii() or not item.replace("_", "").isalnum():
+                continue
+            seen.add(item)
+            ordered.append(((item,), _OBJECT_RULE_CONDITIONAL))
+            if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
+                return tuple(ordered)
+    return tuple(ordered)
 
 
 def _best_schema_instance_path(exc: ValidationError) -> tuple[str | int, ...]:

--- a/tests/unit/mcp/test_root_object_rule_locations.py
+++ b/tests/unit/mcp/test_root_object_rule_locations.py
@@ -1,0 +1,156 @@
+"""Root-level object rules must name safe corrective fields.
+
+Replays the second failed `start` from the 2026-07-27 dogfood: `workspace_ref` without
+`external_ref` previously collapsed to a generic invalid-arguments message because
+`dependentRequired` reports an empty instance path. Nested enum/pattern pointers and hostile
+extras must keep their existing bounded behavior.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from yoetz.mcp.descriptors import descriptor_for
+from yoetz.mcp.errors import authoring_hint, safe_validation_locations
+from yoetz.mcp.server import invalid_request_message
+from yoetz.protocol.models import PublishWorkRequest, StartRequestModel
+
+_START_SCHEMA = descriptor_for("start").input_schema
+_PUBLISH_SCHEMA = descriptor_for("publish_work").input_schema
+
+_BASE_START: dict[str, object] = {
+    "protocol_version": "0.1",
+    "schema_version": "1.0.0",
+    "request_id": "req_00000000-0000-4000-8000-000000000001",
+    "mode": "create",
+    "task_title": "dogfood start",
+    "requested_view": "compact",
+    "actor": {"actor_id": "agent:logical-1", "actor_type": "logical_agent"},
+    "client": {
+        "kind": "cooperative_agent",
+        "version": "0.1.0",
+        "integration": "cooperative_mcp",
+    },
+}
+
+
+def _start_locations(**overrides: object) -> tuple[dict[str, str], ...]:
+    payload = {**_BASE_START, **overrides}
+    with pytest.raises(ValidationError) as captured:
+        StartRequestModel.model_validate(payload)
+    return safe_validation_locations(captured.value)
+
+
+def test_workspace_ref_without_external_ref_names_both_fields_and_pairing_rule() -> None:
+    locations = _start_locations(workspace_ref="workspace-A")
+    assert {"field": "/workspace_ref", "reason": "paired_field_required"} in locations
+    assert {"field": "/external_ref", "reason": "paired_field_required"} in locations
+
+    hint = authoring_hint(_START_SCHEMA, locations)
+    assert "workspace_ref requires external_ref" in hint
+    message = invalid_request_message("start", locations)
+    assert "workspace_ref requires external_ref" in message
+    assert "yoetz://guidance/workflow.md" in message
+
+
+def test_external_ref_without_workspace_ref_is_equally_actionable() -> None:
+    locations = _start_locations(external_ref="external-A")
+    assert {"field": "/external_ref", "reason": "paired_field_required"} in locations
+    assert {"field": "/workspace_ref", "reason": "paired_field_required"} in locations
+    hint = authoring_hint(_START_SCHEMA, locations)
+    assert "external_ref requires workspace_ref" in hint
+
+
+def test_logical_agent_without_refs_remains_valid() -> None:
+    # The dogfood's third-call actor_type change was a red herring; logical_agent is admitted.
+    StartRequestModel.model_validate(_BASE_START)
+
+
+def test_paired_refs_together_remain_valid() -> None:
+    StartRequestModel.model_validate(
+        {**_BASE_START, "external_ref": "external-A", "workspace_ref": "workspace-A"}
+    )
+
+
+def test_attach_if_then_names_safe_required_alternatives() -> None:
+    locations = _start_locations(mode="attach")
+    fields = {item["field"] for item in locations}
+    reasons = {item["reason"] for item in locations}
+    assert "/session_id" in fields
+    assert "/external_ref" in fields
+    assert "/workspace_ref" in fields
+    assert reasons == {"conditional_field_required"}
+
+    hint = authoring_hint(_START_SCHEMA, locations)
+    assert "mode attach requires" in hint
+    assert "session_id" in hint
+    assert "external_ref" in hint
+    assert "workspace_ref" in hint
+
+
+def test_nested_request_id_pattern_retains_existing_behavior() -> None:
+    locations = _start_locations(request_id="not-a-valid-request-id")
+    assert any(item["field"] == "/request_id" for item in locations)
+    hint = authoring_hint(_START_SCHEMA, locations)
+    assert "^req_" in hint
+
+
+def test_nested_event_draft_enum_retains_existing_behavior() -> None:
+    examples = cast(list[object], _PUBLISH_SCHEMA["examples"])
+    base = cast(dict[str, object], examples[0])
+    good = cast(dict[str, object], cast(list[object], base["event_drafts"])[0])
+    secret = "NOT-A-REAL-ENUM-never-echo-this"
+    bad: dict[str, object] = {
+        **good,
+        "event_id": "evt_00000000-0000-4000-8000-000000000099",
+        "schema": {"name": "action_recorded", "version": "1.0.0"},
+        "payload": {
+            "action_id": "act_00000000-0000-4000-8000-000000000098",
+            "action_kind": secret,
+            "description": "x",
+        },
+    }
+    with pytest.raises(ValidationError) as captured:
+        PublishWorkRequest.model_validate({**base, "event_drafts": [good, bad]})
+    locations = safe_validation_locations(captured.value)
+    assert any(item["field"] == "/event_drafts/1/payload/action_kind" for item in locations)
+    assert secret not in repr(locations)
+    hint = authoring_hint(_PUBLISH_SCHEMA, locations)
+    assert "action_kind admits" in hint
+    assert secret not in hint
+
+
+def test_hostile_unknown_property_never_reaches_message_or_details() -> None:
+    secret_key = "hostile_secret_prop"
+    secret_value = "never-echo-this-value-9f3a"
+    with pytest.raises(ValidationError) as captured:
+        StartRequestModel.model_validate({**_BASE_START, secret_key: secret_value})
+    locations = safe_validation_locations(captured.value)
+    assert secret_key not in repr(locations)
+    assert secret_value not in repr(locations)
+    message = invalid_request_message("start", locations)
+    assert secret_key not in message
+    assert secret_value not in message
+    # Unrecognized extras at the model boundary stay generic — no invented field pointers.
+    assert not any(secret_key in item.get("field", "") for item in locations)
+
+
+def test_unrecognized_root_rule_degrades_to_bounded_generic_error() -> None:
+    # Empty locations still produce a bounded public message (examples + guidance), never raise.
+    message = invalid_request_message("start", ())
+    assert message.startswith("The tool arguments are invalid.")
+    assert "yoetz://guidance/workflow.md" in message
+    assert authoring_hint(_START_SCHEMA, ()) != ""
+
+
+def test_object_rule_hint_never_echoes_submitted_values() -> None:
+    secret = "submitted-workspace-value-must-not-leak"
+    locations = _start_locations(workspace_ref=secret)
+    hint = authoring_hint(_START_SCHEMA, locations)
+    message = invalid_request_message("start", locations)
+    assert secret not in hint
+    assert secret not in message
+    assert secret not in repr(locations)


### PR DESCRIPTION
## Summary

Root-level `dependentRequired` and attach `if/then` failures previously raised a bare `schema_instance_invalid` with an empty instance path, so MCP dropped the pointer and agents saw only a generic invalid-arguments message.

This change projects those rules from checked-in schema metadata into closed safe field locations with `paired_field_required` / `conditional_field_required` reason tokens and schema-derived authoring hints (e.g. `workspace_ref` requires `external_ref`; mode `attach` requires `session_id` or `external_ref` and `workspace_ref`). Nested pointers, hostile extras, and unrecognized rules keep existing bounded behavior.

**Fixes #73**

## Plan reference

- Plan: [`docs/plans/2026-07-28-run5-residuals/05-actionable-root-level-validation.md`](docs/plans/2026-07-28-run5-residuals/05-actionable-root-level-validation.md)
- Index: [`docs/plans/2026-07-28-run5-residuals/00-INDEX.md`](docs/plans/2026-07-28-run5-residuals/00-INDEX.md)
- Issue: https://github.com/TheGaySupreme123/yoetz/issues/73

## What changed

- Project known root object-rule failures into safe corrective field locations
- Add closed reason tokens: `paired_field_required`, `conditional_field_required`
- Emit schema-derived authoring hints for dependentRequired and attach conditionals
- Preserve bounded generic degradation for unrecognized rules and hostile extras

## Test plan

```text
uv run pytest tests/unit/mcp/test_root_object_rule_locations.py tests/unit/mcp/test_authoring_hints.py tests/conformance/surfaces/test_mcp_contract_matrix.py -q
# → 53 passed

uv run pytest tests/unit/protocol/test_models_and_schemas.py tests/unit/protocol/test_request_and_entry_identity.py tests/conformance/protocol/test_frozen_schemas.py tests/unit/mcp/ -q
# → 175 passed

ruff check/format + pyright on touched files → clean
```