### PR TITLE
fix(semantic): make a returned reviewer challenge actually reach the user

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -611,6 +611,18 @@ Shared structural gap codes for optional semantic relevance review (distinct fam
 - `semantic_relevance_review_not_run` — evaluation failed/timed out/unavailable without a clean pass;
 - `semantic_review_not_requested` — deterministic-only check; semantic review was never requested.
 
+Two further codes describe a review that did run but could not deliver everything it produced:
+
+- `semantic_review_context_withheld` — the review ran without categories its own profile selected;
+- `semantic_challenges_rejected` — the reviewer returned challenges and post-validation dropped at
+  least one (a citation outside the frozen case, or an unchanged-claim over a withheld source).
+
+Post-validation fences each challenge independently: a rejected challenge costs only itself, the
+challenges beside it still become findings, and the drop is declared through this gap. A judgment
+that fails the *structural* fence yields no semantic findings at all and is recorded as
+`invalid` / `semantic_judgment_rejected` — never as a failed request. A check always commits its
+deterministic findings, whatever the reviewer returned.
+
 The not-configured and not-run codes share the honest compact limitation that semantic relevance
 review was not run; they must not reuse blocked-by-policy wording. The not-requested code marks every
 deterministic-only check and forces coverage incompleteness without changing the deterministic
@@ -632,6 +644,15 @@ credential-unavailable path. These paths use exactly one operation token:
 identity, exception text, payload, and paths remain forbidden from this sink. Exceptions contained
 inside the production composition evaluator retain the existing `semantic_evaluation_failed`
 operation.
+
+Two further check-path operations describe a review that did reach a provider:
+`semantic_judgment_rejected` records a structurally unusable judgment, and
+`semantic_review_accounting` is appended once per dispatched review carrying counts only —
+`semantic_conclusion`, `semantic_challenges_returned`, `semantic_candidates_accepted`,
+`semantic_challenges_rejected`, `semantic_findings_selected`, `semantic_findings_suppressed`.
+The counts reconcile (`returned == accepted + rejected`, `accepted == selected + suppressed`), so
+"the reviewer answered and none of it reached you" is never invisible. Challenge text, refs, and
+provider identity remain forbidden from this sink like every other.
 
 The check-applicability gap family follows the same material-state rule: `check_not_applicable`
 means material work was appended after the recorded check and superseded its verdict, never that

--- a/src/yoetz/adapters/providers/openai_chat_completions.py
+++ b/src/yoetz/adapters/providers/openai_chat_completions.py
@@ -85,9 +85,12 @@ _SYSTEM_INSTRUCTION: Final = (
     "timeline, deterministic finding bases, state/change observations, evidence freshness, "
     "failures, limitations, and selected excerpts. If a material discrepancy exists, address the "
     "main agent directly, explain the discrepancy and strongest plausible alternative, cite only "
-    "supplied refs, and request the smallest resolving action or evidence. Do not invent "
-    "repository facts, fetch more context, overrule deterministic results, waive findings, or "
-    "claim stronger coverage than the packet. Reply with one JSON object and nothing else: no "
+    "supplied refs, and request the smallest resolving action or evidence. Every value in "
+    "cited_refs must come from the packet's citable_refs array and nothing else: an item_id from "
+    "items[] is not citable, and a challenge citing anything outside citable_refs is discarded "
+    "unread. Do not invent repository facts, fetch more context, overrule deterministic results, "
+    "waive findings, or claim stronger coverage than the packet. "
+    "Reply with one JSON object and nothing else: no "
     'prose, no code fence, no explanation outside it. Its exact shape is {"conclusion": one of '
     '"no_material_discrepancy" | "challenges_returned" | "insufficient_packet", '
     '"reviewer_challenges": array of objects with "finding_kind", "summary", "cited_refs", '

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -53,6 +53,8 @@ from yoetz.protocol.models import (
 )
 
 __all__ = [
+    "CHALLENGE_FIELD_GLOSSARY",
+    "FINDING_KIND_GLOSSARY",
     "JUDGMENT_JSON_SCHEMA",
     "OFFICIAL_OPENAI_HOST",
     "OFFICIAL_OPENAI_PATH",
@@ -116,9 +118,11 @@ _SYSTEM_INSTRUCTION: Final = (
     "timeline, deterministic finding bases, state/change observations, evidence freshness, "
     "failures, limitations, and selected excerpts. If a material discrepancy exists, address the "
     "main agent directly, explain the discrepancy and strongest plausible alternative, cite only "
-    "supplied refs, and request the smallest resolving action or evidence. Do not invent "
-    "repository facts, fetch more context, overrule deterministic results, waive findings, or "
-    "claim stronger coverage than the packet."
+    "supplied refs, and request the smallest resolving action or evidence. Every value in "
+    "cited_refs must come from the packet's citable_refs array and nothing else: an item_id from "
+    "items[] is not citable, and a challenge citing anything outside citable_refs is discarded "
+    "unread. Do not invent repository facts, fetch more context, overrule deterministic results, "
+    "waive findings, or claim stronger coverage than the packet."
 )
 
 _PROVIDER_JUDGMENT_ADAPTER: Final[TypeAdapter[ProviderJudgmentModel]] = TypeAdapter(
@@ -221,6 +225,137 @@ def _strip_schema_titles(node: object) -> object:
     return node
 
 
+# Reviewer-facing definitions, written deliberately for the model that receives this schema.
+#
+# These are not docstrings and must never be sourced from one: a docstring explains the contract to
+# a maintainer, while these tell a reviewer what the word means when it has to pick one. Stripping
+# every annotation left the model choosing among fourteen bare enum strings and eight bare field
+# names with no gloss anywhere in the request, which is not a fair question to ask it.
+FINDING_KIND_GLOSSARY: Final[dict[str, str]] = {
+    "action_without_result": "an action was taken but no outcome for it was ever recorded",
+    "claim_without_admissible_evidence": (
+        "a claim of fact or completion rests on no evidence the packet actually contains"
+    ),
+    "completion_with_open_obligations": (
+        "work is presented as finished while obligations it was meant to satisfy remain open"
+    ),
+    "contradictory_claims_unresolved": (
+        "two claims in the packet cannot both be true and neither has been withdrawn or reconciled"
+    ),
+    "diff_does_not_match_account": (
+        "the described change and the change actually shown in the packet differ in substance"
+    ),
+    "evidence_does_not_support_claim": (
+        "evidence is cited for a claim but does not establish what the claim asserts"
+    ),
+    "failed_work_omitted": (
+        "a recorded failure, error, or abandoned attempt is missing from the account given"
+    ),
+    "ledger_stale_or_incomplete": (
+        "the record itself is behind or missing entries, so the packet cannot settle the question"
+    ),
+    "material_limitation_omitted": (
+        "a limitation that changes how the result should be read was not disclosed"
+    ),
+    "questionable_finding_rejection": (
+        "a deterministic finding was dismissed or explained away without adequate grounds"
+    ),
+    "requested_item_never_attempted": (
+        "something the user or an obligation asked for was never worked on at all"
+    ),
+    "result_without_action": "an outcome is recorded with no action in the packet that produced it",
+    "stale_evidence_for_changed_state": (
+        "the cited evidence predates a change to what it describes, so it no longer speaks to it"
+    ),
+    "weak_or_stale_response": (
+        "the answer given is thin or out of date relative to what the packet supports"
+    ),
+}
+
+CHALLENGE_FIELD_GLOSSARY: Final[dict[str, str]] = {
+    "finding_kind": (
+        "Which kind of discrepancy this is; pick the one that fits best. "
+        + "; ".join(f"{kind}: {gloss}" for kind, gloss in sorted(FINDING_KIND_GLOSSARY.items()))
+        + "."
+    ),
+    "summary": "One short line naming the discrepancy, readable on its own.",
+    "cited_refs": (
+        "The refs this challenge rests on. Every value must appear in the packet's citable_refs "
+        "array; an items[].item_id is not a ref. A challenge citing anything else is discarded, "
+        "so cite the specific claim, obligation, event, or finding the discrepancy is about."
+    ),
+    "discrepancy": "What the packet shows that does not fit, stated as fact rather than suspicion.",
+    "alternative_interpretation": (
+        "The strongest honest reading under which there is no problem here. Write the case against "
+        "your own challenge, not a weak version of it."
+    ),
+    "message_to_main_agent": (
+        "What you are telling the agent, addressed to it directly, including the smallest action "
+        "or piece of evidence that would resolve this."
+    ),
+    "requested_next_step": (
+        "The single kind of response you are asking the agent for. act: do the missing work; "
+        "provide_evidence: record evidence that already exists; revise_claim: correct or withdraw "
+        "what was claimed; dispute_with_evidence: rebut this challenge if you believe it is wrong; "
+        "state_unresolved_limitation: say plainly that this cannot be settled here."
+    ),
+    "uncertainty": (
+        "What you could not determine from the packet and what would settle it. Say so plainly "
+        "rather than hedging the challenge itself."
+    ),
+}
+
+
+def _apply_reviewer_glossary(schema: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    """Attach the curated reviewer definitions to the stripped schema.
+
+    Applied after stripping rather than by not stripping, so the only text that can reach a
+    provider is text written above for that purpose.
+    """
+
+    defs = schema.get("$defs")
+    if type(defs) is not dict:
+        raise RuntimeError("provider_judgment_schema_invalid")
+    definitions = cast(dict[str, JsonValue], defs)
+    kinds = definitions.get("FindingKindWire")
+    challenge = definitions.get("ProviderChallenge")
+    if type(kinds) is not dict or type(challenge) is not dict:
+        raise RuntimeError("provider_judgment_schema_invalid")
+    properties = cast(dict[str, JsonValue], challenge).get("properties")
+    if type(properties) is not dict:
+        raise RuntimeError("provider_judgment_schema_invalid")
+    challenge_properties = cast(dict[str, JsonValue], properties)
+    # The glossary must describe exactly the shape the model owns. A field added or renamed there
+    # without a gloss fails the build rather than shipping a silently undefined field.
+    if set(challenge_properties) != set(CHALLENGE_FIELD_GLOSSARY):
+        raise RuntimeError("provider_judgment_schema_invalid")
+    enum_values = cast(dict[str, JsonValue], kinds).get("enum")
+    if type(enum_values) is not list or set(cast(list[JsonValue], enum_values)) != set(
+        FINDING_KIND_GLOSSARY
+    ):
+        raise RuntimeError("provider_judgment_schema_invalid")
+    for name, gloss in CHALLENGE_FIELD_GLOSSARY.items():
+        target = challenge_properties[name]
+        if type(target) is not dict:
+            raise RuntimeError("provider_judgment_schema_invalid")
+        source = cast(dict[str, JsonValue], target)
+        # A property that is a bare ``$ref`` carries its gloss on the referenced definition:
+        # annotations beside ``$ref`` are legal in 2020-12 but not uniformly honored, and the
+        # definition is the one place every use of that vocabulary sees it.
+        reference = source.get("$ref")
+        if type(reference) is str:
+            anchor = reference.removeprefix("#/$defs/")
+            referenced = definitions.get(anchor)
+            if type(referenced) is not dict:
+                raise RuntimeError("provider_judgment_schema_invalid")
+            definitions[anchor] = cast(
+                JsonValue, {**cast(dict[str, JsonValue], referenced), "description": gloss}
+            )
+            continue
+        challenge_properties[name] = cast(JsonValue, {**source, "description": gloss})
+    return schema
+
+
 def build_judgment_json_schema() -> dict[str, JsonValue]:
     """Generate the constrained-output schema from the single owning provider judgment model.
 
@@ -240,7 +375,7 @@ def build_judgment_json_schema() -> dict[str, JsonValue]:
     cleaned = _strip_schema_titles(_sort_schema_lists(_rename_schema_defs(raw)))
     if type(cleaned) is not dict:
         raise RuntimeError("provider_judgment_schema_invalid")
-    return cast(dict[str, JsonValue], cleaned)
+    return _apply_reviewer_glossary(cast(dict[str, JsonValue], cleaned))
 
 
 JUDGMENT_JSON_SCHEMA: Final[dict[str, JsonValue]] = build_judgment_json_schema()

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -13,7 +13,6 @@ from yoetz.domain.findings import (
     FindingKind,
     FindingOrigin,
     RankedFindings,
-    SemanticFailureClass,
     SemanticProvenance,
     finding_from_json,
     finding_to_json,
@@ -175,13 +174,21 @@ class SemanticJudgmentReview:
         if (
             type(self.candidates) is not tuple
             or type(self.challenges_returned) is not int
+            or self.challenges_returned < 0
             or type(self.rejected_by_reason) is not tuple
         ):
+            raise _invalid("semantic_judgment_review_invalid")
+        if any(type(pair) is not tuple or len(pair) != 2 for pair in self.rejected_by_reason):
             raise _invalid("semantic_judgment_review_invalid")
         if any(
             reason not in _SEMANTIC_REJECTION_REASONS or type(count) is not int or count < 1
             for reason, count in self.rejected_by_reason
         ):
+            raise _invalid("semantic_judgment_review_invalid")
+        # The diagnostic this value feeds claims that returned == accepted + rejected. Owning the
+        # invariant here turns any future accounting drift into an immediate failure rather than a
+        # durable count that quietly does not add up.
+        if self.challenges_returned != len(self.candidates) + self.challenges_rejected:
             raise _invalid("semantic_judgment_review_invalid")
 
     @property
@@ -1073,11 +1080,14 @@ def _judgment_rejected_evaluation(
         SemanticStatus.INVALID,
         SemanticReason.SEMANTIC_JUDGMENT_REJECTED,
         None,
+        # failure_class stays unset. Every member of the enum names a provider-side fault, and
+        # this path runs only for the structural fence — the coordinator's own inputs were wrong,
+        # not the provider's answer. Naming one would send an operator after the wrong component;
+        # semantic_judgment_rejected already says exactly what happened.
         replace(
             provenance,
             status=SemanticStatus.INVALID,
             reason=SemanticReason.SEMANTIC_JUDGMENT_REJECTED,
-            failure_class=SemanticFailureClass.RESPONSE_CONTENT,
         ),
         result.attempt_accounting,
         result.operation_lease,

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
-from typing import Literal, Protocol, cast
+from typing import Final, Literal, Protocol, cast
 
 from yoetz.domain.findings import (
     FINDING_KIND_TRAITS,
@@ -12,6 +12,8 @@ from yoetz.domain.findings import (
     Finding,
     FindingKind,
     FindingOrigin,
+    RankedFindings,
+    SemanticFailureClass,
     SemanticProvenance,
     finding_from_json,
     finding_to_json,
@@ -19,6 +21,7 @@ from yoetz.domain.findings import (
 )
 from yoetz.domain.receipts import (
     OPTIONAL_SEMANTIC_REVIEW_BLOCKED_BY_POLICY_GAP,
+    SEMANTIC_CHALLENGES_REJECTED_GAP,
     SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP,
     SEMANTIC_REVIEW_CONTEXT_WITHHELD_GAP,
     SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
@@ -42,7 +45,10 @@ from yoetz.kernel.deterministic_checks import (
 from yoetz.kernel.policies.research_evidence import research_evidence_findings
 from yoetz.kernel.policies.work_integrity import work_integrity_findings
 from yoetz.kernel.ranking import CheckCompleteness, RankingContext, rank_findings
-from yoetz.observability.logging import record_unexpected_exception_without_raising
+from yoetz.observability.logging import (
+    record_bounded_counts_without_raising,
+    record_unexpected_exception_without_raising,
+)
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.ids import IdPort
@@ -84,9 +90,13 @@ from yoetz.protocol.models import (
 )
 
 __all__ = [
+    "SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM",
+    "SEMANTIC_REJECTED_REF_OUTSIDE_CASE",
     "Application",
     "CheckScope",
     "FinalSemanticEvaluation",
+    "SemanticJudgmentRejected",
+    "SemanticJudgmentReview",
     "allocate_findings",
     "case_coverage",
     "check_internal_json",
@@ -127,8 +137,62 @@ _WORK_KINDS = frozenset(
 )
 
 
+SEMANTIC_REJECTED_REF_OUTSIDE_CASE: Final = "ref_outside_case"
+SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM: Final = "hidden_source_claim"
+
+
+class SemanticJudgmentRejected(ValueError):
+    """The reviewer's judgment failed a structural fence and cannot become findings.
+
+    Deliberately narrower than the module's other ``ValueError``s: the commit path catches exactly
+    this, so a rejected judgment records ``invalid``/``semantic_judgment_rejected`` and still
+    commits the deterministic findings, while a genuine coordinator bug keeps its old disposition.
+    """
+
+
 def _invalid(reason: str = "check_coordinator_invalid") -> ValueError:
     return ValueError(reason)
+
+
+def _rejected(reason: str) -> SemanticJudgmentRejected:
+    return SemanticJudgmentRejected(reason)
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticJudgmentReview:
+    """What the reviewer returned and what the post-validation fence did with it.
+
+    ``rejected_by_reason`` is a sorted tuple of bounded ``(reason, count)`` pairs, never text from
+    the challenge itself: it exists so "the reviewer answered and none of it reached you" is a
+    countable fact on the check path instead of silence.
+    """
+
+    candidates: tuple[CandidateFinding, ...]
+    challenges_returned: int
+    rejected_by_reason: tuple[tuple[str, int], ...]
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.candidates) is not tuple
+            or type(self.challenges_returned) is not int
+            or type(self.rejected_by_reason) is not tuple
+        ):
+            raise _invalid("semantic_judgment_review_invalid")
+        if any(
+            reason not in _SEMANTIC_REJECTION_REASONS or type(count) is not int or count < 1
+            for reason, count in self.rejected_by_reason
+        ):
+            raise _invalid("semantic_judgment_review_invalid")
+
+    @property
+    def challenges_rejected(self) -> int:
+        return sum(count for _reason, count in self.rejected_by_reason)
+
+
+_SEMANTIC_REJECTION_REASONS: Final = frozenset(
+    {SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM, SEMANTIC_REJECTED_REF_OUTSIDE_CASE}
+)
+_EMPTY_SEMANTIC_REVIEW: Final = SemanticJudgmentReview((), 0, ())
 
 
 def _projected_finding_json(finding: Finding) -> JsonValue:
@@ -743,17 +807,24 @@ def _resolve_challenge_refs(
     case: DeterministicCase,
     deterministic: tuple[Finding, ...],
     challenge: ReviewerChallenge,
-) -> tuple[str, ...]:
+) -> tuple[str, ...] | None:
+    """Resolve one challenge's citations to frozen subject refs, or ``None`` if any is outside.
+
+    Every per-ref test below is byte-identical to the fence this replaced; only the disposition of
+    a failure changed, from raising (which discarded the entire judgment, and with it the check)
+    to returning ``None`` so the caller can drop this one challenge and count it.
+    """
+
     findings = {str(item.finding_id): item for item in deterministic}
     resolved: set[str] = set()
     for ref in challenge.cited_refs:
         if ref.startswith("fnd_"):
             finding = findings.get(ref)
             if finding is None:
-                raise _invalid("semantic_ref_outside_case")
+                return None
             resolved.update(map(str, finding.subject_refs))
         elif ref not in case.allowed_ids:
-            raise _invalid("semantic_ref_outside_case")
+            return None
         elif ref.startswith(("evt_", "obl_", "clm_")):
             resolved.add(ref)
         else:
@@ -774,11 +845,27 @@ def _resolve_challenge_refs(
                 record = case.projection.evidence.get(evidence_id(ref))
                 source = None if record is None else str(record.source_event_id)
             if source is None:
-                raise _invalid("semantic_ref_outside_case")
+                return None
             resolved.add(source)
     if not resolved:
-        raise _invalid("semantic_ref_outside_case")
+        return None
     return tuple(sorted(resolved, key=str.encode))
+
+
+def _claims_unchanged_over_hidden_source(
+    case: DeterministicCase,
+    challenge: ReviewerChallenge,
+) -> bool:
+    """Whether this challenge asserts nothing changed while its own basis was withheld."""
+
+    return any(
+        "unchanged" in text.casefold()
+        for text in (challenge.discrepancy, challenge.alternative_interpretation)
+    ) and any(
+        _UNAVAILABLE_GAPS & set(case.coverage_by_ref[cast(FindingBasisRef, ref)].known_gaps)
+        for ref in challenge.cited_refs
+        if ref in case.coverage_by_ref
+    )
 
 
 def validate_semantic_judgment(
@@ -788,8 +875,20 @@ def validate_semantic_judgment(
     provenance: SemanticProvenance,
     *,
     expected_frontier: Frontier,
-) -> tuple[CandidateFinding, ...]:
-    """Fence semantic challenges to the exact frozen refs, coverage, and final provenance."""
+) -> SemanticJudgmentReview:
+    """Fence semantic challenges to the exact frozen refs, coverage, and final provenance.
+
+    Each challenge is fenced independently against the same frozen case. A challenge that fails is
+    dropped and counted by reason; the challenges beside it are unaffected, because nothing about
+    one reviewer challenge is evidence about another. No fence is loosened here — the accept test
+    for a single challenge is unchanged.
+
+    The structural checks below stay hard failures: a wrong type, a drifted frontier, or a
+    provenance that is not the final SUCCEEDED attempt means the *coordinator* handed this function
+    the wrong inputs, not that the reviewer answered badly. They raise
+    :class:`SemanticJudgmentRejected`, which the commit path converts into an honest
+    ``invalid``/``semantic_judgment_rejected`` semantic outcome rather than losing the check.
+    """
 
     if (
         type(case) is not DeterministicCase
@@ -799,22 +898,24 @@ def validate_semantic_judgment(
         or provenance.status is not SemanticStatus.SUCCEEDED
         or provenance.reason is not SemanticReason.SEMANTIC_COMPLETED
     ):
-        raise _invalid("semantic_judgment_invalid")
+        raise _rejected("semantic_judgment_invalid")
     if judgment.conclusion != "challenges_returned":
-        return ()
+        return SemanticJudgmentReview((), 0, ())
     coverage = case_coverage(case, semantic=True)
     candidates: list[CandidateFinding] = []
+    rejections: dict[str, int] = {}
     for challenge in judgment.challenges:
         refs = _resolve_challenge_refs(case, deterministic, challenge)
-        if any(
-            "unchanged" in text.casefold()
-            for text in (challenge.discrepancy, challenge.alternative_interpretation)
-        ) and any(
-            _UNAVAILABLE_GAPS & set(case.coverage_by_ref[cast(FindingBasisRef, ref)].known_gaps)
-            for ref in challenge.cited_refs
-            if ref in case.coverage_by_ref
-        ):
-            raise _invalid("semantic_hidden_source_claim")
+        if refs is None:
+            rejections[SEMANTIC_REJECTED_REF_OUTSIDE_CASE] = (
+                rejections.get(SEMANTIC_REJECTED_REF_OUTSIDE_CASE, 0) + 1
+            )
+            continue
+        if _claims_unchanged_over_hidden_source(case, challenge):
+            rejections[SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM] = (
+                rejections.get(SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM, 0) + 1
+            )
+            continue
         policy_id, policy_version = _policy_identity(challenge.finding_kind)
         priority, _actionable = FINDING_KIND_TRAITS[challenge.finding_kind]
         candidates.append(
@@ -839,7 +940,11 @@ def validate_semantic_judgment(
                 provenance,
             )
         )
-    return tuple(candidates)
+    return SemanticJudgmentReview(
+        tuple(candidates),
+        len(judgment.challenges),
+        tuple(sorted(rejections.items(), key=lambda item: item[0].encode("ascii"))),
+    )
 
 
 def _request_digest(
@@ -900,6 +1005,84 @@ async def _semantic_evaluation(
             SemanticStatus.FAILED,
             SemanticReason.COORDINATOR_FAILURE,
         )
+
+
+def _semantic_conclusion_token(result: FinalSemanticEvaluation) -> str:
+    """The reviewer's own conclusion when it reached one; otherwise why it did not."""
+
+    judgment = result.judgment
+    if judgment is None:
+        return result.reason.value
+    return judgment.conclusion
+
+
+def _record_semantic_review_accounting(
+    request: CheckRequest,
+    result: FinalSemanticEvaluation,
+    review: SemanticJudgmentReview,
+    semantic: tuple[Finding, ...],
+    ranked: RankedFindings,
+) -> None:
+    """Say what the reviewer produced and what became of it, on every dispatched review.
+
+    Without this, "the model returned three challenges and none of them reached you" is invisible:
+    the check reports ``semantic_status: succeeded`` and zero semantic findings, which reads
+    identically to a reviewer that found nothing. The record is counts and closed tokens only, and
+    it reconciles — ``returned == accepted + rejected`` and ``accepted == selected + suppressed``.
+    """
+
+    # Provenance present means a provider attempt reached a terminal outcome. Nothing was reviewed
+    # before that, so there is nothing to account for and no reason to fill the durable ring.
+    if result.provenance is None:
+        return
+    selected = sum(
+        1 for finding in ranked.findings if finding.origin is FindingOrigin.SEMANTIC_MODEL_DERIVED
+    )
+    record_bounded_counts_without_raising(
+        component="check",
+        operation="semantic_review_accounting",
+        outcome=result.status.value,
+        request_id=request.request_id,
+        counts={
+            "semantic_conclusion": _semantic_conclusion_token(result),
+            "semantic_challenges_returned": review.challenges_returned,
+            "semantic_candidates_accepted": len(review.candidates),
+            "semantic_challenges_rejected": review.challenges_rejected,
+            "semantic_findings_selected": selected,
+            "semantic_findings_suppressed": len(semantic) - selected,
+        },
+    )
+
+
+def _judgment_rejected_evaluation(
+    result: FinalSemanticEvaluation,
+) -> FinalSemanticEvaluation:
+    """Restate a structurally unusable reviewer answer as the honest terminal semantic outcome.
+
+    ``SemanticStatus.INVALID`` / ``SEMANTIC_JUDGMENT_REJECTED`` has existed in the enum, the ledger
+    CHECK constraints, and ``check-result-1.0.0`` since 0.1 and nothing had ever written it: the
+    rejection escaped as ``INVALID_REQUEST`` instead, taking the whole check — deterministic
+    findings included — with it. The provenance is the same attempt, restated to the outcome it
+    actually reached, because the binding fence requires provenance and result to agree.
+    """
+
+    provenance = result.provenance
+    if provenance is None:  # pragma: no cover - SUCCEEDED always carries final provenance
+        return FinalSemanticEvaluation(SemanticStatus.FAILED, SemanticReason.COORDINATOR_FAILURE)
+    return FinalSemanticEvaluation(
+        SemanticStatus.INVALID,
+        SemanticReason.SEMANTIC_JUDGMENT_REJECTED,
+        None,
+        replace(
+            provenance,
+            status=SemanticStatus.INVALID,
+            reason=SemanticReason.SEMANTIC_JUDGMENT_REJECTED,
+            failure_class=SemanticFailureClass.RESPONSE_CONTENT,
+        ),
+        result.attempt_accounting,
+        result.operation_lease,
+        result.withheld_review_categories,
+    )
 
 
 async def execute_check_commit(
@@ -1002,18 +1185,29 @@ async def execute_check_commit(
         # Durable semantic attempts may renew the check lease (TTL 60s vs timeout up to 300s).
         if semantic_result.operation_lease is not None:
             frozen = FrozenCase(frozen.case, semantic_result.operation_lease)
-        semantic_candidates: tuple[CandidateFinding, ...] = ()
+        review = _EMPTY_SEMANTIC_REVIEW
         if semantic_result.status is SemanticStatus.SUCCEEDED:
             assert semantic_result.judgment is not None
             assert semantic_result.provenance is not None
-            semantic_candidates = validate_semantic_judgment(
-                frozen.case,
-                deterministic,
-                semantic_result.judgment,
-                semantic_result.provenance,
-                expected_frontier=frozen.case.frontier,
-            )
-        semantic = allocate_findings(app.ids, semantic_candidates)
+            try:
+                review = validate_semantic_judgment(
+                    frozen.case,
+                    deterministic,
+                    semantic_result.judgment,
+                    semantic_result.provenance,
+                    expected_frontier=frozen.case.frontier,
+                )
+            except SemanticJudgmentRejected as exc:
+                # The reviewer's answer is unusable, so the check has no semantic result — but the
+                # deterministic findings below were already earned and must still be committed.
+                record_unexpected_exception_without_raising(
+                    exc,
+                    component="check",
+                    operation="semantic_judgment_rejected",
+                    request_id=request.request_id,
+                )
+                semantic_result = _judgment_rejected_evaluation(semantic_result)
+        semantic = allocate_findings(app.ids, review.candidates)
         coverage = case_coverage(
             frozen.case,
             semantic=semantic_result.status is SemanticStatus.SUCCEEDED,
@@ -1033,6 +1227,10 @@ async def execute_check_commit(
             and semantic_result.withheld_review_categories
         ):
             declared_gaps.add(SEMANTIC_REVIEW_CONTEXT_WITHHELD_GAP)
+        # A challenge the fence dropped is material the reviewer raised and the check does not
+        # carry. Saying so is what keeps a dropped challenge from reading as one never made.
+        if review.challenges_rejected:
+            declared_gaps.add(SEMANTIC_CHALLENGES_REJECTED_GAP)
         new_gaps = declared_gaps - set(coverage.known_gaps)
         if new_gaps:
             gaps = set(coverage.known_gaps) | new_gaps
@@ -1060,6 +1258,13 @@ async def execute_check_commit(
             semantic,
             RankingContext(coverage, completeness),
             maximum,
+        )
+        _record_semantic_review_accounting(
+            request,
+            semantic_result,
+            review,
+            semantic,
+            ranked,
         )
         if frozen.lease.phase is not CheckPhase.READY_TO_FINALIZE:
             lease = await runtime.ledger.advance_check_phase(

--- a/src/yoetz/application/semantic_case.py
+++ b/src/yoetz/application/semantic_case.py
@@ -1552,6 +1552,12 @@ def assemble_filtered_review_packet(
         {
             "case_digest": envelope.get("case_digest", ""),
             "case_id": envelope.get("case_id", ""),
+            # The exact ids post-validation will accept in a challenge's cited_refs, in one place
+            # the reviewer can read. The packet already carried them, split across frontier_refs
+            # and local_check_refs, while items[].item_id — the ids most visible in the document —
+            # are not citable at all. Naming the accept set explicitly is what lets a reviewer cite
+            # correctly instead of guessing and having the challenge dropped.
+            "citable_refs": sorted(frontier_refs | local_check_refs),
             "selection_accounting": cast(JsonValue, accounting),
             "dependency_digest": envelope.get("dependency_digest", ""),
             "frontier_refs": sorted(frontier_refs),

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -590,7 +590,9 @@ async def _call_support(
                 from yoetz.cli.provider_status import machine_scope_request
 
                 request = machine_scope_request()
-            request = with_body_schema_version(method, request)
+        # Every support body passes through here, whichever branch built it, so the normalization
+        # is one step rather than a property of one path.
+        request = with_body_schema_version(method, request)
         client = await build_service_client()
         try:
             result = await getattr(client, method)(request, deadline_ms=deadline_ms)

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -6,8 +6,9 @@ import dataclasses
 import importlib
 import os
 import sys
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from enum import Enum
+from functools import cache
 from pathlib import Path
 from typing import Annotated, Any, BinaryIO, Final, Literal, cast
 
@@ -46,10 +47,18 @@ from yoetz.protocol.models import (
     StatusSuccessModel,
     public_model_to_wire,
 )
+from yoetz.protocol.schemas import schema_document_for
 from yoetz.service.client import ServiceClient, connect_service
 from yoetz.service.control_protocol import public_error_code_for_control_reason
 
-__all__ = ["app", "build_service_client", "main", "run_async"]
+__all__ = [
+    "app",
+    "build_service_client",
+    "main",
+    "run_async",
+    "support_methods_carrying_schema_version",
+    "with_body_schema_version",
+]
 
 _MAX_INPUT_BYTES: Final = 1_048_576
 _INPUT = Annotated[
@@ -506,6 +515,63 @@ app.command("status")(_workflow_command("status", StatusRequest))
 app.command("receipt")(_workflow_command("receipt", ReceiptRequest))
 
 
+@cache
+def support_methods_carrying_schema_version() -> frozenset[str]:
+    """Support methods whose frozen request body declares the const ``schema_version`` field.
+
+    Derived from the frozen control-request schema rather than listed here, so a method added or
+    changed there cannot leave this behind.
+    """
+
+    document = schema_document_for("control-request", "1.0.0").json_schema
+    # The catalog hands back frozen values, so JSON arrays arrive as tuples rather than lists.
+    branches = document.get("oneOf")
+    if not isinstance(branches, Sequence) or type(branches) is str:
+        return frozenset()  # pragma: no cover - the frozen schema is a oneOf of calls
+    definitions = document.get("$defs")
+    defs: Mapping[str, JsonValue] = (
+        cast(Mapping[str, JsonValue], definitions) if isinstance(definitions, Mapping) else {}
+    )
+    methods: set[str] = set()
+    for raw in cast(Sequence[JsonValue], branches):
+        if not isinstance(raw, Mapping):
+            continue
+        properties = cast(Mapping[str, JsonValue], raw).get("properties")
+        if not isinstance(properties, Mapping):
+            continue
+        fields = cast(Mapping[str, JsonValue], properties)
+        method_node = fields.get("method")
+        body_node = fields.get("body")
+        if not isinstance(method_node, Mapping) or not isinstance(body_node, Mapping):
+            continue
+        name = cast(Mapping[str, JsonValue], method_node).get("const")
+        reference = cast(Mapping[str, JsonValue], body_node).get("$ref")
+        if type(name) is not str or type(reference) is not str:
+            continue
+        body = defs.get(reference.removeprefix("#/$defs/"))
+        if not isinstance(body, Mapping):
+            continue
+        required = cast(Mapping[str, JsonValue], body).get("required")
+        if isinstance(required, Sequence) and "schema_version" in required:
+            methods.add(name)
+    return frozenset(methods)
+
+
+def with_body_schema_version(method: str, request: JsonObject) -> JsonObject:
+    """Fill in ``schema_version`` when the method's body requires it and the input omitted it.
+
+    The field is a ``const``: there is exactly one value the frozen schema accepts, so an input
+    file without it is unambiguous rather than incomplete. Omitting it used to fail frame encoding
+    before the request left the process, and the caller saw only a closed ``invalid_request`` that
+    named no field. An input that supplies its own value is passed through untouched and still
+    validated, so a wrong version is still rejected rather than silently corrected.
+    """
+
+    if method not in support_methods_carrying_schema_version() or "schema_version" in request:
+        return request
+    return JsonObject({**dict(request), "schema_version": "1.0.0"})
+
+
 async def _call_support(
     method: str,
     input_path: str | None,
@@ -524,6 +590,7 @@ async def _call_support(
                 from yoetz.cli.provider_status import machine_scope_request
 
                 request = machine_scope_request()
+            request = with_body_schema_version(method, request)
         client = await build_service_client()
         try:
             result = await getattr(client, method)(request, deadline_ms=deadline_ms)

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -619,20 +619,23 @@ async def _effective_policy() -> PrivacyPolicy:
 
 async def _propose(candidate: PrivacyPolicy, expected_digest: str) -> str | None:
     from yoetz.adapters.privacy.catalog import encode_privacy_policy_json
-    from yoetz.cli.app import build_service_client
+    from yoetz.cli.app import build_service_client, with_body_schema_version
 
     client = await build_service_client()
     try:
         result = await client.privacy_propose_policy(
-            JsonObject(
-                {
-                    # Required by the frozen privacy_propose_policy body. Without it the frame
-                    # fails validation before it leaves this process, and the whole setup flow
-                    # reports a closed invalid_request that names nothing.
-                    "schema_version": "1.0.0",
-                    "expected_policy_digest": expected_digest,
-                    "candidate_policy": encode_privacy_policy_json(candidate),
-                }
+            # The frozen privacy_propose_policy body requires schema_version. Omitting it fails
+            # frame validation before the request leaves this process, and the whole setup flow
+            # reports a closed invalid_request that names nothing. The shared helper derives both
+            # the requirement and the value from the schema, so there is one source of truth.
+            with_body_schema_version(
+                "privacy_propose_policy",
+                JsonObject(
+                    {
+                        "expected_policy_digest": expected_digest,
+                        "candidate_policy": encode_privacy_policy_json(candidate),
+                    }
+                ),
             )
         )
     finally:

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -626,6 +626,10 @@ async def _propose(candidate: PrivacyPolicy, expected_digest: str) -> str | None
         result = await client.privacy_propose_policy(
             JsonObject(
                 {
+                    # Required by the frozen privacy_propose_policy body. Without it the frame
+                    # fails validation before it leaves this process, and the whole setup flow
+                    # reports a closed invalid_request that names nothing.
+                    "schema_version": "1.0.0",
                     "expected_policy_digest": expected_digest,
                     "candidate_policy": encode_privacy_policy_json(candidate),
                 }

--- a/src/yoetz/domain/receipts.py
+++ b/src/yoetz/domain/receipts.py
@@ -68,6 +68,7 @@ __all__ = [
     "ReceiptSection",
     "ReceiptSectionKey",
     "ReceiptVersionSlice",
+    "SEMANTIC_CHALLENGES_REJECTED_GAP",
     "SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP",
     "SEMANTIC_REVIEW_CONTEXT_WITHHELD_GAP",
     "SEMANTIC_REVIEW_NOT_CONFIGURED_GAP",
@@ -87,6 +88,10 @@ SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP: Final = "semantic_relevance_review_not_ru
 # The review ran, but the inference channel withheld categories the review profile
 # selected, so it judged the work without material it was configured to receive.
 SEMANTIC_REVIEW_CONTEXT_WITHHELD_GAP: Final = "semantic_review_context_withheld"
+# The review ran and returned challenges, and at least one of them was dropped by the
+# post-validation fence. The reviewer said something the check did not carry; coverage says so
+# rather than letting the drop look like the reviewer having found nothing there.
+SEMANTIC_CHALLENGES_REJECTED_GAP: Final = "semantic_challenges_rejected"
 SEMANTIC_REVIEW_NOT_REQUESTED_GAP: Final = "semantic_review_not_requested"
 OPTIONAL_SEMANTIC_REVIEW_BLOCKED_BY_POLICY_GAP: Final = "optional_semantic_review_blocked_by_policy"
 _SEMANTIC_REVIEW_NOT_RUN_GAPS: Final = frozenset(

--- a/src/yoetz/kernel/ranking.py
+++ b/src/yoetz/kernel/ranking.py
@@ -92,6 +92,10 @@ def _selected_with_diversity(
     reviewer that raised two or three material challenges had all but the best silently folded
     into ``suppressed_count``. Up to half the cap is now reservable, which keeps deterministic
     findings in the majority while letting more than one challenge be seen.
+
+    ``max_findings == 1`` reserves nothing and stays deterministic-only, unchanged from before:
+    the single seat goes to the highest-ranked finding, because reserving it would mean returning
+    a semantic challenge in place of every deterministic finding rather than alongside them.
     """
 
     selected = ordered[:max_findings]

--- a/src/yoetz/kernel/ranking.py
+++ b/src/yoetz/kernel/ranking.py
@@ -84,18 +84,32 @@ def _selected_with_diversity(
     semantic: tuple[Finding, ...],
     max_findings: int,
 ) -> tuple[Finding, ...]:
+    """Reserve part of the cap for material semantic challenges the kind order would evict.
+
+    ``rank_key`` puts origin ninth of ten, so finding kind dominates and enough deterministic
+    findings out-rank every semantic one. That ordering is deliberate and is left alone. What
+    changes here is how many reserved seats survive it: the rescue used to be exactly one, so a
+    reviewer that raised two or three material challenges had all but the best silently folded
+    into ``suppressed_count``. Up to half the cap is now reservable, which keeps deterministic
+    findings in the majority while letting more than one challenge be seen.
+    """
+
     selected = ordered[:max_findings]
     if max_findings < 2:
         return selected
-    material_challenges = tuple(
-        finding for finding in semantic if finding.priority in _MATERIAL_CHALLENGE_PRIORITIES
+    material_challenges = sorted(
+        (finding for finding in semantic if finding.priority in _MATERIAL_CHALLENGE_PRIORITIES),
+        key=rank_key,
     )
     if not material_challenges:
         return selected
-    challenge = min(material_challenges, key=rank_key)
-    if challenge in selected:
+    reserved = material_challenges[: max_findings // 2]
+    reserved_ids = {finding.finding_id for finding in reserved}
+    if reserved_ids <= {finding.finding_id for finding in selected}:
         return selected
-    return tuple(sorted((*selected[:-1], challenge), key=rank_key))
+    kept = [finding for finding in selected if finding.finding_id not in reserved_ids]
+    room = max_findings - len(reserved)
+    return tuple(sorted((*reserved, *kept[:room]), key=rank_key))
 
 
 def _verdict(

--- a/src/yoetz/observability/diagnostics.py
+++ b/src/yoetz/observability/diagnostics.py
@@ -43,6 +43,12 @@ _FIELD_ORDER: Final = (
     "reason",
     "origin",
     "request_id",
+    "semantic_conclusion",
+    "semantic_challenges_returned",
+    "semantic_candidates_accepted",
+    "semantic_challenges_rejected",
+    "semantic_findings_selected",
+    "semantic_findings_suppressed",
 )
 _lock = Lock()
 
@@ -62,6 +68,7 @@ def append_diagnostic_record(
     reason: str,
     request_id: str | None = None,
     origin: str | None = None,
+    counts: Mapping[str, object] | None = None,
     root: Path | None = None,
     now: datetime | None = None,
 ) -> None:
@@ -75,6 +82,7 @@ def append_diagnostic_record(
             reason=reason,
             request_id=request_id,
             origin=origin,
+            counts=counts,
             now=now,
         )
         if record is None:
@@ -127,6 +135,7 @@ def _build_record(
     reason: str,
     request_id: str | None,
     origin: str | None,
+    counts: Mapping[str, object] | None,
     now: datetime | None,
 ) -> dict[str, object] | None:
     try:
@@ -148,6 +157,12 @@ def _build_record(
         raw["request_id"] = request_id
     if origin is not None:
         raw["origin"] = origin
+    if counts is not None:
+        # Only names already in _FIELD_ORDER survive the projection below, and each still passes
+        # the same value fence as every other field: a caller cannot widen the record from here.
+        for name, value in counts.items():
+            if type(name) is str and name not in raw:
+                raw[name] = value
     output: dict[str, object] = {}
     for name in _FIELD_ORDER:
         if name not in raw:

--- a/src/yoetz/observability/logging.py
+++ b/src/yoetz/observability/logging.py
@@ -58,6 +58,9 @@ _FIELD_ORDER: Final = (
 )
 _FIELD_SET: Final = frozenset(_FIELD_ORDER)
 _CALLER_FIELDS: Final = _FIELD_SET - {"timestamp", "level", "component", "operation"}
+# Fields a bounded-counts caller may supply. The identity fields the emitter binds itself are
+# excluded so a caller can never pass the same keyword twice.
+_COUNT_FIELDS: Final = _CALLER_FIELDS - {"correlation_id", "request_id", "outcome"}
 _STRUCTURAL_MARKER: Final = "_yoetz_structured_record"
 _STRUCTURAL_FIELDS: Final = "_yoetz_structured_fields"
 _COMPONENT_PATTERN: Final = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$", re.ASCII)
@@ -520,7 +523,11 @@ def record_bounded_counts_without_raising(
     """
 
     correlation_id = _new_correlation()
-    fields = {name: value for name, value in counts.items() if name in _CALLER_FIELDS}
+    # Excluding the names bound directly below is load-bearing, not tidiness: a caller that put
+    # ``outcome`` (or a correlation/request id) in ``counts`` would hand the logger the same
+    # keyword twice, and the TypeError is swallowed by the guard below — the record would vanish
+    # exactly where this function exists to make something visible.
+    fields = {name: value for name, value in counts.items() if name in _COUNT_FIELDS}
     try:
         get_logger(component).info(
             operation,

--- a/src/yoetz/observability/logging.py
+++ b/src/yoetz/observability/logging.py
@@ -28,6 +28,7 @@ __all__ = [
     "configure_logging",
     "get_logger",
     "exception_origin",
+    "record_bounded_counts_without_raising",
     "record_bounded_event_without_raising",
     "record_fatal_exception_without_raising",
     "record_unexpected_exception_without_raising",
@@ -48,6 +49,12 @@ _FIELD_ORDER: Final = (
     "engine_version",
     "policy_version",
     "sqlite_source_id_hash",
+    "semantic_conclusion",
+    "semantic_challenges_returned",
+    "semantic_candidates_accepted",
+    "semantic_challenges_rejected",
+    "semantic_findings_selected",
+    "semantic_findings_suppressed",
 )
 _FIELD_SET: Final = frozenset(_FIELD_ORDER)
 _CALLER_FIELDS: Final = _FIELD_SET - {"timestamp", "level", "component", "operation"}
@@ -488,6 +495,52 @@ def record_bounded_event_without_raising(
             operation=operation,
             reason=reason,
             request_id=request_id,
+        )
+    except BaseException:
+        pass
+    return correlation_id
+
+
+def record_bounded_counts_without_raising(
+    *,
+    component: str,
+    operation: str,
+    outcome: str,
+    counts: Mapping[str, object],
+    request_id: str | None = None,
+) -> str:
+    """Emit bounded structural counters for a reviewed non-exception event.
+
+    Some outcomes are only legible as arithmetic: a semantic review that returned three challenges
+    and produced no findings is not an error on any single call, so nothing raises and nothing is
+    logged, and the loss is invisible. ``counts`` carries integers and closed tokens under names
+    the sinks already allowlist; anything else is dropped there, exactly as for any other record.
+    The durable owner-only line matters because MCP-spawned services swallow stderr, which is where
+    this would otherwise be the only trace.
+    """
+
+    correlation_id = _new_correlation()
+    fields = {name: value for name, value in counts.items() if name in _CALLER_FIELDS}
+    try:
+        get_logger(component).info(
+            operation,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            outcome=outcome,
+            **fields,
+        )
+    except BaseException:
+        pass
+    try:
+        from yoetz.observability.diagnostics import append_diagnostic_record
+
+        append_diagnostic_record(
+            correlation_id=correlation_id,
+            component=component,
+            operation=operation,
+            reason=outcome,
+            request_id=request_id,
+            counts=fields,
         )
     except BaseException:
         pass

--- a/src/yoetz/observability/privacy.py
+++ b/src/yoetz/observability/privacy.py
@@ -95,6 +95,14 @@ _LOG_FIELDS: Final = frozenset(
         "engine_version",
         "policy_version",
         "sqlite_source_id_hash",
+        # Bounded structural accounting for one semantic review: what the reviewer returned and
+        # what became of it. Counts and one closed conclusion token only — never challenge text.
+        "semantic_conclusion",
+        "semantic_challenges_returned",
+        "semantic_candidates_accepted",
+        "semantic_challenges_rejected",
+        "semantic_findings_selected",
+        "semantic_findings_suppressed",
     }
 )
 _MANIFEST_FIELDS: Final = frozenset(
@@ -157,6 +165,7 @@ _TOKEN_FIELDS: Final = frozenset(
         "startup_check_outcome",
         "startup_reason_code",
         "capability_probe_id",
+        "semantic_conclusion",
     }
 )
 _VERSION_FIELDS: Final = frozenset(
@@ -176,7 +185,17 @@ _VERSION_FIELDS: Final = frozenset(
     }
 )
 _INTEGER_FIELDS: Final = frozenset(
-    {"duration_ms", "operation_count", "duration_bucket_ms", "terminal_outcome_count"}
+    {
+        "duration_ms",
+        "operation_count",
+        "duration_bucket_ms",
+        "terminal_outcome_count",
+        "semantic_challenges_returned",
+        "semantic_candidates_accepted",
+        "semantic_challenges_rejected",
+        "semantic_findings_selected",
+        "semantic_findings_suppressed",
+    }
 )
 _BOOLEAN_FIELDS: Final = frozenset({"sqlite_compile_options_ok"})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,34 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import ModuleType
 
 import pytest
 
+import yoetz.observability.diagnostics as diagnostics_module
 from builders import clock as clock_builder_module
 from builders import events as event_builder_module
 from builders import ids as id_builder_module
 from builders import operations as operation_builder_module
 from fixture_loader import FixtureLoader, build_fixture_loader
+
+
+@pytest.fixture(autouse=True)
+def _isolated_diagnostic_log(  # pyright: ignore[reportUnusedFunction]
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep the durable diagnostic ring out of the developer's real log directory.
+
+    ``append_diagnostic_record`` defaults to the platform ``log_dir()``, so any test exercising a
+    path that records one appends to the machine's own ``service.diagnostics.jsonl``. Individual
+    tests that assert on records already redirect it; this makes the default safe for the ones
+    that only pass through. A test that sets its own ``log_dir`` still wins, because its
+    ``monkeypatch`` is applied after this fixture and undone before it.
+    """
+
+    root = tmp_path_factory.mktemp("diagnostics")
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: Path(root))
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from types import ModuleType
 
 import pytest
 
-import yoetz.observability.diagnostics as diagnostics_module
 from builders import clock as clock_builder_module
 from builders import events as event_builder_module
 from builders import ids as id_builder_module
@@ -26,7 +25,17 @@ def _isolated_diagnostic_log(  # pyright: ignore[reportUnusedFunction]
     tests that assert on records already redirect it; this makes the default safe for the ones
     that only pass through. A test that sets its own ``log_dir`` still wins, because its
     ``monkeypatch`` is applied after this fixture and undone before it.
+
+    The import is deliberately inside the fixture. The portable console-boundary job runs
+    ``tests/unit/cli/test_trusted_console.py`` with pytest alone and no project dependencies, and
+    this file is a ``conftest`` on that path; importing the diagnostics module at module scope
+    pulls in ``platformdirs`` through ``yoetz.config.paths`` and breaks collection there.
     """
+
+    try:
+        import yoetz.observability.diagnostics as diagnostics_module
+    except ImportError:
+        return  # No project dependencies installed, so there is no durable sink to redirect.
 
     root = tmp_path_factory.mktemp("diagnostics")
     monkeypatch.setattr(diagnostics_module, "log_dir", lambda: Path(root))

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import pytest
 
+import yoetz.application.check as check_module
 import yoetz.observability.diagnostics as diagnostics_module
 from builders.ledger_adapters import FixedClock, MemoryObjects
 from builders.policy_cases import FRONTIER, clm, make_case, record
@@ -17,6 +18,7 @@ from yoetz.application.service import VerificationPolicy
 from yoetz.domain.events import ClaimKind, ClaimRecordedPayload
 from yoetz.domain.findings import (
     Finding,
+    FindingKind,
     RankedFindings,
     SemanticDispatchKind,
     SemanticProvenance,
@@ -37,7 +39,7 @@ from yoetz.ports.ledger import (
 )
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef
 from yoetz.ports.runtime import BundleRuntimePort, OwnershipFence, RouteCommand, TaskRuntime
-from yoetz.ports.semantic import SamplingParams, SemanticJudgment
+from yoetz.ports.semantic import ReviewerChallenge, SamplingParams, SemanticJudgment
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
 from yoetz.protocol.models import CheckRequest, SemanticReason, SemanticStatus
@@ -273,7 +275,7 @@ class _App:
         return self.semantic_result
 
 
-def _request(mode: str = "deterministic_only") -> CheckRequest:
+def _request(mode: str = "deterministic_only", *, max_findings: str = "1") -> CheckRequest:
     return CheckRequest.model_validate(
         {
             "protocol_version": "0.1",
@@ -286,7 +288,7 @@ def _request(mode: str = "deterministic_only") -> CheckRequest:
                 "head_digest": FRONTIER.head_digest,
             },
             "mode": mode,
-            "max_findings": "1",
+            "max_findings": max_findings,
             "actor": {"actor_id": "harness:test", "actor_type": "harness"},
             "client": {
                 "kind": "test_client",
@@ -500,3 +502,149 @@ async def test_succeeded_review_with_withheld_context_is_not_reported_as_full_co
     agreed.semantic_result = replace(app.semantic_result, withheld_review_categories=())
     clean = await execute_check_commit(agreed, _request("semantic_if_configured"))
     assert SEMANTIC_REVIEW_CONTEXT_WITHHELD_GAP not in clean.coverage.known_gaps
+
+
+def _succeeded(judgment: SemanticJudgment) -> FinalSemanticEvaluation:
+    digest = "sha256:" + "a" * 64
+    return FinalSemanticEvaluation(
+        SemanticStatus.SUCCEEDED,
+        SemanticReason.SEMANTIC_COMPLETED,
+        judgment=judgment,
+        provenance=SemanticProvenance(
+            provider="fake",
+            endpoint_profile_id="fake",
+            endpoint_profile_version="1.0.0",
+            model="fake/model",
+            sdk_version="1.0.0",
+            prompt_digest=digest,
+            schema_digest=digest,
+            policy_digest=digest,
+            privacy_policy_digest=digest,
+            sampling_params=SamplingParams(128),
+            latency_ms=1,
+            semantic_attempt_id="att_30000000-0000-4000-8000-000000000001",
+            dispatch_kind=SemanticDispatchKind.EXTERNAL,
+            privacy_receipt_id="egr_30000000-0000-4000-8000-000000000001",
+            status=SemanticStatus.SUCCEEDED,
+            reason=SemanticReason.SEMANTIC_COMPLETED,
+            provider_request_id="fake-semantic-request-1",
+            egress_authorization_id="aut_30000000-0000-4000-8000-000000000001",
+            request_commitment="hmac-sha256:" + "b" * 64,
+        ),
+    )
+
+
+def _reviewer_challenge(ref: str, *, summary: str = "Evidence gap") -> ReviewerChallenge:
+    return ReviewerChallenge(
+        FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+        summary,
+        (ref,),
+        "The claim lacks a recorded basis.",
+        "The claim may remain unresolved.",
+        "Main agent: provide evidence for the claim.",
+        "provide_evidence",
+        "The missing material may exist outside the case.",
+    )
+
+
+@pytest.mark.anyio
+async def test_rejected_judgment_commits_the_check_instead_of_failing_the_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reviewer answer the fence refuses costs the reviewer's output, never the whole check.
+
+    Regression for a live failure: the post-validation ``ValueError`` escaped ``execute_check_commit``
+    (which caught only ``ProtocolValueError``), reached the daemon catch-all, and became a
+    non-retryable ``INVALID_REQUEST`` with no correlation id. No check was recorded at all, so the
+    deterministic findings were lost and nothing said why. ``SemanticStatus.INVALID`` /
+    ``SEMANTIC_JUDGMENT_REJECTED`` existed for exactly this and had never once been written.
+
+    The structural fence is unreachable through the ordinary call (the coordinator passes the frozen
+    case's own frontier and a SUCCEEDED provenance by construction), so the raise is injected here:
+    what is under test is the disposition of the failure, not its trigger.
+    """
+
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+
+    def _raise(*_args: object, **_kwargs: object) -> object:
+        raise check_module.SemanticJudgmentRejected("semantic_judgment_invalid")
+
+    monkeypatch.setattr(check_module, "validate_semantic_judgment", _raise)
+
+    app = _App(semantic=True)
+    app.semantic_result = _succeeded(
+        SemanticJudgment("challenges_returned", (_reviewer_challenge(str(clm(1))),))
+    )
+
+    result = await execute_check_commit(app, _request("semantic_if_configured"))
+
+    assert result.semantic_status is SemanticStatus.INVALID
+    assert result.semantic_reason is SemanticReason.SEMANTIC_JUDGMENT_REJECTED
+    assert result.semantic_provenance is not None
+    assert result.semantic_provenance.status is SemanticStatus.INVALID
+    assert result.semantic_provenance.reason is SemanticReason.SEMANTIC_JUDGMENT_REJECTED
+    # The whole point: the deterministic findings the user paid for still committed.
+    assert result.findings
+    assert all(finding.origin.value == "deterministic" for finding in result.findings)
+    assert app.ledger.commit_count == 1
+    assert result.verdict.value != "no_issue_detected"
+
+    raw = diagnostics_module.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    operations = {json.loads(line)["operation"] for line in raw.splitlines() if line}
+    assert "semantic_judgment_rejected" in operations
+
+
+@pytest.mark.anyio
+async def test_partial_rejection_keeps_accepted_challenges_and_declares_the_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One unusable challenge costs itself; the others become findings and the loss is declared."""
+
+    from yoetz.domain.receipts import SEMANTIC_CHALLENGES_REJECTED_GAP
+
+    monkeypatch.setattr(diagnostics_module, "log_dir", lambda: tmp_path)
+    app = _App(semantic=True)
+    app.semantic_result = _succeeded(
+        SemanticJudgment(
+            "challenges_returned",
+            (
+                _reviewer_challenge(str(clm(1)), summary="Accepted challenge"),
+                _reviewer_challenge(
+                    "clm_20000000-0000-4000-8000-000000000099", summary="Invented ref"
+                ),
+            ),
+        )
+    )
+
+    result = await execute_check_commit(app, _request("semantic_if_configured", max_findings="4"))
+
+    semantic_findings = [
+        finding for finding in result.findings if finding.origin.value == "semantic_model_derived"
+    ]
+    assert [finding.summary for finding in semantic_findings] == ["Accepted challenge"]
+    assert result.semantic_status is SemanticStatus.SUCCEEDED
+    assert SEMANTIC_CHALLENGES_REJECTED_GAP in result.coverage.known_gaps
+
+    raw = diagnostics_module.diagnostic_log_path(root=tmp_path).read_text(encoding="ascii")
+    accounting = [
+        json.loads(line)
+        for line in raw.splitlines()
+        if line and json.loads(line)["operation"] == "semantic_review_accounting"
+    ]
+    assert len(accounting) == 1
+    record_json = accounting[0]
+    assert record_json["semantic_conclusion"] == "challenges_returned"
+    assert record_json["semantic_challenges_returned"] == 2
+    assert record_json["semantic_candidates_accepted"] == 1
+    assert record_json["semantic_challenges_rejected"] == 1
+    assert record_json["semantic_findings_selected"] == 1
+    assert record_json["semantic_findings_suppressed"] == 0
+    # The record reconciles: nothing the reviewer returned is unaccounted for.
+    assert record_json["semantic_challenges_returned"] == (
+        record_json["semantic_candidates_accepted"] + record_json["semantic_challenges_rejected"]
+    )
+    assert record_json["semantic_candidates_accepted"] == (
+        record_json["semantic_findings_selected"] + record_json["semantic_findings_suppressed"]
+    )
+    assert "Invented ref" not in raw
+    assert "Accepted challenge" not in raw

--- a/tests/integration/providers/test_fake_provider_coordinator.py
+++ b/tests/integration/providers/test_fake_provider_coordinator.py
@@ -27,7 +27,12 @@ from yoetz.adapters.providers.fake import (
     scripted_success,
     scripted_timeout,
 )
-from yoetz.application.check import validate_semantic_judgment
+from yoetz.application.check import (
+    SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM,
+    SEMANTIC_REJECTED_REF_OUTSIDE_CASE,
+    SemanticJudgmentRejected,
+    validate_semantic_judgment,
+)
 from yoetz.domain.findings import (
     FindingKind,
     SemanticDispatchKind,
@@ -215,14 +220,17 @@ async def test_fake_invented_ids_and_coverage_upgrades_are_rejected() -> None:
     )
     invented_result = await invented_evaluator.evaluate(case, deadline)
     assert isinstance(invented_result, SemanticResultSuccess)
-    with pytest.raises(ValueError, match="semantic_ref_outside_case"):
-        validate_semantic_judgment(
-            det_case,
-            (),
-            invented_result.judgment,
-            _finalize(invented_result.provenance, seed="1"),
-            expected_frontier=det_case.frontier,
-        )
+    # An invented ref still yields no finding; it now costs only its own challenge, and the drop
+    # is counted rather than taking the judgment (and the check) down with it.
+    invented_review = validate_semantic_judgment(
+        det_case,
+        (),
+        invented_result.judgment,
+        _finalize(invented_result.provenance, seed="1"),
+        expected_frontier=det_case.frontier,
+    )
+    assert invented_review.candidates == ()
+    assert invented_review.rejected_by_reason == ((SEMANTIC_REJECTED_REF_OUTSIDE_CASE, 1),)
 
     stale_evaluator = ScriptedFakeSemanticEvaluator(
         FakeSemanticScript(
@@ -231,7 +239,7 @@ async def test_fake_invented_ids_and_coverage_upgrades_are_rejected() -> None:
     )
     stale_result = await stale_evaluator.evaluate(case, deadline)
     assert isinstance(stale_result, SemanticResultSuccess)
-    with pytest.raises(ValueError, match="semantic_judgment_invalid"):
+    with pytest.raises(SemanticJudgmentRejected, match="semantic_judgment_invalid"):
         validate_semantic_judgment(
             det_case,
             (),
@@ -254,8 +262,9 @@ async def test_fake_invented_ids_and_coverage_upgrades_are_rejected() -> None:
         _finalize(accepted_result.provenance, seed="3"),
         expected_frontier=det_case.frontier,
     )
-    assert len(accepted) == 1
-    assert accepted[0].subject_refs == (clm(1),)
+    assert len(accepted.candidates) == 1
+    assert accepted.candidates[0].subject_refs == (clm(1),)
+    assert accepted.rejected_by_reason == ()
 
 
 @pytest.mark.anyio
@@ -318,14 +327,14 @@ async def test_fake_structured_packet_and_challenge_matrix() -> None:
         assert isinstance(result, SemanticResultSuccess)
         assert result.judgment.challenges[0].requested_next_step == next_step
 
-        candidates = validate_semantic_judgment(
+        review = validate_semantic_judgment(
             det_case,
             (),
             result.judgment,
             _finalize(result.provenance, seed=str(10 + index)),
             expected_frontier=det_case.frontier,
         )
-        assert len(candidates) == 1
+        assert len(review.candidates) == 1
 
     # The false "missing diff means no change" case: a challenge that claims things are
     # unchanged while its cited ref's recorded coverage says the source was withheld/missing
@@ -351,14 +360,15 @@ async def test_fake_structured_packet_and_challenge_matrix() -> None:
     )
     hidden_result = await hidden_evaluator.evaluate(_approved_case(), _deadline())
     assert isinstance(hidden_result, SemanticResultSuccess)
-    with pytest.raises(ValueError, match="semantic_hidden_source_claim"):
-        validate_semantic_judgment(
-            hidden_case,
-            (),
-            hidden_result.judgment,
-            _finalize(hidden_result.provenance, seed="99"),
-            expected_frontier=hidden_case.frontier,
-        )
+    hidden_review = validate_semantic_judgment(
+        hidden_case,
+        (),
+        hidden_result.judgment,
+        _finalize(hidden_result.provenance, seed="99"),
+        expected_frontier=hidden_case.frontier,
+    )
+    assert hidden_review.candidates == ()
+    assert hidden_review.rejected_by_reason == ((SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM, 1),)
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/providers/test_provider_judgment_contract.py
+++ b/tests/unit/adapters/providers/test_provider_judgment_contract.py
@@ -19,6 +19,8 @@ from yoetz.adapters.providers.openai_chat_completions import (
     normalize_response as normalize_chat_response,
 )
 from yoetz.adapters.providers.openai_responses import (
+    CHALLENGE_FIELD_GLOSSARY,
+    FINDING_KIND_GLOSSARY,
     JUDGMENT_JSON_SCHEMA,
     OpenAIProfile,
     build_judgment_json_schema,
@@ -37,7 +39,11 @@ from yoetz.ports.semantic import (
     SemanticResultTimeout,
 )
 from yoetz.protocol.canonical import JsonValue, canonical_digest, strict_json_parse
-from yoetz.protocol.models import ProviderJudgmentModel
+from yoetz.protocol.models import (
+    ProviderChallengeModel,
+    ProviderJudgmentEnvelopeModel,
+    ProviderJudgmentModel,
+)
 
 _NOW = datetime(2026, 7, 28, tzinfo=UTC)
 _DIGEST = "sha256:" + "c" * 64
@@ -180,7 +186,9 @@ def test_generated_schema_matches_owning_model_and_frozen_artifact() -> None:
         for key, value in cast(dict[str, object], _strip_titles(frozen_doc)).items()
         if key not in {"$id", "$schema"}
     }
-    assert frozen_body == cast(dict[str, object], JUDGMENT_JSON_SCHEMA)
+    # The request schema carries curated reviewer definitions the frozen catalog does not; both
+    # sides drop annotations so what is compared is the shape the two documents must share.
+    assert frozen_body == _strip_titles(cast(dict[str, object], JUDGMENT_JSON_SCHEMA))
     kinds = cast(
         list[str],
         cast(
@@ -229,21 +237,61 @@ def test_request_schema_root_is_an_object_never_a_union() -> None:
 
 
 def test_request_schema_carries_no_docstring_commentary() -> None:
-    """Developer docstrings explain the contract to maintainers, never to the provider."""
+    """Developer docstrings explain the contract to maintainers, never to the provider.
 
-    def _annotations(node: object) -> list[str]:
-        found: list[str] = []
+    The schema does carry descriptions now, but only the curated reviewer definitions written for
+    the model. Every one must come from the glossary; a pydantic docstring reaching the wire — the
+    thing ``_strip_schema_titles`` exists to prevent — fails here.
+    """
+
+    def _annotations(node: object, key_name: str) -> list[object]:
+        found: list[object] = []
         if type(node) is dict:
             for key, value in cast(dict[str, Any], node).items():
-                if key in {"title", "description"}:
-                    found.append(key)
-                found.extend(_annotations(value))
+                if key == key_name:
+                    found.append(value)
+                found.extend(_annotations(value, key_name))
         elif type(node) is list:
             for item in cast(list[Any], node):
-                found.extend(_annotations(item))
+                found.extend(_annotations(item, key_name))
         return found
 
-    assert _annotations(JUDGMENT_JSON_SCHEMA) == []
+    assert _annotations(JUDGMENT_JSON_SCHEMA, "title") == []
+
+    curated = set(CHALLENGE_FIELD_GLOSSARY.values())
+    descriptions = _annotations(JUDGMENT_JSON_SCHEMA, "description")
+    assert descriptions
+    assert set(descriptions) <= curated
+
+    docstrings = {
+        (model.__doc__ or "").strip()
+        for model in (
+            ProviderChallengeModel,
+            ProviderJudgmentEnvelopeModel,
+        )
+    } - {""}
+    assert docstrings
+    assert not docstrings & set(descriptions)
+
+
+def test_every_finding_kind_and_challenge_field_has_a_reviewer_gloss() -> None:
+    """A kind or field the model can emit but has no definition for is an unfair question.
+
+    Adding a ``FindingKind`` or a challenge field without writing its gloss fails here rather than
+    reaching a provider as one more bare token among the rest.
+    """
+
+    assert set(FINDING_KIND_GLOSSARY) == {kind.value for kind in FindingKind}
+    challenge = cast(
+        dict[str, Any], cast(dict[str, Any], JUDGMENT_JSON_SCHEMA["$defs"])["ProviderChallenge"]
+    )
+    assert set(CHALLENGE_FIELD_GLOSSARY) == set(cast(dict[str, Any], challenge["properties"]))
+
+    kind_gloss = cast(
+        dict[str, Any], cast(dict[str, Any], JUDGMENT_JSON_SCHEMA["$defs"])["FindingKindWire"]
+    )["description"]
+    for kind in FindingKind:
+        assert f"{kind.value}: " in kind_gloss
 
 
 def test_envelope_and_bare_judgment_both_normalize() -> None:

--- a/tests/unit/application/test_semantic_case.py
+++ b/tests/unit/application/test_semantic_case.py
@@ -443,3 +443,39 @@ def test_structural_assessments_have_no_finding_prose_items() -> None:
     assert not any(
         item.section in {"deterministic_summary", "deterministic_detail"} for item in semantic.items
     )
+
+
+def test_prepared_payload_names_the_refs_post_validation_will_accept() -> None:
+    """The reviewer gets one list of citable ids, matching the fence exactly.
+
+    Every ``cited_refs`` value is fenced against ``frontier_refs | local_check_refs``, but the
+    packet only ever carried them as two separate arrays, while the ids most visible in the
+    document — ``items[].item_id``, e.g. ``goal-3`` — are not citable at all. Citing wrong costs
+    the challenge, so the accept set is stated explicitly instead of left to be inferred.
+    """
+
+    case = _case_with_material(with_evidence=True)
+    findings = _findings_for(case)
+    semantic = _build(case, ReviewContextProfile.ASSISTED, findings=findings)
+    included = {item.item_id for item in semantic.items}
+    document = strict_json_parse(semantic_case_to_prepared_payload(semantic, included))
+    assert isinstance(document, dict)
+
+    raw_citable = document.get("citable_refs")
+    assert isinstance(raw_citable, list)
+    citable = [ref for ref in cast(list[object], raw_citable) if type(ref) is str]
+    assert len(citable) == len(raw_citable)
+    assert set(citable) == semantic.frontier_refs | semantic.local_check_refs
+    assert citable == sorted(citable)
+    assert citable
+
+    raw_items = document.get("items")
+    assert isinstance(raw_items, list)
+    item_ids: set[str] = set()
+    for row in cast(list[object], raw_items):
+        if isinstance(row, dict):
+            item_id = cast(dict[str, object], row).get("item_id")
+            if type(item_id) is str:
+                item_ids.add(item_id)
+    # The two vocabularies are disjoint: an item_id is never a citable ref.
+    assert not item_ids & set(citable)

--- a/tests/unit/application/test_semantic_post_validation.py
+++ b/tests/unit/application/test_semantic_post_validation.py
@@ -9,6 +9,7 @@ from yoetz.application.check import (
     SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM,
     SEMANTIC_REJECTED_REF_OUTSIDE_CASE,
     SemanticJudgmentRejected,
+    SemanticJudgmentReview,
     validate_semantic_judgment,
 )
 from yoetz.domain.findings import (
@@ -174,3 +175,60 @@ def test_no_material_discrepancy_returns_no_semantic_candidate() -> None:
     assert review.candidates == ()
     assert review.challenges_returned == 0
     assert review.rejected_by_reason == ()
+
+
+def test_rejection_counts_aggregate_and_reasons_sort_deterministically() -> None:
+    """Repeated drops sum, and two reasons come back in one stable order.
+
+    With a single rejection under a single reason, neither the counter nor the sort is observable;
+    a mixed judgment pins both. Deterministic reproducibility is the point — the same judgment
+    must always produce the same accounting.
+    """
+
+    case = make_case(
+        extra_refs=(clm(1), clm(2)),
+        coverage_overrides={clm(1): replace(BASE_COVERAGE, known_gaps=("missing_ref",))},
+    )
+    hidden = ReviewerChallenge(
+        FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+        "Claims no change",
+        (str(clm(1)),),
+        "The file is unchanged.",
+        "Nothing was modified.",
+        "Main agent: no further action required.",
+        "state_unresolved_limitation",
+        "The excerpt was never disclosed.",
+    )
+    judgment = SemanticJudgment(
+        "challenges_returned",
+        (
+            _challenge(_INVENTED, summary="First invented"),
+            hidden,
+            _challenge(str(clm(2)), summary="Real"),
+        ),
+    )
+
+    review = validate_semantic_judgment(
+        case,
+        (),
+        judgment,
+        _provenance(),
+        expected_frontier=case.frontier,
+    )
+
+    assert [candidate.summary for candidate in review.candidates] == ["Real"]
+    assert review.challenges_returned == 3
+    assert review.challenges_rejected == 2
+    # Sorted by ASCII reason token, so hidden_source_claim precedes ref_outside_case.
+    assert review.rejected_by_reason == (
+        (SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM, 1),
+        (SEMANTIC_REJECTED_REF_OUTSIDE_CASE, 1),
+    )
+    assert review.challenges_returned == len(review.candidates) + review.challenges_rejected
+
+
+def test_review_rejects_accounting_that_does_not_add_up() -> None:
+    """The value type owns the reconciliation the diagnostic reports."""
+
+    with pytest.raises(ValueError, match="semantic_judgment_review_invalid"):
+        SemanticJudgmentReview((), 3, ((SEMANTIC_REJECTED_REF_OUTSIDE_CASE, 1),))

--- a/tests/unit/application/test_semantic_post_validation.py
+++ b/tests/unit/application/test_semantic_post_validation.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
-from builders.policy_cases import clm, make_case
-from yoetz.application.check import validate_semantic_judgment
+from builders.policy_cases import BASE_COVERAGE, clm, make_case
+from yoetz.application.check import (
+    SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM,
+    SEMANTIC_REJECTED_REF_OUTSIDE_CASE,
+    SemanticJudgmentRejected,
+    validate_semantic_judgment,
+)
 from yoetz.domain.findings import (
     FindingKind,
     SamplingParams,
@@ -14,6 +21,7 @@ from yoetz.ports.semantic import ReviewerChallenge, SemanticJudgment
 from yoetz.protocol.models import SemanticReason, SemanticStatus
 
 _DIGEST = "sha256:" + "a" * 64
+_INVENTED = "clm_20000000-0000-4000-8000-000000000099"
 
 
 def _provenance() -> SemanticProvenance:
@@ -40,10 +48,10 @@ def _provenance() -> SemanticProvenance:
     )
 
 
-def _challenge(*refs: str) -> ReviewerChallenge:
+def _challenge(*refs: str, summary: str = "Evidence gap") -> ReviewerChallenge:
     return ReviewerChallenge(
         FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
-        "Evidence gap",
+        summary,
         tuple(sorted(refs)),
         "The claim lacks a recorded basis.",
         "The claim may remain unresolved.",
@@ -57,7 +65,7 @@ def test_semantic_judgment_accepts_only_frozen_refs_and_derives_policy() -> None
     case = make_case(extra_refs=(clm(1),))
     judgment = SemanticJudgment("challenges_returned", (_challenge(str(clm(1))),))
 
-    candidates = validate_semantic_judgment(
+    review = validate_semantic_judgment(
         case,
         (),
         judgment,
@@ -65,25 +73,84 @@ def test_semantic_judgment_accepts_only_frozen_refs_and_derives_policy() -> None
         expected_frontier=case.frontier,
     )
 
-    assert len(candidates) == 1
-    assert candidates[0].subject_refs == (clm(1),)
-    assert candidates[0].policy_id == "work-integrity"
-    assert candidates[0].policy_version == "0.1.0"
+    assert len(review.candidates) == 1
+    assert review.candidates[0].subject_refs == (clm(1),)
+    assert review.candidates[0].policy_id == "work-integrity"
+    assert review.candidates[0].policy_version == "0.1.0"
+    assert review.challenges_returned == 1
+    assert review.rejected_by_reason == ()
 
 
-def test_invented_or_stale_semantic_refs_are_rejected() -> None:
+def test_one_bad_challenge_does_not_discard_the_others() -> None:
+    """The fence is per challenge, so an invented ref costs its own challenge and nothing else.
+
+    Regression for the live failure: three returned challenges where the middle one cited an
+    invented ref used to discard all three — and, because the raise escaped the coordinator, the
+    entire check with them.
+    """
+
+    case = make_case(extra_refs=(clm(1), clm(2)))
+    judgment = SemanticJudgment(
+        "challenges_returned",
+        (
+            _challenge(str(clm(1)), summary="First"),
+            _challenge(_INVENTED, summary="Second"),
+            _challenge(str(clm(2)), summary="Third"),
+        ),
+    )
+
+    review = validate_semantic_judgment(
+        case,
+        (),
+        judgment,
+        _provenance(),
+        expected_frontier=case.frontier,
+    )
+
+    assert [candidate.summary for candidate in review.candidates] == ["First", "Third"]
+    assert review.challenges_returned == 3
+    assert review.rejected_by_reason == ((SEMANTIC_REJECTED_REF_OUTSIDE_CASE, 1),)
+    assert review.challenges_rejected == 1
+
+
+def test_hidden_source_claim_is_counted_and_only_costs_its_own_challenge() -> None:
+    """The "nothing changed" claim over a withheld basis is still refused, one challenge at a time."""
+
+    case = make_case(
+        extra_refs=(clm(1), clm(2)),
+        coverage_overrides={clm(1): replace(BASE_COVERAGE, known_gaps=("missing_ref",))},
+    )
+    hidden = ReviewerChallenge(
+        FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+        "Claims no change",
+        (str(clm(1)),),
+        "The file is unchanged.",
+        "Nothing was modified.",
+        "Main agent: no further action required.",
+        "state_unresolved_limitation",
+        "The excerpt was never disclosed.",
+    )
+    judgment = SemanticJudgment(
+        "challenges_returned",
+        (hidden, _challenge(str(clm(2)), summary="Real")),
+    )
+
+    review = validate_semantic_judgment(
+        case,
+        (),
+        judgment,
+        _provenance(),
+        expected_frontier=case.frontier,
+    )
+
+    assert [candidate.summary for candidate in review.candidates] == ["Real"]
+    assert review.rejected_by_reason == ((SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM, 1),)
+
+
+def test_structural_failure_raises_the_narrow_rejection_the_commit_path_catches() -> None:
     case = make_case(extra_refs=(clm(1),))
-    invented = "clm_20000000-0000-4000-8000-000000000099"
 
-    with pytest.raises(ValueError, match="semantic_ref_outside_case"):
-        validate_semantic_judgment(
-            case,
-            (),
-            SemanticJudgment("challenges_returned", (_challenge(invented),)),
-            _provenance(),
-            expected_frontier=case.frontier,
-        )
-    with pytest.raises(ValueError, match="semantic_judgment_invalid"):
+    with pytest.raises(SemanticJudgmentRejected, match="semantic_judgment_invalid"):
         validate_semantic_judgment(
             case,
             (),
@@ -96,13 +163,14 @@ def test_invented_or_stale_semantic_refs_are_rejected() -> None:
 def test_no_material_discrepancy_returns_no_semantic_candidate() -> None:
     case = make_case(extra_refs=(clm(1),))
 
-    assert (
-        validate_semantic_judgment(
-            case,
-            (),
-            SemanticJudgment("no_material_discrepancy", ()),
-            _provenance(),
-            expected_frontier=case.frontier,
-        )
-        == ()
+    review = validate_semantic_judgment(
+        case,
+        (),
+        SemanticJudgment("no_material_discrepancy", ()),
+        _provenance(),
+        expected_frontier=case.frontier,
     )
+
+    assert review.candidates == ()
+    assert review.challenges_returned == 0
+    assert review.rejected_by_reason == ()

--- a/tests/unit/cli/test_support_request_bodies.py
+++ b/tests/unit/cli/test_support_request_bodies.py
@@ -1,0 +1,148 @@
+"""Support-command request bodies must satisfy the frozen control-request schema.
+
+A body that omits a required field fails frame encoding inside the client, before anything is
+sent, and the caller sees only a closed ``invalid_request`` naming no field. That is how
+``privacy propose`` — and with it every policy widening, including the one ``privacy setup``
+performs — stayed unusable: the body it built was missing the const ``schema_version``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from builders.privacy_policies import local_only_policy
+from yoetz.cli.app import (
+    support_methods_carrying_schema_version,
+    with_body_schema_version,
+)
+from yoetz.domain.values import JsonObject
+from yoetz.protocol.canonical import JsonValue
+from yoetz.protocol.schemas import SchemaInstanceInvalid, validate_schema_instance
+
+_REPO = Path(__file__).resolve().parents[3]
+_FROZEN_REQUEST_SCHEMA = _REPO / "schemas" / "service" / "control-request-1.0.0.schema.json"
+
+
+def _frame(method: str, body: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    return {
+        "kind": "call",
+        "protocol_version": "1.0",
+        "rpc_id": "rpc_00000000-0000-4000-8000-000000000001",
+        "service_instance_id": "svc_00000000-0000-4000-8000-000000000001",
+        "service_generation": "1",
+        "method": method,
+        "body": cast(JsonValue, dict(body)),
+    }
+
+
+def test_derived_method_set_matches_the_frozen_schema() -> None:
+    """The runtime set is read from the packaged schema; this reads the repository artifact."""
+
+    document = cast(dict[str, Any], json.loads(_FROZEN_REQUEST_SCHEMA.read_text()))
+    defs = cast(dict[str, Any], document["$defs"])
+    expected: set[str] = set()
+    for branch in cast(list[Any], document["oneOf"]):
+        properties = cast(dict[str, Any], cast(dict[str, Any], branch).get("properties", {}))
+        method_node = properties.get("method")
+        body_node = properties.get("body")
+        if not isinstance(method_node, dict) or not isinstance(body_node, dict):
+            continue
+        method = cast(dict[str, Any], method_node).get("const")
+        reference = cast(dict[str, Any], body_node).get("$ref")
+        if type(method) is not str or type(reference) is not str:
+            continue
+        # Workflow methods point at external operation schemas rather than a local $def; their
+        # bodies are built from the owning pydantic model, which already carries schema_version.
+        body = defs.get(reference.removeprefix("#/$defs/"))
+        if not isinstance(body, dict):
+            continue
+        if "schema_version" in cast(list[str], cast(dict[str, Any], body).get("required", [])):
+            expected.add(method)
+
+    assert support_methods_carrying_schema_version() == frozenset(expected)
+    assert "privacy_propose_policy" in expected
+    # A body whose schema does not declare the field must not have one injected: the setup-wizard
+    # contract closes over unevaluated properties, so an added key would be rejected outright.
+    assert "privacy_get_setup" not in expected
+
+
+def test_cli_fills_the_const_schema_version_and_never_overwrites_one() -> None:
+    supplied = JsonObject({"expected_policy_digest": "sha256:" + "a" * 64})
+    filled = with_body_schema_version("privacy_propose_policy", supplied)
+    assert filled["schema_version"] == "1.0.0"
+    assert filled["expected_policy_digest"] == supplied["expected_policy_digest"]
+
+    untouched = JsonObject({"message_type": "begin"})
+    assert with_body_schema_version("privacy_get_setup", untouched) == untouched
+
+    # A caller that names a version keeps it, so a wrong one is still rejected downstream rather
+    # than silently corrected into a request the caller did not write.
+    explicit = JsonObject({"schema_version": "9.9.9"})
+    assert with_body_schema_version("privacy_propose_policy", explicit)["schema_version"] == "9.9.9"
+
+
+def test_propose_body_without_schema_version_fails_frame_validation() -> None:
+    """Pins the failure mode, so the fix above is testing something real."""
+
+    from yoetz.adapters.privacy.catalog import encode_privacy_policy_json
+
+    policy = encode_privacy_policy_json(local_only_policy())
+    body: dict[str, JsonValue] = {
+        "expected_policy_digest": "sha256:" + "a" * 64,
+        "candidate_policy": cast(JsonValue, policy),
+    }
+    with pytest.raises(SchemaInstanceInvalid):
+        validate_schema_instance(
+            "control-request", "1.0.0", cast(JsonValue, _frame("privacy_propose_policy", body))
+        )
+
+    validate_schema_instance(
+        "control-request",
+        "1.0.0",
+        cast(JsonValue, _frame("privacy_propose_policy", {**body, "schema_version": "1.0.0"})),
+    )
+
+
+@pytest.mark.anyio
+async def test_privacy_setup_propose_sends_a_body_the_frozen_schema_accepts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interactive setup flow builds its own body; it must satisfy the same schema."""
+
+    import yoetz.cli.app as app_module
+    from yoetz.cli.privacy_setup import _propose  # pyright: ignore[reportPrivateUsage]
+
+    sent: list[JsonObject] = []
+
+    class _Client:
+        async def privacy_propose_policy(self, request: JsonObject) -> JsonObject:
+            sent.append(request)
+            return JsonObject(
+                {
+                    "outcome": "decision_required",
+                    "proposal_id": "ppr_00000000-0000-4000-8000-000000000001",
+                }
+            )
+
+        async def close(self) -> None:
+            return None
+
+    async def _client(*_args: object, **_kwargs: object) -> object:
+        return _Client()
+
+    monkeypatch.setattr(app_module, "build_service_client", _client)
+
+    policy = local_only_policy()
+    proposal_id = await _propose(policy, policy.policy_digest)
+    assert proposal_id == "ppr_00000000-0000-4000-8000-000000000001"
+    assert len(sent) == 1
+    validate_schema_instance(
+        "control-request",
+        "1.0.0",
+        cast(JsonValue, _frame("privacy_propose_policy", sent[0])),
+    )

--- a/tests/unit/kernel/test_ranking.py
+++ b/tests/unit/kernel/test_ranking.py
@@ -255,3 +255,67 @@ def test_one_material_reviewer_challenge_slot_at_default_cap() -> None:
         1,
     )
     assert challenge not in max_one.findings
+
+
+def test_reviewer_challenge_slots_scale_with_the_cap() -> None:
+    """More than one material challenge survives when the cap has room for it.
+
+    The rescue used to be exactly one challenge, so a reviewer that raised two or three material
+    discrepancies had all but the best folded into ``suppressed_count`` — invisible, and
+    indistinguishable from a reviewer that only found one. Up to half the cap is reservable now,
+    which keeps deterministic findings in the majority without discarding the rest of the review.
+    """
+
+    deterministic = tuple(_finding(index) for index in range(1, 7))
+    challenges = (
+        _finding(
+            10,
+            kind=FindingKind.MATERIAL_LIMITATION_OMITTED,
+            origin=FindingOrigin.SEMANTIC_MODEL_DERIVED,
+        ),
+        _finding(
+            11,
+            kind=FindingKind.QUESTIONABLE_FINDING_REJECTION,
+            origin=FindingOrigin.SEMANTIC_MODEL_DERIVED,
+        ),
+        _finding(
+            12,
+            kind=FindingKind.REQUESTED_ITEM_NEVER_ATTEMPTED,
+            origin=FindingOrigin.SEMANTIC_MODEL_DERIVED,
+        ),
+    )
+    context = RankingContext(_coverage(), CheckCompleteness.COMPLETE)
+
+    at_six = rank_findings(deterministic, challenges, context, 6)
+    semantic_at_six = [
+        finding
+        for finding in at_six.findings
+        if finding.origin is FindingOrigin.SEMANTIC_MODEL_DERIVED
+    ]
+    assert len(at_six.findings) == 6
+    assert len(semantic_at_six) == 3
+    assert at_six.suppressed_count == 3
+
+    at_four = rank_findings(deterministic, challenges, context, 4)
+    assert (
+        len(
+            [
+                finding
+                for finding in at_four.findings
+                if finding.origin is FindingOrigin.SEMANTIC_MODEL_DERIVED
+            ]
+        )
+        == 2
+    )
+    assert len(at_four.findings) == 4
+
+    # Deterministic findings still hold the majority of every selection.
+    for ranked in (at_six, at_four):
+        deterministic_selected = [
+            finding for finding in ranked.findings if finding.origin is FindingOrigin.DETERMINISTIC
+        ]
+        assert len(deterministic_selected) >= len(ranked.findings) // 2
+
+    # A cap of one still admits no reserved slot at all.
+    at_one = rank_findings(deterministic, challenges, context, 1)
+    assert all(finding.origin is FindingOrigin.DETERMINISTIC for finding in at_one.findings)


### PR DESCRIPTION
Semantic review reached the provider and returned challenges on four of six live calls, and a read-path query for `origin=semantic_model_derived` returned zero findings. This addresses every step between the provider and the agent where that output was being destroyed, plus the CLI bug that made the accompanying policy widening impossible to perform.

## A rejected judgment no longer destroys the check

Post-validation fenced the whole judgment: one bad ref in the third challenge discarded the first two, and the raise escaped `execute_check_commit` (which caught only `ProtocolValueError`) to become a non-retryable `INVALID_REQUEST` with no correlation id — so the deterministic findings were lost too, and nothing recorded why.

Each challenge is now fenced independently against the same frozen case, with the per-ref accept test byte-identical; only the disposition of a failure changed. Structural failures raise a narrow `SemanticJudgmentRejected` that the commit path converts to `SemanticStatus.INVALID` / `SEMANTIC_JUDGMENT_REJECTED` — present in the enum, the ledger CHECK constraints, and `check-result-1.0.0` since 0.1, and never once written — with the deterministic findings still committed.

**Invariant: a check always commits its deterministic findings, whatever the reviewer returned.**

## What the reviewer produced is now reported

- Coverage gap `semantic_challenges_rejected` when the fence drops anything.
- One counts-only durable diagnostic per dispatched review: conclusion, challenges returned, candidates accepted, challenges rejected, semantic findings selected/suppressed. It reconciles (`returned == accepted + rejected`, `accepted == selected + suppressed`), so "the model said three things and you got none of them" is never invisible.

## The model is given what it needs

`cited_refs` must match the frozen ref pattern, but the ids most visible in the packet (`items[].item_id`, e.g. `goal-3`) are not citable at all, and no field named the accept set. The assembled document now carries an explicit `citable_refs` array, and both provider prompts name it as the only citable source. The judgment schema carries a curated reviewer-facing gloss for each of the 14 finding kinds and 8 challenge fields — written for the model, never sourced from a docstring, which is what `_strip_schema_titles` still guarantees.

## Semantic findings stop vanishing

`rank_key` is untouched (kind priority dominating is deliberate); up to half the cap is now reservable for material challenges instead of exactly one.

## `privacy propose` was unusable

Separate commit. The frozen `privacy_propose_policy_body` requires a const `schema_version`, so a body without it failed frame validation inside the client and the caller saw only `invalid_request` naming nothing. `privacy_setup.py::_propose` built exactly that body, so interactive `yoetz privacy setup` could never propose a policy change either — including the review-context widening this work depends on. The CLI now fills the const in when the schema declares it and the input omitted it, passing an explicitly-supplied version through untouched. The method set is derived from the frozen schema, not listed.

## Verification

`uv run pytest tests/unit tests/integration tests/conformance` — 2047 passed. ruff clean; pyright strict 0 errors.

Live dogfood through codex-testing (gpt-5.6-luna) on a seeded obligation/claim mismatch: nine ledger events ending in `check_recorded` and `receipt_recorded`, verdict `insufficient_coverage`, `semantic_status: succeeded`, coverage limitation `semantic_review_context_withheld`, and the new accounting record firing on a real dispatched review. No check died with `INVALID_REQUEST`.

The reviewer returned zero challenges on that run because the inference channel still withholds `obligation_text` — it was asked whether the work satisfied its obligations with the obligations withheld. Confirming that a surviving challenge becomes a finding end-to-end needs the widening ceremony, which requires verified human presence and has not been run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved semantic review validation, allowing valid findings to proceed even when individual challenges are rejected.
  * Added privacy-safe diagnostics with reconciliation counts for semantic review outcomes.
  * Support requests now automatically include the required schema version when applicable.
  * Review results now include complete, citable references.

* **Bug Fixes**
  * Prevented invalid or non-citable references from being accepted as review challenges.
  * Improved selection of material findings when review limits are reached.
  * Preserved deterministic findings when semantic judgments are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes multiple places where a valid reviewer response was silently discarded before reaching the user: post-validation now fences each challenge independently (instead of raising on the first bad ref and dropping the entire judgment), the `SemanticJudgmentRejected` escape path is caught in `execute_check_commit` so deterministic findings always commit, and `privacy propose` is unblocked by injecting the required `schema_version` const.

- **Per-challenge fencing** (`check.py`, `semantic_case.py`): `validate_semantic_judgment` now counts and skips bad challenges instead of raising; a new `SemanticJudgmentReview` return type carries counts, enabling the `semantic_challenges_rejected` gap and the durable `semantic_review_accounting` record that makes \"reviewer returned N, you got 0\" auditable.
- **Reviewer context improvements** (`openai_responses.py`, `openai_chat_completions.py`, `semantic_case.py`): The assembled packet now includes an explicit `citable_refs` array; both provider prompts name it as the only citable source; the judgment schema carries curated reviewer-facing glosses for all 14 finding kinds and 8 challenge fields.
- **Ranking diversity** (`ranking.py`) and **CLI fix** (`app.py`, `privacy_setup.py`): Material semantic challenges can now occupy up to half the cap instead of exactly one slot; `with_body_schema_version` fills the required const field so `yoetz privacy setup` can propose a policy change.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive or narrowly scoped bug fixes with thorough regression tests covering the core invariants.

The three core fixes (per-challenge fencing, structural-rejection catch, CLI schema_version injection) are each guarded by regression tests that pin the exact failure mode. The observability additions follow the existing allowlist pattern precisely. No pre-existing behavior is removed; only the disposition of failure paths changes.

**Files Needing Attention:** check.py is the most consequential file — the structural-rejection accounting path emits all-zero counts worth a second look, and the SemanticJudgmentRejected catch block is the linchpin of the deterministic findings always commit invariant.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/application/check.py | Core fix: per-challenge fencing (was whole-judgment), new SemanticJudgmentRejected exception type, SemanticJudgmentReview data class, and semantic_review_accounting durable record. Logic is sound; accounting emits all-zero counts in the structural-rejection path. |
| src/yoetz/application/semantic_case.py | Adds explicit citable_refs array to the assembled review packet, computed as frontier_refs | local_check_refs — the exact accept set post-validation uses. Straightforward and well-tested. |
| src/yoetz/adapters/providers/openai_responses.py | Adds FINDING_KIND_GLOSSARY and CHALLENGE_FIELD_GLOSSARY, _apply_reviewer_glossary patches descriptions into the judgment JSON schema, and both system instructions are updated with the citable_refs constraint. Struct-level validation guards in _apply_reviewer_glossary ensure schema drift fails fast at module load. |
| src/yoetz/cli/app.py | New support_methods_carrying_schema_version() derives the required-schema_version method set from the frozen schema; with_body_schema_version fills the const when omitted. Method set is correctly derived from the schema, but the injected value 1.0.0 is hardcoded rather than read from the schema's const declaration. |
| src/yoetz/cli/privacy_setup.py | Adds the missing schema_version field to the privacy_propose_policy request body, fixing the unusable interactive setup flow. |
| src/yoetz/kernel/ranking.py | _selected_with_diversity now reserves up to max_findings // 2 seats for material challenges instead of exactly one. Algorithm is correct and well-tested; docstring claims majority for deterministic findings but the cap is 50/50 at even values. |
| src/yoetz/observability/logging.py | Adds record_bounded_counts_without_raising alongside the existing record_bounded_event variant; new semantic count fields added to _FIELD_ORDER and _FIELD_SET. Consistent with existing pattern. |
| tests/integration/application/test_check.py | Adds two integration tests: structural rejection committing deterministic findings and accounting, and partial rejection keeping accepted challenges with correct gap declaration. Tests are thorough and cover the reconciliation invariant. |
| tests/unit/cli/test_support_request_bodies.py | New test file; pins the failure mode (missing schema_version causes SchemaInstanceInvalid), verifies derived method set against the repository artifact, and exercises the full setup flow end-to-end. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ECC as execute_check_commit
    participant VSJ as validate_semantic_judgment
    participant AF as allocate_findings
    participant RSRA as _record_semantic_review_accounting
    participant Ledger

    ECC->>VSJ: validate_semantic_judgment(case, deterministic, judgment, provenance)
    alt Per-challenge fencing
        loop each challenge
            VSJ->>VSJ: _resolve_challenge_refs()
            alt refs outside case
                VSJ->>VSJ: count SEMANTIC_REJECTED_REF_OUTSIDE_CASE
            else hidden source claim
                VSJ->>VSJ: count SEMANTIC_REJECTED_HIDDEN_SOURCE_CLAIM
            else accepted
                VSJ->>VSJ: build CandidateFinding
            end
        end
        VSJ-->>ECC: SemanticJudgmentReview(candidates, challenges_returned, rejected_by_reason)
    else Structural fence fails
        VSJ-->>ECC: raise SemanticJudgmentRejected
        ECC->>ECC: record_unexpected_exception_without_raising
        ECC->>ECC: _judgment_rejected_evaluation to SemanticStatus.INVALID
    end

    ECC->>AF: allocate_findings(ids, review.candidates)
    AF-->>ECC: semantic findings tuple
    ECC->>ECC: "add SEMANTIC_CHALLENGES_REJECTED_GAP if review.challenges_rejected > 0"
    ECC->>RSRA: _record_semantic_review_accounting(request, result, review, semantic, ranked)
    RSRA->>RSRA: record_bounded_counts_without_raising
    ECC->>Ledger: commit_check_if_current(frozen, ranked, ...)
```

<sub>Reviews (2): Last reviewed commit: ["fix(cli): stop privacy propose failing o..."](https://github.com/thegaysupreme123/yoetz/commit/bc7d1256372ddd0467dc6e5e375ad121a482ffed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=20998263)</sub>

<!-- /greptile_comment -->