### PR TITLE
Enforce the provider response cap while streaming

### DIFF
--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -965,12 +965,23 @@ class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
             await response.aclose()
             raise ValueError("openai_response_encoding_forbidden")
         content_length = response.headers.get("content-length")
-        if content_length is not None and int(content_length) > OPENAI_MAX_RESPONSE_BODY_BYTES:
-            await response.aclose()
-            raise ValueError("openai_response_body_too_large")
+        if content_length is not None:
+            try:
+                declared_size = int(content_length)
+            except (TypeError, ValueError):
+                # Provider-controlled header text must not appear in structural errors.
+                await response.aclose()
+                raise ValueError("openai_response_content_length_invalid") from None
+            if declared_size > OPENAI_MAX_RESPONSE_BODY_BYTES:
+                await response.aclose()
+                raise ValueError("openai_response_body_too_large")
         stream = response.stream
-        if isinstance(stream, httpx.AsyncByteStream):
-            response.stream = _BoundedResponseByteStream(stream)
+        if not isinstance(stream, httpx.AsyncByteStream):
+            # Fail closed: never skip the byte cap for sync/missing streams.
+            # Sync streams raise RuntimeError on aclose; use the matching close path.
+            response.close()
+            raise ValueError("openai_response_stream_invalid")
+        response.stream = _BoundedResponseByteStream(stream)
         return response
 
     async def aclose(self) -> None:

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -104,6 +104,9 @@ _ALLOWED_PATHS: Final = frozenset(
         "/v1beta/openai/chat/completions",
     }
 )
