### PR TITLE
fix(setup): refuse pre-existing auto-unlock entry at vault init

### DIFF
--- a/src/yoetz/adapters/keys/os_keyring.py
+++ b/src/yoetz/adapters/keys/os_keyring.py
@@ -207,6 +207,17 @@ class AutoUnlockPassphraseStore:
         self._username = "bundle-" + hashlib.sha256(encoded).hexdigest()
 
     @property
+    def entry_identity(self) -> tuple[str, str]:
+        """Return the (service, account) this store is scoped to, for operator messages.
+
+        Both halves are bounded structural values — a constant service name and a digest of the
+        bundle path — and neither reveals the secret. Setup surfaces them so an operator asked to
+        clear a blocking entry can actually find it in the platform credential store.
+        """
+
+        return _AUTO_UNLOCK_SERVICE_NAME, self._username
+
+    @property
     def available(self) -> bool:
         return self._backend_id in _AUTO_UNLOCK_BACKENDS and all(
             callable(getattr(self._backend, name, None))

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -931,10 +931,20 @@ async def _interactive_provider_setup(
                     if error.reason != "unsupported":
                         provider_report["credential_reason"] = f"auto_unlock_{error.reason}"
                         if error.reason == "entry_exists":
+                            entry_service, entry_account = auto_store.entry_identity
                             typer.echo(
                                 "A pre-existing platform credential entry blocks vault "
-                                "initialization. Clear or repair the scoped auto-unlock "
-                                "entry for this install, then rerun 'yoetz setup'.",
+                                "initialization, because adopting it would make an already "
+                                "known value the vault root passphrase.",
+                                err=True,
+                            )
+                            typer.echo(f"  Credential store service: {entry_service}", err=True)
+                            typer.echo(f"  Account: {entry_account}", err=True)
+                            typer.echo(
+                                "Delete that entry (macOS: Keychain Access; Linux: "
+                                "'secret-tool clear service " + entry_service + "'), then "
+                                "rerun 'yoetz setup'. Keep it only if this install already has "
+                                "a vault, in which case setup did not need to initialize one.",
                                 err=True,
                             )
                         else:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -923,16 +923,27 @@ async def _interactive_provider_setup(
                     bundle_root(_data_dir=current_config.storage.data_dir)
                 )
                 try:
-                    auto_passphrase = auto_store.load_or_create()
+                    # ADR-015 decision 5 / ADR-008: generate a fresh scoped secret for
+                    # vault_initialize. Never adopt a pre-existing entry (load_or_create).
+                    # Matches elevated create_for_initialization fail-closed on entry_exists.
+                    auto_passphrase = auto_store.create_for_initialization()
                 except OSKeyringError as error:
                     if error.reason != "unsupported":
                         provider_report["credential_reason"] = f"auto_unlock_{error.reason}"
-                        typer.echo(
-                            "Platform credential entry could not be verified; vault "
-                            "initialization stopped to avoid a conflicting passphrase. "
-                            "Restore credential-store access, then rerun 'yoetz setup'.",
-                            err=True,
-                        )
+                        if error.reason == "entry_exists":
+                            typer.echo(
+                                "A pre-existing platform credential entry blocks vault "
+                                "initialization. Clear or repair the scoped auto-unlock "
+                                "entry for this install, then rerun 'yoetz setup'.",
+                                err=True,
+                            )
+                        else:
+                            typer.echo(
+                                "Platform credential entry could not be verified; vault "
+                                "initialization stopped to avoid a conflicting passphrase. "
+                                "Restore credential-store access, then rerun 'yoetz setup'.",
+                                err=True,
+                            )
                         return service, provider_report
                     typer.echo("Platform credential store unavailable; choose a vault passphrase")
                     typer.echo("Secure vault setup (hidden local-terminal input)")

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -720,8 +720,8 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
     supplied: list[bytes] = []
     loaded_env: list[object] = []
 
-    def fake_load_or_create(_store: object) -> bytearray:
-        calls.append("load_or_create")
+    def fake_create_for_initialization(_store: object) -> bytearray:
+        calls.append("create_for_initialization")
         return bytearray(b"a" * 48)
 
     async def fake_initialize(passphrase: bytearray | None = None) -> object:
@@ -743,8 +743,8 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
 
     monkeypatch.setattr(
         keyring_module.AutoUnlockPassphraseStore,
-        "load_or_create",
-        fake_load_or_create,
+        "create_for_initialization",
+        fake_create_for_initialization,
     )
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
     monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda: None)
@@ -758,11 +758,100 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
         )
     )
 
