### PR TITLE
fix(privacy): restore intersection, channel ceilings, and data-use runtime guard

### DIFF
--- a/src/yoetz/adapters/memory/privacy.py
+++ b/src/yoetz/adapters/memory/privacy.py
@@ -128,16 +128,22 @@ class MemoryPrivacyPolicyStore:
         ]
         if not eligible:
             raise ValueError("privacy_policy_missing")
+        # ADR-009 / protocol: intersection of every containing current row — not rank-max alone.
         rank = {
             AuthorizationScopeKind.MACHINE: 0,
             AuthorizationScopeKind.WORKSPACE: 1,
             AuthorizationScopeKind.TASK: 2,
             AuthorizationScopeKind.REQUEST: 3,
         }
-        row = max(
-            eligible, key=lambda item: (rank[item.policy.effective_scope.kind], item.generation)
+        ordered = sorted(
+            eligible,
+            key=lambda item: (rank[item.policy.effective_scope.kind], item.generation),
         )
-        return EffectivePrivacyPolicy(row.policy, row.generation, row.policy.policy_digest)
+        composed = ordered[0].policy
+        for row in ordered[1:]:
+            composed = composed.meet(row.policy)
+        generation = max(row.generation for row in eligible)
+        return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(
         self, proposal: PolicyTransitionProposal

--- a/src/yoetz/adapters/privacy/catalog.py
+++ b/src/yoetz/adapters/privacy/catalog.py
@@ -535,19 +535,22 @@ class CatalogPrivacyPolicyStore:
                 eligible.append((policy, cast(int, generation)))
         if not eligible:
             raise ValueError("privacy_policy_missing")
-        policy, generation = max(
+        # ADR-009 / protocol: intersection of every containing current row — not rank-max alone.
+        rank = {
+            AuthorizationScopeKind.MACHINE: 0,
+            AuthorizationScopeKind.WORKSPACE: 1,
+            AuthorizationScopeKind.TASK: 2,
+            AuthorizationScopeKind.REQUEST: 3,
+        }
+        ordered = sorted(
             eligible,
-            key=lambda item: (
-                {
-                    AuthorizationScopeKind.MACHINE: 0,
-                    AuthorizationScopeKind.WORKSPACE: 1,
-                    AuthorizationScopeKind.TASK: 2,
-                    AuthorizationScopeKind.REQUEST: 3,
-                }[item[0].effective_scope.kind],
-                item[1],
-            ),
+            key=lambda item: (rank[item[0].effective_scope.kind], item[1]),
         )
-        return EffectivePrivacyPolicy(policy, generation, policy.policy_digest)
+        composed = ordered[0][0]
+        for policy, _generation in ordered[1:]:
+            composed = composed.meet(policy)
+        generation = max(item[1] for item in eligible)
+        return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(
         self, proposal: PolicyTransitionProposal

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -56,6 +56,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -121,6 +122,7 @@ _PRECONSUME_OUTCOME: Mapping[PrivacyReason, PrivacyOutcome] = MappingProxyType(
         PrivacyReason.DEADLINE_EXPIRED: PrivacyOutcome.TIMEOUT,
         PrivacyReason.PROVIDER_UNAVAILABLE: PrivacyOutcome.TRANSPORT_FAILED,
         PrivacyReason.AUDIT_FAILED: PrivacyOutcome.AUDIT_FAILED,
+        PrivacyReason.POLICY_DENIED: PrivacyOutcome.BLOCKED_BY_POLICY,
     }
 )
 
@@ -171,12 +173,15 @@ class ProviderRegistry:
     human_authority_digest: str
     external: Mapping[ProviderBinding, ExternalProviderFactory]
     local_model: tuple[ProviderBinding, SemanticEvaluatorPort] | None
+    require_current_provider_data_use_evidence: bool = False
 
     def __post_init__(self) -> None:
         if type(self.external) is not MappingProxyType:
             raise TypeError("provider_registry_external_not_immutable")
         if self.local_model is not None and type(self.local_model) is not tuple:
             raise TypeError("provider_registry_local_model_invalid")
+        if type(self.require_current_provider_data_use_evidence) is not bool:
+            raise TypeError("provider_registry_data_use_guard_invalid")
 
     def resolve_external(self, binding: ProviderBinding) -> ExternalProviderFactory | None:
         return self.external.get(binding)
@@ -185,6 +190,14 @@ class ProviderRegistry:
         if self.local_model is not None and self.local_model[0] == binding:
             return self.local_model[1]
         return None
+
+    def data_use_profile(self, binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        factory = self.resolve_external(binding)
+        if factory is None:
+            return None
+        profile = getattr(factory, "profile", None)
+        data_use = getattr(profile, "data_use_profile", None)
+        return data_use if type(data_use) is ProviderDataUseProfile else None
 
 
 def _llm_binding(policy: PrivacyPolicy) -> ProviderBinding | None:
@@ -351,6 +364,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(fenced_external),
                 fenced_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
 
         for factory in stale_external.values():
@@ -449,6 +463,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(new_external),
                 new_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
         return ProviderReconciliation(
             policy.generation, activated, deactivated, tuple(sorted(unavailable))
@@ -608,6 +623,10 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             return PrivacyReason.DEADLINE_EXPIRED
         if now_utc >= authorization.expires_at:
             return PrivacyReason.AUTHORIZATION_EXPIRED
+        if registry.require_current_provider_data_use_evidence:
+            data_use = registry.data_use_profile(case.provider_binding)
+            if data_use is None or not data_use.recommendation_eligible(now_utc):
+                return PrivacyReason.POLICY_DENIED
         return None
 
     async def _preconsume_failure(

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
@@ -15,6 +16,7 @@ from yoetz.domain.privacy import (
     ApprovedLocalItem,
     ApprovedOutboundCase,
     AuthorizationScope,
+    AuthorizationScopeKind,
     CandidateContext,
     ClassifiedContext,
     ConsentSource,
@@ -38,6 +40,7 @@ from yoetz.domain.privacy import (
     PrivacyProfile,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -92,6 +95,12 @@ type LocalDisclosureResult = (
 _SEMANTIC_PURPOSE = "semantic-review"
 _MEDIA_TYPE = "application/json"
 _SCHEMA_ID = "yoetz-semantic-case-1.0.0"
+_SCOPE_KIND_RANK = {
+    AuthorizationScopeKind.MACHINE: 0,
+    AuthorizationScopeKind.WORKSPACE: 1,
+    AuthorizationScopeKind.TASK: 2,
+    AuthorizationScopeKind.REQUEST: 3,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,6 +257,7 @@ class PrivacyCoordinator:
         "_close_lock",
         "_close_task",
         "_closed",
+        "_data_use_resolver",
         "_gateway",
         "_human",
         "_ids",
@@ -267,6 +277,7 @@ class PrivacyCoordinator:
         *,
         service_generation: int = 1,
         human: HumanPrivacyControlPort | None = None,
+        data_use_resolver: Callable[[ProviderBinding], ProviderDataUseProfile | None] | None = None,
     ) -> None:
         if type(service_generation) is not int or service_generation <= 0:
             raise ValueError("privacy_service_generation_invalid")
@@ -279,6 +290,7 @@ class PrivacyCoordinator:
         self._ids = ids
         self._service_generation = service_generation
         self._human = human
+        self._data_use_resolver = data_use_resolver
         self._policy_app: PrivacyPolicyApplication | None = None
         self._closed = False
         self._close_lock = asyncio.Lock()
@@ -699,6 +711,24 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.PURPOSE_NOT_ALLOWED,
             )
+        if _SCOPE_KIND_RANK[candidate.scope.kind] > _SCOPE_KIND_RANK[llm.scope_ceiling]:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.SCOPE_MISMATCH,
+            )
+        if (
+            policy.require_current_provider_data_use_evidence
+            and binding.transport == "external"
+            and not self._data_use_evidence_current(binding)
+        ):
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
 
         classified = self._classifier.classify(candidate, effective)
         decision = self._semantic_decision(classified, effective, binding)
@@ -727,6 +757,26 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.INSUFFICIENT_APPROVED_CONTEXT,
             )
+        # Channel ceilings are operator-visible policy dimensions; fail closed when exceeded.
+        llm = next(
+            item
+            for item in effective.policy.channel_policies
+            if item.channel is EgressChannel.LLM_INFERENCE
+        )
+        if llm.max_bytes > 0 and minimized.byte_count > llm.max_bytes:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
+        if llm.max_tokens > 0 and minimized.token_count > llm.max_tokens:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
 
         task_id = candidate.scope.task_id
         if task_id is None:
@@ -742,6 +792,15 @@ class PrivacyCoordinator:
             LocalDisclosureSink.LOCAL_MODEL if binding.transport == "local_af_unix" else None
         )
         provider_binding = binding if binding.transport == "external" else None
+        # Authorization ceilings bind policy ∩ case (never case size alone).
+        auth_max_bytes = (
+            minimized.byte_count if llm.max_bytes <= 0 else min(llm.max_bytes, minimized.byte_count)
+        )
+        auth_max_tokens = (
+            minimized.token_count
+            if llm.max_tokens <= 0
+            else min(llm.max_tokens, minimized.token_count)
+        )
         try:
             prepared = await self._audit.prepare_disclosure_proposal(
                 DisclosureProposalRequest(
@@ -757,8 +816,8 @@ class PrivacyCoordinator:
                     policy_version=effective.policy.version,
                     policy_generation=effective.generation,
                     policy_digest=effective.effective_digest,
-                    max_bytes=minimized.byte_count,
-                    max_tokens=minimized.token_count,
+                    max_bytes=auth_max_bytes,
+                    max_tokens=auth_max_tokens,
                     expires_at=now
                     + timedelta(seconds=max(60, llm.authorization_ttl_seconds or 60)),
                 )
@@ -1059,6 +1118,17 @@ class PrivacyCoordinator:
             privacy_proposal_id=privacy_proposal_id,
             receipt_id=receipt_id,
         )
+
+    def _data_use_evidence_current(self, binding: ProviderBinding) -> bool:
+        """True when the bound external profile has current recommendation-eligible data-use."""
+
+        resolver = self._data_use_resolver
+        if resolver is None:
+            return False
+        profile = resolver(binding)
+        if type(profile) is not ProviderDataUseProfile:
+            return False
+        return profile.recommendation_eligible(self._clock.now_utc())
 
     def _semantic_decision(
         self,

--- a/src/yoetz/domain/privacy.py
+++ b/src/yoetz/domain/privacy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
 from typing import Final, Literal, cast
@@ -14,7 +14,7 @@ from yoetz.domain.values import (
     validate_commitment,
     validate_sha256_digest,
 )
-from yoetz.protocol.canonical import canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
 from yoetz.protocol.ids import IdKind, validate_id
 from yoetz.protocol.models import DataCategory
 
@@ -667,6 +667,91 @@ class ChannelPolicy:
             if set(self.allowed_data_classes) - {DataClass.PUBLIC_STRUCTURAL}:
                 raise _invalid()
 
+    def meet(self, other: ChannelPolicy) -> ChannelPolicy:
+        """Intersect two channel rows (AND enablement, set meet, min ceilings)."""
+
+        if type(other) is not ChannelPolicy or self.channel is not other.channel:
+            raise _invalid()
+        if not self.enabled or not other.enabled:
+            return ChannelPolicy(
+                self.channel,
+                False,
+                (),
+                (),
+                None,
+                (),
+                AuthorizationScopeKind.MACHINE,
+                False,
+                0,
+                0,
+                0,
+            )
+        binding = (
+            self.provider_binding
+            if self.provider_binding is not None and self.provider_binding == other.provider_binding
+            else None
+        )
+        # Enabled external LLM without an exact shared binding cannot authorize a destination.
+        if self.channel is EgressChannel.LLM_INFERENCE and binding is None:
+            return ChannelPolicy(
+                self.channel,
+                False,
+                (),
+                (),
+                None,
+                (),
+                AuthorizationScopeKind.MACHINE,
+                False,
+                0,
+                0,
+                0,
+            )
+        scope_rank = {
+            AuthorizationScopeKind.MACHINE: 0,
+            AuthorizationScopeKind.WORKSPACE: 1,
+            AuthorizationScopeKind.TASK: 2,
+            AuthorizationScopeKind.REQUEST: 3,
+        }
+        ceiling = (
+            self.scope_ceiling
+            if scope_rank[self.scope_ceiling] <= scope_rank[other.scope_ceiling]
+            else other.scope_ceiling
+        )
+        return ChannelPolicy(
+            self.channel,
+            True,
+            tuple(set(self.allowed_categories) & set(other.allowed_categories)),
+            tuple(set(self.allowed_data_classes) & set(other.allowed_data_classes)),
+            binding,
+            tuple(set(self.allowed_purposes) & set(other.allowed_purposes)),
+            ceiling,
+            self.preview_required or other.preview_required,
+            min(self.max_bytes, other.max_bytes),
+            min(self.max_tokens, other.max_tokens),
+            min(self.authorization_ttl_seconds, other.authorization_ttl_seconds),
+        )
+
+
+_SCOPE_KIND_RANK: Final = {
+    AuthorizationScopeKind.MACHINE: 0,
+    AuthorizationScopeKind.WORKSPACE: 1,
+    AuthorizationScopeKind.TASK: 2,
+    AuthorizationScopeKind.REQUEST: 3,
+}
+_PROFILE_OPENNESS: Final = {
+    PrivacyProfile.LOCAL_ONLY: 0,
+    PrivacyProfile.CONFIRM_EVERY_REQUEST: 1,
+    PrivacyProfile.MINIMAL_EXTERNAL: 2,
+    PrivacyProfile.TRUSTED_PROVIDER: 3,
+}
+_REVIEW_CONTEXT_OPENNESS: Final = {
+    ReviewContextProfile.STRUCTURAL: 0,
+    ReviewContextProfile.GOAL_AWARE: 1,
+    ReviewContextProfile.ASSISTED: 2,
+    ReviewContextProfile.EXPANDED: 3,
+    ReviewContextProfile.CUSTOM: 4,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class PrivacyPolicy:
@@ -773,6 +858,158 @@ class PrivacyPolicy:
         _time(self.created_at)
         if self.supersedes_policy_digest is not None:
             validate_sha256_digest(self.supersedes_policy_digest)
+
+    def meet(self, other: PrivacyPolicy) -> PrivacyPolicy:
+        """Intersect two standing policies (ADR-009 decision 6 / protocol policy resolution).
+
+        Permission fields tighten by meet (AND / set intersection / min ceilings). Identity
+        (``policy_id``, ``version``, ``created_at``, ``effective_scope``) is taken from the
+        more-specific scope when ranks differ, else from ``self``. The result's
+        ``policy_digest`` is recomputed from the meet body so multi-scope composition is not
+        confused with a single stored row.
+        """
+
+        if type(other) is not PrivacyPolicy:
+            raise _invalid()
+        if self.effective_scope.installation_id != other.effective_scope.installation_id:
+            raise _invalid()
+
+        by_self = {channel.channel: channel for channel in self.channel_policies}
+        by_other = {channel.channel: channel for channel in other.channel_policies}
+        channels = tuple(
+            by_self[channel].meet(by_other[channel])
+            for channel in sorted(EgressChannel, key=lambda item: item.value.encode("ascii"))
+        )
+        network = (
+            self.network_egress_permitted
+            and other.network_egress_permitted
+            and any(channel.enabled for channel in channels)
+        )
+        if not network:
+            channels = tuple(
+                ChannelPolicy(
+                    channel.channel,
+                    False,
+                    (),
+                    (),
+                    None,
+                    (),
+                    AuthorizationScopeKind.MACHINE,
+                    False,
+                    0,
+                    0,
+                    0,
+                )
+                for channel in channels
+            )
+
+        llm = next(
+            channel for channel in channels if channel.channel is EgressChannel.LLM_INFERENCE
+        )
+        profile_rank = min(_PROFILE_OPENNESS[self.profile], _PROFILE_OPENNESS[other.profile])
+        if not network or not llm.enabled or llm.provider_binding is None:
+            profile = PrivacyProfile.LOCAL_ONLY
+        else:
+            profile = next(item for item, rank in _PROFILE_OPENNESS.items() if rank == profile_rank)
+            if profile is PrivacyProfile.LOCAL_ONLY:
+                profile = PrivacyProfile.MINIMAL_EXTERNAL
+            if profile is PrivacyProfile.CONFIRM_EVERY_REQUEST and not llm.preview_required:
+                # Meet of preview flags should have ORed; keep construction valid.
+                llm = replace(llm, preview_required=True)
+                channels = tuple(
+                    llm if channel.channel is EgressChannel.LLM_INFERENCE else channel
+                    for channel in channels
+                )
+            if (
+                profile is PrivacyProfile.MINIMAL_EXTERNAL
+                and DataClass.SENSITIVE_CONFIDENTIAL in llm.allowed_data_classes
+            ):
+                llm = replace(
+                    llm,
+                    allowed_data_classes=tuple(
+                        item
+                        for item in llm.allowed_data_classes
+                        if item is not DataClass.SENSITIVE_CONFIDENTIAL
+                    ),
+                )
+                channels = tuple(
+                    llm if channel.channel is EgressChannel.LLM_INFERENCE else channel
+                    for channel in channels
+                )
+
+        review_selection = self.review_selection.meet(other.review_selection)
+        review_rank = min(
+            _REVIEW_CONTEXT_OPENNESS[self.review_context_profile],
+            _REVIEW_CONTEXT_OPENNESS[other.review_context_profile],
+        )
+        review_context = next(
+            item for item, rank in _REVIEW_CONTEXT_OPENNESS.items() if rank == review_rank
+        )
+        if review_context is not ReviewContextProfile.CUSTOM:
+            if review_selection != ReviewSelectionPolicy.for_profile(review_context):
+                review_context = ReviewContextProfile.CUSTOM
+
+        local_enabled = self.local_model_enabled and other.local_model_enabled
+        local_binding = (
+            self.local_model_binding
+            if local_enabled
+            and self.local_model_binding is not None
+            and self.local_model_binding == other.local_model_binding
+            else None
+        )
+        if local_binding is None:
+            local_enabled = False
+
+        identity = (
+            other
+            if _SCOPE_KIND_RANK[other.effective_scope.kind]
+            > _SCOPE_KIND_RANK[self.effective_scope.kind]
+            else self
+        )
+        placeholder = PrivacyPolicy(
+            identity.policy_id,
+            identity.version,
+            "sha256:" + "0" * 64,
+            profile,
+            review_context,
+            review_selection,
+            self.require_current_provider_data_use_evidence
+            or other.require_current_provider_data_use_evidence,
+            network,
+            identity.effective_scope,
+            channels,
+            local_enabled,
+            local_binding,
+            tuple(set(self.local_model_categories) & set(other.local_model_categories)),
+            tuple(set(self.local_model_data_classes) & set(other.local_model_data_classes)),
+            tuple(set(self.agent_context_categories) & set(other.agent_context_categories)),
+            tuple(set(self.agent_context_data_classes) & set(other.agent_context_data_classes)),
+            tuple(
+                set(self.trusted_human_control_categories)
+                & set(other.trusted_human_control_categories)
+            ),
+            tuple(
+                set(self.trusted_human_control_data_classes)
+                & set(other.trusted_human_control_data_classes)
+            ),
+            identity.created_at,
+            None,
+        )
+        return replace(
+            placeholder,
+            policy_digest=canonical_digest(
+                {
+                    "components": sorted((self.policy_digest, other.policy_digest)),
+                    "meet": "yoetz.privacy-policy-meet/1",
+                    "network_egress_permitted": placeholder.network_egress_permitted,
+                    "profile": placeholder.profile.value,
+                    "require_current_provider_data_use_evidence": (
+                        placeholder.require_current_provider_data_use_evidence
+                    ),
+                    "review_context_profile": placeholder.review_context_profile.value,
+                }
+            ),
+        )
 
     @property
     def unsupported_enabled_channels(self) -> tuple[EgressChannel, ...]:

--- a/src/yoetz/domain/privacy.py
+++ b/src/yoetz/domain/privacy.py
@@ -14,7 +14,12 @@ from yoetz.domain.values import (
     validate_commitment,
     validate_sha256_digest,
 )
-from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import (
+    JsonValue,
+    canonical_digest,
+    canonical_encode,
+    strict_json_parse,
+)
 from yoetz.protocol.ids import IdKind, validate_id
 from yoetz.protocol.models import DataCategory
 
@@ -998,16 +1003,19 @@ class PrivacyPolicy:
         return replace(
             placeholder,
             policy_digest=canonical_digest(
-                {
-                    "components": sorted((self.policy_digest, other.policy_digest)),
-                    "meet": "yoetz.privacy-policy-meet/1",
-                    "network_egress_permitted": placeholder.network_egress_permitted,
-                    "profile": placeholder.profile.value,
-                    "require_current_provider_data_use_evidence": (
-                        placeholder.require_current_provider_data_use_evidence
-                    ),
-                    "review_context_profile": placeholder.review_context_profile.value,
-                }
+                cast(
+                    JsonValue,
+                    {
+                        "components": sorted((self.policy_digest, other.policy_digest)),
+                        "meet": "yoetz.privacy-policy-meet/1",
+                        "network_egress_permitted": placeholder.network_egress_permitted,
+                        "profile": placeholder.profile.value,
+                        "require_current_provider_data_use_evidence": (
+                            placeholder.require_current_provider_data_use_evidence
+                        ),
+                        "review_context_profile": placeholder.review_context_profile.value,
+                    },
+                )
             ),
         )
 

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -91,6 +91,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyProfile,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
@@ -1162,6 +1163,16 @@ async def build_privacy_coordinator(
         True,
     )
     await gateway.reconcile_policy(effective, authority)
+
+    def _data_use_for(binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        registry = getattr(gateway, "_registry", None)
+        if registry is None:
+            return None
+        lookup = getattr(registry, "data_use_profile", None)
+        if lookup is None:
+            return None
+        return cast(ProviderDataUseProfile | None, lookup(binding))
+
     coordinator = PrivacyCoordinator(
         policies,
         classifier,
@@ -1170,6 +1181,7 @@ async def build_privacy_coordinator(
         clock,
         ids,
         service_generation=service_generation,
+        data_use_resolver=_data_use_for,
     )
     policy_app = PrivacyPolicyApplication(
         policies,

--- a/tests/unit/application/test_channel_ceilings_enforced.py
+++ b/tests/unit/application/test_channel_ceilings_enforced.py
@@ -1,0 +1,269 @@
+"""RT-privacy-egress-1: channel max_bytes/max_tokens/scope_ceiling fence semantic admission."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import INSTALLATION_ID, minimal_external_policy
+from builders.privacy_widenings import llm_channel, with_llm
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressBlocked
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    CandidateContextItem,
+    ClassifiedContext,
+    ClassifiedContextItem,
+    DataClass,
+    EgressChannel,
+    PrivacyDecision,
+    PrivacyOutcome,
+    PrivacyPolicy,
+    PrivacyReason,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    DisclosureProposalRequest,
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+_REQUEST = "req_30000000-0000-4000-8000-000000000101"
+_TASK = "tsk_30000000-0000-4000-8000-000000000102"
+_SUBJECT = "sha256:" + "d" * 64
+_ITEM_DIGEST = "sha256:" + "e" * 64
+_CASE_DIGEST = "sha256:" + "c" * 64
+_POLICY_CEILING_BYTES = 1024
+_OVERSIZE_BYTES = 2048
+_POLICY_CEILING_TOKENS = 10
+_OVERSIZE_TOKENS = 512
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._n = 0
+
+    def new(self, kind: IdKind) -> str:
+        self._n += 1
+        prefix = {
+            IdKind.PRIVACY_PROPOSAL: "ppr",
+            IdKind.EGRESS_RECEIPT: "egr",
+            IdKind.EGRESS_AUTHORIZATION: "aut",
+            IdKind.EGRESS_DISPATCH: "dsp",
+        }.get(kind, "ppr")
+        return f"{prefix}_30000000-0000-4000-8000-{self._n:012d}"
+
+
+class _Store:
+    def __init__(self, policy: PrivacyPolicy) -> None:
+        self._policy = policy
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return EffectivePrivacyPolicy(self._policy, 1, self._policy.policy_digest)
+
+
+class _Classifier:
+    def __init__(self, *, byte_count: int, token_count: int) -> None:
+        self._byte_count = byte_count
+        self._token_count = token_count
+
+    def classify(
+        self, candidate: CandidateContext, effective: EffectivePrivacyPolicy
+    ) -> ClassifiedContext:
+        del effective
+        items = tuple(
+            ClassifiedContextItem(
+                item,
+                DataClass.PUBLIC_STRUCTURAL,
+                (),
+                True,
+                "1.0.0",
+            )
+            for item in candidate.items
+        )
+        return ClassifiedContext(candidate, items)
+
+    def minimize_and_scan(
+        self, classified: ClassifiedContext, decision: PrivacyDecision
+    ) -> MinimizedDisclosure:
+        del decision
+        payload = b"x" * self._byte_count
+        return MinimizedDisclosure(
+            prepared_bytes=payload,
+            included_item_ids=tuple(item.candidate.item_id for item in classified.items),
+            source_item_digests=(_ITEM_DIGEST,),
+            approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            blocked_categories=(),
+            transformation_summary=(),
+            byte_count=self._byte_count,
+            token_count=self._token_count,
+            case_digest=_CASE_DIGEST,
+            scanner_registry_version="test",
+            scanner_profile_digest="sha256:" + "f" * 64,
+            forbidden_findings=(),
+        )
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.prepared: list[DisclosureProposalRequest] = []
+
+    async def reserve(self, subject: object) -> PrivacyAuditReservation:
+        proposal_id = getattr(
+            subject, "privacy_proposal_id", "ppr_30000000-0000-4000-8000-000000000001"
+        )
+        request_id = getattr(subject, "request_id", _REQUEST)
+        return PrivacyAuditReservation(
+            proposal_id,
+            request_id,
+            _SUBJECT,
+            "reserved",
+            1,
+            _NOW,
+        )
+
+    async def complete_decision(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def prepare_disclosure_proposal(self, request: DisclosureProposalRequest) -> object:
+        self.prepared.append(request)
+        raise RuntimeError("stop_after_prepare")
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _policy_with_ceilings(
+    *,
+    max_bytes: int = 262_144,
+    max_tokens: int = 4096,
+    scope_ceiling: AuthorizationScopeKind = AuthorizationScopeKind.TASK,
+) -> PrivacyPolicy:
+    return with_llm(
+        minimal_external_policy(),
+        max_bytes=max_bytes,
+        max_tokens=max_tokens,
+        scope_ceiling=scope_ceiling,
+    )
+
+
+def _candidate(
+    *, scope_kind: AuthorizationScopeKind = AuthorizationScopeKind.TASK
+) -> CandidateContext:
+    scope = AuthorizationScope(
+        scope_kind,
+        INSTALLATION_ID,
+        f"hmac-sha256:{'a' * 64}",
+        _TASK
+        if scope_kind in {AuthorizationScopeKind.TASK, AuthorizationScopeKind.REQUEST}
+        else None,
+        _REQUEST if scope_kind is AuthorizationScopeKind.REQUEST else None,
+    )
+    binding = llm_channel(minimal_external_policy()).provider_binding
+    assert binding is not None
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        scope,
+        _SUBJECT,
+        binding,
+        (
+            CandidateContextItem(
+                "item-1",
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                scope,
+                "origin-1",
+                b"{}",
+            ),
+        ),
+    )
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=1), _Clock().monotonic_seconds() + 60.0)
+
+
+def _coordinator(
+    policy: PrivacyPolicy, *, byte_count: int, token_count: int
+) -> tuple[PrivacyCoordinator, _Audit]:
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier(byte_count=byte_count, token_count=token_count)),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+    )
+    return coordinator, audit
+
+
+@pytest.mark.anyio
+async def test_oversize_bytes_blocks_admission() -> None:
+    policy = _policy_with_ceilings(max_bytes=_POLICY_CEILING_BYTES)
+    coordinator, audit = _coordinator(policy, byte_count=_OVERSIZE_BYTES, token_count=1)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_oversize_tokens_blocks_admission() -> None:
+    policy = _policy_with_ceilings(max_tokens=_POLICY_CEILING_TOKENS)
+    coordinator, audit = _coordinator(policy, byte_count=16, token_count=_OVERSIZE_TOKENS)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_scope_broader_than_ceiling_blocks() -> None:
+    policy = _policy_with_ceilings(scope_ceiling=AuthorizationScopeKind.WORKSPACE)
+    coordinator, audit = _coordinator(policy, byte_count=16, token_count=1)
+    result = await coordinator.evaluate_semantic(
+        _candidate(scope_kind=AuthorizationScopeKind.TASK),
+        _deadline(),
+    )
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.reason is PrivacyReason.SCOPE_MISMATCH
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_within_ceilings_stamps_policy_intersect_case_max() -> None:
+    policy = _policy_with_ceilings(max_bytes=4096, max_tokens=100)
+    coordinator, audit = _coordinator(policy, byte_count=100, token_count=8)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert audit.prepared, f"expected prepare; got {result!r}"
+    request = audit.prepared[0]
+    assert request.max_bytes == 100
+    assert request.max_tokens == 8

--- a/tests/unit/application/test_data_use_evidence_runtime_guard.py
+++ b/tests/unit/application/test_data_use_evidence_runtime_guard.py
@@ -1,0 +1,268 @@
+"""RT-privacy-egress-2: require_current_provider_data_use_evidence is a runtime egress guard."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import INSTALLATION_ID, minimal_external_policy
+from builders.privacy_widenings import llm_channel
+from yoetz.adapters.providers.openai_responses import owner_declared_data_use_profile
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressBlocked
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    CandidateContextItem,
+    ClassifiedContext,
+    ClassifiedContextItem,
+    DataClass,
+    EgressChannel,
+    PrivacyDecision,
+    PrivacyOutcome,
+    PrivacyPolicy,
+    PrivacyReason,
+    ProviderBinding,
+    ProviderDataUseProfile,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.canonical import canonical_digest
+from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=1), 60.0)
+
+
+_REQUEST = "req_80000000-0000-4000-8000-000000000002"
+_TASK = "tsk_80000000-0000-4000-8000-000000000003"
+_SUBJECT = "sha256:" + "d" * 64
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._n = 0
+
+    def new(self, kind: IdKind) -> str:
+        self._n += 1
+        prefix = {
+            IdKind.PRIVACY_PROPOSAL: "ppr",
+            IdKind.EGRESS_RECEIPT: "egr",
+            IdKind.EGRESS_AUTHORIZATION: "aut",
+            IdKind.EGRESS_DISPATCH: "dsp",
+        }.get(kind, "ppr")
+        return f"{prefix}_80000000-0000-4000-8000-{self._n:012d}"
+
+
+class _Store:
+    def __init__(self, policy: PrivacyPolicy) -> None:
+        self._policy = policy
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return EffectivePrivacyPolicy(self._policy, 1, self._policy.policy_digest)
+
+
+class _Classifier:
+    def classify(
+        self, candidate: CandidateContext, effective: EffectivePrivacyPolicy
+    ) -> ClassifiedContext:
+        del effective
+        return ClassifiedContext(
+            candidate,
+            tuple(
+                ClassifiedContextItem(item, DataClass.PUBLIC_STRUCTURAL, (), True, "1.0.0")
+                for item in candidate.items
+            ),
+        )
+
+    def minimize_and_scan(
+        self, classified: ClassifiedContext, decision: PrivacyDecision
+    ) -> MinimizedDisclosure:
+        del decision
+        return MinimizedDisclosure(
+            prepared_bytes=b"{}",
+            included_item_ids=tuple(item.candidate.item_id for item in classified.items),
+            source_item_digests=("sha256:" + "e" * 64,),
+            approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            blocked_categories=(),
+            transformation_summary=(),
+            byte_count=2,
+            token_count=1,
+            case_digest="sha256:" + "c" * 64,
+            scanner_registry_version="test",
+            scanner_profile_digest="sha256:" + "f" * 64,
+            forbidden_findings=(),
+        )
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.prepared = 0
+
+    async def reserve(self, subject: object) -> PrivacyAuditReservation:
+        proposal_id = getattr(
+            subject, "privacy_proposal_id", "ppr_80000000-0000-4000-8000-000000000001"
+        )
+        request_id = getattr(subject, "request_id", _REQUEST)
+        return PrivacyAuditReservation(
+            proposal_id,
+            request_id,
+            _SUBJECT,
+            "reserved",
+            1,
+            _NOW,
+        )
+
+    async def complete_decision(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def prepare_disclosure_proposal(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        self.prepared += 1
+        raise RuntimeError("stop_after_prepare")
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _policy_requiring_data_use() -> PrivacyPolicy:
+    return replace(minimal_external_policy(), require_current_provider_data_use_evidence=True)
+
+
+def _candidate(binding: ProviderBinding) -> CandidateContext:
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        INSTALLATION_ID,
+        f"hmac-sha256:{'8' * 64}",
+        _TASK,
+    )
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        scope,
+        _SUBJECT,
+        binding,
+        (
+            CandidateContextItem(
+                "item-1",
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                scope,
+                "origin-1",
+                b"{}",
+            ),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_data_use_ineligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    ineligible = owner_declared_data_use_profile(
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "x"}),
+    )
+    assert not ineligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: ineligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_resolver_missing() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=None,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_allows_when_flag_true_and_eligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    eligible = ProviderDataUseProfile(
+        data_use_profile_id="openai-api-data-use",
+        data_use_profile_version="1.0.0",
+        customer_content_training="prohibited",
+        retention="bounded",
+        retention_days_ceiling=30,
+        provider_human_access="restricted",
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "ok"}),
+    )
+    assert eligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: eligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert audit.prepared == 1, f"eligible data-use must reach prepare; got {result!r}"
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.AUDIT_FAILED

--- a/tests/unit/privacy/test_effective_policy_intersection.py
+++ b/tests/unit/privacy/test_effective_policy_intersection.py
@@ -1,0 +1,218 @@
+"""RT-privacy-egress-3: effective_policy intersects ancestor scopes (ADR-009)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+import apsw
+import pytest
+
+from yoetz.adapters.memory.privacy import MemoryPrivacyCatalogState, MemoryPrivacyPolicyStore
+from yoetz.adapters.privacy.catalog import CatalogPrivacyPolicyStore
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ChannelPolicy,
+    DataClass,
+    EgressChannel,
+    PrivacyPolicy,
+    PrivacyProfile,
+    ProviderBinding,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+_INSTALLATION = "ins_30000000-0000-4000-8000-000000000001"
+_WORKSPACE = f"hmac-sha256:{'6' * 64}"
+_TASK = "tsk_30000000-0000-4000-8000-00000000000b"
+_POLICY_M = "pvy_30000000-0000-4000-8000-000000000006"
+_POLICY_W = "pvy_30000000-0000-4000-8000-000000000007"
+_DIGEST_M = f"sha256:{'1' * 64}"
+_DIGEST_W = f"sha256:{'2' * 64}"
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+def _database() -> apsw.Connection:
+    db = apsw.Connection(":memory:")
+    db.execute(Path("migrations/catalog/0001.sql").read_text(encoding="utf-8"))
+    return db
+
+
+def _disabled(channel: EgressChannel) -> ChannelPolicy:
+    return ChannelPolicy(
+        channel,
+        False,
+        (),
+        (),
+        None,
+        (),
+        AuthorizationScopeKind.MACHINE,
+        False,
+        0,
+        0,
+        0,
+    )
+
+
+def _ordered(channels: dict[EgressChannel, ChannelPolicy]) -> tuple[ChannelPolicy, ...]:
+    return tuple(
+        channels[channel] for channel in sorted(EgressChannel, key=lambda item: item.value)
+    )
+
+
+def _local_only(*, scope: AuthorizationScope, policy_id: str, digest: str) -> PrivacyPolicy:
+    return PrivacyPolicy(
+        policy_id,
+        1,
+        digest,
+        PrivacyProfile.LOCAL_ONLY,
+        ReviewContextProfile.STRUCTURAL,
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.STRUCTURAL),
+        False,
+        False,
+        scope,
+        _ordered({channel: _disabled(channel) for channel in EgressChannel}),
+        False,
+        None,
+        (),
+        (),
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (DataClass.PUBLIC_STRUCTURAL,),
+        tuple(DataCategory),
+        (
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+            DataClass.SENSITIVE_CONFIDENTIAL,
+        ),
+        _NOW,
+    )
+
+
+def _minimal_external(*, scope: AuthorizationScope, policy_id: str, digest: str) -> PrivacyPolicy:
+    channels = {channel: _disabled(channel) for channel in EgressChannel}
+    channels[EgressChannel.LLM_INFERENCE] = ChannelPolicy(
+        EgressChannel.LLM_INFERENCE,
+        True,
+        (
+            DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            DataCategory.TASK_DESCRIPTION,
+        ),
+        (DataClass.ORDINARY_USER_CONTENT, DataClass.PUBLIC_STRUCTURAL),
+        ProviderBinding(
+            "fireworks",
+            "accounts/fireworks/models/minimax-m3",
+            "fireworks-responses",
+            "1.0.0",
+            "external",
+        ),
+        ("semantic-review",),
+        AuthorizationScopeKind.TASK,
+        False,
+        262_144,
+        4096,
+        300,
+    )
+    return PrivacyPolicy(
+        policy_id,
+        2,
+        digest,
+        PrivacyProfile.MINIMAL_EXTERNAL,
+        ReviewContextProfile.ASSISTED,
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.ASSISTED),
+        False,
+        True,
+        scope,
+        _ordered(channels),
+        False,
+        None,
+        (),
+        (),
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (DataClass.PUBLIC_STRUCTURAL,),
+        tuple(DataCategory),
+        (
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+            DataClass.SENSITIVE_CONFIDENTIAL,
+        ),
+        _NOW,
+    )
+
+
+def _task_scope() -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        _WORKSPACE,
+        _TASK,
+    )
+
+
+def _workspace_scope() -> AuthorizationScope:
+    return AuthorizationScope(AuthorizationScopeKind.WORKSPACE, _INSTALLATION, _WORKSPACE)
+
+
+def _machine_scope() -> AuthorizationScope:
+    return AuthorizationScope(AuthorizationScopeKind.MACHINE, _INSTALLATION)
+
+
+def _llm_authorized(policy: PrivacyPolicy) -> bool:
+    llm = next(
+        channel
+        for channel in policy.channel_policies
+        if channel.channel is EgressChannel.LLM_INFERENCE
+    )
+    return policy.network_egress_permitted and llm.enabled
+
+
+@pytest.mark.parametrize("store_kind", ["catalog", "memory"])
+def test_effective_policy_intersects_machine_ceiling_with_workspace_overlay(
+    store_kind: str,
+) -> None:
+    machine = _local_only(scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M)
+    workspace = _minimal_external(scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W)
+
+    async def run() -> PrivacyPolicy:
+        if store_kind == "catalog":
+            store: CatalogPrivacyPolicyStore | MemoryPrivacyPolicyStore = CatalogPrivacyPolicyStore(
+                _database(), _Clock()
+            )
+        else:
+            store = MemoryPrivacyPolicyStore(MemoryPrivacyCatalogState(), _Clock())
+        await store.seed_if_absent(machine)
+        await store.seed_if_absent(workspace)
+        effective = await store.effective_policy(_task_scope())
+        return effective.policy
+
+    policy = asyncio.run(run())
+    assert not _llm_authorized(policy), (
+        "effective_policy must meet machine local_only with workspace external, "
+        f"not select workspace alone; profile={policy.profile.value} "
+        f"scope={policy.effective_scope.kind.value} llm_authorized={_llm_authorized(policy)}"
+    )
+    assert policy.profile is PrivacyProfile.LOCAL_ONLY
+    assert policy.network_egress_permitted is False
+
+
+def test_privacy_policy_meet_is_commutative_for_local_and_external() -> None:
+    machine = _local_only(scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M)
+    workspace = _minimal_external(scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W)
+    left = machine.meet(workspace)
+    right = workspace.meet(machine)
+    assert left.network_egress_permitted is False
+    assert right.network_egress_permitted is False
+    assert left.profile is PrivacyProfile.LOCAL_ONLY
+    assert right.profile is PrivacyProfile.LOCAL_ONLY
+    assert _llm_authorized(left) is False
+    assert _llm_authorized(right) is False


### PR DESCRIPTION
## Summary

Restores three high-severity privacy/egress contracts confirmed by red-team (`RT-privacy-egress-1/2/3`). ADRs already require these fences; this aligns Catalog/Memory stores, semantic admission, and the outbound gateway with them.

| ID | Issue | Fix |
| --- | --- | --- |
| RT-privacy-egress-3 | #113 | `PrivacyPolicy.meet` + `effective_policy` intersects all containing current rows (not rank-max single row) |
| RT-privacy-egress-1 | #112 | Enforce LLM `max_bytes` / `max_tokens` / `scope_ceiling` at semantic admission; stamp proposal max as policy ∩ case |
| RT-privacy-egress-2 | #115 | When `require_current_provider_data_use_evidence` is true, block external egress unless the bound data-use profile is recommendation-eligible (coordinator + gateway) |

### Design gate

Privacy/egress is design-gated. Implementation follows existing ADR-009 / protocol / INTERFACES wording (intersection; channel ceilings; data-use runtime guard). Maintainer directed open red-team findings to be fixed and PR’d.

### Non-goals

- PR #114 (vault auto-unlock init) left untouched as requested.
- No ADR flip; behavior restored to stated authority.

## Test plan

- [x] `uv run pytest tests/unit/privacy/test_effective_policy_intersection.py tests/unit/application/test_channel_ceilings_enforced.py tests/unit/application/test_data_use_evidence_runtime_guard.py tests/unit/privacy/test_catalog_audit.py -q`
- [x] Broader slice: `tests/unit/privacy/` + `test_semantic_local_egress` + `test_privacy_policy` + egress gateway integration (54 passed)
- [x] Ruff format/check on touched files
- [ ] CI on this PR

Fixes #112
Fixes #113
Fixes #115

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores three red-team-confirmed privacy/egress fences: multi-scope policy intersection (`PrivacyPolicy.meet`), channel byte/token/scope-ceiling enforcement at semantic admission, and a runtime guard that blocks external egress when `require_current_provider_data_use_evidence` is set but no current-eligible data-use profile is present. The changes touch the domain model, both policy stores, the outbound gateway, the coordinator, and the composition root.

- **RT-privacy-egress-3** (`catalog.py`, `memory/privacy.py`): `effective_policy` now sorts all containing rows by scope rank and folds them with `PrivacyPolicy.meet` instead of returning the single highest-ranked row.
- **RT-privacy-egress-1** (`egress.py`, `domain/privacy.py`): `_semantic_pipeline` enforces `scope_ceiling`, `max_bytes`, and `max_tokens` from the effective channel policy before reaching `prepare_disclosure_proposal`, and stamps the authorization with `min(policy_ceiling, case_size)`.
- **RT-privacy-egress-2** (`egress.py`, `gateway.py`, `ready_composition.py`): A `data_use_resolver` callback is threaded into `PrivacyCoordinator`; both the coordinator and the gateway independently block external egress when the flag is set and the bound provider's data-use profile is absent or ineligible.

<h3>Confidence Score: 4/5</h3>

Safe to merge if the ChannelPolicy.meet ceiling logic is fixed before rollout; the defect only bites when two enabled same-binding channel rows have mismatched zero/non-zero ceiling values.

The three red-team fixes are structurally sound and the new tests cover the stated scenarios. However, ChannelPolicy.meet uses min(self.max_bytes, other.max_bytes) where 0 means no ceiling. A machine-scope policy with max_bytes=4096 intersected with any policy that leaves max_bytes=0 produces min(4096, 0) = 0, silently discarding the byte limit. This undermines the channel-ceiling fence that this PR is specifically intended to restore.

**Files Needing Attention:** src/yoetz/domain/privacy.py — the ChannelPolicy.meet method at lines 729-730 needs a sentinel-aware ceiling merge; the existing tests only intersect a disabled policy with an enabled one, so the min()/0 path is never exercised.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/domain/privacy.py | Adds PrivacyPolicy.meet and ChannelPolicy.meet; ChannelPolicy.meet uses min() for zero-means-unlimited fields (max_bytes, max_tokens), which inverts the meet semantics and can discard a tighter ceiling from the other policy. |
| src/yoetz/adapters/memory/privacy.py | Replaces rank-max single-row selection with sorted intersection via PrivacyPolicy.meet; logic is correct and consistent with the catalog adapter change. |
| src/yoetz/adapters/privacy/catalog.py | Mirrors the memory store change: sorts eligible rows and intersects them via meet; generation is taken as the max across rows, consistent with memory adapter. |
| src/yoetz/adapters/privacy/gateway.py | Adds require_current_provider_data_use_evidence flag to ProviderRegistry, propagates it at construction time, and enforces it in _preconsume_check; also maps POLICY_DENIED into _PRECONSUME_OUTCOME. |
| src/yoetz/application/egress.py | Adds scope_ceiling check, data-use runtime guard, byte/token ceiling enforcement, and policy-intersection-case stamping; correctness of the ceiling check depends on ChannelPolicy.meet which has the min()/0 issue in domain/privacy.py. |
| src/yoetz/service/ready_composition.py | Wires data_use_resolver into PrivacyCoordinator via a closure that reaches into gateway._registry with getattr; fails closed (returns None) if the private attribute is absent. |
| tests/unit/application/test_channel_ceilings_enforced.py | New tests covering oversized-bytes/token blocking and scope ceiling rejection; no test exercises the two-policy intersection path that would expose the min()/0 ceiling bug. |
| tests/unit/application/test_data_use_evidence_runtime_guard.py | New tests for RT-privacy-egress-2; covers ineligible profile blocking, missing resolver (fail-closed), and eligible profile passing through to audit. |
| tests/unit/privacy/test_effective_policy_intersection.py | New tests for RT-privacy-egress-3; validates that machine LOCAL_ONLY + workspace MINIMAL_EXTERNAL meets to LOCAL_ONLY and that meet is commutative, but all intersected policies have non-zero ceilings so the min()/0 path is not covered. |

<sub>Reviews (3): Last reviewed commit: ["fix(privacy): restore policy intersectio..."](https://github.com/thegaysupreme123/yoetz/commit/29ac3f6c3827df46b98407f361d9be674c5f166c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22348709)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->