### PR TITLE
fix(importer): authorize terminal import replay against its writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ describes behavior intended for the first release rather than a change from a pr
   Responses adapter, a local-model AF_UNIX profile, and a scripted fake provider for testing.
 - Codex integration as the first-party harness adapter: an explicit trusted-project skill
   install/status/remove flow, an MCP stdio bridge, and a JSONL transcript importer. The tested
-  Codex version set remains empty pending exact installed-artifact capability evidence.
+  Codex version set remains empty pending exact installed-artifact capability evidence. An import
+  job belongs to the writer that published it: only that writer resumes it or replays its terminal
+  report, and another writer submitting the same source bytes is refused rather than shown the
+  owner's report, request id, or report locator.
 - Backup, restore, and forward-only migration support with frontier-pinned manifests and verified
   route switches; see [`docs/runbooks/`](docs/runbooks/) for the operator procedures.
 

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1920,6 +1920,12 @@ verify these reservations inside their authoritative transaction; terminal trans
 delete them. The closed quarantine registry contains the six source/object/plan/batch/report/phase
 contradiction codes plus `import_commit_state_ambiguous`; malformed or unknown input is a gap.
 
+A job belongs to the writer that published it. `reserve_or_resume` decides that boundary before it
+reads job state, so only the stored `publishing_writer_id` can resume a pending job or replay a
+terminal one; any other writer submitting the same source bytes gets non-retryable
+`INVALID_REQUEST` and never sees the owner's report, request id, or report locator, and its own
+request id stays unaliased. Both adapters decide this at the same point.
+
 Application import/review owns frozen `ImportCodexJsonlRequest`, `ImportReportInternal`,
 `ReviewRequest`, `ReviewCounts`, and `ReviewInternal`. The internal results contain no
 `privacy_projection` and perform no disclosure call; the central application facade projects the

--- a/src/yoetz/adapters/memory/importer.py
+++ b/src/yoetz/adapters/memory/importer.py
@@ -478,6 +478,18 @@ class MemoryImporter:
                 self._state.revision += 1
                 outcome = ImportAllocationOutcome.RESERVED
             else:
+                # The writer boundary is decided before any job state is read or recorded.
+                # A terminal job replays the publishing writer's report, request id, and
+                # report locator, so a foreign writer has to be refused ahead of that branch
+                # rather than one branch after it. Deciding here also keeps the caller's
+                # request id unaliased to a job it can never own. A foreign writer could
+                # never resume a pending job either, so the refusal is not retryable.
+                if job.publishing_writer_id != command.requesting_writer_id:
+                    raise _error(
+                        PublicErrorCode.INVALID_REQUEST,
+                        "This import source belongs to a different writer.",
+                        retryable=False,
+                    )
                 if alias is None:
                     self._state.aliases[alias_key] = _Alias(
                         command.request_digest, identity_digest, now
@@ -485,12 +497,6 @@ class MemoryImporter:
                 if job.state is not ImportState.PENDING:
                     self._state.revision += alias is None
                     return self._allocation(job, command, ImportAllocationOutcome.REPLAYED)
-                if job.publishing_writer_id != command.requesting_writer_id:
-                    raise _error(
-                        PublicErrorCode.OPERATION_PENDING,
-                        "Import is already pending.",
-                        retryable=True,
-                    )
                 live = (
                     job.owner_generation == self._fence.owner_generation
                     and job.lease_expires_at is not None

--- a/src/yoetz/adapters/sqlite/importer.py
+++ b/src/yoetz/adapters/sqlite/importer.py
@@ -291,16 +291,21 @@ class SqliteImporter:
                     )
                     outcome = ImportAllocationOutcome.RESERVED
                 else:
+                    # Same boundary and same order as MemoryImporter: refuse a foreign writer
+                    # before the terminal branch can replay the publishing writer's report,
+                    # request id, and report locator, and before the alias insert below binds
+                    # the caller's request id to a job it can never own. row[6] is
+                    # publishing_writer_id.
+                    if row[6] != command.requesting_writer_id:
+                        raise _error(
+                            PublicErrorCode.INVALID_REQUEST,
+                            "This import source belongs to a different writer.",
+                            retryable=False,
+                        )
                     state = cast(str, row[21])
                     if state != ImportState.PENDING.value:
                         outcome = ImportAllocationOutcome.REPLAYED
                     else:
-                        if row[6] != command.requesting_writer_id:
-                            raise _error(
-                                PublicErrorCode.OPERATION_PENDING,
-                                "Import is already pending.",
-                                retryable=True,
-                            )
                         live = (
                             row[24] == str(self._fence.owner_generation)
                             and row[27] is not None

--- a/tests/conformance/adapters/test_importer_persistence.py
+++ b/tests/conformance/adapters/test_importer_persistence.py
@@ -39,6 +39,7 @@ from yoetz.ports.importer import (
     CapturedImportSource,
     EncryptedImportReportRef,
     ImportAllocation,
+    ImportAllocationOutcome,
     ImportBatch,
     ImportCommand,
     ImportEventCandidate,
@@ -68,6 +69,7 @@ from yoetz.protocol.ids import IdKind
 _TASK = "tsk_00000000-0000-4000-8000-000000000001"
 _SESSION = "ses_00000000-0000-4000-8000-000000000002"
 _WRITER = "wri_00000000-0000-4000-8000-000000000003"
+_OTHER_WRITER = "wri_00000000-0000-4000-8000-000000000009"
 _SERVICE = "svc_00000000-0000-4000-8000-000000000004"
 _DIGEST = "sha256:" + "0" * 64
 _NOW = datetime(2026, 7, 19, tzinfo=UTC)
@@ -163,10 +165,10 @@ def _source(number: int) -> tuple[CapturedImportSource, ImportSourceIdentity]:
     return source, identity
 
 
-def _command(identity: ImportSourceIdentity, number: int) -> ImportCommand:
+def _command(identity: ImportSourceIdentity, number: int, writer: str = _WRITER) -> ImportCommand:
     return ImportCommand(
         session_id=session_id(_SESSION),
-        requesting_writer_id=writer_id(_WRITER),
+        requesting_writer_id=writer_id(writer),
         request_id=request_id(_uuid_id("req", number)),
         request_digest=_DIGEST,
         source_identity=identity,
@@ -545,4 +547,108 @@ async def test_prepare_and_review_sources_are_memory_sqlite_equivalent(tmp_path:
             )
         assert quarantined.value.code is PublicErrorCode.STORAGE_CORRUPT
 
+    writer_db.close()
+
+
+@pytest.mark.anyio
+async def test_reserve_or_resume_refuses_a_foreign_writer(tmp_path: Path) -> None:
+    """A writer that did not publish an import never reaches its job.
+
+    Both adapters keyed replay on the source identity alone, so a second writer submitting
+    the same source bytes was handed the publishing writer's terminal report, original
+    request id, and report object locator. The writer boundary now decides before the
+    terminal branch, in both adapters, for pending and terminal jobs alike.
+    """
+
+    fence = OwnershipFence(_SERVICE, 1, 1, _NONCE)
+    clock = cast(ClockPort, _Clock())
+    ids = cast(IdPort, _Ids())
+    objects = cast(ObjectStorePort, None)
+    ledger = cast(LedgerPort, None)
+    memory_state = MemoryImportState()
+    memory = MemoryImporter(
+        task_id=_TASK,
+        admitted_session_id=_SESSION,
+        ownership_fence=fence,
+        state=memory_state,
+        transaction_lock=asyncio.Lock(),
+        objects=objects,
+        ledger=ledger,
+        clock=clock,
+        ids=ids,
+        plan_preparer=_unexpected_prepare_plan,
+        plan_reader=_unexpected_read_plan,
+    )
+
+    database_path = tmp_path / "foreign-writer.sqlite3"
+    writer_db = apsw.Connection(str(database_path))
+    initialize_bundle(
+        writer_db,
+        {
+            "task_id": _TASK,
+            "owner_generation": "1",
+            "owner_nonce": _NONCE,
+        },
+    )
+    for writer in (_WRITER, _OTHER_WRITER):
+        # The foreign writer is a real, admitted writer: the refusal has to come from the
+        # import writer boundary, not from an absent row or a foreign-key failure.
+        writer_db.execute(
+            "INSERT INTO writers VALUES (?,?,?,?,?,?,?)",
+            (writer, _TASK, _SESSION, 1, "genesis", "active", format_rfc3339_millis(_NOW)),
+        )
+
+    def read_factory() -> apsw.Connection:
+        return apsw.Connection(str(database_path))
+
+    sqlite = SqliteImporter(
+        task_id=_TASK,
+        admitted_session_id=_SESSION,
+        ownership_fence=fence,
+        writer=cast(SqliteWriterThread, _ImmediateWriter(writer_db)),
+        read_factory=read_factory,
+        objects=objects,
+        ledger=ledger,
+        clock=clock,
+        ids=ids,
+        plan_preparer=_unexpected_prepare_plan,
+        plan_reader=_unexpected_read_plan,
+    )
+
+    def aliases_for(writer: str) -> int:
+        rows = writer_db.execute(
+            "SELECT count(*) FROM import_request_aliases WHERE requesting_writer_id=?", (writer,)
+        ).fetchone()
+        return cast(int, cast(tuple[object, ...], rows)[0])
+
+    for number, importer in ((50, memory), (51, sqlite)):
+        source, identity = _source(number)
+        owned = await importer.reserve_or_resume(_command(identity, number * 100 + 1), source)
+
+        # Pending: a foreign writer could never resume this job, so it is refused outright.
+        with pytest.raises(PublicOperationError) as pending:
+            await importer.reserve_or_resume(
+                _command(identity, number * 100 + 2, _OTHER_WRITER), source
+            )
+        assert pending.value.code is PublicErrorCode.INVALID_REQUEST
+        assert pending.value.retryable is False
+
+        await importer.quarantine(owned, ImportSafeReason("import_phase_state_contradiction"))
+
+        # Terminal: the branch that used to hand back the publishing writer's report.
+        with pytest.raises(PublicOperationError) as terminal:
+            await importer.reserve_or_resume(
+                _command(identity, number * 100 + 3, _OTHER_WRITER), source
+            )
+        assert terminal.value.code is PublicErrorCode.INVALID_REQUEST
+        assert terminal.value.retryable is False
+
+        # The publishing writer still replays its own terminal job.
+        replayed = await importer.reserve_or_resume(_command(identity, number * 100 + 4), source)
+        assert replayed.outcome is ImportAllocationOutcome.REPLAYED
+
+    # A refused writer leaves no trace: its request ids stay unbound and free to reuse.
+    assert not [key for key in memory_state.aliases if key[0] == _OTHER_WRITER]
+    assert aliases_for(_OTHER_WRITER) == 0
+    assert aliases_for(_WRITER) > 0
     writer_db.close()


### PR DESCRIPTION
Closes finding 7 (`medium`, `CWE-862`) from the `codex-security` repository scan: *Terminal import replay crosses the publishing-writer boundary*.

## The defect

An import job is keyed by source identity — `(task_id, source_commitment, codex_capability_profile_id, mapping_version)` — and both adapters checked `publishing_writer_id` only *inside* the pending branch:

```python
if job.state is not ImportState.PENDING:
    return self._allocation(job, command, ImportAllocationOutcome.REPLAYED)   # <- foreign writer lands here
if job.publishing_writer_id != command.requesting_writer_id:
    raise ...
```

A terminal job was therefore replayed to whoever asked. Any writer with task access and the same source bytes got the publishing writer's stored report, its original `request_id`, and its report object locator back from `reserve_or_resume`, via `execute_import_codex_jsonl`.

## The fix

Decide the writer boundary before any job state is read, at the same point in both adapters. Only the stored `publishing_writer_id` resumes a pending job or replays a terminal one.

- **`INVALID_REQUEST`, non-retryable.** `PublicErrorCode` is a closed wire enum with no authorization code, and the importer already rejects identity-level problems with `INVALID_REQUEST`. The pending branch previously answered a foreign writer with retryable `OPERATION_PENDING` — telling it to keep retrying a job it could never obtain. That case is now the same single answer, so "pending" and "terminal" no longer differ for a writer that owns neither.
- **Ahead of the alias write.** A refused writer's `request_id` stays unaliased and reusable. SQLite already rolled back; the memory adapter wrote the alias one branch too early.

## Tests

`test_reserve_or_resume_refuses_a_foreign_writer` runs both adapters over pending and terminal jobs:

- negative control: the publishing writer still replays its own terminal job
- the foreign writer is a real admitted row in `writers`, so the refusal cannot come from a foreign-key failure
- asserts no alias survives for the refused writer in either adapter

**Fails before the fix.** With the source changes stashed, the pending assertion gets `OPERATION_PENDING`; with that assertion suppressed, the terminal branch reports `DID NOT RAISE` — it hands over the replay.

## Verification

- full bounded suite: 2748 passed, 16 skipped, 4 xfailed
- `ruff check` / `ruff format --check` clean
- `pyright --strict` clean on the changed files

## Out of scope

`load_review_source(digest, frontier)` is task-scoped rather than writer-scoped — any writer in the task can read any import's review source by digest. The scan did not flag it and it returns review content rather than the owner's request id or report locator, so it is untouched here. It is the nearest sibling of this boundary if it deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Import jobs are now restricted to the writer that originally published them.
  * Other writers receive a non-retryable invalid-request error without access to job status, reports, request IDs, or locators.
  * Original writers can continue to resume pending jobs and replay terminal results normally.

* **Documentation**
  * Updated integration and interface documentation to describe import-job ownership behavior.

* **Tests**
  * Added coverage confirming ownership enforcement for pending and completed imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a missing-authorization defect (CWE-862) in `reserve_or_resume`: both the memory and SQLite importer adapters previously checked `publishing_writer_id` only inside the pending branch, letting any writer with matching source bytes replay a terminal job and receive the original owner's report, `request_id`, and report locator.

- **Memory adapter**: the writer-boundary check is moved to the top of the `else` branch — before the alias write and before the terminal/pending state split — so the foreign writer's `request_id` is never aliased and no state is mutated.
- **SQLite adapter**: same repositioning; the raise triggers `except BaseException → rollback`, ensuring the `INSERT OR IGNORE` alias row never commits.
- **Test `test_reserve_or_resume_refuses_a_foreign_writer`**: exercises both adapters over pending and terminal jobs, includes a positive-control replay for the publishing writer, and verifies that no aliases survive for the refused writer in either adapter's store.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the writer boundary check is minimal, correctly placed in both adapters, and fully covered by new conformance tests that fail without the fix.

The change moves a single guard earlier in both adapters with no new state mutations. The memory adapter's alias write and the SQLite adapter's alias INSERT are both unreachable for a refused writer, and the conformance test verifies this end-to-end for pending and terminal jobs in both adapters.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/memory/importer.py | Writer boundary check moved before alias write and terminal branch; foreign writer now raises INVALID_REQUEST (non-retryable) without touching any state. |
| src/yoetz/adapters/sqlite/importer.py | Same boundary repositioning as the memory adapter; raise before the alias INSERT means SQLite rollback keeps the foreign writer's request id unaliased. |
| tests/conformance/adapters/test_importer_persistence.py | New conformance test covers pending/terminal refusal for both adapters, positive replay control, and alias absence assertions; foreign writer is a real admitted row to rule out FK failures. |
| docs/INTERFACES.md | Adds a prose paragraph documenting the writer-ownership invariant and the INVALID_REQUEST behaviour for foreign writers. |
| CHANGELOG.md | Appends a sentence to the existing importer entry describing the new writer-ownership guarantee. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[reserve_or_resume called] --> B{Job exists for\nsource identity?}
    B -- No --> C[INSERT new job\nWrite alias\nReturn RESERVED]
    B -- Yes --> D{requesting_writer_id\n== publishing_writer_id?}
    D -- No --> E[Raise INVALID_REQUEST\nnon-retryable\nAlias NOT written]
    D -- Yes --> F{job.state\n== PENDING?}
    F -- No --> G[Write alias if new\nReturn REPLAYED]
    F -- Yes --> H{Lease still live?}
    H -- Yes --> I[Raise OPERATION_PENDING\nretryable=True]
    H -- No --> J[Renew lease\nWrite alias\nReturn RESUMED]
```

<sub>Reviews (3): Last reviewed commit: ["fix(importer): authorize terminal import..."](https://github.com/thegaysupreme123/yoetz/commit/4b058a94ce69cb47502ac015a51675865ee1ad7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22265049)</sub>

<!-- /greptile_comment -->