### PR TITLE
[bug]: Workspace inspection follows mutable names after validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,14 @@ describes behavior intended for the first release rather than a change from a pr
 These defects were found and fixed during pre-release development. No published version ever
 carried them; they are listed because each one describes the behavior that now ships.
 
+- **Workspace inspection no longer follows mutable names after validation (security).** Opening an
+  inspect workspace retains an authenticated root directory descriptor for the handle's lifetime.
+  Later reads open descendants descriptor-relatively with no-follow semantics and re-check the root
+  identity; replacing the root directory between open and inspect can no longer redirect a read
+  outside the consented workspace. Intermediate directory symlinks that escape the root are refused
+  (`symlink_escape`); in-root symlink chains remain readable up to a bounded depth. Content that
+  changes during a single read is refused (`read_failed`) rather than returned.
+
 - **Publish recovery must not mask a known authoring error.** When MCP `publish_work` body
   validation fails, envelope-first operation lookup still runs so a committed same-`request_id`
   operation can be recovered. A failed recovery read (for example nested `read_projection_failed`)

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1979,7 +1979,13 @@ Independent verification support (local control, not MCP):
 
 - `WorkspaceInspectPort` — descriptor-safe bounded relative-path artifact inspection under a
   consented workspace root; returns digests + capped excerpts; never absolute paths in public
-  status.
+  status. The handle retains an authenticated root directory descriptor for its lifetime.
+  Descendants are opened descriptor-relatively with no-follow semantics against that descriptor
+  (not by re-resolving the root pathname). In-root symlinks remain readable: targets are resolved
+  only within the root, with a bounded chain depth (eight resolutions per requested path); absolute
+  targets, climbs above the root, and exhausted depth map to `symlink_escape`. Content whose
+  identity or size changes during the read is refused as `read_failed` rather than returned.
+
 - Approved-check runner — executes only commitment-approved argv (`shell=False`, bounded
   time/output, sanitized env, no network unless separately authorized); binds results to the
   observed subject-state digest so later edits stale prior success.

--- a/src/yoetz/adapters/workspace_inspect.py
+++ b/src/yoetz/adapters/workspace_inspect.py
@@ -35,12 +35,23 @@ _READ_CHUNK: Final = 65_536
 _DOMAIN: Final = b"yoetz/workspace-inspect/v1\x00"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class _InspectRoot:
     root: Path
     descriptor: int
     device: int
     inode: int
+
+    def close(self) -> None:
+        if self.descriptor >= 0:
+            os.close(self.descriptor)
+            self.descriptor = -1
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except OSError:
+            pass
 
 
 class _InspectFailure(Exception):

--- a/src/yoetz/adapters/workspace_inspect.py
+++ b/src/yoetz/adapters/workspace_inspect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
 import stat
