### PR TITLE
Harden credential masking in first-run setup flows

### DIFF
--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -35,7 +35,11 @@ exactly those contracts and connects the steps without weakening any existing tr
    separately reauthenticated trusted decision ceremony. On a real local TTY it may invoke the
    already-reviewed hidden-input vault initialize/unlock and credential ceremony; it adds no
    secret field to wizard arguments, configuration, reports, MCP, or agent context. Noninteractive
-   setup remains a report plus explicit follow-up commands and never chooses egress.
+   setup remains a report plus explicit follow-up commands and never chooses egress. The semantic
+   first-run privacy menu suggests `metadata_only`: structural context only, with a foreground
+   confirmation before every provider request. It is a starting draft, not consent or a
+   provider-data-use recommendation. `private` remains the fail-safe no-egress choice, while
+   assisted, expanded, and custom policies remain explicit.
 
 2. **Bounded bare-invocation change (amends ADR-007 decision 3).** The root Typer app drops
    `no_args_is_help=True`; the root callback reproduces the historical help output for every bare
@@ -111,6 +115,14 @@ availability, structured-output interoperability, provider data use, or E-007 ca
    ordinary stdin, environment, config, report, or MCP. A local interactive run may enter the
    existing confidential helper, which reads vault and provider secrets with hidden `/dev/tty`
    input and sends them only over YZS1. Noninteractive setup never provisions a credential.
+   Human setup and provider-status output renders only a constant `********` presence mask after the
+   trusted service confirms the configured profile has a credential; confirmed absence and
+   unreadable state remain distinct. The mask never reflects secret bytes or secret length. A
+   repeated setup run recomposes the service after binding, observes that exact profile, and skips
+   credential entry when presence is already confirmed. If a credential write commits but its
+   result frame is lost, setup recomposes and recovers only from the configured profile's trusted
+   presence bit; an unreadable or absent result remains failed rather than being inferred as
+   success.
 
 8. **Founder-authorized on-demand service start (2026-07-22 amendment).** A mutating interactive
    setup run and the MCP bridge may invoke the shared fixed-command service launcher when the

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -30,16 +30,19 @@ exactly those contracts and connects the steps without weakening any existing tr
    preview→confirm→execute, a service reachability check, and the existing privacy and
    provider-credential ceremonies. Founder-authorized amendment (2026-07-29): before registration,
    interactive first run chooses a complete `local_only` path or a semantic-review path. The latter
-   registers the policy route, configures the provider and credential, asks all thirteen privacy
-   questions, renders the exact bounded disclosure, proposes it, and hands widening to the
-   separately reauthenticated trusted decision ceremony. On a real local TTY it may invoke the
+   registers the policy route, configures the provider and credential, then renders one exact
+   recommended `metadata_only` policy. Accepting that exact draft skips the thirteen expert
+   questions; declining it opens the recipe choice and all settings one by one. Both paths propose
+   the reviewed exact disclosure and hand widening to the separately reauthenticated trusted
+   decision ceremony. On a real local TTY it may invoke the
    already-reviewed hidden-input vault initialize/unlock and credential ceremony; it adds no
    secret field to wizard arguments, configuration, reports, MCP, or agent context. Noninteractive
    setup remains a report plus explicit follow-up commands and never chooses egress. The semantic
-   first-run privacy menu suggests `metadata_only`: structural context only, with a foreground
-   confirmation before every provider request. It is a starting draft, not consent or a
-   provider-data-use recommendation. `private` remains the fail-safe no-egress choice, while
-   assisted, expanded, and custom policies remain explicit.
+   first-run recommendation permits only public structural metadata and declared file types at task
+   scope, with a foreground confirmation before every provider request. It is a starting draft,
+   not consent or a provider-data-use recommendation. `private` remains the fail-safe no-egress
+   choice, while assisted, expanded, and custom policies remain explicit. `yoetz --privacy` enters
+   the same short recommended-first ceremony at any later time.
 
 2. **Bounded bare-invocation change (amends ADR-007 decision 3).** The root Typer app drops
    `no_args_is_help=True`; the root callback reproduces the historical help output for every bare
@@ -118,11 +121,13 @@ availability, structured-output interoperability, provider data use, or E-007 ca
    Human setup and provider-status output renders only a constant `********` presence mask after the
    trusted service confirms the configured profile has a credential; confirmed absence and
    unreadable state remain distinct. The mask never reflects secret bytes or secret length. A
-   repeated setup run recomposes the service after binding, observes that exact profile, and skips
-   credential entry when presence is already confirmed. If a credential write commits but its
-   result frame is lost, setup recomposes and recovers only from the configured profile's trusted
-   presence bit; an unreadable or absent result remains failed rather than being inferred as
-   success.
+   repeated setup run recomposes the service after binding and observes that exact profile. When
+   presence is confirmed, it asks whether to reuse the stored credential (default) or replace it
+   through the same hidden-input ceremony. If an initial credential write commits but its result
+   frame is lost, setup may recover only from the configured profile's trusted presence bit. A
+   replacement started with presence already true cannot use that bit as proof that the new value
+   committed; an ambiguous replacement remains failed instead of inheriting the old value's
+   presence as success.
 
 8. **Founder-authorized on-demand service start (2026-07-22 amendment).** A mutating interactive
    setup run and the MCP bridge may invoke the shared fixed-command service launcher when the

--- a/docs/adr/ADR-013-interactive-control-menu.md
+++ b/docs/adr/ADR-013-interactive-control-menu.md
@@ -31,6 +31,10 @@ the privacy posture, unlock or stop the service) had to reassemble the correct s
 
 2. **`yoetz menu` is a new top-level command** that opens the same menu explicitly. On a
    non-TTY it fails closed with a usage error (exit 2) and never prompts.
+   Founder-authorized amendment (2026-07-29): `yoetz --privacy` is a direct root shortcut to the
+   trusted privacy ceremony. It first renders the exact recommended `metadata_only` draft and its
+   tradeoffs; only declining that draft opens the detailed one-by-one questions. The shortcut
+   cannot be combined with a subcommand or provider-setup flags.
 
 3. **The menu is a dispatcher, not a new authority.** Every menu action invokes an operation the
    command tree already exposes, with its existing gates intact: MCP registration keeps

--- a/docs/protocol/privacy-setup-wizard.md
+++ b/docs/protocol/privacy-setup-wizard.md
@@ -48,6 +48,14 @@ and the user may edit; the label is echoed only while the answers still exactly 
 and reverts to `custom` after any edit. **Selecting a recipe never commits a widening, provisions a
 credential, or skips the review/decision step.**
 
+The first-run CLI and `yoetz --privacy` add a bounded convenience path above that contract. They
+materialize and render the exact `metadata_only` draft first: public structural metadata and
+declared file types, task scope, and per-request confirmation. Accepting that rendered draft sends
+the same typed answers directly to proposal; declining it opens the recipe selector and the
+thirteen questions one by one. Neither branch skips exact review or the separately reauthenticated
+widening decision. The convenience recommendation is privacy-first UI guidance, not the conditional
+provider-data-use recommendation attached to `assisted_review`.
+
 ### The fail-safe default draft
 
 With no answers, the draft is `local_only`, `review_context=structural`, `network_egress=false`, all

--- a/docs/protocol/privacy-setup-wizard.md
+++ b/docs/protocol/privacy-setup-wizard.md
@@ -48,13 +48,15 @@ and the user may edit; the label is echoed only while the answers still exactly 
 and reverts to `custom` after any edit. **Selecting a recipe never commits a widening, provisions a
 credential, or skips the review/decision step.**
 
-The first-run CLI and `yoetz --privacy` add a bounded convenience path above that contract. They
-materialize and render the exact `metadata_only` draft first: public structural metadata and
-declared file types, task scope, and per-request confirmation. Accepting that rendered draft sends
-the same typed answers directly to proposal; declining it opens the recipe selector and the
-thirteen questions one by one. Neither branch skips exact review or the separately reauthenticated
-widening decision. The convenience recommendation is privacy-first UI guidance, not the conditional
-provider-data-use recommendation attached to `assisted_review`.
+The first-run CLI and `yoetz --privacy` add a bounded convenience path above that contract. With an
+external provider configured, they materialize and render the exact `metadata_only` draft first:
+public structural metadata and declared file types, task scope, and per-request confirmation.
+Without an external provider binding, they render the exact `private` draft instead, keeping network
+egress off. Accepting the rendered draft sends the same typed answers directly to proposal;
+declining it opens the recipe selector and the thirteen questions one by one. Neither branch skips
+exact review or the separately reauthenticated widening decision. The convenience recommendation is
+privacy-first UI guidance, not the conditional provider-data-use recommendation attached to
+`assisted_review`.
 
 ### The fail-safe default draft
 

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -47,18 +47,19 @@ Setup is a linear path inside the interface, each finished step collapsing into 
 5. **Installation activity**, with each step reported only once its postcondition was checked.
 6. **Secure storage** — the system keyring, or a Yoetz passphrase.
 7. **Review mode** — finish in complete local-only mode, or configure semantic review.
