### PR TITLE
docs: register paired and conditional field validation reasons

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -84,7 +84,31 @@ ordinary dictionary with exactly `code`, `message`, `retryable`, and bound `corr
 adds `safe_details` only when nonempty, as a new ordinary dictionary in ASCII key order. The frozen
 public-error JSON Schema remains a structural superset of this exact mapping-only runtime emitter.
 Allowlisted `safe_details` keys include structural recovery fields such as `reason_code`,
-`sequence`, and `head_digest` (for `FRONTIER_CONFLICT` current-head recovery). Protocol reason
+`sequence`, and `head_digest` (for `FRONTIER_CONFLICT` current-head recovery). For MCP
+`INVALID_REQUEST` validation failures, `safe_details` may also carry parallel `fields` and
+`reasons` arrays: each entry is an allowlisted JSON pointer and a closed reason token for that
+location (same index order; at most eight locations). Pointers use only trusted location segments;
+unknown or hostile property names are never echoed. Closed reason tokens are:
+
+- `missing` — a required property is absent;
+- `extra_forbidden` — an additional property is not admitted;
+- `invalid_type` / `invalid_value` — type or admitted-value failure at the named path;
+- `invalid_type_or_value` — residual validation failure when no more specific closed token applies;
+- `paired_field_required` — a schema `dependentRequired` pair is incomplete (for example `start`
+  with `workspace_ref` present and `external_ref` absent, or the inverse). Both the present field
+  and the required peer are named; the authoring hint states the schema peer rule (e.g.
+  `workspace_ref requires external_ref`) without echoing submitted values;
+- `conditional_field_required` — a root-level schema `if`/`then` (or equivalent closed object rule)
+  activated required alternatives (for example `start` with `mode` `attach` without `session_id`
+  or the paired external/workspace refs). Named fields are the safe required alternatives; the
+  authoring hint states the activating condition when it is a bounded schema const (e.g.
+  `mode attach requires …`).
+
+These object-rule tokens are projected only from checked-in schema metadata and validator kind —
+never from caller-controlled keys or free-form exception text. Unrecognized object rules degrade
+to a bounded generic `INVALID_REQUEST` without inventing field pointers.
+
+Protocol reason
 `response_projection_failed` marks a post-commit shaping failure for non-`publish_work` writes (and
 for the genuinely impossible case where even the minimal publish envelope cannot be built): the
 write may already be durable, so the public error is retryable and same-`request_id` resume is the


### PR DESCRIPTION
## Summary

- Documents the public MCP `INVALID_REQUEST` `safe_details.fields` / `safe_details.reasons` contract in `docs/INTERFACES.md`.
- Defines closed reason tokens including the new object-rule tokens `paired_field_required` and `conditional_field_required` (meanings, emission conditions, and that hints come only from schema metadata).

Follow-up to the P1 review on #74 (`src/yoetz/mcp/errors.py`): these tokens were emitted by the implementation and tests but were not registered on a public-contract page.

## Test plan

- [ ] Read the new INTERFACES paragraph against `src/yoetz/mcp/errors.py` (`_SAFE_VALIDATION_REASONS`, `_SAFE_VALUE_ERROR_REASON_TOKENS`, object-rule hint helpers).
- [ ] Confirm tokens match `tests/unit/mcp/test_root_object_rule_locations.py` cases (`workspace_ref` pairing, attach `if`/`then`).

Tracked by #73.