@@ -29,18 +30,49 @@ __all__ = [
 
 WORKSPACE_INSPECT_FORMAT: Final = "yoetz.workspace-inspect/1"
 _MAX_FILE_BYTES: Final = 1_048_576
+_MAX_SYMLINK_DEPTH: Final = 8
+_READ_CHUNK: Final = 65_536
 _DOMAIN: Final = b"yoetz/workspace-inspect/v1\x00"
 
 
 @dataclass(frozen=True, slots=True)
 class _InspectRoot:
     root: Path
+    descriptor: int
     device: int
     inode: int
 
 
+class _InspectFailure(Exception):
+    __slots__ = ("limitation",)
+
+    def __init__(self, limitation: WorkspaceInspectLimitation) -> None:
+        self.limitation = limitation
+        super().__init__(limitation.value)
+
+
 def _sha256(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _same_file_snapshot(before: os.stat_result, after: os.stat_result) -> bool:
+    return (
+        before.st_dev,
+        before.st_ino,
+        before.st_mode,
+        before.st_size,
+        before.st_mtime_ns,
+        before.st_ctime_ns,
+        before.st_nlink,
+    ) == (
+        after.st_dev,
+        after.st_ino,
+        after.st_mode,
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+        after.st_nlink,
+    )
 
 
 def _lexically_safe_absolute(path: Path) -> Path:
@@ -52,26 +84,88 @@ def _lexically_safe_absolute(path: Path) -> Path:
     return Path(os.path.abspath(text))
 
 
-def open_inspect_workspace(path: Path) -> LocalWorkspaceHandle:
-    """Validate one explicit local workspace root for inspection."""
+def _platform_supports_boundary() -> bool:
+    return (
+        os.open in os.supports_dir_fd
+        and hasattr(os, "O_NOFOLLOW")
+        and os.O_NOFOLLOW != 0
+        and os.stat in os.supports_dir_fd
+        and os.readlink in os.supports_dir_fd
+    )
 
+
+def open_inspect_workspace(path: Path) -> LocalWorkspaceHandle:
+    """Validate one explicit local workspace root for inspection.
+
+    The returned handle retains an authenticated root directory descriptor for its
+    lifetime. Inspection opens descendants descriptor-relatively with no-follow
+    semantics against that descriptor; callers must not close it.
+    """
+
+    if not _platform_supports_boundary():
+        raise ValueError("unsafe_root")
     root = _lexically_safe_absolute(path)
     if root.is_symlink() or not root.is_dir():
         raise ValueError("unsafe_root")
-    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0)
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-    descriptor = os.open(os.fspath(root), flags)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptor = -1
     try:
+        descriptor = os.open(os.fspath(root), flags)
         facts = os.fstat(descriptor)
         if not stat.S_ISDIR(facts.st_mode):
             raise ValueError("unsafe_root")
-        payload = _InspectRoot(root=root, device=facts.st_dev, inode=facts.st_ino)
+        payload = _InspectRoot(
+            root=root,
+            descriptor=descriptor,
+            device=facts.st_dev,
+            inode=facts.st_ino,
+        )
+        descriptor = -1
         return LocalWorkspaceHandle._from_validated_descriptor(  # pyright: ignore[reportPrivateUsage]
             payload
         )
     finally:
-        os.close(descriptor)
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _split_relative_components(relative: str) -> list[str] | None:
+    components = relative.split("/")
+    if not components or any(part in {"", ".", ".."} for part in components):
+        return None
+    if any("\x00" in part for part in components):
+        return None
+    return components
+
+
+def _join_symlink_target(parent_components: list[str], target: str) -> list[str] | None:
+    """Lexically join a relative symlink target onto its parent path under the root.
+
+    Pure string work: no filesystem access. Absolute targets and climbs above the
+    root return None (caller maps to SYMLINK_ESCAPE).
+    """
+
+    if not target or target.startswith("/") or "\x00" in target:
+        return None
+    parts = list(parent_components)
+    for part in target.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not parts:
+                return None
+            parts.pop()
+            continue
+        parts.append(part)
+    return parts
+
+
+def _component_is_symlink(parent_fd: int, component: str) -> bool:
+    try:
+        facts = os.stat(component, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    return stat.S_ISLNK(facts.st_mode)
 
 
 class LocalWorkspaceInspectAdapter:
@@ -94,8 +188,25 @@ class LocalWorkspaceInspectAdapter:
                 (WorkspaceInspectLimitation.UNSAFE_ROOT,),
                 None,
             )
-        root = self._root_from_descriptor(descriptor)
-        if root is None:
+        root_identity = self._root_from_descriptor(descriptor)
+        if root_identity is None:
+            return WorkspaceInspectResult(
+                WorkspaceInspectStatus.REJECTED,
+                (),
+                (WorkspaceInspectLimitation.UNSAFE_ROOT,),
+                None,
+            )
+        root_fd, device, inode = root_identity
+        try:
+            facts = os.fstat(root_fd)
+        except OSError:
+            return WorkspaceInspectResult(
+                WorkspaceInspectStatus.REJECTED,
+                (),
+                (WorkspaceInspectLimitation.UNSAFE_ROOT,),
+                None,
+            )
+        if not stat.S_ISDIR(facts.st_mode) or facts.st_dev != device or facts.st_ino != inode:
             return WorkspaceInspectResult(
                 WorkspaceInspectStatus.REJECTED,
                 (),
@@ -114,7 +225,7 @@ class LocalWorkspaceInspectAdapter:
             )
 
         for relative in command.relative_paths:
-            artifact, limitation = self._inspect_one(root, relative)
+            artifact, limitation = self._inspect_one(root_fd, relative)
             if artifact is not None:
                 artifacts.append(artifact)
             if limitation is not None:
@@ -159,43 +270,42 @@ class LocalWorkspaceInspectAdapter:
         )
         return WorkspaceInspectResult(status, tuple(artifacts), ordered_limitations, selection)
 
