### PR TITLE
fix(privacy): enforce provider data-use evidence at runtime egress

### DIFF
--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -308,6 +308,20 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             connected.add(registry.local_model[0].provider_id)
         return tuple(sorted(connected, key=str.encode))
 
+    def bound_data_use_profile(self, binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        """Return the nonsecret data-use profile of the live factory for this exact binding.
+
+        ``None`` means no live factory, so admission fails closed rather than treating an absent
+        registry as satisfied evidence.
+        """
+
+        if type(binding) is not ProviderBinding:
+            raise TypeError("privacy_gateway_provider_binding_invalid")
+        registry = self._current_registry()
+        if registry is None:
+            return None
+        return registry.data_use_profile(binding)
+
     def has_connected_provider_binding(self, binding: ProviderBinding) -> bool:
         """Return whether the exact configured binding is live in the current registry."""
 

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -56,6 +56,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -121,6 +122,7 @@ _PRECONSUME_OUTCOME: Mapping[PrivacyReason, PrivacyOutcome] = MappingProxyType(
         PrivacyReason.DEADLINE_EXPIRED: PrivacyOutcome.TIMEOUT,
         PrivacyReason.PROVIDER_UNAVAILABLE: PrivacyOutcome.TRANSPORT_FAILED,
         PrivacyReason.AUDIT_FAILED: PrivacyOutcome.AUDIT_FAILED,
+        PrivacyReason.POLICY_DENIED: PrivacyOutcome.BLOCKED_BY_POLICY,
     }
 )
 
@@ -171,12 +173,15 @@ class ProviderRegistry:
     human_authority_digest: str
     external: Mapping[ProviderBinding, ExternalProviderFactory]
     local_model: tuple[ProviderBinding, SemanticEvaluatorPort] | None
+    require_current_provider_data_use_evidence: bool = False
 
     def __post_init__(self) -> None:
         if type(self.external) is not MappingProxyType:
             raise TypeError("provider_registry_external_not_immutable")
         if self.local_model is not None and type(self.local_model) is not tuple:
             raise TypeError("provider_registry_local_model_invalid")
+        if type(self.require_current_provider_data_use_evidence) is not bool:
+            raise TypeError("provider_registry_data_use_guard_invalid")
 
     def resolve_external(self, binding: ProviderBinding) -> ExternalProviderFactory | None:
         return self.external.get(binding)
@@ -185,6 +190,14 @@ class ProviderRegistry:
         if self.local_model is not None and self.local_model[0] == binding:
             return self.local_model[1]
         return None