-    assert calls == ["load_or_create"]
+    assert calls == ["create_for_initialization"]
     assert loaded_env == [os.environ]
     assert supplied == [b"a" * 48]
     assert service["state"] == "ready"
     assert report["binding"] == "skipped"
+
+
+def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RT-vault-secrets-1 / ADR-015: pre-existing scoped entry must block vault init.
+
+    Interactive setup must use create_for_initialization (like elevated bootstrap)
+    and must never submit a pre-planted auto-unlock secret to vault_initialize.
+    """
+
+    import base64
+    import hashlib
+
+    import yoetz.adapters.keys.os_keyring as keyring_module
+    import yoetz.cli.provider_binding as binding_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+    import yoetz.config.paths as paths_module
+
+    # Known secret that must not become the vault root passphrase.
+    planted = bytearray(b"attacker-known-vault-secret-0123456789abcdef!!!!")
+    assert 32 <= len(planted) <= 128
+
+    class _AtomicBackend:
+        def __init__(self) -> None:
+            self.values: dict[tuple[str, str], str] = {}
+
+        def get_password(self, service: str, username: str) -> str | None:
+            return self.values.get((service, username))
+
+        def set_password(self, service: str, username: str, password: str) -> None:
+            self.values[(service, username)] = password
+
+    backend = _AtomicBackend()
+    store = keyring_module.AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
+    store._backend_id = (  # pyright: ignore[reportPrivateUsage]
+        "keyring.backends.macOS.Keyring"
+    )
+    store.save(bytearray(planted))
+    encoded = base64.urlsafe_b64encode(planted).rstrip(b"=").decode("ascii")
+    username = "bundle-" + hashlib.sha256(
+        os.fsencode(os.path.abspath(tmp_path.resolve()))
+    ).hexdigest()
+    assert backend.values[("yoetz.auto-unlock.v1", username)] == encoded
+    with pytest.raises(keyring_module.OSKeyringError) as elevated_exc:
+        store.create_for_initialization()
+    assert elevated_exc.value.reason == "entry_exists"
+
+    supplied: list[bytes] = []
+
+    async def fake_initialize(passphrase: bytearray | None = None) -> object:
+        supplied.append(bytes(passphrase or b""))
+        return object()
+
+    async def fake_reachability(*, start_if_absent: bool = False) -> dict[str, object]:
+        del start_if_absent
+        return {"reachable": True, "state": "ready", "vault_mode": "passphrase"}
+
+    def fake_store(_path: Path) -> keyring_module.AutoUnlockPassphraseStore:
+        return store
+
+    def fake_load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(storage=SimpleNamespace(data_dir=tmp_path))
+
+    def fake_bundle_root(*, _data_dir: Path | None = None, _probe: object | None = None) -> Path:
+        del _data_dir, _probe
+        return tmp_path.resolve()
+
+    monkeypatch.setattr(keyring_module, "AutoUnlockPassphraseStore", fake_store)
+    monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
+    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda: None)
+    monkeypatch.setattr(config_module, "load_config", fake_load_config)
+    monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
+    monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
+
+    service, report = asyncio.run(
+        setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
+            {"reachable": True, "state": "locked", "vault_mode": "uninitialized"}
+        )
+    )
+
+    # Fail-closed: no vault_initialize with the planted secret; entry unchanged.
+    assert supplied == []
+    assert service == {"reachable": True, "state": "locked", "vault_mode": "uninitialized"}
+    assert report["credential_reason"] == "auto_unlock_entry_exists"
+    assert report["binding"] == "skipped"
+    assert backend.values[("yoetz.auto-unlock.v1", username)] == encoded
 
 
 def test_uninitialized_setup_stops_after_write_with_failed_readback(

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -805,9 +805,9 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
     )
     store.save(bytearray(planted))
     encoded = base64.urlsafe_b64encode(planted).rstrip(b"=").decode("ascii")
-    username = "bundle-" + hashlib.sha256(
-        os.fsencode(os.path.abspath(tmp_path.resolve()))
-    ).hexdigest()
+    username = (
+        "bundle-" + hashlib.sha256(os.fsencode(os.path.abspath(tmp_path.resolve()))).hexdigest()
+    )
     assert backend.values[("yoetz.auto-unlock.v1", username)] == encoded
     with pytest.raises(keyring_module.OSKeyringError) as elevated_exc:
         store.create_for_initialization()

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -766,7 +766,7 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
 
 
 def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """RT-vault-secrets-1 / ADR-015: pre-existing scoped entry must block vault init.
 
