### PR TITLE
Make publication failures actionable and isolate hooks tests

### DIFF
--- a/src/yoetz/application/publish_work.py
+++ b/src/yoetz/application/publish_work.py
@@ -271,11 +271,38 @@ _LOCATABLE_DRAFT_SUBFIELDS: Final = frozenset(
 )
 
 
-def _draft_pointer(event_index: int, subfield: str | None) -> str | None:
+# The payload fields that own a canonical set, which are frozen schema names declared by
+# `yoetz.domain.events`. `/event_drafts/N/payload` alone cannot be acted on: a rejected batch left
+# an agent guessing which of several reference lists broke the canonical set form.
+_LOCATABLE_PAYLOAD_FIELDS: Final = frozenset(
+    {
+        "affected_obligation_ids",
+        "disputes_refs",
+        "evidence_refs",
+        "obligation_ids",
+        "obligation_refs",
+        "redaction_target_event_ids",
+        "redaction_target_object_ids",
+        "replacement_obligation_ids",
+        "resolution_evidence_refs",
+        "returned_finding_ids",
+        "scope",
+        "source_refs",
+        "supporting_refs",
+        "target_event_ids",
+        "target_object_ids",
+    }
+)
+
+
+def _draft_pointer(
+    event_index: int, subfield: str | None, payload_field: str | None = None
+) -> str | None:
     """Locate one rejected draft without ever naming caller-supplied keys or values.
 
     Every segment is a frozen schema name plus the draft's ordinal, which is bounded by
-    ``MAX_EVENTS_PER_BATCH``. Nothing here is derived from the submitted payload.
+    ``MAX_EVENTS_PER_BATCH``. Nothing here is derived from the submitted payload: a payload field
+    is admitted only when it is already registered in ``_LOCATABLE_PAYLOAD_FIELDS``.
     """
 
     if type(event_index) is not int or not 0 <= event_index < MAX_EVENTS_PER_BATCH:
@@ -284,7 +311,18 @@ def _draft_pointer(event_index: int, subfield: str | None) -> str | None:
         return f"/event_drafts/{event_index}"
     if subfield not in _LOCATABLE_DRAFT_SUBFIELDS:
         return None
