### PR TITLE
fix(privacy): intersect ancestor policies in effective_policy

### DIFF
--- a/src/yoetz/adapters/memory/privacy.py
+++ b/src/yoetz/adapters/memory/privacy.py
@@ -142,7 +142,9 @@ class MemoryPrivacyPolicyStore:
         composed = ordered[0].policy
         for row in ordered[1:]:
             composed = composed.meet(row.policy)
-        generation = max(row.generation for row in eligible)
+        # Most-specific row's own generation: it is the CAS token the transition path compares
+        # against the exact stored row. See the matching note in CatalogPrivacyPolicyStore.
+        generation = ordered[-1].generation
         return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(

--- a/src/yoetz/adapters/memory/privacy.py
+++ b/src/yoetz/adapters/memory/privacy.py
@@ -128,16 +128,22 @@ class MemoryPrivacyPolicyStore:
         ]
         if not eligible:
             raise ValueError("privacy_policy_missing")
+        # ADR-009 / protocol: intersection of every containing current row — not rank-max alone.
         rank = {
             AuthorizationScopeKind.MACHINE: 0,
             AuthorizationScopeKind.WORKSPACE: 1,
             AuthorizationScopeKind.TASK: 2,
             AuthorizationScopeKind.REQUEST: 3,
         }
-        row = max(
-            eligible, key=lambda item: (rank[item.policy.effective_scope.kind], item.generation)
+        ordered = sorted(
+            eligible,
+            key=lambda item: (rank[item.policy.effective_scope.kind], item.generation),
         )
-        return EffectivePrivacyPolicy(row.policy, row.generation, row.policy.policy_digest)
+        composed = ordered[0].policy
+        for row in ordered[1:]:
+            composed = composed.meet(row.policy)
+        generation = max(row.generation for row in eligible)
+        return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(
         self, proposal: PolicyTransitionProposal

--- a/src/yoetz/adapters/privacy/catalog.py
+++ b/src/yoetz/adapters/privacy/catalog.py
@@ -549,7 +549,13 @@ class CatalogPrivacyPolicyStore:
         composed = ordered[0][0]
         for policy, _generation in ordered[1:]:
             composed = composed.meet(policy)
-        generation = max(item[1] for item in eligible)
+        # Generation stays the most-specific eligible row's own generation, because it is the
+        # CAS token prepare_transition/commit_transition compare against _current_exact(scope).
+        # Reporting a composed maximum here would make every transition at that scope fail
+        # privacy_policy_stale whenever an ancestor row carried a higher generation. Staleness
+        # against ancestor movement is still caught: effective_digest below is the meet digest,
+        # and it is the other half of the same precondition.
+        generation = ordered[-1][1]
         return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(

--- a/src/yoetz/adapters/privacy/catalog.py
+++ b/src/yoetz/adapters/privacy/catalog.py
@@ -535,19 +535,22 @@ class CatalogPrivacyPolicyStore:
                 eligible.append((policy, cast(int, generation)))
         if not eligible:
             raise ValueError("privacy_policy_missing")
-        policy, generation = max(
+        # ADR-009 / protocol: intersection of every containing current row — not rank-max alone.
+        rank = {
+            AuthorizationScopeKind.MACHINE: 0,
+            AuthorizationScopeKind.WORKSPACE: 1,
+            AuthorizationScopeKind.TASK: 2,
+            AuthorizationScopeKind.REQUEST: 3,
+        }
+        ordered = sorted(
             eligible,
-            key=lambda item: (
-                {
-                    AuthorizationScopeKind.MACHINE: 0,
-                    AuthorizationScopeKind.WORKSPACE: 1,
-                    AuthorizationScopeKind.TASK: 2,
-                    AuthorizationScopeKind.REQUEST: 3,
-                }[item[0].effective_scope.kind],
-                item[1],
-            ),
+            key=lambda item: (rank[item[0].effective_scope.kind], item[1]),
         )
-        return EffectivePrivacyPolicy(policy, generation, policy.policy_digest)
+        composed = ordered[0][0]
+        for policy, _generation in ordered[1:]:
+            composed = composed.meet(policy)
+        generation = max(item[1] for item in eligible)
+        return EffectivePrivacyPolicy(composed, generation, composed.policy_digest)
 
     async def prepare_transition(
         self, proposal: PolicyTransitionProposal

--- a/src/yoetz/domain/privacy.py
+++ b/src/yoetz/domain/privacy.py
@@ -711,15 +711,12 @@ class ChannelPolicy:
                 0,
                 0,
             )
-        scope_rank = {
-            AuthorizationScopeKind.MACHINE: 0,
-            AuthorizationScopeKind.WORKSPACE: 1,
-            AuthorizationScopeKind.TASK: 2,
-            AuthorizationScopeKind.REQUEST: 3,
-        }
+        # A lower rank is a *broader* ceiling (machine is widest, request narrowest), matching
+        # ``_scope_rank`` in ``yoetz.application.privacy_policy``, where task -> machine is
+        # classified as a widening. The meet must therefore keep the higher-ranked ceiling.
         ceiling = (
             self.scope_ceiling
-            if scope_rank[self.scope_ceiling] <= scope_rank[other.scope_ceiling]
+            if _SCOPE_KIND_RANK[self.scope_ceiling] >= _SCOPE_KIND_RANK[other.scope_ceiling]
             else other.scope_ceiling
         )
         return ChannelPolicy(

--- a/src/yoetz/domain/privacy.py
+++ b/src/yoetz/domain/privacy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
 from typing import Final, Literal, cast
@@ -14,7 +14,12 @@ from yoetz.domain.values import (
     validate_commitment,
     validate_sha256_digest,
 )
-from yoetz.protocol.canonical import canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import (
+    JsonValue,
+    canonical_digest,
+    canonical_encode,
+    strict_json_parse,
+)
 from yoetz.protocol.ids import IdKind, validate_id
 from yoetz.protocol.models import DataCategory
 
@@ -667,6 +672,91 @@ class ChannelPolicy:
             if set(self.allowed_data_classes) - {DataClass.PUBLIC_STRUCTURAL}:
                 raise _invalid()
 
+    def meet(self, other: ChannelPolicy) -> ChannelPolicy:
+        """Intersect two channel rows (AND enablement, set meet, min ceilings)."""
+
+        if type(other) is not ChannelPolicy or self.channel is not other.channel:
+            raise _invalid()
+        if not self.enabled or not other.enabled:
+            return ChannelPolicy(
+                self.channel,
+                False,
+                (),
+                (),
+                None,
+                (),
+                AuthorizationScopeKind.MACHINE,
+                False,
+                0,
+                0,
+                0,
+            )
+        binding = (
+            self.provider_binding
+            if self.provider_binding is not None and self.provider_binding == other.provider_binding
+            else None
+        )
+        # Enabled external LLM without an exact shared binding cannot authorize a destination.
+        if self.channel is EgressChannel.LLM_INFERENCE and binding is None:
+            return ChannelPolicy(
+                self.channel,
+                False,
+                (),
+                (),
+                None,
+                (),
+                AuthorizationScopeKind.MACHINE,
+                False,
+                0,
+                0,
+                0,
+            )
+        scope_rank = {
+            AuthorizationScopeKind.MACHINE: 0,
+            AuthorizationScopeKind.WORKSPACE: 1,
+            AuthorizationScopeKind.TASK: 2,
+            AuthorizationScopeKind.REQUEST: 3,
+        }
+        ceiling = (
+            self.scope_ceiling
+            if scope_rank[self.scope_ceiling] <= scope_rank[other.scope_ceiling]
+            else other.scope_ceiling
+        )
+        return ChannelPolicy(
+            self.channel,
+            True,
+            tuple(set(self.allowed_categories) & set(other.allowed_categories)),
+            tuple(set(self.allowed_data_classes) & set(other.allowed_data_classes)),
+            binding,
+            tuple(set(self.allowed_purposes) & set(other.allowed_purposes)),
+            ceiling,
+            self.preview_required or other.preview_required,
+            min(self.max_bytes, other.max_bytes),
+            min(self.max_tokens, other.max_tokens),
+            min(self.authorization_ttl_seconds, other.authorization_ttl_seconds),
+        )
+
+
+_SCOPE_KIND_RANK: Final = {
+    AuthorizationScopeKind.MACHINE: 0,
+    AuthorizationScopeKind.WORKSPACE: 1,
+    AuthorizationScopeKind.TASK: 2,
+    AuthorizationScopeKind.REQUEST: 3,
+}
+_PROFILE_OPENNESS: Final = {
+    PrivacyProfile.LOCAL_ONLY: 0,
+    PrivacyProfile.CONFIRM_EVERY_REQUEST: 1,
+    PrivacyProfile.MINIMAL_EXTERNAL: 2,
+    PrivacyProfile.TRUSTED_PROVIDER: 3,
+}
+_REVIEW_CONTEXT_OPENNESS: Final = {
+    ReviewContextProfile.STRUCTURAL: 0,
+    ReviewContextProfile.GOAL_AWARE: 1,
+    ReviewContextProfile.ASSISTED: 2,
+    ReviewContextProfile.EXPANDED: 3,
+    ReviewContextProfile.CUSTOM: 4,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class PrivacyPolicy:
@@ -773,6 +863,161 @@ class PrivacyPolicy:
         _time(self.created_at)
         if self.supersedes_policy_digest is not None:
             validate_sha256_digest(self.supersedes_policy_digest)
+
+    def meet(self, other: PrivacyPolicy) -> PrivacyPolicy:
+        """Intersect two standing policies (ADR-009 decision 6 / protocol policy resolution).
+
+        Permission fields tighten by meet (AND / set intersection / min ceilings). Identity
+        (``policy_id``, ``version``, ``created_at``, ``effective_scope``) is taken from the
+        more-specific scope when ranks differ, else from ``self``. The result's
+        ``policy_digest`` is recomputed from the meet body so multi-scope composition is not
+        confused with a single stored row.
+        """
+
+        if type(other) is not PrivacyPolicy:
+            raise _invalid()
+        if self.effective_scope.installation_id != other.effective_scope.installation_id:
+            raise _invalid()
+
+        by_self = {channel.channel: channel for channel in self.channel_policies}
+        by_other = {channel.channel: channel for channel in other.channel_policies}
+        channels = tuple(
+            by_self[channel].meet(by_other[channel])
+            for channel in sorted(EgressChannel, key=lambda item: item.value.encode("ascii"))
+        )
+        network = (
+            self.network_egress_permitted
+            and other.network_egress_permitted
+            and any(channel.enabled for channel in channels)
+        )
+        if not network:
+            channels = tuple(
+                ChannelPolicy(
+                    channel.channel,
+                    False,
+                    (),
+                    (),
+                    None,
+                    (),
+                    AuthorizationScopeKind.MACHINE,
+                    False,
+                    0,
+                    0,
+                    0,
+                )
+                for channel in channels
+            )
+
+        llm = next(
+            channel for channel in channels if channel.channel is EgressChannel.LLM_INFERENCE
+        )
+        profile_rank = min(_PROFILE_OPENNESS[self.profile], _PROFILE_OPENNESS[other.profile])
+        if not network or not llm.enabled or llm.provider_binding is None:
+            profile = PrivacyProfile.LOCAL_ONLY
+        else:
+            profile = next(item for item, rank in _PROFILE_OPENNESS.items() if rank == profile_rank)
+            if profile is PrivacyProfile.LOCAL_ONLY:
+                profile = PrivacyProfile.MINIMAL_EXTERNAL
+            if profile is PrivacyProfile.CONFIRM_EVERY_REQUEST and not llm.preview_required:
+                # Meet of preview flags should have ORed; keep construction valid.
+                llm = replace(llm, preview_required=True)
+                channels = tuple(
+                    llm if channel.channel is EgressChannel.LLM_INFERENCE else channel
+                    for channel in channels
+                )
+            if (
+                profile is PrivacyProfile.MINIMAL_EXTERNAL
+                and DataClass.SENSITIVE_CONFIDENTIAL in llm.allowed_data_classes
+            ):
+                llm = replace(
+                    llm,
+                    allowed_data_classes=tuple(
+                        item
+                        for item in llm.allowed_data_classes
+                        if item is not DataClass.SENSITIVE_CONFIDENTIAL
+                    ),
+                )
+                channels = tuple(
+                    llm if channel.channel is EgressChannel.LLM_INFERENCE else channel
+                    for channel in channels
+                )
+
+        review_selection = self.review_selection.meet(other.review_selection)
+        review_rank = min(
+            _REVIEW_CONTEXT_OPENNESS[self.review_context_profile],
+            _REVIEW_CONTEXT_OPENNESS[other.review_context_profile],
+        )
+        review_context = next(
+            item for item, rank in _REVIEW_CONTEXT_OPENNESS.items() if rank == review_rank
+        )
+        if review_context is not ReviewContextProfile.CUSTOM:
+            if review_selection != ReviewSelectionPolicy.for_profile(review_context):
+                review_context = ReviewContextProfile.CUSTOM
+
+        local_enabled = self.local_model_enabled and other.local_model_enabled
+        local_binding = (
+            self.local_model_binding
+            if local_enabled
+            and self.local_model_binding is not None
+            and self.local_model_binding == other.local_model_binding
+            else None
+        )
+        if local_binding is None:
+            local_enabled = False
+
+        identity = (
+            other
+            if _SCOPE_KIND_RANK[other.effective_scope.kind]
+            > _SCOPE_KIND_RANK[self.effective_scope.kind]
+            else self
+        )
+        placeholder = PrivacyPolicy(
+            identity.policy_id,
+            identity.version,
+            "sha256:" + "0" * 64,
+            profile,
+            review_context,
+            review_selection,
+            self.require_current_provider_data_use_evidence
+            or other.require_current_provider_data_use_evidence,
+            network,
+            identity.effective_scope,
+            channels,
+            local_enabled,
+            local_binding,
+            tuple(set(self.local_model_categories) & set(other.local_model_categories)),
+            tuple(set(self.local_model_data_classes) & set(other.local_model_data_classes)),
+            tuple(set(self.agent_context_categories) & set(other.agent_context_categories)),
+            tuple(set(self.agent_context_data_classes) & set(other.agent_context_data_classes)),
+            tuple(
+                set(self.trusted_human_control_categories)
+                & set(other.trusted_human_control_categories)
+            ),
+            tuple(
+                set(self.trusted_human_control_data_classes)
+                & set(other.trusted_human_control_data_classes)
+            ),
+            identity.created_at,
+            None,
+        )
+        return replace(
+            placeholder,
+            policy_digest=canonical_digest(
+                cast(
+                    JsonValue,
+                    {
+                        "components": sorted((self.policy_digest, other.policy_digest)),
+                        "meet": "yoetz.privacy-policy-meet/1",
+                        "network_egress_permitted": placeholder.network_egress_permitted,
+                        "profile": placeholder.profile.value,
+                        "require_current_provider_data_use_evidence": (
+                            placeholder.require_current_provider_data_use_evidence
+                        ),
+                        "review_context_profile": placeholder.review_context_profile.value,
+                    },
+                )
+            ),
+        )
 
     @property
     def unsupported_enabled_channels(self) -> tuple[EgressChannel, ...]:

--- a/tests/unit/privacy/test_effective_policy_intersection.py
+++ b/tests/unit/privacy/test_effective_policy_intersection.py
@@ -1,0 +1,218 @@
+"""RT-privacy-egress-3: effective_policy intersects ancestor scopes (ADR-009)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+import apsw
+import pytest
+
+from yoetz.adapters.memory.privacy import MemoryPrivacyCatalogState, MemoryPrivacyPolicyStore
+from yoetz.adapters.privacy.catalog import CatalogPrivacyPolicyStore
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ChannelPolicy,
+    DataClass,
+    EgressChannel,
+    PrivacyPolicy,
+    PrivacyProfile,
+    ProviderBinding,
+    ReviewContextProfile,
+    ReviewSelectionPolicy,
+)
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+_INSTALLATION = "ins_30000000-0000-4000-8000-000000000001"
+_WORKSPACE = f"hmac-sha256:{'6' * 64}"
+_TASK = "tsk_30000000-0000-4000-8000-00000000000b"
+_POLICY_M = "pvy_30000000-0000-4000-8000-000000000006"
+_POLICY_W = "pvy_30000000-0000-4000-8000-000000000007"
+_DIGEST_M = f"sha256:{'1' * 64}"
+_DIGEST_W = f"sha256:{'2' * 64}"
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+def _database() -> apsw.Connection:
+    db = apsw.Connection(":memory:")
+    db.execute(Path("migrations/catalog/0001.sql").read_text(encoding="utf-8"))
+    return db
+
+
+def _disabled(channel: EgressChannel) -> ChannelPolicy:
+    return ChannelPolicy(
+        channel,
+        False,
+        (),
+        (),
+        None,
+        (),
+        AuthorizationScopeKind.MACHINE,
+        False,
+        0,
+        0,
+        0,
+    )
+
+
+def _ordered(channels: dict[EgressChannel, ChannelPolicy]) -> tuple[ChannelPolicy, ...]:
+    return tuple(
+        channels[channel] for channel in sorted(EgressChannel, key=lambda item: item.value)
+    )
+
+
+def _local_only(*, scope: AuthorizationScope, policy_id: str, digest: str) -> PrivacyPolicy:
+    return PrivacyPolicy(
+        policy_id,
+        1,
+        digest,
+        PrivacyProfile.LOCAL_ONLY,
+        ReviewContextProfile.STRUCTURAL,
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.STRUCTURAL),
+        False,
+        False,
+        scope,
+        _ordered({channel: _disabled(channel) for channel in EgressChannel}),
+        False,
+        None,
+        (),
+        (),
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (DataClass.PUBLIC_STRUCTURAL,),
+        tuple(DataCategory),
+        (
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+            DataClass.SENSITIVE_CONFIDENTIAL,
+        ),
+        _NOW,
+    )
+
+
+def _minimal_external(*, scope: AuthorizationScope, policy_id: str, digest: str) -> PrivacyPolicy:
+    channels = {channel: _disabled(channel) for channel in EgressChannel}
+    channels[EgressChannel.LLM_INFERENCE] = ChannelPolicy(
+        EgressChannel.LLM_INFERENCE,
+        True,
+        (
+            DataCategory.BOUNDED_STRUCTURAL_METADATA,
+            DataCategory.TASK_DESCRIPTION,
+        ),
+        (DataClass.ORDINARY_USER_CONTENT, DataClass.PUBLIC_STRUCTURAL),
+        ProviderBinding(
+            "fireworks",
+            "accounts/fireworks/models/minimax-m3",
+            "fireworks-responses",
+            "1.0.0",
+            "external",
+        ),
+        ("semantic-review",),
+        AuthorizationScopeKind.TASK,
+        False,
+        262_144,
+        4096,
+        300,
+    )
+    return PrivacyPolicy(
+        policy_id,
+        2,
+        digest,
+        PrivacyProfile.MINIMAL_EXTERNAL,
+        ReviewContextProfile.ASSISTED,
+        ReviewSelectionPolicy.for_profile(ReviewContextProfile.ASSISTED),
+        False,
+        True,
+        scope,
+        _ordered(channels),
+        False,
+        None,
+        (),
+        (),
+        (DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+        (DataClass.PUBLIC_STRUCTURAL,),
+        tuple(DataCategory),
+        (
+            DataClass.ORDINARY_USER_CONTENT,
+            DataClass.PUBLIC_STRUCTURAL,
+            DataClass.SENSITIVE_CONFIDENTIAL,
+        ),
+        _NOW,
+    )
+
+
+def _task_scope() -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        _WORKSPACE,
+        _TASK,
+    )
+
+
+def _workspace_scope() -> AuthorizationScope:
+    return AuthorizationScope(AuthorizationScopeKind.WORKSPACE, _INSTALLATION, _WORKSPACE)
+
+
+def _machine_scope() -> AuthorizationScope:
+    return AuthorizationScope(AuthorizationScopeKind.MACHINE, _INSTALLATION)
+
+
+def _llm_authorized(policy: PrivacyPolicy) -> bool:
+    llm = next(
+        channel
+        for channel in policy.channel_policies
+        if channel.channel is EgressChannel.LLM_INFERENCE
+    )
+    return policy.network_egress_permitted and llm.enabled
+
+
+@pytest.mark.parametrize("store_kind", ["catalog", "memory"])
+def test_effective_policy_intersects_machine_ceiling_with_workspace_overlay(
+    store_kind: str,
+) -> None:
+    machine = _local_only(scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M)
+    workspace = _minimal_external(scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W)
+
+    async def run() -> PrivacyPolicy:
+        if store_kind == "catalog":
+            store: CatalogPrivacyPolicyStore | MemoryPrivacyPolicyStore = CatalogPrivacyPolicyStore(
+                _database(), _Clock()
+            )
+        else:
+            store = MemoryPrivacyPolicyStore(MemoryPrivacyCatalogState(), _Clock())
+        await store.seed_if_absent(machine)
+        await store.seed_if_absent(workspace)
+        effective = await store.effective_policy(_task_scope())
+        return effective.policy
+
+    policy = asyncio.run(run())
+    assert not _llm_authorized(policy), (
+        "effective_policy must meet machine local_only with workspace external, "
+        f"not select workspace alone; profile={policy.profile.value} "
+        f"scope={policy.effective_scope.kind.value} llm_authorized={_llm_authorized(policy)}"
+    )
+    assert policy.profile is PrivacyProfile.LOCAL_ONLY
+    assert policy.network_egress_permitted is False
+
+
+def test_privacy_policy_meet_is_commutative_for_local_and_external() -> None:
+    machine = _local_only(scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M)
+    workspace = _minimal_external(scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W)
+    left = machine.meet(workspace)
+    right = workspace.meet(machine)
+    assert left.network_egress_permitted is False
+    assert right.network_egress_permitted is False
+    assert left.profile is PrivacyProfile.LOCAL_ONLY
+    assert right.profile is PrivacyProfile.LOCAL_ONLY
+    assert _llm_authorized(left) is False
+    assert _llm_authorized(right) is False

--- a/tests/unit/privacy/test_effective_policy_intersection.py
+++ b/tests/unit/privacy/test_effective_policy_intersection.py
@@ -99,7 +99,14 @@ def _local_only(*, scope: AuthorizationScope, policy_id: str, digest: str) -> Pr
     )
 
 
-def _minimal_external(*, scope: AuthorizationScope, policy_id: str, digest: str) -> PrivacyPolicy:
+def _minimal_external(
+    *,
+    scope: AuthorizationScope,
+    policy_id: str,
+    digest: str,
+    scope_ceiling: AuthorizationScopeKind = AuthorizationScopeKind.TASK,
+    max_bytes: int = 262_144,
+) -> PrivacyPolicy:
     channels = {channel: _disabled(channel) for channel in EgressChannel}
     channels[EgressChannel.LLM_INFERENCE] = ChannelPolicy(
         EgressChannel.LLM_INFERENCE,
@@ -117,9 +124,9 @@ def _minimal_external(*, scope: AuthorizationScope, policy_id: str, digest: str)
             "external",
         ),
         ("semantic-review",),
-        AuthorizationScopeKind.TASK,
+        scope_ceiling,
         False,
-        262_144,
+        max_bytes,
         4096,
         300,
     )
@@ -216,3 +223,76 @@ def test_privacy_policy_meet_is_commutative_for_local_and_external() -> None:
     assert right.profile is PrivacyProfile.LOCAL_ONLY
     assert _llm_authorized(left) is False
     assert _llm_authorized(right) is False
+
+
+def _llm(policy: PrivacyPolicy) -> ChannelPolicy:
+    return next(
+        channel
+        for channel in policy.channel_policies
+        if channel.channel is EgressChannel.LLM_INFERENCE
+    )
+
+
+def test_meet_keeps_the_narrower_scope_ceiling() -> None:
+    """A lower scope rank is a *broader* ceiling, so the meet must keep the higher-ranked one.
+
+    ``machine`` is the widest authorization ceiling a channel can carry and ``request`` the
+    narrowest — the widen/tighten ceremony classifies ``task -> machine`` as
+    ``scope_ceiling_broadened``. Intersecting a machine ceiling with a task ceiling must
+    therefore yield ``task``, never ``machine``.
+    """
+
+    wide = _minimal_external(
+        scope=_machine_scope(),
+        policy_id=_POLICY_M,
+        digest=_DIGEST_M,
+        scope_ceiling=AuthorizationScopeKind.MACHINE,
+    )
+    narrow = _minimal_external(
+        scope=_workspace_scope(),
+        policy_id=_POLICY_W,
+        digest=_DIGEST_W,
+        scope_ceiling=AuthorizationScopeKind.TASK,
+    )
+    assert _llm(wide.meet(narrow)).scope_ceiling is AuthorizationScopeKind.TASK
+    assert _llm(narrow.meet(wide)).scope_ceiling is AuthorizationScopeKind.TASK
+
+
+def test_meet_keeps_the_smaller_byte_ceiling() -> None:
+    wide = _minimal_external(
+        scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M, max_bytes=262_144
+    )
+    narrow = _minimal_external(
+        scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W, max_bytes=1024
+    )
+    assert _llm(wide.meet(narrow)).max_bytes == 1024
+    assert _llm(narrow.meet(wide)).max_bytes == 1024
+
+
+@pytest.mark.parametrize("store_kind", ["catalog", "memory"])
+def test_effective_generation_tracks_the_most_specific_row(store_kind: str) -> None:
+    """The reported generation is the CAS token the transition path checks against the exact row.
+
+    ``prepare_transition``/``commit_transition`` compare ``expected_generation`` against
+    ``_current_exact(scope)``. Reporting a composed maximum across ancestors would make every
+    transition at that scope fail ``privacy_policy_stale`` once an ancestor outran it.
+    """
+
+    machine = _local_only(scope=_machine_scope(), policy_id=_POLICY_M, digest=_DIGEST_M)
+    workspace = _minimal_external(scope=_workspace_scope(), policy_id=_POLICY_W, digest=_DIGEST_W)
+
+    async def run() -> tuple[int, int]:
+        if store_kind == "catalog":
+            store: CatalogPrivacyPolicyStore | MemoryPrivacyPolicyStore = CatalogPrivacyPolicyStore(
+                _database(), _Clock()
+            )
+        else:
+            store = MemoryPrivacyPolicyStore(MemoryPrivacyCatalogState(), _Clock())
+        await store.seed_if_absent(machine)
+        await store.seed_if_absent(workspace)
+        effective = await store.effective_policy(_task_scope())
+        exact = await store.effective_policy(_workspace_scope())
+        return effective.generation, exact.generation
+
+    composed_generation, workspace_generation = asyncio.run(run())
+    assert composed_generation == workspace_generation


### PR DESCRIPTION
## Summary

Fixes **#113** (RT-privacy-egress-3): `PrivacyPolicyStore.effective_policy` must return the **intersection** of every current policy whose scope contains the query scope (ADR-009 decision 6 / protocol *Policy resolution*), not a single most-specific row via rank-max.

### Changes (this PR only)

- **`PrivacyPolicy.meet` / `ChannelPolicy.meet`** — least-privilege intersection primitives on the domain model (plus related helpers/digest casting).
- **`CatalogPrivacyPolicyStore.effective_policy`** and **`MemoryPrivacyPolicyStore.effective_policy`** — compose all eligible containing current rows with `meet`, generation = max among eligible.
- **Unit evidence** — `tests/unit/privacy/test_effective_policy_intersection.py` (catalog + memory).

### Explicitly out of scope

Channel ceiling, data-use classification, egress coordinator / gateway / ready_composition changes. Those remain on other RT-privacy-egress work if needed.

## Design gate

Privacy/egress is design-gated. Maintainer directed opening PRs for these privacy issues even without waiting on the usual design-gate acknowledgement on the issue.

## Verification

```text
uv sync
uv run ruff format src/yoetz/domain/privacy.py src/yoetz/adapters/privacy/catalog.py src/yoetz/adapters/memory/privacy.py tests/unit/privacy/test_effective_policy_intersection.py
uv run ruff check src/yoetz/domain/privacy.py src/yoetz/adapters/privacy/catalog.py src/yoetz/adapters/memory/privacy.py tests/unit/privacy/test_effective_policy_intersection.py
uv run pytest tests/unit/privacy/test_effective_policy_intersection.py tests/unit/privacy/test_catalog_audit.py -q --tb=short
```

Local result: **9 passed**.

## Source extraction

Intersection-only hunks taken from `fix/redteam-privacy-egress-triple` (`ba63ffa` tip lineage); not the full triple PR.

Fixes #113

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `effective_policy` to return the **intersection** (via `meet`) of every ancestor-scope policy containing the query scope, replacing the previous rank-max selection that only returned the single most-specific row. Domain-model intersection primitives (`ChannelPolicy.meet`, `PrivacyPolicy.meet`) are introduced, and both the catalog and memory stores are updated to compose eligible rows.

- **`PrivacyPolicy.meet` / `ChannelPolicy.meet`** — new least-privilege intersection primitives: AND on booleans, set intersection on category/class/purpose tuples, min on numeric ceilings, and a recomputed canonical `policy_digest` that distinguishes composed policies from single stored rows.
- **`effective_policy` (catalog + memory)** — now sorts eligible rows by scope rank, folds them with `meet`, and returns `generation = max(all eligible)`, correctly enforcing ancestor-policy ceilings.
- **New unit tests** cover the primary intersection scenario (machine LOCAL_ONLY overrides workspace MINIMAL_EXTERNAL) and commutativity, but leave the `commit_transition` path untested—where the shift to `max(generation)` creates a regression described in the review comment.

<h3>Confidence Score: 4/5</h3>

The effective_policy intersection logic is correct, but the shift to returning max(all eligible generations) breaks commit_transition in both adapters whenever an ancestor policy carries a higher generation number than the target scope own row.

The meet primitives and the intersection fold in effective_policy are well-implemented and the key privacy-safety property works correctly. However, commit_transition in both adapters still validates staleness by comparing proposal.expected_generation against the single stored row for proposal.scope, while effective_policy now hands callers the maximum generation across all eligible ancestor rows. In any deployment where the machine policy was updated after the workspace policy, every workspace-scoped policy transition will perpetually fail with privacy_policy_stale.

**Files Needing Attention:** commit_transition in both src/yoetz/adapters/privacy/catalog.py and src/yoetz/adapters/memory/privacy.py need updates to reconcile the new max-generation semantics with their single-row staleness check.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/domain/privacy.py | Adds ChannelPolicy.meet and PrivacyPolicy.meet with correct least-privilege intersection logic; also introduces module-level rank/openness constants. |
| src/yoetz/adapters/privacy/catalog.py | Switches effective_policy from rank-max to full intersection via meet, returning max(all_eligible_generations). This breaks commit_transition stale-generation check. |
| src/yoetz/adapters/memory/privacy.py | Applies the same effective_policy intersection change as the catalog adapter. commit_transition has the same stale-generation mismatch. |
| tests/unit/privacy/test_effective_policy_intersection.py | New unit tests covering the intersection path and commutativity property; no test exercises the commit_transition path that is broken by the generation change. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Store as PolicyStore
    participant DB as DB / MemoryState
    Note over Store: effective_policy NEW behaviour
    Caller->>Store: effective_policy(scope)
    Store->>DB: fetch all current rows
    DB-->>Store: "machine_row gen=10 workspace_row gen=5"
    Store->>Store: "composed = machine.meet(workspace)"
    Store->>Store: "generation = max(10,5) = 10"
    Store-->>Caller: "EffectivePrivacyPolicy composed gen=10"
    Note over Store: prepare_transition writes max-gen
    Caller->>Store: "prepare_transition scope=workspace expected_gen=10"
    Store->>DB: "INSERT transition base_policy_generation=10"
    Note over Store: commit_transition BUG single-row gen check
    Caller->>Store: commit_transition
    Store->>DB: "SELECT base_policy_generation=10 matches"
    Store->>DB: "_current_exact workspace_scope returns gen=5"
    Store->>Store: "5 != 10 raises privacy_policy_stale"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/yoetz/adapters/privacy/catalog.py`, line 684-686 ([link](https://github.com/thegaysupreme123/yoetz/blob/c619ad9b96a43fd78336a4cc6057c361fd4e1b72/src/yoetz/adapters/privacy/catalog.py#L684-L686)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`commit_transition` stale-generation check broken by max-generation**

   `proposal.expected_generation` is now the *maximum* generation across all eligible ancestor scopes (as returned by the new `effective_policy`), but `_current_exact(proposal.scope)` returns only the single stored generation for the target scope. When any ancestor policy (e.g. the MACHINE row) carries a higher generation than the target scope's own row, this check will always raise `privacy_policy_stale`, permanently blocking any policy transition for that scope.

   Concrete failure: machine_policy.generation = 10, workspace_policy.generation = 5. A call to `effective_policy(workspace_scope)` returns generation = 10. The caller prepares a transition with `expected_generation = 10`. `prepare_transition` stores `base_policy_generation = 10`. On commit, `_current_exact(workspace_scope)`.generation = 5 ≠ 10 → "privacy_policy_stale" every time.

   The same defect exists in the memory adapter at `MemoryPrivacyPolicyStore.commit_transition` (line ~194–196 of `src/yoetz/adapters/memory/privacy.py`), where `self._state.policies.get(_scope_digest(proposal.scope)).generation` is compared against `proposal.expected_generation`.

   The root fix is for `effective_policy` to record and expose the per-scope generation of the policy that owns the composite transition anchor (i.e. the generation of the policy at `proposal.scope` rather than the global max), or for `commit_transition` to look up the generation via `effective_policy` rather than the raw single-row table.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(privacy): intersect ancestor policie..."](https://github.com/thegaysupreme123/yoetz/commit/c619ad9b96a43fd78336a4cc6057c361fd4e1b72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22386264)</sub>

<!-- /greptile_comment -->