-    def _root_from_descriptor(self, descriptor: object) -> Path | None:
+    def _root_from_descriptor(self, descriptor: object) -> tuple[int, int, int] | None:
         if type(descriptor) is _InspectRoot:
-            return descriptor.root
+            if type(descriptor.descriptor) is not int or descriptor.descriptor < 0:
+                return None
+            return descriptor.descriptor, descriptor.device, descriptor.inode
         root = getattr(descriptor, "root", None)
-        if isinstance(root, Path):
-            return root
-        return None
+        fd = getattr(descriptor, "descriptor", None)
+        device = getattr(descriptor, "device", None)
+        inode = getattr(descriptor, "inode", None)
+        if (
+            not isinstance(root, Path)
+            or type(fd) is not int
+            or fd < 0
+            or type(device) is not int
+            or type(inode) is not int
+        ):
+            return None
+        return fd, device, inode
 
     def _inspect_one(
-        self, root: Path, relative: str
+        self, root_fd: int, relative: str
     ) -> tuple[InspectedArtifact | None, WorkspaceInspectLimitation | None]:
-        try:
-            root_resolved = root.resolve(strict=True)
-        except OSError:
-            return None, WorkspaceInspectLimitation.UNSAFE_ROOT
-        candidate = root_resolved / relative
-        try:
-            candidate.relative_to(root_resolved)
-        except ValueError:
+        components = _split_relative_components(relative)
+        if components is None:
             return None, WorkspaceInspectLimitation.PATH_OUT_OF_SCOPE
-        if candidate.is_symlink():
-            try:
-                target = candidate.resolve(strict=True)
-                target.relative_to(root_resolved)
-            except OSError, ValueError:
-                return None, WorkspaceInspectLimitation.SYMLINK_ESCAPE
+        fd = -1
         try:
-            if not candidate.is_file():
-                return None, WorkspaceInspectLimitation.NOT_A_FILE
-            size = candidate.stat().st_size
-            if size > _MAX_FILE_BYTES:
-                return None, WorkspaceInspectLimitation.OVERSIZED_CONTENT
-            data = candidate.read_bytes()
+            fd = self._open_relative(root_fd, components)
+            data = self._read_regular_file(fd)
+        except _InspectFailure as exc:
+            return None, exc.limitation
         except OSError:
             return None, WorkspaceInspectLimitation.READ_FAILED
-        if len(data) > _MAX_FILE_BYTES:
-            return None, WorkspaceInspectLimitation.OVERSIZED_CONTENT
+        finally:
+            if fd >= 0:
+                os.close(fd)
         truncated = len(data) > MAX_INSPECT_EXCERPT_BYTES
         excerpt = data[:MAX_INSPECT_EXCERPT_BYTES]
         digest = _sha256(_DOMAIN + relative.encode("utf-8") + b"\x00" + data)
@@ -209,3 +319,106 @@ class LocalWorkspaceInspectAdapter:
             ),
             None,
         )