-    return f"/event_drafts/{event_index}/{subfield}"
+    pointer = f"/event_drafts/{event_index}/{subfield}"
+    # Only the payload has opaque interior structure worth naming one level deeper.
+    if subfield == "payload" and payload_field in _LOCATABLE_PAYLOAD_FIELDS:
+        return f"{pointer}/{payload_field}"
+    return pointer
+
+
+def _payload_field_of(exc: BaseException) -> str | None:
+    """Read the owning payload field a protocol rejection carried, if it named one."""
+
+    field = getattr(exc, "field", None)
+    return field if type(field) is str else None
 
 
 def _event_invalid(
@@ -292,6 +330,7 @@ def _event_invalid(
     *,
     event_index: int | None = None,
     subfield: str | None = None,
+    payload_field: str | None = None,
 ) -> PublicOperationError:
     # Only a stale frontier is fixed by rereading status; every other reason needs the event
     # payload corrected first, and retrying it unchanged would fail the same way.
@@ -304,7 +343,7 @@ def _event_invalid(
         message = "The event batch is invalid. Correct the event payload before retrying."
     details: dict[str, str] = {"reason_code": reason_code}
     if event_index is not None:
-        pointer = _draft_pointer(event_index, subfield)
+        pointer = _draft_pointer(event_index, subfield, payload_field)
         if pointer is not None:
             # Which draft failed is the difference between a one-line fix and re-deriving the
             # whole batch; a batch may carry up to MAX_EVENTS_PER_BATCH drafts.
@@ -375,7 +414,10 @@ def _decode_draft(value: JsonValue, event_index: int) -> _PreparedDraft:
             raise
         except (TypeError, ValueError) as exc:
             raise _event_invalid(
-                _reason_code_of(exc), event_index=event_index, subfield=subfield
+                _reason_code_of(exc),
+                event_index=event_index,
+                subfield=subfield,
+                payload_field=_payload_field_of(exc),
             ) from exc
 
     schema_source = _locate("schema", lambda: _mapping(_field(source, "schema")))

--- a/src/yoetz/domain/events.py
+++ b/src/yoetz/domain/events.py
@@ -320,18 +320,25 @@ def _tuple(value: object, minimum: int, maximum: int) -> tuple[object, ...]:
     return items
 
 
-def _validate_ascii_sorted_unique(values: tuple[str, ...]) -> None:
+def _validate_ascii_sorted_unique(values: tuple[str, ...], *, field: str | None = None) -> None:
+    """Enforce the canonical set form, naming the owning field so a rejection is actionable.
+
+    ``field`` is a frozen payload field name from this module, never caller data. A non-ASCII
+    member is its own reason: reporting it as unsorted sent agents hunting for an ordering bug
+    that was not there.
+    """
+
     previous: bytes | None = None
     for value in values:
         try:
             encoded = value.encode("ascii", errors="strict")
         except UnicodeEncodeError as exc:
-            raise ProtocolValueError("unsorted_set_field") from exc
+            raise ProtocolValueError("set_member_not_ascii", field=field) from exc
         if previous is not None:
             if encoded == previous:
-                raise ProtocolValueError("duplicate_set_member")
+                raise ProtocolValueError("duplicate_set_member", field=field)
             if encoded < previous:
-                raise ProtocolValueError("unsorted_set_field")
+                raise ProtocolValueError("unsorted_set_field", field=field)
         previous = encoded
 
 
@@ -341,10 +348,11 @@ def _id_tuple[T](
     *,
     minimum: int = 0,
     maximum: int = MAX_REF_LIST,
+    field: str | None = None,
 ) -> tuple[T, ...]:
     raw = _tuple(value, minimum, maximum)
     validated = tuple(constructor(item) for item in raw)
-    _validate_ascii_sorted_unique(cast(tuple[str, ...], validated))
+    _validate_ascii_sorted_unique(cast(tuple[str, ...], validated), field=field)
     return validated
 
 
@@ -377,10 +385,11 @@ def _evidence_result_tuple(
     *,
     minimum: int = 0,
     maximum: int = MAX_REF_LIST,
+    field: str | None = None,
 ) -> tuple[EvidenceId | ResultId, ...]:
     raw = _tuple(value, minimum, maximum)
     result = tuple(_evidence_result_ref(item) for item in raw)
-    _validate_ascii_sorted_unique(cast(tuple[str, ...], result))
+    _validate_ascii_sorted_unique(cast(tuple[str, ...], result), field=field)
     return result
 
 
@@ -453,6 +462,7 @@ class ObligationChange:
             self.replacement_obligation_ids,
             obligation_id,
             maximum=8,
+            field="replacement_obligation_ids",
         )
         object.__setattr__(self, "replacement_obligation_ids", replacements)
         if change in {ObligationChangeKind.SUPERSEDED, ObligationChangeKind.WAIVED}:
@@ -600,8 +610,12 @@ class ProjectionLocator:
             raise ProtocolValueError("invalid_projection_locator") from exc
         events = tuple(event_id(item) for item in raw_events)
         objects = tuple(object_id(item) for item in raw_objects)
-        _validate_ascii_sorted_unique(cast(tuple[str, ...], events))
-        _validate_ascii_sorted_unique(cast(tuple[str, ...], objects))
+        _validate_ascii_sorted_unique(
+            cast(tuple[str, ...], events), field="redaction_target_event_ids"
+        )
+        _validate_ascii_sorted_unique(
+            cast(tuple[str, ...], objects), field="redaction_target_object_ids"
+        )
         object.__setattr__(self, "redaction_target_event_ids", events)
         object.__setattr__(self, "redaction_target_object_ids", objects)
         key_kind = _locator_key_kind(self.schema)
@@ -708,7 +722,7 @@ class PlanPublishedPayload:
         object.__setattr__(
             self,
             "obligation_refs",
-            _id_tuple(self.obligation_refs, obligation_id),
+            _id_tuple(self.obligation_refs, obligation_id, field="obligation_refs"),
         )
         object.__setattr__(
             self,
@@ -872,12 +886,13 @@ class ObligationPublishedPayload:
         object.__setattr__(
             self,
             "source_refs",
-            _id_tuple(self.source_refs, event_id),
+            _id_tuple(self.source_refs, event_id, field="source_refs"),
         )
         minimum = 1 if status is ObligationStatus.RESOLVED else 0
         resolution_refs = _evidence_result_tuple(
             self.resolution_evidence_refs,
             minimum=minimum,
+            field="resolution_evidence_refs",
         )
         object.__setattr__(self, "resolution_evidence_refs", resolution_refs)
         if status is ObligationStatus.OPEN and resolution_refs:
@@ -901,6 +916,7 @@ class AssignmentRecordedPayload:
                 self.obligation_ids,
                 obligation_id,
                 minimum=1,
+                field="obligation_ids",
             ),
         )
         object.__setattr__(
@@ -943,7 +959,7 @@ class DecisionRecordedPayload:
         object.__setattr__(
             self,
             "affected_obligation_ids",
-            _id_tuple(self.affected_obligation_ids, obligation_id),
+            _id_tuple(self.affected_obligation_ids, obligation_id, field="affected_obligation_ids"),
         )
         if self.supersedes_event_id is not None:
             object.__setattr__(
@@ -977,7 +993,7 @@ class ActionRecordedPayload:
         object.__setattr__(
             self,
             "obligation_refs",
-            _id_tuple(self.obligation_refs, obligation_id),
+            _id_tuple(self.obligation_refs, obligation_id, field="obligation_refs"),
         )
         object.__setattr__(
             self,
@@ -1018,7 +1034,7 @@ class ResultRecordedPayload:
         object.__setattr__(
             self,
             "evidence_refs",
-            _id_tuple(self.evidence_refs, evidence_id),
+            _id_tuple(self.evidence_refs, evidence_id, field="evidence_refs"),
         )
 
 
@@ -1101,18 +1117,18 @@ class ClaimRecordedPayload:
         object.__setattr__(self, "statement", _bounded_text(self.statement, MAX_TEXT_BYTES))
         supporting_raw = _tuple(self.supporting_refs, 0, MAX_REF_LIST)
         supporting = tuple(_claim_supporting_ref(item) for item in supporting_raw)
-        _validate_ascii_sorted_unique(cast(tuple[str, ...], supporting))
+        _validate_ascii_sorted_unique(cast(tuple[str, ...], supporting), field="supporting_refs")
         object.__setattr__(self, "supporting_refs", supporting)
         if self.subject_state is not None:
             object.__setattr__(self, "subject_state", _subject_state(self.subject_state))
         object.__setattr__(
             self,
             "obligation_refs",
-            _id_tuple(self.obligation_refs, obligation_id),
+            _id_tuple(self.obligation_refs, obligation_id, field="obligation_refs"),
         )
         disputes_raw = _tuple(self.disputes_refs, 0, MAX_ALTERNATIVES)
         disputes = tuple(_claim_dispute_ref(item) for item in disputes_raw)
-        _validate_ascii_sorted_unique(cast(tuple[str, ...], disputes))
+        _validate_ascii_sorted_unique(cast(tuple[str, ...], disputes), field="disputes_refs")
         object.__setattr__(self, "disputes_refs", disputes)
 
 
@@ -1181,7 +1197,7 @@ class ResponseRecordedPayload:
         object.__setattr__(
             self,
             "evidence_refs",
-            _evidence_result_tuple(self.evidence_refs),
+            _evidence_result_tuple(self.evidence_refs, field="evidence_refs"),
         )
         if disposition in {ResponseDisposition.REJECTED, ResponseDisposition.WAIVED}:
             if self.reason is None:
@@ -1203,8 +1219,8 @@ class RedactionRecordedPayload:
     remaining_gap: str
 
     def __post_init__(self) -> None:
-        events = _id_tuple(self.target_event_ids, event_id)
-        objects = _id_tuple(self.target_object_ids, object_id)
+        events = _id_tuple(self.target_event_ids, event_id, field="target_event_ids")
+        objects = _id_tuple(self.target_object_ids, object_id, field="target_object_ids")
         if not events and not objects:
             raise ProtocolValueError("redaction_target_required")
         object.__setattr__(self, "target_event_ids", events)
@@ -1262,8 +1278,8 @@ class CheckRecordedPayload:
         object.__setattr__(self, "policies", policies)
         if type(self.scope) is not CheckScopeModel:
             raise ProtocolValueError("invalid_event_value_type")
-        _id_tuple(self.scope.claim_ids, claim_id)
-        _id_tuple(self.scope.obligation_ids, obligation_id)
+        _id_tuple(self.scope.claim_ids, claim_id, field="scope")
+        _id_tuple(self.scope.obligation_ids, obligation_id, field="scope")
         executions_raw = _tuple(self.policy_executions, 1, 2)
         if any(type(execution) is not CheckPolicyExecutionModel for execution in executions_raw):
             raise ProtocolValueError("invalid_event_value_type")
@@ -1286,6 +1302,7 @@ class CheckRecordedPayload:
                 self.returned_finding_ids,
                 finding_id,
                 maximum=_MAX_FINDINGS_LIMIT,
+                field="returned_finding_ids",
             ),
         )
         object.__setattr__(
@@ -1522,10 +1539,12 @@ def _decode_scope(value: object) -> CheckScopeModel:
     claim_ids = _id_tuple(
         tuple(_array(_field(source, "claim_ids"))),
         claim_id,
+        field="scope",
     )
     obligation_ids = _id_tuple(
         tuple(_array(_field(source, "obligation_ids"))),
         obligation_id,
+        field="scope",
     )
     try:
         return CheckScopeModel.model_validate(

--- a/src/yoetz/mcp/descriptors.py
+++ b/src/yoetz/mcp/descriptors.py
@@ -935,7 +935,9 @@ _POLICY_TOOL_DESCRIPTORS: Final = (
         "Call for material multi-step, delegated, resumable, or verification-heavy work before "
         "substantive work; skip trivial questions or edits. Records or resumes a cooperative work "
         "session and returns its compact record. It does not show that work outside the published "
-        "record occurred. Guidance: yoetz://guidance/workflow.md.",
+        "record occurred. Every request_id across these tools is a fresh req_ prefixed random "
+        "UUID, and workspace_ref and external_ref are admitted only as a pair. Guidance: "
+        "yoetz://guidance/workflow.md.",
         read_only=False,
         idempotent=True,
     ),
@@ -951,7 +953,9 @@ _POLICY_TOOL_DESCRIPTORS: Final = (
         "validate a batch and preview what would be accepted without appending; the preview is not "
         "evidential and is not citable as a check, publication, or coverage source. After "
         "publishing the material claim and evidence, call check, disposition any findings with "
-        "respond, then call receipt before claiming completion. Guidance: "
+        "respond, then call receipt before claiming completion. Every reference list, in a draft "
+        "envelope and in a payload alike, is admitted only when its members are unique and already "
+        "in ascending ASCII order; a rejection names the owning field. Guidance: "
         "yoetz://guidance/publication-policy.md.",
         read_only=False,
         idempotent=True,
@@ -1055,8 +1059,8 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
     {
         "policy": MappingProxyType(
             {
-                "start": "sha256:d87c67630fbf0d75c6bde24383e5a0d56b8b4e66cda214998b60e5106b401d1a",
-                "publish_work": "sha256:384d539552ebc03b03892d4bfe05462b20fca734701198e46c3b143826535a56",
+                "start": "sha256:47e93d5f95052135270685becfa02f16784968c0d04428943ef1480b8a3687df",
+                "publish_work": "sha256:2215e3060629db7f09d162b5a9cc6a993eb21f8503578ed252c2fe2ef5fba792",
                 "check": "sha256:7779e486e6790b9d26b698566eafcc7b48792c32dade57f53869ee75b29a9018",
                 "respond": "sha256:4a05e83bfce79c5ca6c767c535070fe6011278b6fdbe38958725398928ec751e",
                 "status": "sha256:6abdca221944fc026c915a01ea9cd9110074279532acac5fe285e0e07f3f6b77",
@@ -1065,8 +1069,8 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
         ),
         "strict": MappingProxyType(
             {
-                "start": "sha256:d87c67630fbf0d75c6bde24383e5a0d56b8b4e66cda214998b60e5106b401d1a",
-                "publish_work": "sha256:384d539552ebc03b03892d4bfe05462b20fca734701198e46c3b143826535a56",
+                "start": "sha256:47e93d5f95052135270685becfa02f16784968c0d04428943ef1480b8a3687df",
+                "publish_work": "sha256:2215e3060629db7f09d162b5a9cc6a993eb21f8503578ed252c2fe2ef5fba792",
                 "check": "sha256:692ddaf55f6845a8e5a78d54590f61b55f92e30405d5591ee6a138b61dd5d111",
                 "respond": "sha256:4a05e83bfce79c5ca6c767c535070fe6011278b6fdbe38958725398928ec751e",
                 "status": "sha256:6abdca221944fc026c915a01ea9cd9110074279532acac5fe285e0e07f3f6b77",
@@ -1077,8 +1081,8 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
 )
 TOOL_DESCRIPTOR_SET_DIGEST: Final[Mapping[McpRouteProfile, str]] = MappingProxyType(
     {
-        "policy": "sha256:5884d2597909ec877135672ba869cc210249c2ff08fa76e6039600d0de1949d7",
-        "strict": "sha256:b2df0892bc3dd9d52e0ad463bebfbda8aa48d3519f6e2d6c84f6d3cd5b5a29bb",
+        "policy": "sha256:4850a84f993c26ed0d80a5f7c19a2d058f14c603501064138bcda53f7b2d9ea4",
+        "strict": "sha256:46984b916409aa79097068c0198a1c99efb76f9df75f63329c3d6763389d99b2",
     }
 )
 

--- a/src/yoetz/protocol/errors.py
+++ b/src/yoetz/protocol/errors.py
@@ -247,14 +247,21 @@ _EMPTY_SAFE_DETAILS: Mapping[str, SafeDetailValue] = MappingProxyType({})
 class ProtocolValueError(ValueError):
     """A bounded internal protocol-value failure."""
 
-    __slots__ = ("reason_code",)
+    __slots__ = ("field", "reason_code")
 
     reason_code: str
+    field: str | None
 
-    def __init__(self, reason_code: str) -> None:
+    def __init__(self, reason_code: str, *, field: str | None = None) -> None:
         if type(reason_code) is not str or reason_code not in PROTOCOL_REASON_CODES:
             raise ValueError("unregistered_protocol_reason_code")
+        if field is not None and type(field) is not str:
+            raise ValueError("unregistered_protocol_reason_code")
         self.reason_code = reason_code
+        # A hint naming the owning payload field, never a value. Callers that turn this into a
+        # public error location must still check it against their own frozen allowlist, so a
+        # caller-derived string can never reach a public pointer through this attribute.
+        self.field = field
         super().__init__(reason_code)
 
 

--- a/tests/conformance/operations/test_publish_work_contract.py
+++ b/tests/conformance/operations/test_publish_work_contract.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from builders.replay import replay_records
 from yoetz.application.publish_work import (
     Application,
+    _draft_pointer,  # pyright: ignore[reportPrivateUsage]
     prepare_publication,
 )
 from yoetz.domain.events import EventPayload, encode_payload
@@ -213,6 +214,49 @@ def test_unsorted_causal_parents_reject_as_event_invalid_unsorted_set_field() ->
         "reason_code": "unsorted_set_field",
         "field": "/event_drafts/0",
     }
+
+
+def test_unsorted_payload_set_field_is_located_by_name() -> None:
+    """A rejected reference list names itself, so the fix does not need guesswork.
+
+    Regression for the 2026-07-30 dogfood: `/event_drafts/N/payload` alone left an agent
+    choosing between `supporting_refs` and `obligation_refs` by trial and error.
+    """
+
+    base = _request_for_record("claim_recorded")
+    draft = dict(cast(dict[str, object], base.event_drafts[0]))
+    payload = dict(cast(dict[str, object], draft["payload"]))
+    payload["supporting_refs"] = (
+        "evd_00000000-0000-4000-8000-000000000002",
+        "evd_00000000-0000-4000-8000-000000000001",
+    )
+    draft["payload"] = payload
+    request = base.model_copy(update={"event_drafts": (draft,)})
+
+    with pytest.raises(PublicOperationError) as caught:
+        prepare_publication(
+            request,
+            channel=PublicationChannel.LOCAL_CLI,
+            app=cast(Application, _App()),
+        )
+
+    assert caught.value.code is PublicErrorCode.EVENT_INVALID
+    assert caught.value.safe_details == {
+        "reason_code": "unsorted_set_field",
+        "field": "/event_drafts/0/payload/supporting_refs",
+    }
+
+
+def test_payload_pointer_admits_only_registered_field_names() -> None:
+    """An unregistered field name degrades to the payload pointer rather than echoing itself."""
+
+    assert (
+        _draft_pointer(0, "payload", "supporting_refs") == "/event_drafts/0/payload/supporting_refs"
+    )
+    assert _draft_pointer(0, "payload", "../../etc/passwd") == "/event_drafts/0/payload"
+    assert _draft_pointer(0, "payload", None) == "/event_drafts/0/payload"
+    # Only the payload is descended into; every other subfield stays one level deep.
+    assert _draft_pointer(0, "schema", "supporting_refs") == "/event_drafts/0/schema"
 
 
 def _unknown_import_request() -> PublishWorkRequestModel:

--- a/tests/conformance/surfaces/test_mcp_contract_matrix.py
+++ b/tests/conformance/surfaces/test_mcp_contract_matrix.py
@@ -219,8 +219,8 @@ def test_descriptor_text_is_frozen_and_honest() -> None:
     assert tuple(TOOL_DESCRIPTORS) == ("policy", "strict")
     assert tuple(TOOL_DESCRIPTOR_DIGESTS) == ("policy", "strict")
     assert TOOL_DESCRIPTOR_SET_DIGEST == {
-        "policy": "sha256:5884d2597909ec877135672ba869cc210249c2ff08fa76e6039600d0de1949d7",
-        "strict": "sha256:b2df0892bc3dd9d52e0ad463bebfbda8aa48d3519f6e2d6c84f6d3cd5b5a29bb",
+        "policy": "sha256:4850a84f993c26ed0d80a5f7c19a2d058f14c603501064138bcda53f7b2d9ea4",
+        "strict": "sha256:46984b916409aa79097068c0198a1c99efb76f9df75f63329c3d6763389d99b2",
     }
     for profile, descriptors in TOOL_DESCRIPTORS.items():
         assert tuple(item.name for item in descriptors) == _EXPECTED_TOOL_NAMES
@@ -236,6 +236,14 @@ def test_descriptor_text_is_frozen_and_honest() -> None:
     assert "Omitting mode resolves through the configured verification policy" in check_description
     assert descriptor_for("start").description.startswith(
         "Call for material multi-step, delegated, resumable, or verification-heavy work"
+    )
+    # The two argument conventions a first-time caller cannot infer from prose alone. Both cost a
+    # rejected start call in the 2026-07-30 dogfood before the descriptor named them.
+    start_description = descriptor_for("start").description
+    assert "fresh req_ prefixed random UUID" in start_description
+    assert "workspace_ref and external_ref are admitted only as a pair" in start_description
+    assert (
+        "unique and already in ascending ASCII order" in descriptor_for("publish_work").description
     )
     for descriptors in TOOL_DESCRIPTORS.values():
         assert {item.name for item in descriptors if item.annotations.read_only} == {"status"}

--- a/tests/subprocess/test_hooks_cli.py
+++ b/tests/subprocess/test_hooks_cli.py
@@ -3,22 +3,57 @@
 from __future__ import annotations
 
 import json
+import sys
+from importlib import import_module
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
-import yoetz.adapters.integrations.codex_lifecycle as lifecycle
 import yoetz.cli.app as cli
 
 _RUNNER = CliRunner()
 
+# The resume path reaches these through lazy in-function imports, so load them up front: their
+# `state_dir` bindings must already exist when `_redirect_state_dir` scans `sys.modules`.
+_LAZILY_REACHED_MODULES = (
+    "yoetz.adapters.integrations.codex_lifecycle",
+    "yoetz.adapters.integrations.observation_local",
+    "yoetz.cli.observe_hooks",
+)
+
+
+def _redirect_state_dir(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    """Point every imported binding of ``state_dir`` at ``root``.
+
+    Each module does ``from yoetz.config.paths import state_dir``, so patching one module leaves
+    the others bound to the real user state directory. Patching only ``codex_lifecycle`` let the
+    ``resume`` path reach ``observation_local``'s binding and read real host observation state:
+    the assertions below then passed on a clean runner and failed on any machine that had used
+    Yoetz, so dogfooding the tool broke its own suite.
+    """
+
+    def _state_dir(*, _probe: object | None = None) -> Path:
+        del _probe
+        return root
+
+    for name in _LAZILY_REACHED_MODULES:
+        import_module(name)
+
+    patched = 0
+    for name, module in tuple(sys.modules.items()):
+        if not name.startswith("yoetz."):
+            continue
+        if getattr(module, "state_dir", None) is None:
+            continue
+        monkeypatch.setattr(module, "state_dir", _state_dir, raising=False)
+        patched += 1
+    # A future module that resolves its own state root must not silently reintroduce host reads.
+    assert patched >= 2, f"expected several state_dir bindings, patched {patched}"
+
 
 def test_hooks_session_start_inactive_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    def _state_dir(*, _probe: object | None = None) -> Path:
-        return tmp_path
-
-    monkeypatch.setattr(lifecycle, "state_dir", _state_dir)
+    _redirect_state_dir(monkeypatch, tmp_path)
     result = _RUNNER.invoke(
         cli.app,
         ["hooks", "session-start"],


### PR DESCRIPTION
Closes #93

## What changed

- report canonical-set failures at an allowlisted payload-field pointer instead of only the enclosing payload
- distinguish non-ASCII set members from ordering failures
- document request ID, paired workspace reference, and canonical reference-list conventions in MCP descriptors
- refresh the frozen descriptor digests
- redirect imported Yoetz `state_dir` bindings in the hooks CLI test so it cannot read real host state

## Why

The 2026-07-30 dogfood run encountered rejected calls whose public error location did not identify the failing reference list. That forced trial-and-error correction. The same run also exposed a hooks test that could reach persisted user observation state through lazy imports and become machine-dependent.

The public field hint remains bounded to frozen schema names: unknown or caller-derived hints degrade to the payload-level pointer.

## User and developer impact

Agents receive an actionable, safe location for malformed canonical reference lists and enough descriptor guidance to form valid first calls. The hooks subprocess test is deterministic regardless of whether the developer has used Yoetz locally.

## Validation

- `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/conformance/operations/test_publish_work_contract.py tests/conformance/surfaces/test_mcp_contract_matrix.py tests/subprocess/test_hooks_cli.py` — 38 passed
- `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check ...` — passed
- `npx --no-install pyright ...` — 0 errors, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Error messages for rejected event drafts now identify the specific payload field causing the issue.
  * Validation feedback now pinpoints invalid, duplicate, non-ASCII, or incorrectly ordered reference lists.
  * Reference lists must contain unique entries in ascending ASCII order.

* **Documentation**
  * Updated tool guidance clarifies request ID generation and the required pairing of workspace and external references.
  * Publishing guidance now explains reference-list requirements and field-specific rejection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the actionability of canonical-set validation failures in `publish_work` by carrying an owning payload field name through the error chain and surfacing it as a JSON Pointer in the public error response. It also fixes a non-deterministic hooks CLI test caused by patching only one `state_dir` binding while other modules retained references to the real user state directory.

- **Error pointer depth**: `ProtocolValueError` gains a `field` slot; `_validate_ascii_sorted_unique`, `_id_tuple`, and `_evidence_result_tuple` forward the owning field name so that a rejection like `unsorted_set_field` now reports `/event_drafts/N/payload/supporting_refs` instead of stopping at `/event_drafts/N/payload`. A frozen allowlist (`_LOCATABLE_PAYLOAD_FIELDS`) in `publish_work.py` gates which names may appear in the public pointer, preventing caller-derived strings from escaping.
- **Non-ASCII vs. ordering distinction**: `UnicodeEncodeError` inside `_validate_ascii_sorted_unique` was previously reported as `unsorted_set_field`, sending agents looking for an ordering bug that wasn't there; it is now reported as the pre-existing `set_member_not_ascii` code.
- **Test isolation**: `_redirect_state_dir` now pre-imports all lazily-reached modules and patches every `yoetz.*` binding of `state_dir` found in `sys.modules`, with an assertion that at least two bindings were patched so a future unpatched module cannot silently re-introduce host reads.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the error-pointer changes are additive and fully contained behind a frozen allowlist, and the test-isolation fix removes a genuine source of machine-dependent failures without altering production behaviour.

The allowlist in _LOCATABLE_PAYLOAD_FIELDS is the only gate between the new field hint and the public JSON Pointer, and it is a frozenset of string literals — no caller input can bypass it. The _payload_field_of extractor performs a strict type check before returning the hint, and the existing _normalize_detail handler validates the assembled pointer as a well-formed JSON Pointer before it is serialised.

**Files Needing Attention:** No files require special attention. The _LAZILY_REACHED_MODULES list in test_hooks_cli.py will need a manual update if a future module introduces its own state_dir binding, but the patched >= 2 assertion ensures that gap is caught at test time rather than silently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/application/publish_work.py | Adds _LOCATABLE_PAYLOAD_FIELDS allowlist and extends _draft_pointer to emit a third path segment for payload fields; _payload_field_of extracts the field hint from a ProtocolValueError safely. |
| src/yoetz/domain/events.py | Propagates field= keyword through _validate_ascii_sorted_unique, _id_tuple, and _evidence_result_tuple at every call site; replaces the misreported unsorted_set_field code for non-ASCII members with set_member_not_ascii. |
| src/yoetz/protocol/errors.py | Adds field slot to ProtocolValueError with type-strict validation; field is validated as a JSON pointer by the existing _normalize_detail handler before it may appear in a public error response. |
| tests/subprocess/test_hooks_cli.py | Replaces single-module monkeypatch with a scan-all-yoetz-modules approach; pre-imports known lazily-reached modules and asserts ≥2 bindings were patched to guard against future regressions. |
| src/yoetz/mcp/descriptors.py | Adds request_id/workspace_ref/external_ref conventions to start descriptor and canonical-set ordering requirement to publish_work descriptor; refreshes SHA-256 digests for both profiles. |
| tests/conformance/operations/test_publish_work_contract.py | Adds regression test for per-field pointer in unsorted-ref rejections and a unit test proving unregistered field names degrade to the payload-level pointer. |
| tests/conformance/surfaces/test_mcp_contract_matrix.py | Updates frozen digest assertions and adds substring checks for the two new descriptor conventions added to start and publish_work. |

<sub>Reviews (2): Last reviewed commit: ["fix: make publication failures actionabl..."](https://github.com/thegaysupreme123/yoetz/commit/96d6469f4da1a822c4bf7b6b8fc6309a0c2e35da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=20887238)</sub>

<!-- /greptile_comment -->