-8. **Semantic setup, when selected** — provider/model, hidden API-key entry, all thirteen privacy
-   answers, the exact disclosure preview, and the separately reauthenticated widening decision.
-   The suggested first-run draft is **Metadata only**: structural context only, with a foreground
-   confirmation before every provider request. This is a privacy-minimizing usable starting point,
-   not consent; **Private** remains available for no network egress, and broader recipes remain
-   explicit choices.
+8. **Semantic setup, when selected** — provider/model, hidden API-key entry, then one exact
+   recommended privacy policy. **Metadata only** sends public structural metadata and declared file
+   types, asks before every provider request, and uses task scope. Accepting it skips the thirteen
+   expert questions; declining it opens those settings one by one. The exact disclosure and
+   separately reauthenticated widening decision remain mandatory.
 9. **Finish**, stating each readiness layer separately.
 
 Credential status is presence-only. Human output shows the fixed mask `********` when the trusted
 service confirms that the configured provider has a stored credential, `not stored` when absence
 is confirmed, and `unknown` when the service or vault cannot answer. The mask is constant: it never
 contains or encodes any character, length, prefix, suffix, or fingerprint of the API key.
+When a credential is already stored for the exact provider/model, setup asks whether to reuse it
+(the default) or replace it through a new hidden-input ceremony.
 
 `codex mcp get` runs first; an existing foreign entry is always preserved, never replaced, and
 there is no force-replace option anywhere in the interface.
@@ -71,8 +72,9 @@ The official Codex App exists on macOS and Windows. Linux setup uses the same fl
 standalone Codex CLI and does not fabricate an app installation that OpenAI does not publish.
 
 Re-run any time with `yoetz setup run` (the prompt-driven wizard, unchanged) or `/connect` in the
-interface. Inspect posture read-only with `yoetz setup status`. Manage registration directly with
-`yoetz integrate mcp status|preview|install`.
+interface. Change privacy any time with `yoetz --privacy`. Inspect posture read-only with
+`yoetz setup status`. Manage registration directly with `yoetz integrate mcp
+status|preview|install`.
 
 ## Re-run or repair a ceremony
 
@@ -80,7 +82,8 @@ The wizard uses these same commands and trusted boundaries; each remains availab
 
 ```text
 yoetz service run                  # foreground service under a supervisor you choose
-yoetz privacy setup                # all 13 answers, exact preview, trusted decision
+yoetz --privacy                    # recommended policy first; customize only when declined
+yoetz privacy setup                # equivalent long-form command
 yoetz provider endpoint            # bind a reviewed preset or owner-declared HTTPS origin + model
 yoetz provider credential set      # provision the API credential through the terminal ceremony
 ```

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -49,7 +49,16 @@ Setup is a linear path inside the interface, each finished step collapsing into 
 7. **Review mode** — finish in complete local-only mode, or configure semantic review.
 8. **Semantic setup, when selected** — provider/model, hidden API-key entry, all thirteen privacy
    answers, the exact disclosure preview, and the separately reauthenticated widening decision.
+   The suggested first-run draft is **Metadata only**: structural context only, with a foreground
+   confirmation before every provider request. This is a privacy-minimizing usable starting point,
+   not consent; **Private** remains available for no network egress, and broader recipes remain
+   explicit choices.
 9. **Finish**, stating each readiness layer separately.
+
+Credential status is presence-only. Human output shows the fixed mask `********` when the trusted
+service confirms that the configured provider has a stored credential, `not stored` when absence
+is confirmed, and `unknown` when the service or vault cannot answer. The mask is constant: it never
+contains or encodes any character, length, prefix, suffix, or fingerprint of the API key.
 
 `codex mcp get` runs first; an existing foreign entry is always preserved, never replaced, and
 there is no force-replace option anywhere in the interface.