+
+    def _open_relative(self, root_fd: int, components: list[str]) -> int:
+        """Open the final component descriptor-relatively from ``root_fd``.
+
+        Intermediate directory and final-component symlinks are resolved only within
+        the root, with a shared resolution budget of ``_MAX_SYMLINK_DEPTH``. The
+        returned fd is owned by the caller; intermediate fds are closed before return.
+        """
+
+        if not components:
+            raise _InspectFailure(WorkspaceInspectLimitation.PATH_OUT_OF_SCOPE)
+        remaining_symlinks = _MAX_SYMLINK_DEPTH
+        path_components = list(components)
+        base_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW
+
+        while True:
+            parent_fd = root_fd
+            owned: list[int] = []
+            try:
+                for index, component in enumerate(path_components):
+                    is_final = index == len(path_components) - 1
+                    flags = base_flags if is_final else base_flags | os.O_DIRECTORY
+                    try:
+                        new_fd = os.open(component, flags, dir_fd=parent_fd)
+                    except OSError as exc:
+                        if _component_is_symlink(parent_fd, component):
+                            if remaining_symlinks <= 0:
+                                raise _InspectFailure(
+                                    WorkspaceInspectLimitation.SYMLINK_ESCAPE
+                                ) from exc
+                            try:
+                                target = os.readlink(component, dir_fd=parent_fd)
+                            except OSError as read_exc:
+                                raise _InspectFailure(
+                                    WorkspaceInspectLimitation.SYMLINK_ESCAPE
+                                ) from read_exc
+                            if os.path.isabs(target):
+                                raise _InspectFailure(
+                                    WorkspaceInspectLimitation.SYMLINK_ESCAPE
+                                ) from exc
+                            joined = _join_symlink_target(path_components[:index], target)
+                            if joined is None:
+                                raise _InspectFailure(
+                                    WorkspaceInspectLimitation.SYMLINK_ESCAPE
+                                ) from exc
+                            remaining_symlinks -= 1
+                            path_components = joined + path_components[index + 1 :]
+                            if not path_components:
+                                raise _InspectFailure(
+                                    WorkspaceInspectLimitation.NOT_A_FILE
+                                ) from exc
+                            break
+                        if exc.errno in {errno.ENOENT, errno.ENOTDIR}:
+                            raise _InspectFailure(WorkspaceInspectLimitation.NOT_A_FILE) from exc
+                        raise _InspectFailure(WorkspaceInspectLimitation.READ_FAILED) from exc
+                    if is_final:
+                        for intermediate in owned:
+                            os.close(intermediate)
+                        owned.clear()
+                        return new_fd
+                    owned.append(new_fd)
+                    parent_fd = new_fd
+                else:
+                    # for-loop completed without opening a final component.
+                    raise _InspectFailure(WorkspaceInspectLimitation.NOT_A_FILE)
+            finally:
+                for intermediate in owned:
+                    try:
+                        os.close(intermediate)
+                    except OSError:
+                        pass
+
+    def _read_regular_file(self, fd: int) -> bytes:
+        try:
+            before = os.fstat(fd)
+        except OSError as exc:
+            raise _InspectFailure(WorkspaceInspectLimitation.READ_FAILED) from exc
+        if not stat.S_ISREG(before.st_mode):
+            raise _InspectFailure(WorkspaceInspectLimitation.NOT_A_FILE)
+        if before.st_size > _MAX_FILE_BYTES:
+            raise _InspectFailure(WorkspaceInspectLimitation.OVERSIZED_CONTENT)
+
+        chunks: list[bytes] = []
+        total = 0
+        limit = _MAX_FILE_BYTES + 1
+        try:
+            while total < limit:
+                chunk = os.read(fd, min(_READ_CHUNK, limit - total))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                total += len(chunk)
+        except OSError as exc:
+            raise _InspectFailure(WorkspaceInspectLimitation.READ_FAILED) from exc
+        if total > _MAX_FILE_BYTES:
+            raise _InspectFailure(WorkspaceInspectLimitation.OVERSIZED_CONTENT)
+        try:
+            after = os.fstat(fd)
+        except OSError as exc:
+            raise _InspectFailure(WorkspaceInspectLimitation.READ_FAILED) from exc
+        if total != before.st_size or not _same_file_snapshot(before, after):
+            raise _InspectFailure(WorkspaceInspectLimitation.READ_FAILED)
+        return b"".join(chunks)

