### PR TITLE
Bound Idle Control-Socket Connections

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1166,7 +1166,9 @@ complete within **5 seconds** (entire read/write, including partial frames); aft
 session with no active requests may remain inactive for at most **5 minutes**, after which the
 stream is closed and the listener admission slot is released. Active requests exempt the session
 from the inactive timer until the final in-flight call completes; long-running calls are not
-cancelled solely for lack of a subsequent frame.
+cancelled solely for lack of a subsequent frame. Each control-result write is also wall-clock
+bounded (**5 minutes**): a peer that stops reading cannot retain an in-flight call entry (and
+thus the inactive-session exemption) indefinitely via send backpressure.
 
 The private `ControlCallRequest` envelope may carry `route_profile=policy|strict` only for `check`
 and `status`. It is set by the MCP bridge from its immutable process profile, is absent from public
@@ -2238,7 +2240,9 @@ facade and are never MCP tools.
   released. The inactive-session deadline starts immediately when no calls are active and only
   when the final call completes when calls are active; it covers a complete frame read so dripped
   partial bytes cannot retain capacity indefinitely. Active long-running calls are not cancelled
-  merely because no additional frame arrives.
+  merely because no additional frame arrives. Each control-result write is wall-clock bounded
+  (**5 minutes**) so a stalled peer cannot keep a call marked in-flight (and idle-exempt) via
+  send backpressure alone.
 - `adapters/session_events.py`: positively tested lock/suspend monitoring. v0.1 exposes foreground
   `service run` only; user-service-manager installers and hidden client spawn are absent.
 - `adapters/sqlite/connection.py`: `open_writer(path) -> apsw.Connection` (frozen PRAGMA + build

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1160,6 +1160,14 @@ arbitrary-path, or policy-loosening field or method. `service_status` is availab
 task operations are not. MCP cannot invoke lifecycle, privacy-control, or observation-control
 methods.
 
+Ordinary-control sessions are peer-authenticated over the fixed owner-only AF_UNIX control
+endpoint. Public connection liveness (enforced by the daemon, not a wire field): handshake must
+complete within **5 seconds** (entire read/write, including partial frames); after handshake, a
+session with no active requests may remain inactive for at most **5 minutes**, after which the
+stream is closed and the listener admission slot is released. Active requests exempt the session
+from the inactive timer until the final in-flight call completes; long-running calls are not
+cancelled solely for lack of a subsequent frame.
+
 The private `ControlCallRequest` envelope may carry `route_profile=policy|strict` only for `check`
 and `status`. It is set by the MCP bridge from its immutable process profile, is absent from public
 operation request models, and is rejected on every other control method. `strict` prevents
@@ -2221,6 +2229,16 @@ facade and are never MCP tools.
   runtime directory with `0700` parent/`0600` endpoints. Async bind/connect functions have no path
   overload or TCP fallback. Framing/schema/state-machine ownership remains in the ordinary and
   confidential protocol modules; these transport values never enter public workflow results.
+  Ordinary-control connection admission is bounded: each accepted stream holds one of a fixed
+  listener capacity (128) until the stream closes. The daemon enforces private wall-clock
+  liveness bounds on that path (no wire fields, error reasons, configuration options, or public
+  APIs): an ordinary-control client must complete the entire handshake — including partial-frame
+  drip — within **5 seconds**, and after handshake a session with no active requests may remain
+  inactive for at most **5 minutes** before the stream is closed and the admission slot is
+  released. The inactive-session deadline starts immediately when no calls are active and only
+  when the final call completes when calls are active; it covers a complete frame read so dripped
+  partial bytes cannot retain capacity indefinitely. Active long-running calls are not cancelled
+  merely because no additional frame arrives.
 - `adapters/session_events.py`: positively tested lock/suspend monitoring. v0.1 exposes foreground
   `service run` only; user-service-manager installers and hidden client spawn are absent.
 - `adapters/sqlite/connection.py`: `open_writer(path) -> apsw.Connection` (frozen PRAGMA + build

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -137,6 +137,7 @@ from yoetz.service.confidential_protocol import (
     encode_human_frame,
 )
 from yoetz.service.control_protocol import (
+    ControlFrame,
     ControlProtocolError,
     ControlSession,
     ControlStream,
@@ -167,6 +168,12 @@ _INSTALLATION_MARKER_DOMAIN = b"yoetz/installation-state/v1\x00"
 _SERVICE_GENERATION_DOMAIN = b"yoetz/service-generation/v1\x00"
 _MAX_INSTALLATION_MARKER_BYTES = 65_536
 _HUMAN_HEADER = struct.Struct(">4sBBI")
+# Ordinary-control connection liveness bounds (private; no wire/config surface).
+# Handshake must finish within this wall-clock window, including partial-frame drip.
+_CONTROL_HANDSHAKE_DEADLINE_SECONDS: Final = 5.0
+# After handshake, a session with no active calls may stay silent for at most this long
+# before the stream is closed and the listener admission slot is released.
+_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS: Final = 300.0
 
 _WORKFLOW_METHODS = frozenset(
     {
@@ -1018,9 +1025,17 @@ class ServiceDaemon:
         calls: dict[str, asyncio.Task[None]] = {}
         write_lock = asyncio.Lock()
         try:
-            session = await server_handshake(stream, stream.peer_identity, self.status())
+            try:
+                async with asyncio.timeout(_CONTROL_HANDSHAKE_DEADLINE_SECONDS):
+                    session = await server_handshake(stream, stream.peer_identity, self.status())
+            except TimeoutError:
+                return
             while not self._stop_event.is_set():
-                request = parse_control_request(await read_control_frame(stream))
+                try:
+                    frame = await self._read_control_frame_idle_aware(stream, calls)
+                except TimeoutError:
+                    return
+                request = parse_control_request(frame)
                 session.admit(request)
                 if not isinstance(request, ControlCallRequest):
                     target = calls.get(request.target_rpc_id)
@@ -1041,6 +1056,44 @@ class ServiceDaemon:
                 task.cancel()
             await asyncio.gather(*calls.values(), return_exceptions=True)
             await stream.aclose()
+
+    async def _read_control_frame_idle_aware(
+        self,
+        stream: ControlStream,
+        calls: dict[str, asyncio.Task[None]],
+    ) -> ControlFrame:
+        """Read one frame; apply inactive-session idle only when no calls are active.
+
+        The idle deadline starts immediately when the session has no in-flight calls, and only
+        after the final call completes when the session is busy. It covers the complete frame so
+        dripped partial bytes cannot retain a listener slot past the bound. Active long-running
+        calls are not cancelled merely because no additional frame arrives.
+        """
+
+        read_task = asyncio.create_task(read_control_frame(stream))
+        try:
+            while True:
+                if calls:
+                    done, _pending = await asyncio.wait(
+                        {read_task, *calls.values()},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if read_task in done:
+                        return await read_task
+                    # A call finished; re-check whether any remain before starting idle.
+                    continue
+                try:
+                    async with asyncio.timeout(_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS):
+                        return await read_task
+                except TimeoutError:
+                    read_task.cancel()
+                    await asyncio.gather(read_task, return_exceptions=True)
+                    raise
+        except BaseException:
+            if not read_task.done():
+                read_task.cancel()
+                await asyncio.gather(read_task, return_exceptions=True)
+            raise
 
     async def _serve_call(
         self,

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -174,6 +174,10 @@ _CONTROL_HANDSHAKE_DEADLINE_SECONDS: Final = 5.0
 # After handshake, a session with no active calls may stay silent for at most this long
 # before the stream is closed and the listener admission slot is released.
 _CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS: Final = 300.0
+# Response-frame send must complete within this wall-clock window. A stalled peer that stops
+# reading cannot retain an in-flight entry in ``calls`` (and thus the inactive-session exemption)
+# indefinitely via write backpressure on sock_sendall.
+_CONTROL_RESPONSE_WRITE_DEADLINE_SECONDS: Final = 300.0
 
 _WORKFLOW_METHODS = frozenset(
     {
@@ -1080,7 +1084,11 @@ class ServiceDaemon:
                     )
                     if read_task in done:
                         return await read_task
-                    # A call finished; re-check whether any remain before starting idle.
+                    # Done-callbacks that pop from ``calls`` are scheduled via call_soon and may
+                    # not have run yet. Prune completed tasks now so idle can start on this turn.
+                    for rpc_id, task in tuple(calls.items()):
+                        if task.done():
+                            calls.pop(rpc_id, None)
                     continue
                 try:
                     async with asyncio.timeout(_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS):
@@ -1105,7 +1113,8 @@ class ServiceDaemon:
         result = await self.dispatch(session.client_kind, request, _defer_stop=True)
         session.correlate(result)
         async with write_lock:
-            await write_control_frame(stream, result)
+            async with asyncio.timeout(_CONTROL_RESPONSE_WRITE_DEADLINE_SECONDS):
+                await write_control_frame(stream, result)
         if request.method is ControlMethod.SERVICE_STOP and result.outcome == "ok":
             await self.stop()
 

--- a/tests/integration/service/test_control_connection_idle_bounds.py
+++ b/tests/integration/service/test_control_connection_idle_bounds.py
@@ -36,6 +36,7 @@ from yoetz.ports.control import (
 )
 from yoetz.protocol.ids import IdKind, new_id
 from yoetz.service.control_protocol import (
+    ControlProtocolError,
     client_handshake,
     parse_control_result,
     read_control_frame,
@@ -314,10 +315,13 @@ async def test_active_request_exempts_session_from_idle_deadline(
         assert result.method is ControlMethod.SERVICE_STATUS
 
         # After the final call completes, the inactive deadline begins. Withholding the next
-        # frame must eventually close the stream.
+        # frame must eventually close the stream. Assert the server-side close path
+        # (ControlProtocolError on EOF), not a client wait_for TimeoutError that would mask a
+        # missing idle eviction.
         await asyncio.sleep(_SHORT_IDLE + 0.25)
-        with pytest.raises(Exception):
+        with pytest.raises(ControlProtocolError) as idle_close:
             await asyncio.wait_for(read_control_frame(client), timeout=1.0)
+        assert idle_close.value.reason == "frame_invalid"
     finally:
         await client.aclose()
         await _shutdown(daemon, accept_task, listener)

--- a/tests/integration/service/test_control_connection_idle_bounds.py
+++ b/tests/integration/service/test_control_connection_idle_bounds.py
@@ -1,0 +1,360 @@
+"""AF_UNIX regressions for ordinary-control handshake and inactive-session bounds.
+
+Closes the validated slot-exhaustion path (issue #106): same-UID clients that withhold the
+handshake or the next post-handshake frame must not retain listener admission capacity
+indefinitely. Active long-running calls remain exempt from the inactive timer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sys
+import tempfile
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import yoetz.adapters.control.unix_socket as unix_socket_module
+import yoetz.service.daemon as daemon_module
+from yoetz.adapters.control.unix_socket import (
+    RUNTIME_DIRECTORY_MODE,
+    AuthenticatedUnixStream,
+    bind_control_listener,
+    close_endpoint,
+    connect_control,
+)
+from yoetz.domain.values import JsonObject
+from yoetz.ports.control import (
+    ControlCallRequest,
+    ControlClientKind,
+    ControlMethod,
+    ControlResult,
+    ServiceState,
+)
+from yoetz.protocol.ids import IdKind, new_id
+from yoetz.service.control_protocol import (
+    client_handshake,
+    parse_control_result,
+    read_control_frame,
+    write_control_frame,
+)
+from yoetz.service.daemon import ServiceComposition, ServiceDaemon
+from yoetz.service.lifecycle import ServiceLifecycle
+from yoetz.service.vault import VaultMode
+
+_INSTANCE_ID = "svc_00000000-0000-4000-8000-000000000106"
+_COMMITMENT = "sha256:" + "6" * 64
+_CAPACITY = 2
+_SHORT_HANDSHAKE = 0.25
+_SHORT_IDLE = 0.35
+_LONG_CALL = 0.9
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def runtime_directory(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    runtime = Path(tempfile.mkdtemp(prefix=".yctl-idle-", dir=Path.cwd()))
+    runtime.chmod(RUNTIME_DIRECTORY_MODE)
+    monkeypatch.setattr(
+        "yoetz.adapters.control.unix_socket._runtime_directory",
+        lambda: runtime,
+    )
+    try:
+        yield runtime
+    finally:
+        shutil.rmtree(runtime)
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return datetime(2026, 8, 2, tzinfo=UTC)
+
+    def monotonic_seconds(self) -> float:
+        return 10.0
+
+
+class _GenerationStore:
+    def advance(self, instance_id: str) -> int:
+        assert instance_id == _INSTANCE_ID
+        return 1
+
+
+class _Capability:
+    active = False
+
+
+class _Monitor:
+    capability = _Capability()
+
+    async def start(self, callback: object) -> None:
+        del callback
+
+    async def close(self) -> None:
+        return None
+
+
+class _Vault:
+    mode = VaultMode.OS_KEYRING
+    generation = 1
+    ready = True
+
+    async def lock(self) -> None:
+        self.ready = False
+
+    async def close(self) -> None:
+        self.ready = False
+
+
+class _Application:
+    provider_credential_connected = False
+
+    async def close(self) -> None:
+        return None
+
+
+async def _daemon_with_real_listener() -> tuple[ServiceDaemon, asyncio.Task[None]]:
+    listener = await bind_control_listener()
+    lifecycle = ServiceLifecycle(
+        _Clock(),
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment=_COMMITMENT,
+        instance_id=_INSTANCE_ID,
+    )
+    composition = ServiceComposition(
+        lifecycle=lifecycle,
+        control_listener=listener,  # pyright: ignore[reportArgumentType]
+        secret_ingress_listener=None,
+        human_control_listener=None,
+        human_control_service=None,
+        session_monitor=_Monitor(),  # pyright: ignore[reportArgumentType]
+        vault=_Vault(),
+        application=_Application(),  # pyright: ignore[reportArgumentType]
+    )
+    daemon = ServiceDaemon(_composition=composition)
+    await daemon.start()
+    assert daemon.composition.lifecycle.state is ServiceState.READY
+    accept_task = asyncio.create_task(
+        daemon._accept_loop(  # pyright: ignore[reportPrivateUsage]
+            listener,  # pyright: ignore[reportArgumentType]
+            daemon._serve_control_connection,  # pyright: ignore[reportPrivateUsage]
+        )
+    )
+    return daemon, accept_task
+
+
+async def _shutdown(
+    daemon: ServiceDaemon,
+    accept_task: asyncio.Task[None],
+    listener: object,
+) -> None:
+    accept_task.cancel()
+    await asyncio.gather(accept_task, return_exceptions=True)
+    await daemon.close()
+    await close_endpoint(listener)  # pyright: ignore[reportArgumentType]
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" or sys.platform.startswith("linux")),
+    reason="certified local peer APIs are macOS/Linux only",
+)
+async def test_handshake_withholders_release_slots_after_deadline(
+    runtime_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del runtime_directory
+    monkeypatch.setattr(unix_socket_module, "_MAX_ACTIVE_CONNECTIONS", _CAPACITY)
+    monkeypatch.setattr(daemon_module, "_CONTROL_HANDSHAKE_DEADLINE_SECONDS", _SHORT_HANDSHAKE)
+    monkeypatch.setattr(daemon_module, "_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS", _SHORT_IDLE)
+
+    daemon, accept_task = await _daemon_with_real_listener()
+    listener = daemon.composition.control_listener
+    holders = [await connect_control() for _ in range(_CAPACITY)]
+    try:
+        # Fill every admission slot with clients that never send a handshake. Connect still
+        # succeeds into the listen backlog; the bound is that a further session cannot complete
+        # handshake until a slot is released.
+        await asyncio.sleep(0.05)
+
+        legitimate = await connect_control()
+        blocked_handshake = asyncio.create_task(
+            client_handshake(legitimate, ControlClientKind.CLI, "0.1.0")
+        )
+        await asyncio.sleep(0.1)
+        assert not blocked_handshake.done(), (
+            "legitimate handshake must wait while capacity is exhausted"
+        )
+
+        # After the short handshake deadline, stale streams close and release slots.
+        session = await asyncio.wait_for(blocked_handshake, timeout=_SHORT_HANDSHAKE + 1.5)
+        try:
+            assert session.protocol_version == "1.0"
+            assert session.service_instance_id == _INSTANCE_ID
+        finally:
+            await legitimate.aclose()
+    finally:
+        for holder in holders:
+            await holder.aclose()
+        await _shutdown(daemon, accept_task, listener)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" or sys.platform.startswith("linux")),
+    reason="certified local peer APIs are macOS/Linux only",
+)
+async def test_post_handshake_frame_withholders_release_slots_after_idle(
+    runtime_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del runtime_directory
+    monkeypatch.setattr(unix_socket_module, "_MAX_ACTIVE_CONNECTIONS", _CAPACITY)
+    monkeypatch.setattr(daemon_module, "_CONTROL_HANDSHAKE_DEADLINE_SECONDS", 5.0)
+    monkeypatch.setattr(daemon_module, "_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS", _SHORT_IDLE)
+
+    daemon, accept_task = await _daemon_with_real_listener()
+    listener = daemon.composition.control_listener
+    holders: list[AuthenticatedUnixStream] = []
+    try:
+        for _ in range(_CAPACITY):
+            client = await connect_control()
+            holders.append(client)
+            await client_handshake(client, ControlClientKind.CLI, "0.1.0")
+            # Withhold every subsequent frame; idle countdown starts immediately.
+
+        await asyncio.sleep(0.05)
+        legitimate = await connect_control()
+        blocked_handshake = asyncio.create_task(
+            client_handshake(legitimate, ControlClientKind.CLI, "0.1.0")
+        )
+        await asyncio.sleep(0.1)
+        assert not blocked_handshake.done(), (
+            "legitimate handshake must wait while idle sessions hold slots"
+        )
+
+        session = await asyncio.wait_for(blocked_handshake, timeout=_SHORT_IDLE + 1.5)
+        try:
+            assert session.service_instance_id == _INSTANCE_ID
+        finally:
+            await legitimate.aclose()
+    finally:
+        for holder in holders:
+            await holder.aclose()
+        await _shutdown(daemon, accept_task, listener)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" or sys.platform.startswith("linux")),
+    reason="certified local peer APIs are macOS/Linux only",
+)
+async def test_active_request_exempts_session_from_idle_deadline(
+    runtime_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request longer than the idle interval still completes; idle starts only after it ends."""
+
+    del runtime_directory
+    monkeypatch.setattr(unix_socket_module, "_MAX_ACTIVE_CONNECTIONS", 8)
+    monkeypatch.setattr(daemon_module, "_CONTROL_HANDSHAKE_DEADLINE_SECONDS", 5.0)
+    monkeypatch.setattr(daemon_module, "_CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS", _SHORT_IDLE)
+
+    original_dispatch = ServiceDaemon.dispatch
+
+    async def _slow_status_dispatch(
+        self: ServiceDaemon,
+        client_kind: ControlClientKind,
+        request: ControlCallRequest,
+        *,
+        projection_context: object | None = None,
+        _defer_stop: bool = False,
+    ) -> ControlResult:
+        if request.method is ControlMethod.SERVICE_STATUS:
+            await asyncio.sleep(_LONG_CALL)
+        return await original_dispatch(
+            self,
+            client_kind,
+            request,
+            projection_context=projection_context,  # pyright: ignore[reportArgumentType]
+            _defer_stop=_defer_stop,
+        )
+
+    monkeypatch.setattr(ServiceDaemon, "dispatch", _slow_status_dispatch)
+
+    daemon, accept_task = await _daemon_with_real_listener()
+    listener = daemon.composition.control_listener
+    client = await connect_control()
+    try:
+        session = await client_handshake(client, ControlClientKind.CLI, "0.1.0")
+        request = ControlCallRequest(
+            kind="call",
+            protocol_version="1.0",
+            rpc_id=new_id(IdKind.CONTROL_RPC),
+            service_instance_id=session.service_instance_id,
+            service_generation=session.service_generation,
+            method=ControlMethod.SERVICE_STATUS,
+            body=JsonObject({}),
+        )
+        # No further frames while the call is in flight; idle must not cancel it.
+        await write_control_frame(client, request)
+        assert _LONG_CALL > _SHORT_IDLE
+        await asyncio.sleep(_SHORT_IDLE + 0.1)
+        # Stream must still be live so the result frame can arrive after the long call.
+        result = parse_control_result(
+            await asyncio.wait_for(read_control_frame(client), timeout=_LONG_CALL + 1.0)
+        )
+        assert result.outcome == "ok"
+        assert result.method is ControlMethod.SERVICE_STATUS
+
+        # After the final call completes, the inactive deadline begins. Withholding the next
+        # frame must eventually close the stream.
+        await asyncio.sleep(_SHORT_IDLE + 0.25)
+        with pytest.raises(Exception):
+            await asyncio.wait_for(read_control_frame(client), timeout=1.0)
+    finally:
+        await client.aclose()
+        await _shutdown(daemon, accept_task, listener)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not (sys.platform == "darwin" or sys.platform.startswith("linux")),
+    reason="certified local peer APIs are macOS/Linux only",
+)
+async def test_valid_handshake_and_service_status_still_succeed(
+    runtime_directory: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retain a positive control for ordinary valid handshake + one structural call."""
+
+    del runtime_directory
+    monkeypatch.setattr(unix_socket_module, "_MAX_ACTIVE_CONNECTIONS", 8)
+
+    daemon, accept_task = await _daemon_with_real_listener()
+    listener = daemon.composition.control_listener
+    client = await connect_control()
+    try:
+        session = await client_handshake(client, ControlClientKind.CLI, "0.1.0")
+        request = ControlCallRequest(
+            kind="call",
+            protocol_version="1.0",
+            rpc_id=new_id(IdKind.CONTROL_RPC),
+            service_instance_id=session.service_instance_id,
+            service_generation=session.service_generation,
+            method=ControlMethod.SERVICE_STATUS,
+            body=JsonObject({}),
+        )
+        await write_control_frame(client, request)
+        result = parse_control_result(await read_control_frame(client))
+        assert result.outcome == "ok"
+        assert result.method is ControlMethod.SERVICE_STATUS
+    finally:
+        await client.aclose()
+        await _shutdown(daemon, accept_task, listener)


### PR DESCRIPTION
## Summary

Closes the same-UID ordinary-control AF_UNIX slot-exhaustion path without changing the wire protocol (**Fixes #106**).

Ordinary-control clients must finish the handshake within **5 seconds** and may remain inactive for at most **5 minutes** when no requests are active. Active long-running calls are exempt from the idle timer. Existing stream cleanup still releases the listener admission slot.

### What changed

- Private daemon constants for the 5s handshake deadline and 5min inactive-session idle
- Bounded handshake read/write (including partial-frame slowloris)
- Idle-aware post-handshake frame reader: deadline starts when no calls are active; cancel pending frame read and close stream on expiry
- Document bounds in `docs/INTERFACES.md`
- AF_UNIX regressions with reduced test-only capacity (handshake withhold, post-handshake frame withhold, positive long-call control)

### Why

Admitted clients could hold listener capacity indefinitely by withholding the handshake or post-handshake frames, denying legitimate local control clients (availability / local DoS against the control plane).

## Plan reference

Issue [#106](https://github.com/TheGaySupreme123/yoetz/issues/106) — Fix Issue 04 plan: bound idle ordinary-control socket connections (handshake + inactive session). Design-gated protocol/public control behavior; disconnect timing documented in INTERFACES.md.

## Test plan

- [x] `uv run --locked pytest tests/integration/service/test_control_connection_idle_bounds.py -v` → 4 passed
- [x] `uv run --locked pytest tests/integration/service/test_local_control_channel.py tests/capability/test_local_control_channel.py tests/unit/service/test_control_protocol.py tests/unit/service/test_client.py tests/integration/service/test_daemon_clients.py tests/integration/service/test_control_connection_idle_bounds.py -v` → 71 passed
- [x] `uv run ruff check` + `format --check` on `daemon.py` and idle bounds tests → pass
- [x] `npx --no-install pyright` on same → 0 errors
- [x] AF_UNIX slot-exhaustion regressions (handshake withhold, post-handshake withhold) green
- [x] Positive long-call control: request longer than test idle interval completes; idle begins after request finishes

## Fixes

Fixes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection liveness protections for control sessions.
  * Handshakes must complete within 5 seconds.
  * Inactive sessions close after 5 minutes, while active requests remain connected.
  * Long-running requests are not cancelled solely because no new data is received.
  * Listener capacity is limited to 128 connections, with slots reclaimed after sessions close.
* **Tests**
  * Added coverage for connection limits, timeout handling, active requests, and valid service-status requests.
* **Documentation**
  * Documented control-connection timeout and admission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Closes the AF_UNIX control-socket slot-exhaustion path (issue #106) by enforcing a 5-second handshake deadline and a 5-minute inactive-session deadline on ordinary-control connections. Both bounds are private wall-clock limits with no wire, config, or public API surface.

- `daemon.py` wraps `server_handshake` with `asyncio.timeout(5)` and introduces `_read_control_frame_idle_aware`, which uses an `asyncio.wait` loop to detect when the `calls` dict empties before arming the 300-second idle timer; `read_task` is explicitly cancelled in every exception path.
- New integration tests cover handshake-withhold, post-handshake frame-withhold, and long-call exemption using monkeypatched sub-second constants.
- `docs/INTERFACES.md` documents both bounds in the ordinary-control session and AF_UNIX transport sections.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the timeout and idle-timer logic is correct, all exception paths cancel the background read task, and the slot-exhaustion regressions pass.

The _read_control_frame_idle_aware loop is well-structured: read_task cleanup is handled in both the TimeoutError and BaseException branches, CancelledError propagates cleanly through asyncio.timeout, and the idle timer correctly arms only when calls is empty. The one test assertion — pytest.raises(Exception) for the post-call stream-closure check — is too broad to distinguish a server-side idle eviction from a wait_for timeout, so a broken idle timer would still pass that assertion. The calls-dict/done-callback timing in the loop means the 300-second timer starts one event-loop turn after the final call completes rather than exactly at that moment.

**Files Needing Attention:** tests/integration/service/test_control_connection_idle_bounds.py — the test_active_request_exempts_session_from_idle_deadline post-idle assertion; src/yoetz/service/daemon.py — _read_control_frame_idle_aware loop re-entry when done callbacks are pending

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/service/daemon.py | Adds handshake (5s) and inactive-session (300s) timeouts to _serve_control_connection; new _read_control_frame_idle_aware method correctly cancels read_task on timeout and propagates CancelledError without double-cancellation |
| tests/integration/service/test_control_connection_idle_bounds.py | New integration tests for handshake-withhold, post-handshake frame-withhold, long-call exemption, and positive control; tests use sub-second timing constants patched via monkeypatch which could be fragile under load |
| docs/INTERFACES.md | Documents the new 5s/300s liveness bounds in both the ordinary-control session section and the AF_UNIX transport section; accurate and consistent with the implementation |

<sub>Reviews (1): Last reviewed commit: ["fix(service): bound idle ordinary-contro..."](https://github.com/thegaysupreme123/yoetz/commit/e954232f53845a0db84bcb8d7ada722dc23f0ba9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22256562)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->