--- a/docs/usage/privacy-and-semantic-review.md
+++ b/docs/usage/privacy-and-semantic-review.md
@@ -49,7 +49,8 @@ Only a reauthenticated local human can loosen effective policy, and loosening is
 ## Commands
 
 ```text
-yoetz privacy setup             # guided policy review
+yoetz --privacy                 # recommended policy first; customize only when declined
+yoetz privacy setup             # equivalent guided policy review
 yoetz privacy show              # current effective policy
 yoetz privacy tighten           # tighten (proceeds through gates)
 yoetz privacy propose           # propose a change for decision
@@ -60,6 +61,14 @@ yoetz privacy receipts          # inspect bounded structural egress receipts
 
 `export-desired` / `apply-desired` are the reviewable path for version-controlling policy. The
 asymmetry is the point: tightening can flow through gates, widening always requires a human.
+
+The CLI recommends **Metadata only** as the privacy-first semantic starting point: public
+structural metadata and declared file types, task scope, and a foreground approval before every
+provider request. Its advantage is minimal disclosure; its tradeoff is less problem-specific
+feedback. Accepting the displayed exact policy skips the thirteen expert questions. Declining it
+opens Private, Assisted review, Expanded review, Custom, and every underlying setting one by one.
+When no external provider is configured, the shortcut recommends Private instead. The final
+trusted widening decision is never skipped.
 
 ### `/privacy` in the terminal interface
 

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -564,32 +564,36 @@ privacy_app.command("propose")(_support_command("privacy_propose_policy"))
 privacy_app.command("tighten")(_support_command("privacy_tighten_policy"))
 
 
+async def _run_privacy_setup_command() -> int:
+    from yoetz.cli.privacy_setup import run_privacy_setup
+    from yoetz.cli.unlock import HumanCeremonyCliError
+
+    try:
+        report = await run_privacy_setup(
+            recipe_hint="metadata_only",
+            offer_recommended=True,
+        )
+    except ControlError as error:
+        return _control_failure(error)
+    except (HumanCeremonyCliError, OSError, ValueError) as error:
+        reason = getattr(error, "reason", None)
+        typer.echo(
+            f"privacy_setup_failed: {reason if type(reason) is str else 'privacy_setup_failed'}",
+            err=True,
+        )
+        return 20
+    if report.outcome == "failed":
+        typer.echo(f"privacy_setup_failed: {report.reason or 'invalid'}", err=True)
+        return 20
+    _human_or_json(report, json_output=False)
+    return 0
+
+
 @privacy_app.command("setup")
 def privacy_setup() -> None:
-    """Review all privacy choices and apply them through the trusted local ceremony."""
+    """Review privacy choices and apply them through the trusted local ceremony."""
 
-    async def _run() -> int:
-        from yoetz.cli.privacy_setup import run_privacy_setup
-        from yoetz.cli.unlock import HumanCeremonyCliError
-
-        try:
-            report = await run_privacy_setup()
-        except ControlError as error:
-            return _control_failure(error)
-        except (HumanCeremonyCliError, OSError, ValueError) as error:
-            reason = getattr(error, "reason", None)
-            typer.echo(
-                f"privacy_setup_failed: {reason if type(reason) is str else 'privacy_setup_failed'}",
-                err=True,
-            )
-            return 20
-        if report.outcome == "failed":
-            typer.echo(f"privacy_setup_failed: {report.reason or 'invalid'}", err=True)
-            return 20
-        _human_or_json(report, json_output=False)
-        return 0
-
-    _finish(run_async(_run))
+    _finish(run_async(_run_privacy_setup_command))
 
 
 async def _service_call(method: str, json_output: bool) -> int:
@@ -1478,6 +1482,13 @@ def root(
             help="Set up the LLM model and API key through the secure local wizard.",
         ),
     ] = False,
+    privacy: Annotated[
+        bool,
+        typer.Option(
+            "--privacy",
+            help="Review or change the privacy policy through the trusted local wizard.",
+        ),
+    ] = False,
     fireworks: Annotated[
         bool,
         typer.Option("--fireworks", help="Use the bundled Fireworks Responses profile."),
@@ -1501,6 +1512,13 @@ def root(
     if version:
         typer.echo(__version__)
         raise typer.Exit(0)
+    if privacy:
+        if context.invoked_subcommand is not None:
+            raise typer.BadParameter("--privacy cannot be combined with a subcommand")
+        if set_provider or grok or fireworks or provider_name is not None or model is not None:
+            raise typer.BadParameter("--privacy cannot be combined with provider setup options")
+        _finish(run_async(_run_privacy_setup_command))
+        return
     if set_provider:
         if context.invoked_subcommand is not None:
             raise typer.BadParameter("--set cannot be combined with a subcommand")

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import Final, Literal, cast
@@ -501,7 +502,7 @@ async def _effective_policy() -> PrivacyPolicy:
         await client.close()
     plain = cast(dict[str, JsonValue], dict(raw))
     policy = plain.get("policy")
-    if type(policy) is not dict:
+    if not isinstance(policy, Mapping):
         raise ValueError("privacy_setup_effective_unavailable")
     return decode_privacy_policy_canonical(canonical_encode(cast(JsonValue, policy)))
 

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -264,7 +264,7 @@ def _render_recipe_options(*, recommended: PrivacyRecipe | None = None) -> None:
     typer.echo("You can change this any time by running 'yoetz --privacy'.")
 
 
-def _recipe_choice(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
+def _recipe_choice(hint: PrivacyRecipe | None) -> PrivacyRecipe:
     while True:
         raw = typer.prompt(
             "Choose a privacy option",
@@ -276,7 +276,7 @@ def _recipe_choice(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
         typer.echo("Please enter 1, 2, 3, 4, or 5.")
 
 
-def _recipe_prompt(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
+def _recipe_prompt(hint: PrivacyRecipe | None) -> PrivacyRecipe:
     _render_recipe_options()
     return _recipe_choice(hint)
 
@@ -701,8 +701,6 @@ async def run_privacy_setup(
             typer.echo("")
             typer.echo("Customize privacy one setting at a time.")
             recipe = _recipe_choice(recommended_recipe)
-            if recipe is None:
-                return PrivacySetupReport("failed", current.profile.value, reason="recipe_invalid")
             try:
                 answers = _ask_answers(recipe, current)
                 candidate = build_candidate_policy(current, answers, now=datetime.now(UTC))
@@ -713,8 +711,6 @@ async def run_privacy_setup(
                 return PrivacySetupReport("cancelled", current.profile.value)
     else:
         recipe = _recipe_prompt(recipe_hint)
-        if recipe is None:
-            return PrivacySetupReport("failed", current.profile.value, reason="recipe_invalid")
         try:
             answers = _ask_answers(recipe, current)
             candidate = build_candidate_policy(current, answers, now=datetime.now(UTC))

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -1,8 +1,9 @@
 """Trusted interactive privacy setup used by first run and ``privacy setup``.
 
-Recipe selection is only a starting draft.  The human still reviews all thirteen
-setup answers, sees the exact resulting disclosure boundary, and approves any
-widening through the existing locally reauthenticated privacy ceremony.
+The recommended-first path renders one exact bounded policy and asks one question.
+Only declining it opens all thirteen expert settings.  Both paths show the exact
+resulting disclosure boundary and approve any widening through the existing locally
+reauthenticated privacy ceremony.
 """
 
 from __future__ import annotations
@@ -61,6 +62,20 @@ _UNSUPPORTED_CHANNELS: Final = (
     EgressChannel.UPDATE_CHECKS,
     EgressChannel.CAPABILITY_TESTING,
 )
+_RECIPE_DEFAULTS: Final = {
+    "private": "1",
+    "metadata_only": "2",
+    "assisted_review": "3",
+    "expanded_review": "4",
+    "custom": "5",
+}
+_RECIPE_CHOICES: Final = {
+    "1": "private",
+    "2": "metadata_only",
+    "3": "assisted_review",
+    "4": "expanded_review",
+    "5": "custom",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,31 +240,140 @@ def _interactive_terminal() -> bool:
         return False
 
 
-def _recipe_prompt(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
-    typer.echo("Privacy recipe (a draft, not consent):")
-    typer.echo("  1. Private — no network egress")
-    typer.echo("  2. Metadata only — structural context, confirm every request")
-    typer.echo("  3. Assisted review — requires current eligible provider data-use evidence")
-    typer.echo("  4. Expanded review — broader in-scope excerpts")
-    typer.echo("  5. Custom — bounded review without a provider data-use recommendation")
-    defaults = {
-        "private": "1",
-        "metadata_only": "2",
-        "assisted_review": "3",
-        "expanded_review": "4",
-        "custom": "5",
-    }
-    raw = typer.prompt("Choose a draft", default=defaults.get(hint or "private", "1")).strip()
-    return cast(
-        PrivacyRecipe | None,
-        {
-            "1": "private",
-            "2": "metadata_only",
-            "3": "assisted_review",
-            "4": "expanded_review",
-            "5": "custom",
-        }.get(raw),
+def _render_recipe_options(*, recommended: PrivacyRecipe | None = None) -> None:
+    typer.echo("Privacy options:")
+    typer.echo(
+        "  1. Private"
+        + (" (recommended)" if recommended == "private" else "")
+        + " — maximum confidentiality; no network egress or external semantic review"
     )
+    typer.echo(
+        "  2. Metadata only"
+        + (" (recommended)" if recommended == "metadata_only" else "")
+        + " — strongest semantic privacy; structural metadata only and approval every request"
+    )
+    typer.echo(
+        "  3. Assisted review — better problem-specific feedback from bounded excerpts; "
+        "requires eligible provider data-use evidence"
+    )
+    typer.echo(
+        "  4. Expanded review — most reviewer context and detail; allows broader in-scope excerpts"
+    )
+    typer.echo("  5. Custom — maximum control; review each privacy setting one by one")
+    typer.echo("Credentials, secrets, complete transcripts, and unrelated files are never sent.")
+    typer.echo("You can change this any time by running 'yoetz --privacy'.")
+
+
+def _recipe_choice(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
+    while True:
+        raw = typer.prompt(
+            "Choose a privacy option",
+            default=_RECIPE_DEFAULTS.get(hint or "private", "1"),
+        ).strip()
+        choice = cast(PrivacyRecipe | None, _RECIPE_CHOICES.get(raw))
+        if choice is not None:
+            return choice
+        typer.echo("Please enter 1, 2, 3, 4, or 5.")
+
+
+def _recipe_prompt(hint: PrivacyRecipe | None) -> PrivacyRecipe | None:
+    _render_recipe_options()
+    return _recipe_choice(hint)
+
+
+def _recommended_metadata_answers(current: PrivacyPolicy) -> PrivacySetupAnswers:
+    external, _local = _configured_bindings()
+    if external is None:
+        raise ValueError("privacy_setup_provider_binding_required")
+    return PrivacySetupAnswers(
+        network_egress=True,
+        local_models=False,
+        external_provider=external,
+        require_current_provider_data_use_evidence=False,
+        local_model_binding=None,
+        review_context=ReviewContextProfile.STRUCTURAL,
+        content_categories=(
+            DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            DataCategory.DECLARED_FILE_TYPE,
+        ),
+        content_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+        agent_context_categories=(
+            current.agent_context_categories
+            or (
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                DataCategory.DECLARED_FILE_TYPE,
+            )
+        ),
+        agent_context_data_classes=(
+            current.agent_context_data_classes or (DataClass.PUBLIC_STRUCTURAL,)
+        ),
+        local_model_categories=(),
+        local_model_data_classes=(),
+        request_confirmation=True,
+        telemetry=False,
+        crash_diagnostics=False,
+        updates=False,
+        capability_testing=False,
+        authorization_scope=AuthorizationScopeKind.TASK,
+    )
+
+
+def _recommended_private_answers(current: PrivacyPolicy) -> PrivacySetupAnswers:
+    return PrivacySetupAnswers(
+        network_egress=False,
+        local_models=False,
+        external_provider=None,
+        require_current_provider_data_use_evidence=False,
+        local_model_binding=None,
+        review_context=ReviewContextProfile.STRUCTURAL,
+        content_categories=(),
+        content_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+        agent_context_categories=(
+            current.agent_context_categories
+            or (
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                DataCategory.DECLARED_FILE_TYPE,
+            )
+        ),
+        agent_context_data_classes=(
+            current.agent_context_data_classes or (DataClass.PUBLIC_STRUCTURAL,)
+        ),
+        local_model_categories=(),
+        local_model_data_classes=(),
+        request_confirmation=False,
+        telemetry=False,
+        crash_diagnostics=False,
+        updates=False,
+        capability_testing=False,
+        authorization_scope=AuthorizationScopeKind.MACHINE,
+    )
+
+
+def _review_context_prompt(default: ReviewContextProfile) -> ReviewContextProfile:
+    typer.echo("4/13 Review context: structural, goal_aware, assisted, or expanded")
+    while True:
+        raw = typer.prompt("Review context", default=default.value).strip()
+        try:
+            review = ReviewContextProfile(raw)
+        except ValueError:
+            typer.echo("Choose structural, goal_aware, assisted, or expanded.")
+            continue
+        if review is ReviewContextProfile.CUSTOM:
+            typer.echo("Custom selectors use desired-state TOML; choose a listed context here.")
+            continue
+        return review
+
+
+def _authorization_scope_prompt(default: str) -> AuthorizationScopeKind:
+    while True:
+        raw = typer.prompt(
+            "13/13 Authorization ceiling (request, task, workspace, machine)",
+            default=default,
+        ).strip()
+        try:
+            return AuthorizationScopeKind(raw)
+        except ValueError:
+            typer.echo("Choose request, task, workspace, or machine.")
 
 
 def _categories_prompt(
@@ -360,14 +484,7 @@ def _ask_answers(recipe: PrivacyRecipe, current: PrivacyPolicy) -> PrivacySetupA
             "3/13b Require a current eligible provider data-use record?",
             default=recipe == "assisted_review",
         )
-    typer.echo("4/13 Review context: structural, goal_aware, assisted, or expanded")
-    review_raw = typer.prompt("Review context", default=context.value).strip()
-    try:
-        review = ReviewContextProfile(review_raw)
-    except ValueError as exc:
-        raise ValueError("privacy_setup_review_context_invalid") from exc
-    if review is ReviewContextProfile.CUSTOM:
-        raise ValueError("privacy_setup_custom_requires_desired_state")
+    review = _review_context_prompt(context)
     content = _categories_prompt(5, "External content categories", tuple(categories))
     content_classes = _data_classes_prompt(
         5,
@@ -412,18 +529,11 @@ def _ask_answers(recipe: PrivacyRecipe, current: PrivacyPolicy) -> PrivacySetupA
     capability = typer.confirm(
         "12/13 Enable external capability testing? (unsupported; stays off)", default=False
     )
-    scope_raw = typer.prompt(
-        "13/13 Authorization ceiling (request, task, workspace, machine)",
-        default=(
-            "workspace"
-            if recipe in {"assisted_review", "expanded_review"}
-            else ("task" if semantic else "machine")
-        ),
-    ).strip()
-    try:
-        scope = AuthorizationScopeKind(scope_raw)
-    except ValueError as exc:
-        raise ValueError("privacy_setup_scope_invalid") from exc
+    scope = _authorization_scope_prompt(
+        "workspace"
+        if recipe in {"assisted_review", "expanded_review"}
+        else ("task" if semantic else "machine")
+    )
 
     if network and not use_provider:
         raise ValueError("privacy_setup_provider_binding_required")
@@ -550,6 +660,7 @@ async def _decide(proposal_id: str) -> object:
 async def run_privacy_setup(
     *,
     recipe_hint: PrivacyRecipe | None = None,
+    offer_recommended: bool = False,
 ) -> PrivacySetupReport:
     """Run the trusted questionnaire and apply only an explicitly approved draft."""
 
@@ -560,20 +671,61 @@ async def run_privacy_setup(
             reason="local_terminal_required",
         )
     current = await _effective_policy()
-    recipe = _recipe_prompt(recipe_hint)
-    if recipe is None:
-        return PrivacySetupReport("failed", current.profile.value, reason="recipe_invalid")
-    try:
-        answers = _ask_answers(recipe, current)
-        candidate = build_candidate_policy(current, answers, now=datetime.now(UTC))
-    except ValueError as error:
-        return PrivacySetupReport("failed", current.profile.value, reason=str(error))
-    _render_review(candidate)
-    if not typer.confirm(
-        "Create this exact privacy proposal?",
-        default=False,
-    ):
-        return PrivacySetupReport("cancelled", current.profile.value)
+    if offer_recommended:
+        recommended_recipe: PrivacyRecipe = "metadata_only"
+        try:
+            recommended_answers = _recommended_metadata_answers(current)
+        except ValueError as error:
+            if str(error) != "privacy_setup_provider_binding_required":
+                return PrivacySetupReport("failed", current.profile.value, reason=str(error))
+            recommended_recipe = "private"
+            recommended_answers = _recommended_private_answers(current)
+        _render_recipe_options(recommended=recommended_recipe)
+        typer.echo("")
+        if recommended_recipe == "metadata_only":
+            typer.echo("Recommended policy: Metadata only")
+            typer.echo(
+                "Why: it enables semantic review while minimizing disclosure and asks before "
+                "every provider request."
+            )
+        else:
+            typer.echo("Recommended policy: Private")
+            typer.echo("Why: no external provider is configured, so this keeps network egress off.")
+        candidate = build_candidate_policy(
+            current,
+            recommended_answers,
+            now=datetime.now(UTC),
+        )
+        _render_review(candidate)
+        if not typer.confirm("Use this recommended privacy policy?", default=True):
+            typer.echo("")
+            typer.echo("Customize privacy one setting at a time.")
+            recipe = _recipe_choice(recommended_recipe)
+            if recipe is None:
+                return PrivacySetupReport("failed", current.profile.value, reason="recipe_invalid")
+            try:
+                answers = _ask_answers(recipe, current)
+                candidate = build_candidate_policy(current, answers, now=datetime.now(UTC))
+            except ValueError as error:
+                return PrivacySetupReport("failed", current.profile.value, reason=str(error))
+            _render_review(candidate)
+            if not typer.confirm("Use this exact custom privacy policy?", default=False):
+                return PrivacySetupReport("cancelled", current.profile.value)
+    else:
+        recipe = _recipe_prompt(recipe_hint)
+        if recipe is None:
+            return PrivacySetupReport("failed", current.profile.value, reason="recipe_invalid")
+        try:
+            answers = _ask_answers(recipe, current)
+            candidate = build_candidate_policy(current, answers, now=datetime.now(UTC))
+        except ValueError as error:
+            return PrivacySetupReport("failed", current.profile.value, reason=str(error))
+        _render_review(candidate)
+        if not typer.confirm(
+            "Create this exact privacy proposal?",
+            default=False,
+        ):
+            return PrivacySetupReport("cancelled", current.profile.value)
     if _substantive_identity(candidate) == _substantive_identity(current):
         return PrivacySetupReport("unchanged", current.profile.value)
     proposal_id = await _propose(candidate, current.policy_digest)

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -258,7 +258,7 @@ async def provider_status_report() -> dict[str, JsonValue]:
             {
                 "condition": "llm_inference_channel",
                 "state": "disabled",
-                "next_command": "yoetz privacy setup",
+                "next_command": "yoetz --privacy",
             }
         )
 

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -19,9 +19,15 @@ from yoetz.ports.control import ControlClientKind, ControlError
 from yoetz.protocol.canonical import JsonValue, canonical_encode
 from yoetz.service.client import connect_service
 
-__all__ = ["machine_scope_request", "provider_status_report", "run_provider_status"]
+__all__ = [
+    "credential_human_display",
+    "machine_scope_request",
+    "provider_status_report",
+    "run_provider_status",
+]
 
 _SCHEMA: Final = "yoetz.provider-status/1"
+_CREDENTIAL_MASK: Final = "********"
 # This report probes the persistent user service over the fixed endpoint only. It never starts
 # one, unlike the MCP bridge's connect-on-demand path.
 _PROBED_LIFECYCLE: Final = "user_service_no_autostart"
@@ -47,7 +53,7 @@ def _emit(value: Mapping[str, JsonValue], *, json_output: bool) -> None:
             f"model={binding.get('model')} "
             f"profile={binding.get('endpoint_profile_id')}"
         )
-    print(f"credential_connected: {value.get('credential_connected')}")
+    print(f"credential: {credential_human_display(value.get('credential_connected'))}")
     print(f"llm_inference_enabled: {value.get('llm_inference_enabled')}")
     print(f"semantic_ready: {value.get('semantic_ready')}")
     blockers = value.get("blockers")
@@ -69,6 +75,16 @@ def _emit(value: Mapping[str, JsonValue], *, json_output: bool) -> None:
         print("next commands:")
         for step in next_steps:
             print(f"  - {step}")
+
+
+def credential_human_display(value: object) -> str:
+    """Render credential presence without reflecting any property of the stored secret."""
+
+    if value is True:
+        return _CREDENTIAL_MASK
+    if value is False:
+        return "not stored"
+    return "unknown"
 
 
 def _channel_enabled(policy: Mapping[str, object], channel: str) -> bool | None:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -63,7 +63,7 @@ _HARNESS_DISPLAY_NAMES: Final[dict[HarnessId, str]] = {HarnessId.CODEX: "Codex"}
 
 _NEXT_SERVICE: Final = "run 'yoetz service run' under your selected user supervisor"
 _NEXT_UNLOCK: Final = "run 'yoetz service unlock' from a local terminal if the vault is locked"
-_NEXT_PRIVACY: Final = "run 'yoetz privacy setup' to review recipes and provider binding"
+_NEXT_PRIVACY: Final = "run 'yoetz --privacy' to review or change the privacy policy"
 _NEXT_PROVIDER_TOML: Final = (
     "run 'yoetz provider endpoint' (or edit config.toml) to choose a reviewed provider "
     "or an owner-declared HTTPS origin+model — never put API keys in TOML"
@@ -905,6 +905,7 @@ async def _interactive_provider_setup(
         "credential": "skipped",
     }
     auto_passphrase: bytearray | None = None
+    replacing_stored_credential = False
 
     def wipe_auto_passphrase() -> None:
         nonlocal auto_passphrase
@@ -1008,11 +1009,14 @@ async def _interactive_provider_setup(
     if credential_before is True:
         from yoetz.cli.provider_status import credential_human_display
 
-        provider_report["credential"] = "stored"
-        provider_report["credential_display"] = credential_human_display(True)
         typer.echo(f"  Credential: {credential_human_display(True)} (already stored)")
-        wipe_auto_passphrase()
-        return service, provider_report
+        if typer.confirm("Use the stored credential for this provider and model?", default=True):
+            provider_report["credential"] = "stored"
+            provider_report["credential_display"] = credential_human_display(True)
+            wipe_auto_passphrase()
+            return service, provider_report
+        replacing_stored_credential = True
+        typer.echo("Enter a new credential to replace the stored value.")
 
     # A Keychain-provisioned passphrase vault is already ready without the
     # human knowing its generated passphrase. Load that same scoped secret
@@ -1052,9 +1056,15 @@ async def _interactive_provider_setup(
         provider_report["credential"] = "failed"
         provider_report["credential_reason"] = error.reason
     except ConfidentialClientError as error:
-        # The vault write may have committed before the result/close frame was lost. Recompose
-        # and inspect only the exact configured profile's presence bit; never retry with a wiped
-        # buffer and never turn an unreadable state into a success claim.
+        # An initial vault write may have committed before the result/close frame was lost.
+        # Recompose and inspect only the exact configured profile's presence bit; never retry with
+        # a wiped buffer and never turn an unreadable state into a success claim.
+        if replacing_stored_credential:
+            # Presence was already true before the write, so it cannot distinguish the old value
+            # from a committed replacement. Preserve that uncertainty instead of claiming success.
+            provider_report["credential"] = "failed"
+            provider_report["credential_reason"] = f"credential_{error.reason}"
+            return await _service_reachability(), provider_report
         service = await _restart_service_for_semantic_composition()
         credential_after: bool | None = None
         if service.get("state") == "ready":
@@ -1251,14 +1261,11 @@ async def run_setup_wizard(
             from yoetz.cli.unlock import HumanCeremonyCliError
             from yoetz.ports.control import ControlError
 
-            typer.echo("")
-            typer.echo("Choose what semantic review may send:")
-            typer.echo(
-                "  Suggested first-run default: Metadata only — structural context, "
-                "with confirmation before every provider request"
-            )
             try:
-                privacy_result = await run_privacy_setup(recipe_hint="metadata_only")
+                privacy_result = await run_privacy_setup(
+                    recipe_hint="metadata_only",
+                    offer_recommended=True,
+                )
             except (ControlError, HumanCeremonyCliError, OSError, ValueError) as error:
                 reason = getattr(error, "reason", None)
                 if type(error) is ValueError:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -896,6 +896,7 @@ async def _interactive_provider_setup(
     from yoetz.config.models import ConfigError
     from yoetz.config.paths import bundle_root
     from yoetz.config.write import provider_preset
+    from yoetz.service.confidential_client import ConfidentialClientError
     from yoetz.service.confidential_protocol import ProviderCredentialTarget
     from yoetz.service.vault import provider_credential_profile_binding
 
@@ -989,6 +990,30 @@ async def _interactive_provider_setup(
         wipe_auto_passphrase()
         return service, provider_report
 
+    # The service snapshots its configured provider and credential capability at composition
+    # time. Refresh it after writing the binding before deciding whether this exact profile
+    # already has a credential. This also makes a repeated setup run idempotent: an existing
+    # credential is shown as present and is never requested again.
+    service = await _restart_service_for_semantic_composition()
+    credential_before: bool | None = None
+    if service.get("state") == "ready":
+        from yoetz.cli.provider_status import provider_status_report
+
+        try:
+            status_before = await provider_status_report()
+        except OSError, ValueError:
+            status_before = {}
+        observed_before = status_before.get("credential_connected")
+        credential_before = observed_before if type(observed_before) is bool else None
+    if credential_before is True:
+        from yoetz.cli.provider_status import credential_human_display
+
+        provider_report["credential"] = "stored"
+        provider_report["credential_display"] = credential_human_display(True)
+        typer.echo(f"  Credential: {credential_human_display(True)} (already stored)")
+        wipe_auto_passphrase()
+        return service, provider_report
+
     # A Keychain-provisioned passphrase vault is already ready without the
     # human knowing its generated passphrase. Load that same scoped secret
     # only for the one provider-reauthentication ceremony, so setup asks for
@@ -1026,8 +1051,36 @@ async def _interactive_provider_setup(
     except HumanCeremonyCliError as error:
         provider_report["credential"] = "failed"
         provider_report["credential_reason"] = error.reason
+    except ConfidentialClientError as error:
+        # The vault write may have committed before the result/close frame was lost. Recompose
+        # and inspect only the exact configured profile's presence bit; never retry with a wiped
+        # buffer and never turn an unreadable state into a success claim.
+        service = await _restart_service_for_semantic_composition()
+        credential_after: bool | None = None
+        if service.get("state") == "ready":
+            from yoetz.cli.provider_status import provider_status_report
+
+            try:
+                status_after = await provider_status_report()
+            except OSError, ValueError:
+                status_after = {}
+            observed_after = status_after.get("credential_connected")
+            credential_after = observed_after if type(observed_after) is bool else None
+        if credential_after is True:
+            from yoetz.cli.provider_status import credential_human_display
+
+            provider_report["credential"] = "stored"
+            provider_report["credential_display"] = credential_human_display(True)
+            provider_report["credential_reason"] = "stored_result_recovered"
+        else:
+            provider_report["credential"] = "failed"
+            provider_report["credential_reason"] = f"credential_{error.reason}"
     else:
         provider_report["credential"] = result.activation_status
+        if result.activation_status == "stored":
+            from yoetz.cli.provider_status import credential_human_display
+
+            provider_report["credential_display"] = credential_human_display(True)
     finally:
         wipe_auto_passphrase()
     return await _service_reachability(), provider_report
@@ -1102,7 +1155,14 @@ async def run_provider_setup(
     credential = provider_report.get("credential")
     typer.echo("")
     typer.echo(f"Provider binding: {binding}")
-    typer.echo(f"API key: {credential}")
+    from yoetz.cli.provider_status import credential_human_display
+
+    typer.echo(
+        "Credential: "
+        + credential_human_display(
+            True if credential == "stored" else (False if credential == "failed" else None)
+        )
+    )
     if binding != "configured" or credential != "stored":
         reason = provider_report.get("credential_reason")
         if type(reason) is str:
@@ -1191,13 +1251,27 @@ async def run_setup_wizard(
             from yoetz.cli.unlock import HumanCeremonyCliError
             from yoetz.ports.control import ControlError
 
+            typer.echo("")
+            typer.echo("Choose what semantic review may send:")
+            typer.echo(
+                "  Suggested first-run default: Metadata only — structural context, "
+                "with confirmation before every provider request"
+            )
             try:
-                privacy_result = await run_privacy_setup(recipe_hint="custom")
+                privacy_result = await run_privacy_setup(recipe_hint="metadata_only")
             except (ControlError, HumanCeremonyCliError, OSError, ValueError) as error:
+                reason = getattr(error, "reason", None)
+                if type(error) is ValueError:
+                    value_error_reason = str(error)
+                    reason = (
+                        value_error_reason
+                        if value_error_reason.startswith("privacy_setup_")
+                        else "privacy_setup_failed"
+                    )
                 privacy = {
                     "outcome": "failed",
                     "profile": "unknown",
-                    "reason": getattr(error, "reason", "privacy_setup_failed"),
+                    "reason": reason if type(reason) is str else "privacy_setup_failed",
                 }
             else:
                 privacy = {
@@ -1398,7 +1472,15 @@ def _emit_human_report(report: dict[str, JsonValue]) -> None:
         )
     if isinstance(provider, dict):
         typer.echo(f"  Provider binding: {provider.get('binding')}")
-        typer.echo(f"  Provider credential: {provider.get('credential')}")
+        from yoetz.cli.provider_status import credential_human_display
+
+        credential = provider.get("credential")
+        typer.echo(
+            "  Credential: "
+            + credential_human_display(
+                True if credential == "stored" else (False if credential == "failed" else None)
+            )
+        )
     if isinstance(privacy, dict):
         line = f"  Privacy: {privacy.get('outcome')} ({privacy.get('profile')})"
         if privacy.get("reason"):

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -325,6 +325,63 @@ def test_interactive_registration_n_declines_without_mutation(
         assert all(call[1:3] == ("mcp", "get") for call in calls)
 
 
+def test_semantic_first_run_suggests_and_selects_metadata_only_privacy_draft(
+    wizard_env: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.privacy_setup as privacy_setup_module
+    import yoetz.cli.provider_status as provider_status_module
+    import yoetz.cli.setup as setup_module
+
+    wizard_env["outputs"] = [
+        CommandOutput(1, b""),  # preview get: absent
+        CommandOutput(1, b""),  # apply re-preview get: absent
+        CommandOutput(0, b""),  # add
+        _yoetz_entry("policy"),  # verify get
+    ]
+    recipe_hints: list[str | None] = []
+
+    async def ready(*, start_if_absent: bool = False) -> dict[str, object]:
+        del start_if_absent
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    async def provider_setup(
+        service: dict[str, object],
+        *,
+        provider_choice: str | None = None,
+        model: str | None = None,
+    ) -> tuple[dict[str, object], dict[str, object]]:
+        del provider_choice, model
+        return service, {"binding": "configured", "credential": "stored"}
+
+    async def privacy_setup(*, recipe_hint: str | None = None) -> SimpleNamespace:
+        recipe_hints.append(recipe_hint)
+        return SimpleNamespace(
+            outcome="configured",
+            profile="confirm_every_request",
+            proposal_id="pvp_1",
+            reason=None,
+        )
+
+    async def provider_status() -> dict[str, object]:
+        return {"semantic_ready": True}
+
+    monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
+    monkeypatch.setattr(setup_module, "_service_reachability", ready)
+    monkeypatch.setattr(setup_module, "_interactive_provider_setup", provider_setup)
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", ready)
+    monkeypatch.setattr(privacy_setup_module, "run_privacy_setup", privacy_setup)
+    monkeypatch.setattr(provider_status_module, "provider_status_report", provider_status)
+
+    result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n2\nY\n")
+
+    assert result.exit_code == 0
+    assert recipe_hints == ["metadata_only"]
+    assert "Choose what semantic review may send:" in result.stdout
+    assert "Suggested first-run default: Metadata only" in result.stdout
+    assert "Privacy: configured (confirm_every_request)" in result.stdout
+
+
 def test_no_codex_found_still_completes_with_guidance(wizard_env: dict[str, object]) -> None:
     wizard_env["binaries"] = ()
     result = _RUNNER.invoke(cli.app, ["setup", "run", "--non-interactive", "--json"])
@@ -797,6 +854,12 @@ def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthenticat
         del start_if_absent
         return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
 
+    async def fake_restart() -> dict[str, object]:
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    async def fake_provider_status() -> dict[str, object]:
+        return {"credential_connected": False}
+
     def fake_provider_preset(_provider: str) -> SimpleNamespace:
         return SimpleNamespace(choice="fireworks", provider_id="fireworks")
 
@@ -806,6 +869,10 @@ def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthenticat
     monkeypatch.setattr(binding_module, "apply_provider_endpoint_choice", fake_write)
     monkeypatch.setattr(unlock_module, "set_provider_credential", fake_set)
     monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", fake_restart)
+    import yoetz.cli.provider_status as provider_status_module
+
+    monkeypatch.setattr(provider_status_module, "provider_status_report", fake_provider_status)
     monkeypatch.setattr(
         write_module,
         "provider_preset",
@@ -824,3 +891,133 @@ def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthenticat
     assert supplied_reauthentication == [b"a" * 48]
     assert report["binding"] == "configured"
     assert report["credential"] == "stored"
+    assert report["credential_display"] == "********"
+
+
+def test_existing_bound_credential_is_masked_and_not_requested_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import yoetz.cli.provider_binding as binding_module
+    import yoetz.cli.provider_status as provider_status_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+    import yoetz.config.write as write_module
+
+    provider = SimpleNamespace(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+    )
+
+    def fake_load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(storage=SimpleNamespace(data_dir=tmp_path), provider=provider)
+
+    def fake_write(*_args: object, **_kwargs: object) -> tuple[Path, object]:
+        return tmp_path / "config.toml", object()
+
+    def fake_preset(_provider: object) -> SimpleNamespace:
+        return SimpleNamespace(choice="fireworks", provider_id="fireworks")
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        fake_load_config,
+    )
+    monkeypatch.setattr(
+        binding_module,
+        "apply_provider_endpoint_choice",
+        fake_write,
+    )
+    monkeypatch.setattr(write_module, "provider_preset", fake_preset)
+
+    async def fake_restart() -> dict[str, object]:
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    async def fake_status() -> dict[str, object]:
+        return {"credential_connected": True}
+
+    async def forbidden_set(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("stored credential must not be requested again")
+
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", fake_restart)
+    monkeypatch.setattr(provider_status_module, "provider_status_report", fake_status)
+    monkeypatch.setattr(unlock_module, "set_provider_credential", forbidden_set)
+
+    _service, report = asyncio.run(
+        setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
+            {"reachable": True, "state": "ready", "vault_mode": "passphrase"},
+            provider_choice="fireworks",
+            model="accounts/fireworks/models/minimax-m3",
+        )
+    )
+
+    assert report["credential"] == "stored"
+    assert report["credential_display"] == "********"
+
+
+def test_lost_credential_result_recovers_from_recomposed_presence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import yoetz.cli.provider_binding as binding_module
+    import yoetz.cli.provider_status as provider_status_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+    import yoetz.config.write as write_module
+    from yoetz.service.confidential_client import ConfidentialClientError
+
+    provider = SimpleNamespace(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+    )
+    status_reads = iter((False, True))
+
+    def fake_load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(storage=SimpleNamespace(data_dir=tmp_path), provider=provider)
+
+    def fake_write(*_args: object, **_kwargs: object) -> tuple[Path, object]:
+        return tmp_path / "config.toml", object()
+
+    def fake_preset(_provider: object) -> SimpleNamespace:
+        return SimpleNamespace(choice="fireworks", provider_id="fireworks")
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        fake_load_config,
+    )
+    monkeypatch.setattr(
+        binding_module,
+        "apply_provider_endpoint_choice",
+        fake_write,
+    )
+    monkeypatch.setattr(write_module, "provider_preset", fake_preset)
+
+    async def fake_restart() -> dict[str, object]:
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    async def fake_status() -> dict[str, object]:
+        return {"credential_connected": next(status_reads)}
+
+    async def lost_result(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialClientError("ambiguous")
+
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", fake_restart)
+    monkeypatch.setattr(provider_status_module, "provider_status_report", fake_status)
+    monkeypatch.setattr(unlock_module, "set_provider_credential", lost_result)
+
+    _service, report = asyncio.run(
+        setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
+            {"reachable": True, "state": "ready", "vault_mode": "passphrase"},
+            provider_choice="fireworks",
+            model="accounts/fireworks/models/minimax-m3",
+        )
+    )
+
+    assert report["credential"] == "stored"
+    assert report["credential_display"] == "********"
+    assert report["credential_reason"] == "stored_result_recovered"

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -531,10 +531,10 @@ def test_root_privacy_shortcut_dispatches_guided_privacy_setup(
 
 
 def test_root_privacy_shortcut_rejects_provider_setup_options() -> None:
-    result = _RUNNER.invoke(cli.app, ["--privacy", "--set"])
+    result = _RUNNER.invoke(cli.app, ["--privacy", "--set"], env={"NO_COLOR": "1"})
 
     assert result.exit_code == 2
-    assert "--privacy cannot be combined" in result.output
+    assert "--privacy cannot be combined" in _plain(result.output)
 
 
 def test_root_set_fireworks_dispatches_simple_provider_setup(
@@ -1110,7 +1110,7 @@ def test_lost_credential_result_recovers_from_recomposed_presence(
     monkeypatch.setattr(write_module, "provider_preset", fake_preset)
 
     async def fake_restart() -> dict[str, object]:
-        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+        return {"reachable": True, "state": "ready", "vault_mode": "os_managed"}
 
     async def fake_status() -> dict[str, object]:
         return {"credential_connected": next(status_reads)}
@@ -1124,7 +1124,7 @@ def test_lost_credential_result_recovers_from_recomposed_presence(
 
     _service, report = asyncio.run(
         setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
-            {"reachable": True, "state": "ready", "vault_mode": "passphrase"},
+            {"reachable": True, "state": "ready", "vault_mode": "os_managed"},
             provider_choice="fireworks",
             model="accounts/fireworks/models/minimax-m3",
         )

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -186,7 +186,7 @@ def test_non_interactive_without_accept_is_a_dry_run(wizard_env: dict[str, objec
     assert not cast(Path, wizard_env["marker"]).exists()
     # Honest next steps always include the confidential ceremonies it cannot run.
     steps = " ".join(report["next_steps"])
-    assert "yoetz privacy setup" in steps
+    assert "yoetz --privacy" in steps
     assert "yoetz provider credential set" in steps
     assert "yoetz service run" in steps
 
@@ -339,7 +339,7 @@ def test_semantic_first_run_suggests_and_selects_metadata_only_privacy_draft(
         CommandOutput(0, b""),  # add
         _yoetz_entry("policy"),  # verify get
     ]
-    recipe_hints: list[str | None] = []
+    privacy_calls: list[tuple[str | None, bool]] = []
 
     async def ready(*, start_if_absent: bool = False) -> dict[str, object]:
         del start_if_absent
@@ -354,8 +354,12 @@ def test_semantic_first_run_suggests_and_selects_metadata_only_privacy_draft(
         del provider_choice, model
         return service, {"binding": "configured", "credential": "stored"}
 
-    async def privacy_setup(*, recipe_hint: str | None = None) -> SimpleNamespace:
-        recipe_hints.append(recipe_hint)
+    async def privacy_setup(
+        *,
+        recipe_hint: str | None = None,
+        offer_recommended: bool = False,
+    ) -> SimpleNamespace:
+        privacy_calls.append((recipe_hint, offer_recommended))
         return SimpleNamespace(
             outcome="configured",
             profile="confirm_every_request",
@@ -376,9 +380,7 @@ def test_semantic_first_run_suggests_and_selects_metadata_only_privacy_draft(
     result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n2\nY\n")
 
     assert result.exit_code == 0
-    assert recipe_hints == ["metadata_only"]
-    assert "Choose what semantic review may send:" in result.stdout
-    assert "Suggested first-run default: Metadata only" in result.stdout
+    assert privacy_calls == [("metadata_only", True)]
     assert "Privacy: configured (confirm_every_request)" in result.stdout
 
 
@@ -509,6 +511,30 @@ def test_bare_invocation_without_tty_prints_help() -> None:
     result = _RUNNER.invoke(cli.app, [])
     assert result.exit_code == 0
     assert "Usage" in result.stdout
+
+
+def test_root_privacy_shortcut_dispatches_guided_privacy_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    async def privacy_setup() -> int:
+        calls.append("privacy")
+        return 0
+
+    monkeypatch.setattr(cli, "_run_privacy_setup_command", privacy_setup)
+
+    result = _RUNNER.invoke(cli.app, ["--privacy"])
+
+    assert result.exit_code == 0
+    assert calls == ["privacy"]
+
+
+def test_root_privacy_shortcut_rejects_provider_setup_options() -> None:
+    result = _RUNNER.invoke(cli.app, ["--privacy", "--set"])
+
+    assert result.exit_code == 2
+    assert "--privacy cannot be combined" in result.output
 
 
 def test_root_set_fireworks_dispatches_simple_provider_setup(
@@ -894,7 +920,7 @@ def test_ready_auto_unlock_vault_reuses_scoped_secret_for_provider_reauthenticat
     assert report["credential_display"] == "********"
 
 
-def test_existing_bound_credential_is_masked_and_not_requested_again(
+def test_existing_bound_credential_can_be_reused_without_requesting_it_again(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     import yoetz.cli.provider_binding as binding_module
@@ -945,6 +971,11 @@ def test_existing_bound_credential_is_masked_and_not_requested_again(
     monkeypatch.setattr(provider_status_module, "provider_status_report", fake_status)
     monkeypatch.setattr(unlock_module, "set_provider_credential", forbidden_set)
 
+    def reuse(*_args: object, **_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(setup_module.typer, "confirm", reuse)
+
     _service, report = asyncio.run(
         setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
             {"reachable": True, "state": "ready", "vault_mode": "passphrase"},
@@ -955,6 +986,87 @@ def test_existing_bound_credential_is_masked_and_not_requested_again(
 
     assert report["credential"] == "stored"
     assert report["credential_display"] == "********"
+
+
+@pytest.mark.parametrize(
+    ("result_lost", "expected_credential"),
+    [(False, "stored"), (True, "failed")],
+)
+def test_existing_bound_credential_replacement_does_not_inherit_old_presence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    result_lost: bool,
+    expected_credential: str,
+) -> None:
+    import yoetz.cli.provider_binding as binding_module
+    import yoetz.cli.provider_status as provider_status_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+    import yoetz.config.write as write_module
+    from yoetz.service.confidential_client import ConfidentialClientError
+
+    provider = SimpleNamespace(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+    )
+    replacements: list[object] = []
+
+    def fake_load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(storage=SimpleNamespace(data_dir=tmp_path), provider=provider)
+
+    def fake_write(*_args: object, **_kwargs: object) -> tuple[Path, object]:
+        return tmp_path / "config.toml", object()
+
+    def fake_preset(_provider: object) -> SimpleNamespace:
+        return SimpleNamespace(choice="fireworks", provider_id="fireworks")
+
+    async def fake_restart() -> dict[str, object]:
+        return {"reachable": True, "state": "ready", "vault_mode": "os_managed"}
+
+    async def fake_status() -> dict[str, object]:
+        return {"credential_connected": True}
+
+    async def replace(target: object, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        replacements.append(target)
+        if result_lost:
+            raise ConfidentialClientError("ambiguous")
+        return SimpleNamespace(activation_status="stored")
+
+    async def fake_reachability(*, start_if_absent: bool = False) -> dict[str, object]:
+        del start_if_absent
+        return {"reachable": True, "state": "ready", "vault_mode": "os_managed"}
+
+    monkeypatch.setattr(config_module, "load_config", fake_load_config)
+    monkeypatch.setattr(binding_module, "apply_provider_endpoint_choice", fake_write)
+    monkeypatch.setattr(write_module, "provider_preset", fake_preset)
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", fake_restart)
+    monkeypatch.setattr(provider_status_module, "provider_status_report", fake_status)
+    monkeypatch.setattr(unlock_module, "set_provider_credential", replace)
+    monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
+
+    def replace_stored(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(setup_module.typer, "confirm", replace_stored)
+
+    _service, report = asyncio.run(
+        setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
+            {"reachable": True, "state": "ready", "vault_mode": "os_managed"},
+            provider_choice="fireworks",
+            model="accounts/fireworks/models/minimax-m3",
+        )
+    )
+
+    assert len(replacements) == 1
+    assert report["credential"] == expected_credential
+    if result_lost:
+        assert report["credential_reason"] == "credential_ambiguous"
+        assert "credential_display" not in report
+    else:
+        assert report["credential_display"] == "********"
 
 
 def test_lost_credential_result_recovers_from_recomposed_presence(

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -16,6 +16,7 @@ from yoetz.domain.privacy import (
     ProviderBinding,
     ReviewContextProfile,
 )
+from yoetz.domain.values import JsonObject
 from yoetz.protocol.models import DataCategory
 from yoetz.service.confidential_protocol import PrivacyDecisionResult
 
@@ -105,6 +106,59 @@ def test_network_egress_requires_an_exact_provider_binding() -> None:
             _answers(external_provider=None),
             now=datetime(2026, 7, 29, tzinfo=UTC),
         )
+
+
+def test_metadata_only_hint_is_the_selected_privacy_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    prompts: list[tuple[str, str]] = []
+
+    def prompt(label: str, *, default: str) -> str:
+        prompts.append((label, default))
+        return default
+
+    monkeypatch.setattr(module.typer, "prompt", prompt)
+
+    recipe = module._recipe_prompt("metadata_only")  # pyright: ignore[reportPrivateUsage]
+
+    assert recipe == "metadata_only"
+    assert prompts == [("Choose a draft", "2")]
+
+
+@pytest.mark.anyio
+async def test_effective_policy_accepts_service_json_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.app as app_module
+    import yoetz.cli.privacy_setup as module
+    import yoetz.cli.provider_status as provider_status_module
+    from yoetz.adapters.privacy.catalog import encode_privacy_policy_json
+
+    current = local_only_policy()
+
+    class Client:
+        async def privacy_get_effective(self, request: object) -> JsonObject:
+            assert request == JsonObject({"scope": "machine"})
+            return JsonObject({"policy": encode_privacy_policy_json(current)})
+
+        async def close(self) -> None:
+            return None
+
+    async def build_client() -> Client:
+        return Client()
+
+    monkeypatch.setattr(app_module, "build_service_client", build_client)
+    monkeypatch.setattr(
+        provider_status_module,
+        "machine_scope_request",
+        lambda: JsonObject({"scope": "machine"}),
+    )
+
+    observed = await module._effective_policy()  # pyright: ignore[reportPrivateUsage]
+
+    assert observed == current
 
 
 @pytest.mark.anyio

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -124,7 +124,215 @@ def test_metadata_only_hint_is_the_selected_privacy_default(
     recipe = module._recipe_prompt("metadata_only")  # pyright: ignore[reportPrivateUsage]
 
     assert recipe == "metadata_only"
-    assert prompts == [("Choose a draft", "2")]
+    assert prompts == [("Choose a privacy option", "2")]
+
+
+def test_recommended_metadata_policy_is_bounded_and_confirmation_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    current = local_only_policy()
+    external = _answers().external_provider
+    monkeypatch.setattr(module, "_configured_bindings", lambda: (external, None))
+
+    answers = module._recommended_metadata_answers(  # pyright: ignore[reportPrivateUsage]
+        current
+    )
+
+    assert answers.network_egress is True
+    assert answers.external_provider == external
+    assert answers.review_context is ReviewContextProfile.STRUCTURAL
+    assert answers.content_categories == (
+        DataCategory.BOUNDED_STRUCTURAL_METADATA,
+        DataCategory.DECLARED_FILE_TYPE,
+    )
+    assert answers.content_data_classes == (DataClass.PUBLIC_STRUCTURAL,)
+    assert answers.request_confirmation is True
+    assert answers.require_current_provider_data_use_evidence is False
+    assert answers.authorization_scope is AuthorizationScopeKind.TASK
+
+
+def test_private_recommendation_requires_no_provider() -> None:
+    import yoetz.cli.privacy_setup as module
+
+    answers = module._recommended_private_answers(  # pyright: ignore[reportPrivateUsage]
+        local_only_policy()
+    )
+
+    assert answers.network_egress is False
+    assert answers.external_provider is None
+    assert answers.content_categories == ()
+    assert answers.request_confirmation is False
+    assert answers.authorization_scope is AuthorizationScopeKind.MACHINE
+
+
+def test_privacy_options_explain_tradeoffs_and_change_command(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    module._render_recipe_options(  # pyright: ignore[reportPrivateUsage]
+        recommended="metadata_only"
+    )
+
+    output = capsys.readouterr().out
+    assert "Private — maximum confidentiality" in output
+    assert "Metadata only (recommended)" in output
+    assert "Assisted review — better problem-specific feedback" in output
+    assert "Expanded review — most reviewer context" in output
+    assert "Custom — maximum control" in output
+    assert "yoetz --privacy" in output
+
+
+def test_named_review_context_reprompts_instead_of_aborting_on_yes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    answers = iter(("y", "assisted"))
+
+    def prompt(*_args: object, **_kwargs: object) -> str:
+        return next(answers)
+
+    monkeypatch.setattr(module.typer, "prompt", prompt)
+
+    review = module._review_context_prompt(  # pyright: ignore[reportPrivateUsage]
+        ReviewContextProfile.ASSISTED
+    )
+
+    assert review is ReviewContextProfile.ASSISTED
+    assert "Choose structural, goal_aware, assisted, or expanded." in capsys.readouterr().out
+
+
+@pytest.mark.anyio
+async def test_accepting_recommended_policy_skips_one_by_one_questions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    current = local_only_policy()
+
+    async def effective() -> PrivacyPolicy:
+        return current
+
+    def recommended(_current: PrivacyPolicy) -> PrivacySetupAnswers:
+        return _answers(
+            review_context=ReviewContextProfile.STRUCTURAL,
+            content_categories=(
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                DataCategory.DECLARED_FILE_TYPE,
+            ),
+            content_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+            request_confirmation=True,
+            require_current_provider_data_use_evidence=False,
+        )
+
+    def forbidden_questions(*_args: object) -> PrivacySetupAnswers:
+        raise AssertionError("recommended acceptance must skip detailed questions")
+
+    prompts: list[str] = []
+
+    def confirm(prompt: str, *, default: bool = False) -> bool:
+        prompts.append(prompt)
+        assert default is True
+        return True
+
+    async def propose(_candidate: PrivacyPolicy, _digest: str) -> str:
+        return "pvp_1"
+
+    async def decide(_proposal: str) -> PrivacyDecisionResult:
+        return PrivacyDecisionResult("committed", "sha256:" + "c" * 64)
+
+    def render_options(**_kwargs: object) -> None:
+        return None
+
+    def render_review(_candidate: PrivacyPolicy) -> None:
+        return None
+
+    monkeypatch.setattr(module, "_interactive_terminal", lambda: True)
+    monkeypatch.setattr(module, "_effective_policy", effective)
+    monkeypatch.setattr(module, "_recommended_metadata_answers", recommended)
+    monkeypatch.setattr(module, "_ask_answers", forbidden_questions)
+    monkeypatch.setattr(module, "_render_recipe_options", render_options)
+    monkeypatch.setattr(module, "_render_review", render_review)
+    monkeypatch.setattr(module.typer, "confirm", confirm)
+    monkeypatch.setattr(module, "_propose", propose)
+    monkeypatch.setattr(module, "_decide", decide)
+
+    report = await module.run_privacy_setup(
+        recipe_hint="metadata_only",
+        offer_recommended=True,
+    )
+
+    assert report.outcome == "configured"
+    assert prompts == ["Use this recommended privacy policy?"]
+
+
+@pytest.mark.anyio
+async def test_declining_recommended_policy_opens_one_by_one_questions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.privacy_setup as module
+
+    current = local_only_policy()
+    detailed: list[str] = []
+    confirmations = iter((False, True))
+
+    async def effective() -> PrivacyPolicy:
+        return current
+
+    def recommended(_current: PrivacyPolicy) -> PrivacySetupAnswers:
+        return _answers(
+            review_context=ReviewContextProfile.STRUCTURAL,
+            content_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            content_data_classes=(DataClass.PUBLIC_STRUCTURAL,),
+            request_confirmation=True,
+            require_current_provider_data_use_evidence=False,
+        )
+
+    def answers(recipe: object, _current: PrivacyPolicy) -> PrivacySetupAnswers:
+        detailed.append(str(recipe))
+        return _answers()
+
+    async def propose(_candidate: PrivacyPolicy, _digest: str) -> str:
+        return "pvp_1"
+
+    async def decide(_proposal: str) -> PrivacyDecisionResult:
+        return PrivacyDecisionResult("committed", "sha256:" + "c" * 64)
+
+    def choose(_hint: object) -> str:
+        return "custom"
+
+    def render_options(**_kwargs: object) -> None:
+        return None
+
+    def render_review(_candidate: PrivacyPolicy) -> None:
+        return None
+
+    def confirm(_prompt: str, *, default: bool = False) -> bool:
+        del default
+        return next(confirmations)
+
+    monkeypatch.setattr(module, "_interactive_terminal", lambda: True)
+    monkeypatch.setattr(module, "_effective_policy", effective)
+    monkeypatch.setattr(module, "_recommended_metadata_answers", recommended)
+    monkeypatch.setattr(module, "_recipe_choice", choose)
+    monkeypatch.setattr(module, "_ask_answers", answers)
+    monkeypatch.setattr(module, "_render_recipe_options", render_options)
+    monkeypatch.setattr(module, "_render_review", render_review)
+    monkeypatch.setattr(module.typer, "confirm", confirm)
+    monkeypatch.setattr(module, "_propose", propose)
+    monkeypatch.setattr(module, "_decide", decide)
+
+    report = await module.run_privacy_setup(
+        recipe_hint="metadata_only",
+        offer_recommended=True,
+    )
+
+    assert report.outcome == "configured"
+    assert detailed == ["custom"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -170,7 +170,7 @@ async def test_llm_inference_channel_is_actually_read_from_canonical_policy(
     assert len(channel_blockers) == 1
     # "disabled" is a read answer; "unknown" would mean the policy was never inspected.
     assert channel_blockers[0]["state"] == "disabled"
-    assert channel_blockers[0]["next_command"] == "yoetz privacy setup"
+    assert channel_blockers[0]["next_command"] == "yoetz --privacy"
 
 
 async def test_credential_for_a_different_provider_is_not_counted(

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -33,6 +33,13 @@ def _provider(provider_id: str = "openai") -> ProviderProfileConfig:
     )
 
 
+def test_credential_human_display_uses_one_constant_mask() -> None:
+    assert module.credential_human_display(True) == "********"
+    assert module.credential_human_display(False) == "not stored"
+    assert module.credential_human_display(None) == "unknown"
+    assert module.credential_human_display("a-real-key-must-never-be-reflected") == "unknown"
+
+
 def _policy(*, llm_inference_enabled: bool, profile: str = "local_only") -> dict[str, object]:
     return {
         "policy": {


### PR DESCRIPTION
## Summary

- Mask provider credentials and sensitive setup values consistently in CLI output.
- Document first-run setup, privacy review, and interactive control-menu behavior.
- Improve provider status and setup-wizard handling with focused coverage.

## Testing

- Added and updated subprocess and unit tests for setup, privacy setup, and provider status behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `yoetz --privacy` shortcut for reviewing or changing privacy settings.
  * First-run setup now recommends a metadata-only privacy policy before offering detailed customization.
  * Accepting the recommendation skips the expert questionnaire; declining opens the full guided flow.
  * Added safer credential reuse and replacement handling during provider setup.

* **Improvements**
  * Credential status now displays only masked presence, absence, or unknown status.
  * Updated setup guidance and next-step commands throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens credential masking in CLI output (replacing raw status values with a fixed `********` mask via a new `credential_human_display` helper), adds a recommended-first privacy setup flow (`offer_recommended=True` in `run_privacy_setup`), and introduces a `--privacy` root shortcut that bypasses the full thirteen-question wizard in favour of a single pre-composed `metadata_only` draft.

- `provider_status.py` gains `credential_human_display` — `True` → `********`, `False` → `\"not stored\"`, anything else → `\"unknown\"` — and the human-readable emit path is updated everywhere.
- `privacy_setup.py` refactors the wizard into a recommended-first path (accept skips detailed questions; decline opens them one by one) and fixes an `isinstance(policy, Mapping)` check.
- `setup.py` adds a credential-presence probe that allows reuse of an already-stored credential and recovers from a lost commit frame via a post-write presence check — but introduces two new `except OSError, ValueError:` clauses at lines 1005 and 1075 that are Python 2 syntax and cause a `SyntaxError` in Python 3.