--- a/tests/unit/adapters/test_workspace_inspect.py
+++ b/tests/unit/adapters/test_workspace_inspect.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from yoetz.adapters.workspace_inspect import LocalWorkspaceInspectAdapter, open_inspect_workspace
+from yoetz.adapters import workspace_inspect as workspace_inspect_module
+from yoetz.adapters.workspace_inspect import (
+    LocalWorkspaceInspectAdapter,
+    open_inspect_workspace,
+)
+from yoetz.ports.subject_state import LocalWorkspaceHandle
 from yoetz.ports.workspace_inspect import (
     WorkspaceInspectCommand,
     WorkspaceInspectLimitation,
@@ -55,3 +62,144 @@ def test_inspect_never_returns_absolute_paths(tmp_path: Path) -> None:
     payload = repr(result)
     assert str(tmp_path) not in payload
     assert "/workspace" not in result.artifacts[0].relative_path
+
+
+def test_root_replacement_after_open_cannot_redirect_reads(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("consented-content\n", encoding="utf-8")
+    handle = open_inspect_workspace(workspace)
+
+    aside = tmp_path / "workspace-aside"
+    os.rename(workspace, aside)
+    replacement = tmp_path / "workspace"
+    replacement.mkdir()
+    (replacement / "note.txt").write_text("SECRET=should-not-leak\n", encoding="utf-8")
+
+    result = LocalWorkspaceInspectAdapter().inspect(WorkspaceInspectCommand(handle, ("note.txt",)))
+    assert result.status is WorkspaceInspectStatus.INSPECTED
+    assert result.artifacts[0].excerpt == b"consented-content\n"
+    payload = repr(result)
+    assert "SECRET=" not in payload
+    assert b"SECRET=" not in result.artifacts[0].excerpt
+
+
+def test_intermediate_directory_symlink_cannot_escape_the_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "note.txt").write_text("SECRET=via-dir-link\n", encoding="utf-8")
+    (workspace / "srclink").symlink_to(outside, target_is_directory=True)
+
+    handle = open_inspect_workspace(workspace)
+    result = LocalWorkspaceInspectAdapter().inspect(
+        WorkspaceInspectCommand(handle, ("srclink/note.txt",))
+    )
+    assert result.status is WorkspaceInspectStatus.REJECTED
+    assert WorkspaceInspectLimitation.SYMLINK_ESCAPE in result.limitations
+    assert result.artifacts == ()
+    assert "SECRET=" not in repr(result)
+
+
+def test_in_root_symlink_is_still_inspected(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    src = workspace / "src"
+    src.mkdir(parents=True)
+    (src / "note.txt").write_text("in-root-target\n", encoding="utf-8")
+    (workspace / "link.txt").symlink_to("src/note.txt")
+    (workspace / "hop1").symlink_to("link.txt")
+    (workspace / "via").mkdir()
+    (workspace / "via" / "dirlink").symlink_to("../src", target_is_directory=True)
+
+    handle = open_inspect_workspace(workspace)
+    adapter = LocalWorkspaceInspectAdapter()
+
+    direct = adapter.inspect(WorkspaceInspectCommand(handle, ("link.txt",)))
+    assert direct.status is WorkspaceInspectStatus.INSPECTED
+    assert direct.artifacts[0].excerpt == b"in-root-target\n"
+
+    two_hop = adapter.inspect(WorkspaceInspectCommand(handle, ("hop1",)))
+    assert two_hop.status is WorkspaceInspectStatus.INSPECTED
+    assert two_hop.artifacts[0].excerpt == b"in-root-target\n"
+
+    via_dir = adapter.inspect(WorkspaceInspectCommand(handle, ("via/dirlink/note.txt",)))
+    assert via_dir.status is WorkspaceInspectStatus.INSPECTED
+    assert via_dir.artifacts[0].excerpt == b"in-root-target\n"
+
+
+def test_symlink_chain_depth_is_bounded(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "leaf.txt").write_text("deep-target\n", encoding="utf-8")
+    previous = "leaf.txt"
+    # One more hop than the adapter will resolve.
+    for index in range(workspace_inspect_module._MAX_SYMLINK_DEPTH + 1):  # pyright: ignore[reportPrivateUsage]
+        name = f"link{index}.txt"
+        (workspace / name).symlink_to(previous)
+        previous = name
+
+    handle = open_inspect_workspace(workspace)
+    result = LocalWorkspaceInspectAdapter().inspect(WorkspaceInspectCommand(handle, (previous,)))
+    assert result.status is WorkspaceInspectStatus.REJECTED
+    assert WorkspaceInspectLimitation.SYMLINK_ESCAPE in result.limitations
+    assert result.artifacts == ()
+
+
+def test_absolute_symlink_target_is_refused(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "note.txt"
+    target.write_text("absolute-target\n", encoding="utf-8")
+    (workspace / "abs-link.txt").symlink_to(target.resolve())
+
+    handle = open_inspect_workspace(workspace)
+    result = LocalWorkspaceInspectAdapter().inspect(
+        WorkspaceInspectCommand(handle, ("abs-link.txt",))
+    )
+    assert result.status is WorkspaceInspectStatus.REJECTED
+    assert WorkspaceInspectLimitation.SYMLINK_ESCAPE in result.limitations
+    assert result.artifacts == ()
+
+
+def test_content_changing_read_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "note.txt"
+    original = b"stable-bytes-0123456789\n"
+    target.write_bytes(original)
+
+    real_read = workspace_inspect_module.os.read
+    mutated = {"done": False}
+
+    def flaky_read(fd: int, n: int) -> bytes:
+        if not mutated["done"]:
+            mutated["done"] = True
+            # Same-inode rewrite so the open descriptor's fstat changes mid-read.
+            # (os.replace would swap the directory entry while leaving this fd on
+            # the original inode, which would not exercise the change check.)
+            with open(target, "wb") as handle:
+                handle.write(b"MUTATED-SECRET-should-not-appear\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        return real_read(fd, n)
+
+    monkeypatch.setattr(workspace_inspect_module.os, "read", flaky_read)
+    handle = open_inspect_workspace(workspace)
+    result = LocalWorkspaceInspectAdapter().inspect(WorkspaceInspectCommand(handle, ("note.txt",)))
+    assert result.status is WorkspaceInspectStatus.REJECTED
+    assert WorkspaceInspectLimitation.READ_FAILED in result.limitations
+    assert result.artifacts == ()
+    assert "MUTATED-SECRET" not in repr(result)
+
+
+def test_unusable_workspace_payload_is_refused(tmp_path: Path) -> None:
+    payload = SimpleNamespace(root=tmp_path)
+    handle = LocalWorkspaceHandle._from_validated_descriptor(  # pyright: ignore[reportPrivateUsage]
+        payload
+    )
+    result = LocalWorkspaceInspectAdapter().inspect(WorkspaceInspectCommand(handle, ("note.txt",)))
+    assert result.status is WorkspaceInspectStatus.REJECTED
+    assert result.limitations == (WorkspaceInspectLimitation.UNSAFE_ROOT,)
+    assert result.artifacts == ()
+    assert result.selection_digest is None


### PR DESCRIPTION
## Summary

Closes **finding 5** (workspace inspect TOCTOU / intermediate symlink escape): `open_inspect_workspace` retained device/inode but closed the root descriptor, then every later read re-resolved the pathname. Replacing the root between open and inspect redirected the excerpt outside the consented workspace. Intermediate directory symlinks were followed with only a full-path `is_symlink` guard, so `srclink/note.txt` could escape via an absolute link.

**What changed:** Mirror `git_subject_state` — retain an authenticated root fd on the handle, re-verify identity before the path loop, and open each component with `dir_fd` + `O_NOFOLLOW`. In-root symlinks stay readable via bounded descriptor-relative resolution (depth 8); absolute targets, root climbs, and exhausted depth map to `symlink_escape`. Reads use one fd with before/after `fstat` identity checks so mid-read content changes refuse. Payloads without a live descriptor are refused rather than falling back to name-based reads. Platforms without `dir_fd`/`O_NOFOLLOW` fail closed at open.

**Why:** Excerpts can reach a lower-trust agent via the observation-advice path; a bounded service-readable file outside consent must not leak.

## Plan / issue

- Issue: https://github.com/TheGaySupreme123/yoetz/issues/109
- Design gate: not required (adapter-local containment; INTERFACES docs only document the stronger handle contract)
- Scope: `workspace_inspect` adapter + unit regressions + CHANGELOG / INTERFACES

## Test plan

- [x] `uv run --locked pytest tests/unit/adapters/test_workspace_inspect.py -v` → 11 passed
- [x] `uv run --locked pytest tests/unit/adapters/test_workspace_inspect.py tests/unit/adapters/test_approved_checks.py tests/unit/adapters/test_check_sandbox.py tests/unit/adapters/test_git_subject_state.py -v` → 24 passed
- [x] `uv run --locked pytest tests/integration/observation/test_production_composition.py tests/integration/observation/test_acceptance_scenarios.py -v` → 34 passed
- [x] Exploit-closure: pre-fix `origin/main` fails both escape regressions (secret leak); post-fix passes both
- [x] `uv run ruff check` / `ruff format --check` + `npx --no-install pyright` on touched files → clean

## Fixes

Fixes #109

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `open_inspect_workspace` against a TOCTOU symlink-escape class of bugs by retaining the root directory file descriptor across the handle's lifetime and walking descendants descriptor-relatively with `O_NOFOLLOW`. Mid-read content changes are now caught by a before/after `fstat` identity check.

- **Root fd retained, re-verified on each `inspect` call**: replaces the previous pattern that closed the fd after recording device/inode, allowing root-directory substitution between `open` and `inspect`.
- **`_open_relative` walks path components via `dir_fd` + `O_NOFOLLOW`**: relative in-root symlinks are followed with a depth-8 budget; absolute targets, root-escaping `..` chains, and exhausted budgets all map to `symlink_escape`.
- **`_read_regular_file` rejects mid-read mutations**: compares full `stat` snapshots before and after reading, returning `read_failed` if any field diverges.

<h3>Confidence Score: 4/5</h3>

The core security fix is correct and well-tested, but the root file descriptor opened in open_inspect_workspace has no cleanup path - _InspectRoot is frozen with no __del__, unlike the _GitRoot pattern it explicitly mirrors.

The TOCTOU fix and descriptor-relative traversal are implemented correctly and covered by targeted regression tests. The one gap is that _InspectRoot (frozen dataclass, no __del__, no close()) leaks the retained root fd when the handle is GC'd. In a long-running service opening many workspace handles this will exhaust file descriptors. _GitRoot in git_subject_state.py handles this with a mutable dataclass plus close() and __del__. That omission should be resolved before this ships to a production service.

**Files Needing Attention:** src/yoetz/adapters/workspace_inspect.py - the _InspectRoot dataclass needs fd lifecycle management (close/finalizer) consistent with _GitRoot in git_subject_state.py.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/workspace_inspect.py | Rewrites workspace inspection to retain an authenticated root fd and use O_NOFOLLOW + dir_fd traversal. Core logic is sound but the root fd is never closed (no __del__ or close() on _InspectRoot), unlike the _GitRoot pattern it mirrors. |
| tests/unit/adapters/test_workspace_inspect.py | Adds eight new regression tests covering TOCTOU root-swap, intermediate dir-symlink escape, in-root symlinks, chain depth bounding, absolute symlink targets, mid-read content mutation, and bad payloads. Tests are well-scoped and cover the announced exploit cases. |
| CHANGELOG.md | Adds a changelog entry describing the workspace inspection security fix; documentation only. |
| docs/INTERFACES.md | Extends the WorkspaceInspectPort contract description to document the retained root descriptor, no-follow traversal, bounded symlink resolution depth, and mid-read identity check; documentation only. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant open_inspect_workspace
    participant LocalWorkspaceInspectAdapter
    participant _open_relative
    participant _read_regular_file

    Caller->>open_inspect_workspace: path
    open_inspect_workspace->>open_inspect_workspace: _platform_supports_boundary()
    open_inspect_workspace->>open_inspect_workspace: "os.open(root, O_RDONLY|O_DIRECTORY|O_NOFOLLOW)"
    open_inspect_workspace->>open_inspect_workspace: os.fstat(descriptor) store device+inode
    open_inspect_workspace-->>Caller: LocalWorkspaceHandle (retains root fd)

    Caller->>LocalWorkspaceInspectAdapter: inspect(command)
    LocalWorkspaceInspectAdapter->>LocalWorkspaceInspectAdapter: os.fstat(root_fd) re-verify device+inode
    loop each relative_path
        LocalWorkspaceInspectAdapter->>_open_relative: root_fd, components
        loop walk components with O_NOFOLLOW and dir_fd
            alt component is symlink
                _open_relative->>_open_relative: "os.readlink(dir_fd=parent)"
                _open_relative->>_open_relative: _join_symlink_target reject absolute or escape
                _open_relative->>_open_relative: decrement remaining_symlinks budget
            else regular component
                _open_relative->>_open_relative: "os.open(component, dir_fd=parent)"
            end
        end
        _open_relative-->>LocalWorkspaceInspectAdapter: file fd or _InspectFailure
        LocalWorkspaceInspectAdapter->>_read_regular_file: fd
        _read_regular_file->>_read_regular_file: fstat before
        _read_regular_file->>_read_regular_file: os.read chunks
        _read_regular_file->>_read_regular_file: fstat after _same_file_snapshot check
        _read_regular_file-->>LocalWorkspaceInspectAdapter: bytes or _InspectFailure
    end
    LocalWorkspaceInspectAdapter-->>Caller: WorkspaceInspectResult
```

<sub>Reviews (2): Last reviewed commit: ["fix(workspace-inspect): keep root fd and..."](https://github.com/thegaysupreme123/yoetz/commit/7111e8540d9b5b2133e13fe6e092643429e82259) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22293883)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->