@@ -852,6 +852,15 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
     assert report["credential_reason"] == "auto_unlock_entry_exists"
     assert report["binding"] == "skipped"
     assert backend.values[("yoetz.auto-unlock.v1", username)] == encoded
+
+    # Blocking is only useful if the operator can find and clear the entry that blocked them,
+    # and the message must never echo the secret it refused to adopt.
+    stderr = capsys.readouterr().err
+    assert "yoetz.auto-unlock.v1" in stderr
+    assert username in stderr
+    assert "yoetz setup" in stderr
+    assert encoded not in stderr
+    assert planted.decode("ascii") not in stderr
 
 
 def test_uninitialized_setup_stops_after_write_with_failed_readback(


### PR DESCRIPTION
## Summary

Fixes interactive first-run setup adopting a **pre-existing** bundle-scoped platform auto-unlock credential as the vault root passphrase.

- **Issue:** #111 (`RT-vault-secrets-1`)
- **Authority:** ADR-015 decision 5 (pre-existing scoped entry must block initialization; must not become the vault secret); elevated path already uses `create_for_initialization`.
- **Not design-gated:** ADRs already require generate-or-block; this aligns interactive setup with elevated bootstrap.

## Vulnerability (non-weaponized)

Uninitialized `yoetz setup` called `AutoUnlockPassphraseStore.load_or_create()`, which returns any existing `yoetz.auto-unlock.v1` / `bundle-<digest>` secret and submitted it to `initialize_passphrase_vault`. An attacker (or leftover prior install) that could plant that scoped credential before pristine init could force a known vault passphrase.

Elevated bootstrap already fail-closes via `create_for_initialization()` → `entry_exists`. Interactive setup did not.

Prerequisite is write access to the platform credential store for that exact identity (same-UID local process, leftover install). ADR-004 excludes general same-UID host compromise from crypto claims, but this is an in-scope Yoetz enforcement bug because ADR-015 requires fail-closed and elevated already implements it.

## Fix

In `src/yoetz/cli/setup.py` uninitialized branch:

- Call `create_for_initialization()` instead of `load_or_create()`.
- Map non-`unsupported` `OSKeyringError` reasons (including `entry_exists`) to `auto_unlock_*` credential reasons, matching elevated.
- Clearer operator message when the reason is `entry_exists`.

Passphrase-mode unlock continues to use `load()` for legitimate post-init reuse.

## Tests

- Updated `test_uninitialized_provider_setup_provisions_auto_unlock` to expect `create_for_initialization`.
- Added `test_uninitialized_setup_refuses_preexisting_auto_unlock_entry` (regression for this finding): planted scoped entry must not reach vault initialize; report `auto_unlock_entry_exists`; vault remains uninitialized.

```text
uv run pytest \
  tests/subprocess/test_setup_wizard_cli.py::test_uninitialized_provider_setup_provisions_auto_unlock \
  tests/subprocess/test_setup_wizard_cli.py::test_uninitialized_setup_refuses_preexisting_auto_unlock_entry \
  tests/subprocess/test_setup_wizard_cli.py::test_uninitialized_setup_stops_after_write_with_failed_readback \
  tests/integration/objects/test_key_backends.py::test_initialization_refuses_preexisting_auto_unlock_entry \
  tests/unit/cli/test_elevated.py -q
```

Result: **26 passed**. Ruff clean; pyright clean on `setup.py`.

## Test plan

- [x] Focused pytest suite above
- [x] Ruff on touched Python
- [x] Pyright on `src/yoetz/cli/setup.py`
- [ ] Maintainer: re-run suite on macOS keyring backends if desired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault setup security by generating a new auto-unlock secret during initialization.
  * Prevented vault initialization when an existing auto-unlock credential is detected.
  * Added safeguards for unreadable or unverifiable credential-store writes.
  * Preserved existing stored secrets when setup validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security vulnerability where interactive `yoetz setup` could adopt a pre-existing platform auto-unlock credential as the vault root passphrase by switching from `load_or_create()` to `create_for_initialization()`. The fix aligns interactive initialization with the elevated bootstrap path, which already fail-closed on pre-existing entries.

- **`src/yoetz/cli/setup.py`**: Replaces `auto_store.load_or_create()` with `auto_store.create_for_initialization()` so any pre-planted keyring entry raises `OSKeyringError(\"entry_exists\")` and blocks initialization; adds a distinct, actionable user message for that case.
- **`tests/subprocess/test_setup_wizard_cli.py`**: Updates the existing happy-path test to expect `create_for_initialization`, and adds a new regression test that plants a known credential in the keyring, runs setup, and asserts vault initialization is never called and the credential is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a focused one-line swap in the uninitialized vault branch backed by a direct regression test that confirms vault initialization is never called when a pre-existing entry is present.

The fix is minimal and surgical — swapping load_or_create for create_for_initialization in exactly the code path described in the vulnerability report. The surrounding error handling already existed and is preserved correctly; only the entry_exists message is added. The regression test exercises the full end-to-end path: it plants a known credential, runs the interactive setup function directly, and asserts that initialize_passphrase_vault is never reached and the credential remains unchanged.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/cli/setup.py | Replaces load_or_create() with create_for_initialization() in the uninitialized vault branch; error handling correctly maps all non-unsupported OSKeyringError reasons to auto_unlock_* credential reasons and returns early; entry_exists gets a clearer user message. |
| tests/subprocess/test_setup_wizard_cli.py | Updated happy-path test to expect create_for_initialization; new regression test plants a known keyring credential, verifies vault initialize is never called and the entry remains unchanged, with correct credential_reason assertion. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User / Attacker
    participant S as setup.py (_interactive_provider_setup)
    participant K as AutoUnlockPassphraseStore
    participant V as initialize_passphrase_vault

    Note over U,K: Attacker plants known credential before yoetz setup

    U->>K: save(known_secret) into keyring

    Note over S,V: yoetz setup runs (uninitialized vault branch)

    S->>K: create_for_initialization()
    K->>K: load_with_reason() returns existing entry
    K-->>S: raise OSKeyringError(entry_exists) [wipes loaded secret]

    S->>S: "credential_reason = auto_unlock_entry_exists"
    S->>S: echo error message to stderr
    S-->>U: "return (service=uninitialized, report) [early return, vault unchanged]"

    Note over V: initialize_passphrase_vault is NEVER called
```

<sub>Reviews (2): Last reviewed commit: ["fix(setup): refuse pre-existing auto-unl..."](https://github.com/thegaysupreme123/yoetz/commit/183ec513336a8146d42ee2624212c10764578303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22314655)</sub>

<!-- /greptile_comment -->