+# Response content codings that transform nothing, so the raw-stream cap already bounds the
+# decoded body. Every other coding is refused: decompression could expand past the cap.
+_NO_OP_CONTENT_CODINGS: Final = frozenset({"", "identity"})
 _IDENTITY_PATTERN: Final = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$", re.ASCII)
 _MODEL_PATTERN: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$", re.ASCII)
 _HOSTNAME_PATTERN: Final = re.compile(
@@ -961,7 +964,13 @@ class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
         request.headers["authorization"] = f"Bearer {token}"
         response = await self._inner.handle_async_request(request)
         content_encoding = response.headers.get("content-encoding")
-        if content_encoding is not None and content_encoding.strip().lower() != "identity":
+        if content_encoding is not None and any(
+            coding.strip().lower() not in _NO_OP_CONTENT_CODINGS
+            for coding in content_encoding.split(",")
+        ):
+            # Only the no-op codings pass: a real coding would let decompression expand past
+            # the raw-stream cap. An absent, empty, or ``identity`` header states no coding at
+            # all, so refusing those would fail an honest uncompressed response for nothing.
             await response.aclose()
             raise ValueError("openai_response_encoding_forbidden")
         content_length = response.headers.get("content-length")

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import re
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Final, Protocol, cast
 
@@ -835,6 +836,38 @@ def classify_provider_failure(
     )
 
 
+class _BoundedResponseByteStream(httpx.AsyncByteStream):
+    """Count raw response bytes and refuse anything above the provider body cap.
+
+    ``Content-Length`` is only an early-rejection hint; chunked or headerless bodies still
+    stream through this wrapper so the cap is enforced on the bytes the SDK actually reads.
+    The overflowing chunk is never yielded: the underlying stream is closed first, then a
+    private size failure is raised for classification as generic transport unavailability.
+    """
+
+    __slots__ = ("_closed", "_inner", "_received")
+
+    def __init__(self, inner: httpx.AsyncByteStream) -> None:
+        self._inner = inner
+        self._received = 0
+        self._closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        async for chunk in self._inner:
+            size = len(chunk)
+            if self._received + size > OPENAI_MAX_RESPONSE_BODY_BYTES:
+                await self.aclose()
+                raise ValueError("openai_response_body_too_large")
+            self._received += size
+            yield chunk
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._inner.aclose()
+
+
 class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
     """Adapter-private, one-attempt custom HTTP transport bound to one credential handle.
 
@@ -842,7 +875,9 @@ class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
     method, destination, or encoding mismatch. It ignores poisoned proxy/netrc/environment
     configuration (``trust_env=False``), strips any SDK-fixed ``Authorization`` placeholder, and
     injects the real credential only inside :meth:`inject_and_start`, which the credential handle
-    invokes exactly once.
+    invokes exactly once. Response bodies are capped at :data:`OPENAI_MAX_RESPONSE_BODY_BYTES`
+    whether or not ``Content-Length`` is present; non-identity ``Content-Encoding`` is refused
+    so decompression cannot bypass the raw-stream cap.
     """
 
     __slots__ = (
@@ -925,9 +960,17 @@ class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
         token = bytes(credential_view).decode("ascii")
         request.headers["authorization"] = f"Bearer {token}"
         response = await self._inner.handle_async_request(request)
+        content_encoding = response.headers.get("content-encoding")
+        if content_encoding is not None and content_encoding.strip().lower() != "identity":
+            await response.aclose()
+            raise ValueError("openai_response_encoding_forbidden")
         content_length = response.headers.get("content-length")
         if content_length is not None and int(content_length) > OPENAI_MAX_RESPONSE_BODY_BYTES:
+            await response.aclose()
             raise ValueError("openai_response_body_too_large")
+        stream = response.stream
+        if isinstance(stream, httpx.AsyncByteStream):
+            response.stream = _BoundedResponseByteStream(stream)
         return response
 
     async def aclose(self) -> None:

--- a/src/yoetz/adapters/providers/openai_responses.py
+++ b/src/yoetz/adapters/providers/openai_responses.py
@@ -968,7 +968,7 @@ class OneAttemptCredentialTransport(httpx.AsyncBaseTransport):
         if content_length is not None:
             try:
                 declared_size = int(content_length)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 # Provider-controlled header text must not appear in structural errors.
                 await response.aclose()
                 raise ValueError("openai_response_content_length_invalid") from None

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -357,6 +357,61 @@ async def test_declared_content_length_above_cap_closes_without_reading() -> Non
 
 
 @pytest.mark.anyio
+async def test_malformed_content_length_closes_without_reading() -> None:
+    """Non-integer Content-Length must aclose and fail closed without leaking header text."""
+
+    body = _success_body()
+    inner = _ScriptedStreamTransport(
+        chunks=[body],
+        headers={"content-length": "not-a-number"},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+    assert inner.stream.chunks_started == 0
+
+
+@pytest.mark.anyio
+async def test_non_async_response_stream_is_rejected_fail_closed() -> None:
+    """Sync/missing streams must not silently skip the raw byte cap."""
+
+    body = _success_body()
+
+    class _SyncBodyStream(httpx.SyncByteStream):
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+            self.closed = False
+
+        def __iter__(self):  # noqa: ANN204 - httpx SyncByteStream contract
+            yield self._payload
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _SyncStreamTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self.stream = _SyncBodyStream(body)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            await request.aread()
+            return httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+                stream=self.stream,
+            )
+
+    inner = _SyncStreamTransport()
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+
+
+@pytest.mark.anyio
 async def test_non_identity_content_encoding_is_rejected_fail_closed() -> None:
     body = _success_body()
     inner = _ScriptedStreamTransport(

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -462,3 +462,56 @@ async def test_headerless_body_exactly_at_cap_is_accepted_by_transport() -> None
     assert body == exact
     assert inner.stream.closed is True
     assert inner.stream.chunks_started == 3
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("declared", ["identity", "", "  ", "identity, identity"])
+async def test_no_op_content_codings_are_accepted(declared: str) -> None:
+    """A header that states no coding must not fail an otherwise honest response."""
+
+    inner = _ScriptedStreamTransport(
+        chunks=[_success_body()],
+        headers={"content-encoding": declared},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultSuccess
+
+
+@pytest.mark.anyio
+async def test_a_real_coding_beside_identity_is_still_rejected() -> None:
+    inner = _ScriptedStreamTransport(
+        chunks=[_success_body()],
+        headers={"content-encoding": "identity, gzip"},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+    assert inner.stream.chunks_started == 0
+
+
+@pytest.mark.anyio
+async def test_stream_of_neither_flavour_stays_unavailable() -> None:
+    """A stream of neither flavour fails closed, whichever error the close path raises."""
+
+    class _OpaqueStream:
+        def __iter__(self):  # noqa: ANN204 - deliberately neither httpx stream flavour
+            yield b"{}"
+
+    class _OpaqueStreamTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            await request.aread()
+            response = httpx.Response(
+                200,
+                request=request,
+                headers={"content-type": "application/json"},
+            )
+            cast(Any, response).stream = _OpaqueStream()
+            return response
+
+    result, _, _ = await _evaluate_with_inner(_OpaqueStreamTransport())
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -9,16 +10,23 @@ import httpx
 import pytest
 
 from yoetz.adapters.providers.openai_responses import (
+    OPENAI_MAX_RESPONSE_BODY_BYTES,
     OneAttemptCredentialTransport,
     OpenAIProfile,
     OpenAIResponsesEvaluator,
     owner_declared_data_use_profile,
     render_case,
 )
+from yoetz.domain.findings import SemanticFailureClass
 from yoetz.domain.privacy import ApprovedOutboundCase, DataCategory, ProviderBinding
 from yoetz.ports.secret_memory import ProviderAttemptAuthBinding, ProviderAuthTransportCallback
-from yoetz.ports.semantic import Deadline, SemanticResultSuccess
+from yoetz.ports.semantic import (
+    Deadline,
+    SemanticResultSuccess,
+    SemanticResultUnavailable,
+)
 from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
+from yoetz.protocol.models import SemanticStatus
 
 _NOW = datetime(2026, 7, 25, tzinfo=UTC)
 _DIGEST = "sha256:" + "c" * 64
@@ -44,6 +52,51 @@ class _CaptureTransport(httpx.AsyncBaseTransport):
                     }
                 ],
             },
+        )
+
+
+class _ChunkedBodyStream(httpx.AsyncByteStream):
+    """Async multi-chunk body used to exercise the raw response-byte cap."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.closed = False
+        self.chunks_started = 0
+
+    async def __aiter__(self):  # noqa: ANN204 - httpx AsyncByteStream contract
+        for chunk in self._chunks:
+            if self.closed:
+                return
+            self.chunks_started += 1
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _ScriptedStreamTransport(httpx.AsyncBaseTransport):
+    """Return a header-controlled streamed response and record the request body."""
+
+    def __init__(
+        self,
+        *,
+        chunks: list[bytes],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.request_body: bytes | None = None
+        self.stream = _ChunkedBodyStream(chunks)
+        self._headers = headers
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.request_body = await request.aread()
+        headers = {"content-type": "application/json"}
+        if self._headers is not None:
+            headers.update(self._headers)
+        return httpx.Response(
+            200,
+            request=request,
+            headers=headers,
+            stream=self.stream,
         )
 
 
@@ -99,9 +152,8 @@ def _case() -> ApprovedOutboundCase:
     )
 
 
-@pytest.mark.anyio
-async def test_pinned_sdk_preserves_the_rendered_responses_body() -> None:
-    profile = OpenAIProfile(
+def _profile() -> OpenAIProfile:
+    return OpenAIProfile(
         provider_id="fireworks",
         model="accounts/fireworks/models/minimax-m3",
         endpoint_profile_id="fireworks-responses",
@@ -116,6 +168,98 @@ async def test_pinned_sdk_preserves_the_rendered_responses_body() -> None:
         host="api.fireworks.ai",
         base_path_prefix="/inference/v1",
     )
+
+
+def _binding(rendered_body_sha256: str) -> ProviderAttemptAuthBinding:
+    return ProviderAttemptAuthBinding(
+        provider_id="fireworks",
+        model_id="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+        purpose="semantic-review",
+        authorization_scope_digest=_DIGEST,
+        purpose_digest=canonical_digest({"purpose": "semantic-review"}),
+        dispatch_id="dsp_60000000-0000-4000-8000-000000000001",
+        request_body_digest=rendered_body_sha256,
+        service_generation=1,
+        monotonic_deadline=30.0,
+    )
+
+
+def _success_body() -> bytes:
+    return json.dumps(
+        {
+            "id": "resp_test",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": _JUDGMENT}],
+                }
+            ],
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _padded_body(target_size: int) -> bytes:
+    """Build a valid-looking Responses JSON body of exactly ``target_size`` bytes."""
+
+    base = {
+        "id": "resp_test",
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": _JUDGMENT}],
+            }
+        ],
+        "padding": "",
+    }
+    encoded = json.dumps(base, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > target_size:
+        raise AssertionError("base body already exceeds target size")
+    pad_len = target_size - len(encoded)
+    base["padding"] = "x" * pad_len
+    body = json.dumps(base, separators=(",", ":")).encode("utf-8")
+    # json.dumps may expand escaping; pad with raw ASCII so length is exact.
+    if len(body) != target_size:
+        # Recompute with exact pad after measuring overhead of the padding field.
+        overhead = len(body) - pad_len
+        if overhead > target_size:
+            raise AssertionError("unable to build body of target size")
+        base["padding"] = "x" * (target_size - overhead)
+        body = json.dumps(base, separators=(",", ":")).encode("utf-8")
+    if len(body) != target_size:
+        raise AssertionError(f"expected {target_size} bytes, got {len(body)}")
+    return body
+
+
+async def _evaluate_with_inner(
+    inner: httpx.AsyncBaseTransport,
+) -> tuple[Any, OpenAIProfile, ApprovedOutboundCase]:
+    profile = _profile()
+    case = _case()
+    rendered = render_case(case)
+    transport = OneAttemptCredentialTransport(
+        rendered=rendered,
+        credential=_Credential(),
+        binding=_binding(rendered.body_sha256),
+        host=profile.host,
+        port=profile.port,
+        path=profile.path,
+    )
+    cast(Any, transport)._inner = inner
+    result = await OpenAIResponsesEvaluator(profile, transport, _Clock()).evaluate(
+        case,
+        Deadline(_NOW + timedelta(seconds=30), 30.0),
+    )
+    return result, profile, case
+
+
+@pytest.mark.anyio
+async def test_pinned_sdk_preserves_the_rendered_responses_body() -> None:
+    profile = _profile()
     case = _case()
     rendered = render_case(case)
     body = cast(dict[str, Any], strict_json_parse(rendered.body))
@@ -137,41 +281,14 @@ async def test_pinned_sdk_preserves_the_rendered_responses_body() -> None:
 
 @pytest.mark.anyio
 async def test_evaluator_dispatches_the_audited_rendered_body_verbatim() -> None:
-    profile = OpenAIProfile(
-        provider_id="fireworks",
-        model="accounts/fireworks/models/minimax-m3",
-        endpoint_profile_id="fireworks-responses",
-        endpoint_profile_version="1.0.0",
-        timeout_seconds=60,
-        supports_structured_outputs=True,
-        data_use_profile=owner_declared_data_use_profile(
-            reviewed_at=_NOW,
-            expires_at=_NOW + timedelta(days=30),
-            evidence_digest=_DIGEST,
-        ),
-        host="api.fireworks.ai",
-        base_path_prefix="/inference/v1",
-    )
+    profile = _profile()
     case = _case()
     rendered = render_case(case)
-    binding = ProviderAttemptAuthBinding(
-        provider_id="fireworks",
-        model_id="accounts/fireworks/models/minimax-m3",
-        endpoint_profile_id="fireworks-responses",
-        endpoint_profile_version="1.0.0",
-        purpose="semantic-review",
-        authorization_scope_digest=_DIGEST,
-        purpose_digest=canonical_digest({"purpose": "semantic-review"}),
-        dispatch_id="dsp_60000000-0000-4000-8000-000000000001",
-        request_body_digest=rendered.body_sha256,
-        service_generation=1,
-        monotonic_deadline=30.0,
-    )
     capture = _CaptureTransport()
     transport = OneAttemptCredentialTransport(
         rendered=rendered,
         credential=_Credential(),
-        binding=binding,
+        binding=_binding(rendered.body_sha256),
         host=profile.host,
         port=profile.port,
         path=profile.path,
@@ -188,3 +305,105 @@ async def test_evaluator_dispatches_the_audited_rendered_body_verbatim() -> None
     assert result.provenance.policy_digest == case.policy_digest
     assert result.provenance.privacy_policy_digest == case.policy_digest
     assert result.provenance.policy_digest != "sha256:" + "0" * 64
+
+
+@pytest.mark.anyio
+async def test_headerless_body_over_cap_is_rejected_before_parsing() -> None:
+    """Chunked/headerless body of cap+1 fails closed as transport-unavailable."""
+
+    oversize = _padded_body(OPENAI_MAX_RESPONSE_BODY_BYTES + 1)
+    # Split so the overflow is only visible after the first chunk has been accepted.
+    split_at = OPENAI_MAX_RESPONSE_BODY_BYTES // 2
+    inner = _ScriptedStreamTransport(chunks=[oversize[:split_at], oversize[split_at:]])
+    result, _profile_unused, _case_unused = await _evaluate_with_inner(inner)
+    del _profile_unused, _case_unused
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.status is SemanticStatus.UNAVAILABLE
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+    # Stream iteration starts, but the body is closed as soon as the cap is exceeded.
+    assert inner.stream.chunks_started >= 1
+
+
+@pytest.mark.anyio
+async def test_misleading_small_content_length_still_enforces_stream_cap() -> None:
+    oversize = _padded_body(OPENAI_MAX_RESPONSE_BODY_BYTES + 1)
+    split_at = OPENAI_MAX_RESPONSE_BODY_BYTES // 2
+    inner = _ScriptedStreamTransport(
+        chunks=[oversize[:split_at], oversize[split_at:]],
+        headers={"content-length": "16"},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+
+
+@pytest.mark.anyio
+async def test_declared_content_length_above_cap_closes_without_reading() -> None:
+    body = _success_body()
+    inner = _ScriptedStreamTransport(
+        chunks=[body],
+        headers={"content-length": str(OPENAI_MAX_RESPONSE_BODY_BYTES + 1)},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+    assert inner.stream.chunks_started == 0
+
+
+@pytest.mark.anyio
+async def test_non_identity_content_encoding_is_rejected_fail_closed() -> None:
+    body = _success_body()
+    inner = _ScriptedStreamTransport(
+        chunks=[body],
+        headers={"content-encoding": "gzip"},
+    )
+    result, _, _ = await _evaluate_with_inner(inner)
+
+    assert type(result) is SemanticResultUnavailable
+    assert result.provenance.failure_class is SemanticFailureClass.TRANSPORT
+    assert inner.stream.closed is True
+    assert inner.stream.chunks_started == 0
+
+
+@pytest.mark.anyio
+async def test_headerless_body_exactly_at_cap_is_accepted_by_transport() -> None:
+    """Identity streaming that totals the cap remains supported."""
+
+    exact = b"a" * OPENAI_MAX_RESPONSE_BODY_BYTES
+    split_at = OPENAI_MAX_RESPONSE_BODY_BYTES // 3
+    chunks = [exact[:split_at], exact[split_at : 2 * split_at], exact[2 * split_at :]]
+    assert sum(len(chunk) for chunk in chunks) == OPENAI_MAX_RESPONSE_BODY_BYTES
+    inner = _ScriptedStreamTransport(chunks=chunks)
+
+    profile = _profile()
+    case = _case()
+    rendered = render_case(case)
+    transport = OneAttemptCredentialTransport(
+        rendered=rendered,
+        credential=_Credential(),
+        binding=_binding(rendered.body_sha256),
+        host=profile.host,
+        port=profile.port,
+        path=profile.path,
+    )
+    cast(Any, transport)._inner = inner
+
+    # Drive the one-attempt path the same way the SDK does, then read the body.
+    request = httpx.Request(
+        "POST",
+        f"https://{profile.host}{profile.path}",
+        content=rendered.body,
+        headers={"content-type": "application/json"},
+    )
+    response = await transport.handle_async_request(request)
+    body = await response.aread()
+
+    assert body == exact
+    assert inner.stream.closed is True
+    assert inner.stream.chunks_started == 3


### PR DESCRIPTION
## Summary

Enforces the 1 MiB OpenAI-compatible response body cap on streamed, chunked, and headerless bodies. Previously `Content-Length` was only an early-reject hint; chunked or headerless bodies could grow unbounded until the SDK finished reading.

### What changed
- Private `AsyncByteStream` wrapper counts raw response bytes during streaming and fail-closes (close + error) at 1 MiB
- Keeps `Content-Length` as an early reject path and closes the response when oversize is declared
- Fail-closed on non-identity `Content-Encoding` (compressed bodies are rejected rather than silently uncapped after decode)

### Why
Without a stream-level byte counter, dishonest or missing `Content-Length` left a path past the documented provider response cap. Closing the response on oversize and rejecting compressed encodings keeps the cap honest and fail-closed.

**Plan / issue:** https://github.com/TheGaySupreme123/yoetz/issues/104

Fixes #104

## Test plan

- [x] `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked pytest tests/unit/adapters/providers/test_openai_responses_request_shape.py -q` → 7 passed
- [x] `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked pytest tests/unit/adapters/providers tests/capability/test_provider_profile_live.py -q` → 60 passed
- [x] `ruff check` / `ruff format --check` → pass
- [x] `npx --no-install pyright` → 0 errors
- [x] `git diff --check` → pass
- [x] `scripts/scan_public_boundary.py` → PASS

Regression coverage includes oversize streams, dishonest `Content-Length`, declared oversize, compressed responses, and exact-cap acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against oversized streamed response bodies.
  * Responses with unsupported content encoding are now rejected safely.
  * Invalid or misleading response size information is handled safely.
  * Connections are closed promptly when response validation fails.
  * Responses exactly at the configured size limit continue to be accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the streaming gap in the OpenAI-compatible provider response cap: previously `Content-Length` was only an early-rejection hint, allowing chunked or headerless bodies to grow unbounded. It introduces `_BoundedResponseByteStream`, which counts raw bytes during iteration and fail-closes the connection at 1 MiB, and also rejects non-identity `Content-Encoding` to prevent decompression from bypassing the cap.

- New `_BoundedResponseByteStream` wraps the inner `httpx.AsyncByteStream`, counts bytes per chunk, calls `aclose()` and raises immediately when the cap is exceeded — the overflowing chunk is never yielded.
- `inject_and_start` now checks `Content-Encoding` before reading the stream, and calls `response.aclose()` before raising on both the encoding-forbidden and the declared-oversize paths.
- Five new unit tests cover oversize headerless streams, misleading `Content-Length`, declared-oversize early close, compressed-body rejection, and exact-cap acceptance.

<h3>Confidence Score: 3/5</h3>

Safe to merge after the malformed `Content-Length` response-leak is addressed; the streaming cap itself works correctly for well-formed headers.

The core mechanism is sound and the new tests are thorough, but `inject_and_start` still has a path where `int(content_length)` can throw before `response.aclose()` is reached — the one case the PR's own cleanup discipline missed. A hostile provider sending a non-integer `Content-Length` header would leave the response connection unreleased. All other early-exit branches were properly closed in this PR.

**Files Needing Attention:** The `inject_and_start` method in `src/yoetz/adapters/providers/openai_responses.py` around the `int(content_length)` conversion (lines 967–970) needs a guard so a malformed header also closes the response before propagating.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/providers/openai_responses.py | Adds `_BoundedResponseByteStream` wrapper and wires it into `inject_and_start`; also adds Content-Encoding rejection and proper `response.aclose()` before raises — but `int(content_length)` on a malformed header can still raise before `aclose()` is reached, leaving the response unclosed. |
| tests/unit/adapters/providers/test_openai_responses_request_shape.py | Adds five new test cases (oversize headerless stream, misleading Content-Length, declared-oversize early close, gzip rejection, exact-cap acceptance) with supporting helpers; refactors existing tests to share `_profile()` and `_binding()` factories. Coverage is thorough for the happy paths and the explicitly designed enforcement scenarios. |

<sub>Reviews (1): Last reviewed commit: ["fix(providers): enforce response body ca..."](https://github.com/thegaysupreme123/yoetz/commit/425facdce5fd6b5a25291ac5034d7739d840b48a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22114629)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->