<h3>Confidence Score: 2/5</h3>

The new credential-probe block in `setup.py` cannot be compiled by Python 3 due to two Python 2 bare-comma exception clauses, making the entire module unimportable.

Two new `except OSError, ValueError:` expressions at lines 1005 and 1075 of `setup.py` use Python 2 syntax that Python 3 rejects with a `SyntaxError` at parse time. Because Python compiles the entire file before executing any of it, the module cannot be imported at all — every setup wizard path, including the new credential-reuse and lost-result-recovery flows, becomes unreachable. The rest of the change is logically sound.

**Files Needing Attention:** `src/yoetz/cli/setup.py` — the two new exception clauses on the credential-probe paths must be fixed before the module can be imported. Lines 118 and 177 in the same file carry the same pre-existing pattern and will also need to be addressed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/cli/setup.py | Adds credential-presence probe and reuse flow, but introduces two `except OSError, ValueError:` clauses (Python 2 syntax) at lines 1005 and 1075 — SyntaxErrors that prevent the module from compiling in Python 3. |
| src/yoetz/cli/privacy_setup.py | Adds recommended-first privacy flow (`offer_recommended`), extracts `_recipe_choice`, `_review_context_prompt`, `_authorization_scope_prompt`, and fixes `isinstance(policy, Mapping)` over `type(policy) is not dict`. Logic looks sound. |
| src/yoetz/cli/provider_status.py | Adds `credential_human_display` that returns a fixed `********` mask for `True`, `"not stored"` for `False`, and `"unknown"` for anything else — correctly prevents credential leakage in human output. |
| src/yoetz/cli/app.py | Extracts `_run_privacy_setup_command` to module level and adds `--privacy` root shortcut with correct mutual-exclusion guards against subcommands and provider-setup flags. |
| tests/subprocess/test_setup_wizard_cli.py | Adds coverage for recommended-privacy first-run flow, `--privacy` shortcut dispatch and rejection, credential reuse, replacement non-inheritance, and lost-result recovery — comprehensive for the new paths. |
| tests/unit/cli/test_privacy_setup.py | Adds unit tests for recommended metadata/private answers, recipe option rendering, review-context reprompt, accept/decline recommended flow, and `_effective_policy` JSON-object acceptance. |
| tests/unit/cli/test_provider_status.py | Adds `test_credential_human_display_uses_one_constant_mask` verifying the mask for True, False, None, and arbitrary strings — good boundary coverage. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["yoetz --privacy / privacy setup"] --> B{offer_recommended?}
    B -- yes --> C[_recommended_metadata_answers]
    C -- provider configured --> D[build_candidate_policy metadata_only]
    C -- no provider --> E[_recommended_private_answers\nbuild_candidate_policy private]
    D --> F[_render_review]
    E --> F
    F --> G{User accepts\nrecommended?}
    G -- Yes --> H[_substantive_identity check]
    G -- No --> I[_recipe_choice\n_ask_answers\nbuild_candidate_policy]
    I --> J[_render_review custom]
    J --> K{User confirms\ncustom?}
    K -- Yes --> H
    K -- No --> L[cancelled]
    H -- unchanged --> M[unchanged]
    H -- changed --> N[_propose to _decide]
    N --> O[configured]
    B -- no --> P[_recipe_prompt\n_ask_answers]
    P --> Q[_render_review]
    Q --> R{User confirms?}
    R -- Yes --> H
    R -- No --> L
```

<sub>Reviews (2): Last reviewed commit: ["fix(setup): streamline privacy and crede..."](https://github.com/thegaysupreme123/yoetz/commit/db43d400ab7f771596cf334ad820bea70c7045b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=20034368)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->