+
+    def data_use_profile(self, binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        factory = self.resolve_external(binding)
+        if factory is None:
+            return None
+        profile = getattr(factory, "profile", None)
+        data_use = getattr(profile, "data_use_profile", None)
+        return data_use if type(data_use) is ProviderDataUseProfile else None
 
 
 def _llm_binding(policy: PrivacyPolicy) -> ProviderBinding | None:
@@ -351,6 +364,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(fenced_external),
                 fenced_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
 
         for factory in stale_external.values():
@@ -449,6 +463,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(new_external),
                 new_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
         return ProviderReconciliation(
             policy.generation, activated, deactivated, tuple(sorted(unavailable))
@@ -608,6 +623,10 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             return PrivacyReason.DEADLINE_EXPIRED
         if now_utc >= authorization.expires_at:
             return PrivacyReason.AUTHORIZATION_EXPIRED
+        if registry.require_current_provider_data_use_evidence:
+            data_use = registry.data_use_profile(case.provider_binding)
+            if data_use is None or not data_use.recommendation_eligible(now_utc):
+                return PrivacyReason.POLICY_DENIED
         return None
 
     async def _preconsume_failure(

--- a/src/yoetz/adapters/providers/openai_responses_factory.py
+++ b/src/yoetz/adapters/providers/openai_responses_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Final
 
 from yoetz.adapters.privacy.gateway import ExternalProviderFactory
 from yoetz.adapters.providers.openai_responses import (
@@ -28,10 +29,29 @@ from yoetz.protocol.canonical import canonical_digest
 
 __all__ = [
     "OpenAIResponsesExternalFactory",
+    "endpoint_profile_data_use_reviewed",
     "external_factory_builders_from_config",
     "openai_profile_from_provider_config",
     "provider_binding_from_config",
 ]
+
+# Exactly one shipped endpoint profile carries reviewed data-use facts. Every other profile —
+# fireworks, the Vercel gateway, and any owner-declared HTTPS origin — gets
+# ``owner_declared_data_use_profile``, whose facts are ``unknown`` and therefore never
+# ``recommendation_eligible``. Keep this in step with openai_profile_from_provider_config and
+# chat_completions_profile_from_provider_config.
+_REVIEWED_DATA_USE_ENDPOINT_PROFILE_IDS: Final = frozenset({OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID})
+
+
+def endpoint_profile_data_use_reviewed(endpoint_profile_id: str) -> bool:
+    """True when this endpoint profile ships recommendation-eligible provider data-use evidence.
+
+    A policy that sets ``require_current_provider_data_use_evidence`` against a profile this
+    returns ``False`` for cannot dispatch external semantic review at all, so setup surfaces the
+    pairing before the operator commits it rather than at first dispatch.
+    """
+
+    return endpoint_profile_id in _REVIEWED_DATA_USE_ENDPOINT_PROFILE_IDS
 
 
 def provider_binding_from_config(provider: ProviderProfileConfig) -> ProviderBinding:

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
@@ -39,6 +40,7 @@ from yoetz.domain.privacy import (
     PrivacyProfile,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -259,6 +261,7 @@ class PrivacyCoordinator:
         "_close_lock",
         "_close_task",
         "_closed",
+        "_data_use_resolver",
         "_gateway",
         "_human",
         "_ids",
@@ -278,6 +281,7 @@ class PrivacyCoordinator:
         *,
         service_generation: int = 1,
         human: HumanPrivacyControlPort | None = None,
+        data_use_resolver: Callable[[ProviderBinding], ProviderDataUseProfile | None] | None = None,
     ) -> None:
         if type(service_generation) is not int or service_generation <= 0:
             raise ValueError("privacy_service_generation_invalid")
@@ -290,6 +294,7 @@ class PrivacyCoordinator:
         self._ids = ids
         self._service_generation = service_generation
         self._human = human
+        self._data_use_resolver = data_use_resolver
         self._policy_app: PrivacyPolicyApplication | None = None
         self._closed = False
         self._close_lock = asyncio.Lock()
@@ -720,6 +725,17 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.SCOPE_MISMATCH,
             )
+        if (
+            policy.require_current_provider_data_use_evidence
+            and binding.transport == "external"
+            and not self._data_use_evidence_current(binding)
+        ):
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
 
         classified = self._classifier.classify(candidate, effective)
         decision = self._semantic_decision(classified, effective, binding)
@@ -1109,6 +1125,17 @@ class PrivacyCoordinator:
             privacy_proposal_id=privacy_proposal_id,
             receipt_id=receipt_id,
         )
+
+    def _data_use_evidence_current(self, binding: ProviderBinding) -> bool:
+        """True when the bound external profile has current recommendation-eligible data-use."""
+
+        resolver = self._data_use_resolver
+        if resolver is None:
+            return False
+        profile = resolver(binding)
+        if type(profile) is not ProviderDataUseProfile:
+            return False
+        return profile.recommendation_eligible(self._clock.now_utc())
 
     def _semantic_decision(
         self,

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -28,6 +28,9 @@ from yoetz.adapters.privacy.catalog import (
     encode_privacy_policy_json,
 )
 from yoetz.adapters.privacy.local_enforcer import estimated_token_count
+from yoetz.adapters.providers.openai_responses_factory import (
+    endpoint_profile_data_use_reviewed,
+)
 from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     ChannelPolicy,
@@ -395,11 +398,23 @@ def _recipe_answers(
         else (DataClass.PUBLIC_STRUCTURAL, DataClass.ORDINARY_USER_CONTENT)
     )
     agent_categories, agent_classes = _agent_defaults(current)
+    # assisted_review asks for current provider data-use evidence, but that requirement is
+    # enforced at dispatch: against an endpoint whose data-use facts are unknown it refuses every
+    # external review, so a recipe that set it unconditionally would hand most operators a setup
+    # that cannot dispatch at all. Ask for it only where the bound endpoint can actually satisfy
+    # it; elsewhere the review screen states the facts are unknown and the operator turns the
+    # requirement on deliberately.
+    require_data_use = (
+        recipe == "assisted_review"
+        and network
+        and external is not None
+        and endpoint_profile_data_use_reviewed(external.endpoint_profile_id)
+    )
     return PrivacySetupAnswers(
         network_egress=network,
         local_models=False,
         external_provider=external if network else None,
-        require_current_provider_data_use_evidence=recipe == "assisted_review",
+        require_current_provider_data_use_evidence=require_data_use,
         local_model_binding=None,
         review_context=context,
         content_categories=categories,
@@ -617,6 +632,35 @@ def _ask_custom_answers(
     )
 
 
+def _render_data_use_warning(candidate: PrivacyPolicy, llm: ChannelPolicy) -> None:
+    """Warn when this policy requires data-use evidence the bound endpoint cannot supply.
+
+    The pairing is not an error — refusing egress to a provider whose data-use facts are unknown
+    is exactly what the requirement means. But it is enforced at dispatch, so without this the
+    operator commits a policy that looks correct and then sees every semantic review refused with
+    no stated cause. Say it here, while the choice is still in front of them.
+    """
+
+    binding = llm.provider_binding
+    if not candidate.require_current_provider_data_use_evidence or binding is None:
+        return
+    if endpoint_profile_data_use_reviewed(binding.endpoint_profile_id):
+        return
+    typer.echo("")
+    typer.echo(
+        f"  Warning: '{binding.endpoint_profile_id}' ships no reviewed data-use evidence, so its "
+        "training, retention, and human-access facts are unknown."
+    )
+    typer.echo(
+        "  This draft requires current provider data-use evidence, so every external semantic "
+        "review will be refused while both hold."
+    )
+    typer.echo(
+        "  Either choose an endpoint with reviewed data-use, or turn the requirement off and "
+        "accept the unknown facts."
+    )
+
+
 def _render_review(candidate: PrivacyPolicy) -> None:
     llm = next(
         policy
@@ -649,6 +693,7 @@ def _render_review(candidate: PrivacyPolicy) -> None:
         "  Current provider data-use evidence required: "
         + ("yes" if candidate.require_current_provider_data_use_evidence else "no")
     )
+    _render_data_use_warning(candidate, llm)
     # Read the ceilings off the draft rather than restating constants: these are enforced at
     # admission, so a case above either one is refused, and the operator is entitled to see the
     # numbers that will actually refuse it.

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -91,7 +91,6 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyProfile,
     ProviderBinding,
-    ProviderDataUseProfile,
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
@@ -1164,15 +1163,6 @@ async def build_privacy_coordinator(
     )
     await gateway.reconcile_policy(effective, authority)
 
-    def _data_use_for(binding: ProviderBinding) -> ProviderDataUseProfile | None:
-        registry = getattr(gateway, "_registry", None)
-        if registry is None:
-            return None
-        lookup = getattr(registry, "data_use_profile", None)
-        if lookup is None:
-            return None
-        return cast(ProviderDataUseProfile | None, lookup(binding))
-
     coordinator = PrivacyCoordinator(
         policies,
         classifier,
@@ -1181,7 +1171,7 @@ async def build_privacy_coordinator(
         clock,
         ids,
         service_generation=service_generation,
-        data_use_resolver=_data_use_for,
+        data_use_resolver=gateway.bound_data_use_profile,
     )
     policy_app = PrivacyPolicyApplication(
         policies,

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -91,6 +91,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyProfile,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
@@ -1162,6 +1163,16 @@ async def build_privacy_coordinator(
         True,
     )
     await gateway.reconcile_policy(effective, authority)
+
+    def _data_use_for(binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        registry = getattr(gateway, "_registry", None)
+        if registry is None:
+            return None
+        lookup = getattr(registry, "data_use_profile", None)
+        if lookup is None:
+            return None
+        return cast(ProviderDataUseProfile | None, lookup(binding))
+
     coordinator = PrivacyCoordinator(
         policies,
         classifier,
@@ -1170,6 +1181,7 @@ async def build_privacy_coordinator(
         clock,
         ids,
         service_generation=service_generation,
+        data_use_resolver=_data_use_for,
     )
     policy_app = PrivacyPolicyApplication(
         policies,

--- a/tests/unit/application/test_data_use_evidence_runtime_guard.py
+++ b/tests/unit/application/test_data_use_evidence_runtime_guard.py
@@ -1,0 +1,268 @@
+"""RT-privacy-egress-2: require_current_provider_data_use_evidence is a runtime egress guard."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import INSTALLATION_ID, minimal_external_policy
+from builders.privacy_widenings import llm_channel
+from yoetz.adapters.providers.openai_responses import owner_declared_data_use_profile
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressBlocked
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    CandidateContextItem,
+    ClassifiedContext,
+    ClassifiedContextItem,
+    DataClass,
+    EgressChannel,
+    PrivacyDecision,
+    PrivacyOutcome,
+    PrivacyPolicy,
+    PrivacyReason,
+    ProviderBinding,
+    ProviderDataUseProfile,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.canonical import canonical_digest
+from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=1), 60.0)
+
+
+_REQUEST = "req_80000000-0000-4000-8000-000000000002"
+_TASK = "tsk_80000000-0000-4000-8000-000000000003"
+_SUBJECT = "sha256:" + "d" * 64
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._n = 0
+
+    def new(self, kind: IdKind) -> str:
+        self._n += 1
+        prefix = {
+            IdKind.PRIVACY_PROPOSAL: "ppr",
+            IdKind.EGRESS_RECEIPT: "egr",
+            IdKind.EGRESS_AUTHORIZATION: "aut",
+            IdKind.EGRESS_DISPATCH: "dsp",
+        }.get(kind, "ppr")
+        return f"{prefix}_80000000-0000-4000-8000-{self._n:012d}"
+
+
+class _Store:
+    def __init__(self, policy: PrivacyPolicy) -> None:
+        self._policy = policy
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return EffectivePrivacyPolicy(self._policy, 1, self._policy.policy_digest)
+
+
+class _Classifier:
+    def classify(
+        self, candidate: CandidateContext, effective: EffectivePrivacyPolicy
+    ) -> ClassifiedContext:
+        del effective
+        return ClassifiedContext(
+            candidate,
+            tuple(
+                ClassifiedContextItem(item, DataClass.PUBLIC_STRUCTURAL, (), True, "1.0.0")
+                for item in candidate.items
+            ),
+        )
+
+    def minimize_and_scan(
+        self, classified: ClassifiedContext, decision: PrivacyDecision
+    ) -> MinimizedDisclosure:
+        del decision
+        return MinimizedDisclosure(
+            prepared_bytes=b"{}",
+            included_item_ids=tuple(item.candidate.item_id for item in classified.items),
+            source_item_digests=("sha256:" + "e" * 64,),
+            approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            blocked_categories=(),
+            transformation_summary=(),
+            byte_count=2,
+            token_count=1,
+            case_digest="sha256:" + "c" * 64,
+            scanner_registry_version="test",
+            scanner_profile_digest="sha256:" + "f" * 64,
+            forbidden_findings=(),
+        )
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.prepared = 0
+
+    async def reserve(self, subject: object) -> PrivacyAuditReservation:
+        proposal_id = getattr(
+            subject, "privacy_proposal_id", "ppr_80000000-0000-4000-8000-000000000001"
+        )
+        request_id = getattr(subject, "request_id", _REQUEST)
+        return PrivacyAuditReservation(
+            proposal_id,
+            request_id,
+            _SUBJECT,
+            "reserved",
+            1,
+            _NOW,
+        )
+
+    async def complete_decision(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def prepare_disclosure_proposal(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        self.prepared += 1
+        raise RuntimeError("stop_after_prepare")
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _policy_requiring_data_use() -> PrivacyPolicy:
+    return replace(minimal_external_policy(), require_current_provider_data_use_evidence=True)
+
+
+def _candidate(binding: ProviderBinding) -> CandidateContext:
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        INSTALLATION_ID,
+        f"hmac-sha256:{'8' * 64}",
+        _TASK,
+    )
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        scope,
+        _SUBJECT,
+        binding,
+        (
+            CandidateContextItem(
+                "item-1",
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                scope,
+                "origin-1",
+                b"{}",
+            ),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_data_use_ineligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    ineligible = owner_declared_data_use_profile(
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "x"}),
+    )
+    assert not ineligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: ineligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_resolver_missing() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=None,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_allows_when_flag_true_and_eligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    eligible = ProviderDataUseProfile(
+        data_use_profile_id="openai-api-data-use",
+        data_use_profile_version="1.0.0",
+        customer_content_training="prohibited",
+        retention="bounded",
+        retention_days_ceiling=30,
+        provider_human_access="restricted",
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "ok"}),
+    )
+    assert eligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: eligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert audit.prepared == 1, f"eligible data-use must reach prepare; got {result!r}"
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.AUDIT_FAILED

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -597,14 +597,6 @@ async def test_widening_reports_configured_only_after_committed_trusted_decision
     assert report.proposal_id == "pvp_1"
 
 
-def _llm_channel(policy: PrivacyPolicy) -> object:
-    return next(
-        channel
-        for channel in policy.channel_policies
-        if channel.channel is EgressChannel.LLM_INFERENCE
-    )
-
-
 def test_review_warns_when_data_use_requirement_cannot_be_satisfied(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -13,6 +13,7 @@ from yoetz.cli.privacy_setup import (
     PrivacySetupAnswers,
     build_candidate_policy,
 )
+from yoetz.config.models import OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID
 from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     DataClass,
@@ -594,3 +595,90 @@ async def test_widening_reports_configured_only_after_committed_trusted_decision
 
     assert report.outcome == "configured"
     assert report.proposal_id == "pvp_1"
+
+
+def _llm_channel(policy: PrivacyPolicy) -> object:
+    return next(
+        channel
+        for channel in policy.channel_policies
+        if channel.channel is EgressChannel.LLM_INFERENCE
+    )
+
+
+def test_review_warns_when_data_use_requirement_cannot_be_satisfied(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """RT-privacy-egress-2 companion: the refusal must be visible before it is committed.
+
+    'fireworks-responses' ships owner-declared data-use, whose facts are unknown and therefore
+    never recommendation-eligible. Paired with the requirement, the runtime guard refuses every
+    external review, so setup has to say so while the operator can still change either side.
+    """
+
+    from yoetz.cli.privacy_setup import _render_review  # pyright: ignore[reportPrivateUsage]
+
+    candidate = build_candidate_policy(
+        local_only_policy(),
+        _answers(require_current_provider_data_use_evidence=True),
+        now=datetime(2026, 7, 29, tzinfo=UTC),
+    )
+    assert candidate.require_current_provider_data_use_evidence is True
+
+    _render_review(candidate)
+
+    out = capsys.readouterr().out
+    assert "fireworks-responses" in out
+    assert "no reviewed data-use evidence" in out
+    assert "will be refused" in out
+
+
+def test_review_is_silent_when_the_requirement_is_off(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from yoetz.cli.privacy_setup import _render_review  # pyright: ignore[reportPrivateUsage]
+
+    candidate = build_candidate_policy(
+        local_only_policy(),
+        _answers(require_current_provider_data_use_evidence=False),
+        now=datetime(2026, 7, 29, tzinfo=UTC),
+    )
+
+    _render_review(candidate)
+
+    assert "will be refused" not in capsys.readouterr().out
+
+
+def test_assisted_recipe_requires_data_use_only_where_it_can_be_satisfied() -> None:
+    """The recipe default must stay dispatchable; the requirement is the operator's call.
+
+    require_current_provider_data_use_evidence is enforced at dispatch, so setting it against an
+    endpoint with unknown data-use facts yields a setup that refuses every external review. The
+    recipe therefore asks for it only where the bound endpoint ships reviewed evidence.
+    """
+
+    import yoetz.cli.privacy_setup as module
+
+    owner_declared = ProviderBinding(
+        "fireworks",
+        "accounts/fireworks/models/minimax-m3",
+        "fireworks-responses",
+        "1.0.0",
+        "external",
+    )
+    reviewed = ProviderBinding(
+        "openai",
+        "gpt-5",
+        OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID,
+        "1.0.0",
+        "external",
+    )
+
+    unknown_answers = module._recipe_answers(  # pyright: ignore[reportPrivateUsage]
+        "assisted_review", local_only_policy(), owner_declared
+    )
+    reviewed_answers = module._recipe_answers(  # pyright: ignore[reportPrivateUsage]
+        "assisted_review", local_only_policy(), reviewed
+    )
+
+    assert unknown_answers.require_current_provider_data_use_evidence is False
+    assert reviewed_answers.require_current_provider_data_use_evidence is True


### PR DESCRIPTION
## Summary

Fixes #115 (`RT-privacy-egress-2`).

When the standing effective policy has `require_current_provider_data_use_evidence=true` and the destination is external, runtime egress now fails closed unless the bound provider has current recommendation-eligible data-use evidence.

### Changes (this PR only)

- **`PrivacyCoordinator`**: optional `data_use_resolver`; predispatch block when the flag is set, transport is external, and evidence is missing/ineligible.
- **`ProviderRegistry` / gateway**: carry the policy flag, expose `data_use_profile`, map `POLICY_DENIED` in preconsume outcomes, and re-check eligibility at dispatch preconsume (defense in depth).
- **`ready_composition`**: wire resolver from the gateway registry snapshot.
- **Tests**: ineligible, missing resolver, and eligible paths.

Deliberately **not** included (separate issues/PRs):

- Channel ceiling `max_bytes` / `max_tokens` / scope-ceiling enforcement (#112).
- `PrivacyPolicy.meet` / store intersection (#113).

### Design gate

Privacy/egress is design-gated. **Maintainer directed opening of dedicated PRs for the remaining red-team privacy restorations**, overriding the usual wait-for-acknowledgement gate for this fix series.

Source of truth for the combined fix lived on `fix/redteam-privacy-egress-triple` (PR #116); this PR extracts only the data-use runtime guard.

## Verification

```text
uv sync
uv run ruff format <touched>
uv run ruff check <touched>
uv run pytest tests/unit/application/test_data_use_evidence_runtime_guard.py -q
```

Result: **3 passed**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a runtime egress guard that enforces `require_current_provider_data_use_evidence` at two layers: a predispatch check in `PrivacyCoordinator` (application layer) and a re-check inside `PolicyEnforcingOutboundGateway._predispatch_reason` (defense in depth). When the policy flag is set and the bound external provider lacks current recommendation-eligible data-use evidence, egress is rejected with `BLOCKED_BY_POLICY / POLICY_DENIED` before any data leaves the system.

- **`PrivacyCoordinator`** gains an optional `data_use_resolver` callback and a transport-gated predispatch block; fail-closed when no resolver is provided.
- **`ProviderRegistry`** carries the policy flag, exposes `data_use_profile(binding)`, and the preconsume `_predispatch_reason` re-checks eligibility at actual dispatch time using a fresh `now_utc`.
- **`ready_composition`** wires the resolver by reading the gateway's current registry snapshot at call time; three unit tests cover ineligible evidence, missing resolver, and eligible paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fail-closed design means any bridging failure blocks egress rather than leaking data, and both enforcement layers are logically correct.

The two-layer guard (predispatch in PrivacyCoordinator plus re-check at gateway preconsume) is correct and consistent. The authorization-stale mechanism prevents a window between the two checks from being exploited. The only structural concern is the private-attribute bridge in ready_composition.py, but its failure mode is fail-closed, so no data leaks if it silently degrades.

**Files Needing Attention:** ready_composition.py — the `_data_use_for` closure should eventually be replaced with a public gateway method to avoid silent degradation on internal refactors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/application/egress.py | Adds `data_use_resolver` param to `PrivacyCoordinator` and a transport-gated predispatch block; `_data_use_evidence_current` helper applies strict type check and fail-closed semantics. Logic is correct. |
| src/yoetz/adapters/privacy/gateway.py | Adds `require_current_provider_data_use_evidence` to `ProviderRegistry`, `data_use_profile()` accessor, and `POLICY_DENIED` entry in `_PRECONSUME_OUTCOME`; defense-in-depth check in `_predispatch_reason` is correctly placed and uses fresh `now_utc`. |
| src/yoetz/service/ready_composition.py | Wires `data_use_resolver` via a closure that reads `gateway._registry` through `getattr` — accessing a private attribute instead of a public method on the gateway, which silently returns `None` and blocks all egress if the attribute is ever renamed. |
| tests/unit/application/test_data_use_evidence_runtime_guard.py | New test file covering ineligible evidence, missing resolver, and eligible paths; assertions are precise and the eligible path correctly verifies the flow reaches the audit prepare stage. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as PrivacyCoordinator
    participant R as data_use_resolver (_data_use_for)
    participant GW as PolicyEnforcingOutboundGateway
    participant PR as ProviderRegistry

    C->>C: evaluate_semantic(candidate, deadline)
    C->>C: _evaluate_semantic_predispatch()
    note over C: check policy.require_current_provider_data_use_evidence AND binding.transport == external
    C->>R: _data_use_evidence_current(binding)
    R->>GW: getattr(_registry)
    GW-->>R: ProviderRegistry snapshot
    R->>PR: data_use_profile(binding)
    PR-->>R: ProviderDataUseProfile or None
    R->>R: profile.recommendation_eligible(now_utc)
    R-->>C: bool
    alt evidence missing or ineligible
        C-->>C: BLOCKED_BY_POLICY / POLICY_DENIED
    else evidence current
        C->>C: classify, minimize, prepare_proposal
        C->>GW: dispatch_external_semantic(case, authorization, deadline)
        GW->>GW: _predispatch_reason() defense-in-depth
        GW->>PR: data_use_profile(binding)
        PR-->>GW: ProviderDataUseProfile or None
        GW->>GW: recommendation_eligible(now_utc)
        alt still eligible at dispatch time
            GW->>GW: proceed with external call
        else expired between predispatch and dispatch
            GW-->>C: BLOCKED_BY_POLICY / POLICY_DENIED
        end
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(privacy): enforce provider data-use ..."](https://github.com/thegaysupreme123/yoetz/commit/855a1279c11a0ed9f09c17fbff5e7e3af5a8acdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22392752)</sub>

<!-- /greptile_comment -->