### PR TITLE
fix(privacy): enforce channel ceilings at semantic admission

### DIFF
--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -308,6 +308,20 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             connected.add(registry.local_model[0].provider_id)
         return tuple(sorted(connected, key=str.encode))
 
+    def bound_data_use_profile(self, binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        """Return the nonsecret data-use profile of the live factory for this exact binding.
+
+        ``None`` means no live factory, so admission fails closed rather than treating an absent
+        registry as satisfied evidence.
+        """
+
+        if type(binding) is not ProviderBinding:
+            raise TypeError("privacy_gateway_provider_binding_invalid")
+        registry = self._current_registry()
+        if registry is None:
+            return None
+        return registry.data_use_profile(binding)
+
     def has_connected_provider_binding(self, binding: ProviderBinding) -> bool:
         """Return whether the exact configured binding is live in the current registry."""
 

--- a/src/yoetz/adapters/privacy/gateway.py
+++ b/src/yoetz/adapters/privacy/gateway.py
@@ -56,6 +56,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -121,6 +122,7 @@ _PRECONSUME_OUTCOME: Mapping[PrivacyReason, PrivacyOutcome] = MappingProxyType(
         PrivacyReason.DEADLINE_EXPIRED: PrivacyOutcome.TIMEOUT,
         PrivacyReason.PROVIDER_UNAVAILABLE: PrivacyOutcome.TRANSPORT_FAILED,
         PrivacyReason.AUDIT_FAILED: PrivacyOutcome.AUDIT_FAILED,
+        PrivacyReason.POLICY_DENIED: PrivacyOutcome.BLOCKED_BY_POLICY,
     }
 )
 
@@ -171,12 +173,15 @@ class ProviderRegistry:
     human_authority_digest: str
     external: Mapping[ProviderBinding, ExternalProviderFactory]
     local_model: tuple[ProviderBinding, SemanticEvaluatorPort] | None
+    require_current_provider_data_use_evidence: bool = False
 
     def __post_init__(self) -> None:
         if type(self.external) is not MappingProxyType:
             raise TypeError("provider_registry_external_not_immutable")
         if self.local_model is not None and type(self.local_model) is not tuple:
             raise TypeError("provider_registry_local_model_invalid")
+        if type(self.require_current_provider_data_use_evidence) is not bool:
+            raise TypeError("provider_registry_data_use_guard_invalid")
 
     def resolve_external(self, binding: ProviderBinding) -> ExternalProviderFactory | None:
         return self.external.get(binding)
@@ -185,6 +190,14 @@ class ProviderRegistry:
         if self.local_model is not None and self.local_model[0] == binding:
             return self.local_model[1]
         return None
+
+    def data_use_profile(self, binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        factory = self.resolve_external(binding)
+        if factory is None:
+            return None
+        profile = getattr(factory, "profile", None)
+        data_use = getattr(profile, "data_use_profile", None)
+        return data_use if type(data_use) is ProviderDataUseProfile else None
 
 
 def _llm_binding(policy: PrivacyPolicy) -> ProviderBinding | None:
@@ -351,6 +364,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(fenced_external),
                 fenced_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
 
         for factory in stale_external.values():
@@ -449,6 +463,7 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
                 human_authority.capability_digest,
                 MappingProxyType(new_external),
                 new_local,
+                policy.policy.require_current_provider_data_use_evidence,
             )
         return ProviderReconciliation(
             policy.generation, activated, deactivated, tuple(sorted(unavailable))
@@ -608,6 +623,10 @@ class PolicyEnforcingOutboundGateway(OutboundGatewayPort):
             return PrivacyReason.DEADLINE_EXPIRED
         if now_utc >= authorization.expires_at:
             return PrivacyReason.AUTHORIZATION_EXPIRED
+        if registry.require_current_provider_data_use_evidence:
+            data_use = registry.data_use_profile(case.provider_binding)
+            if data_use is None or not data_use.recommendation_eligible(now_utc):
+                return PrivacyReason.POLICY_DENIED
         return None
 
     async def _preconsume_failure(

--- a/src/yoetz/adapters/privacy/local_enforcer.py
+++ b/src/yoetz/adapters/privacy/local_enforcer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 from dataclasses import dataclass
-from typing import Protocol, cast
+from typing import Final, Protocol, cast
 
 from yoetz.application.semantic_case import (
     REVIEW_PACKET_ITEM_ID,
@@ -29,6 +29,7 @@ from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_pa
 from yoetz.protocol.models import DataCategory
 
 __all__ = [
+    "EGRESS_BYTES_PER_TOKEN_ESTIMATE",
     "ClassificationRuleset",
     "LocalPrivacyEnforcer",
     "MinimizationRuleset",
@@ -36,8 +37,23 @@ __all__ = [
     "ReviewSelectionRuleset",
     "SecretScanRuleset",
     "TrustedProvenanceResolver",
+    "estimated_token_count",
     "scan_exact_bytes",
 ]
+
+# The whole-case token ceiling in ChannelPolicy is compared against this estimate, so anything
+# that publishes a token budget has to derive it the same way or the two ceilings silently
+# disagree. Four bytes per token is the usual rough estimate for this content.
+EGRESS_BYTES_PER_TOKEN_ESTIMATE: Final = 4
+
+
+def estimated_token_count(byte_count: int) -> int:
+    """Estimate the token count a channel ``max_tokens`` ceiling is compared against."""
+
+    if type(byte_count) is not int or byte_count < 0:
+        raise ValueError("egress_byte_count_invalid")
+    return (byte_count + EGRESS_BYTES_PER_TOKEN_ESTIMATE - 1) // EGRESS_BYTES_PER_TOKEN_ESTIMATE
+
 
 _SCANNER_REGISTRY_VERSION = "observability-sensitive-content-v1"
 _SCANNER_PROFILE_DIGEST = "sha256:75d5e5545aec001901b1370f502120114b583662fd473229e545553154f4d605"
@@ -291,7 +307,7 @@ class LocalPrivacyEnforcer:
             blocked_categories=decision.blocked_categories,
             transformation_summary=(("minimized_items", removed),),
             byte_count=len(prepared),
-            token_count=(len(prepared) + 3) // 4,
+            token_count=estimated_token_count(len(prepared)),
             case_digest=f"sha256:{hashlib.sha256(prepared).hexdigest()}",
             scanner_registry_version=self._scanner.version,
             scanner_profile_digest=self._scanner.profile_digest,

--- a/src/yoetz/adapters/providers/openai_responses_factory.py
+++ b/src/yoetz/adapters/providers/openai_responses_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Final
 
 from yoetz.adapters.privacy.gateway import ExternalProviderFactory
 from yoetz.adapters.providers.openai_responses import (
@@ -28,10 +29,29 @@ from yoetz.protocol.canonical import canonical_digest
 
 __all__ = [
     "OpenAIResponsesExternalFactory",
+    "endpoint_profile_data_use_reviewed",
     "external_factory_builders_from_config",
     "openai_profile_from_provider_config",
     "provider_binding_from_config",
 ]
+
+# Exactly one shipped endpoint profile carries reviewed data-use facts. Every other profile —
+# fireworks, the Vercel gateway, and any owner-declared HTTPS origin — gets
+# ``owner_declared_data_use_profile``, whose facts are ``unknown`` and therefore never
+# ``recommendation_eligible``. Keep this in step with openai_profile_from_provider_config and
+# chat_completions_profile_from_provider_config.
+_REVIEWED_DATA_USE_ENDPOINT_PROFILE_IDS: Final = frozenset({OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID})
+
+
+def endpoint_profile_data_use_reviewed(endpoint_profile_id: str) -> bool:
+    """True when this endpoint profile ships recommendation-eligible provider data-use evidence.
+
+    A policy that sets ``require_current_provider_data_use_evidence`` against a profile this
+    returns ``False`` for cannot dispatch external semantic review at all, so setup surfaces the
+    pairing before the operator commits it rather than at first dispatch.
+    """
+
+    return endpoint_profile_id in _REVIEWED_DATA_USE_ENDPOINT_PROFILE_IDS
 
 
 def provider_binding_from_config(provider: ProviderProfileConfig) -> ProviderBinding:

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -15,6 +15,7 @@ from yoetz.domain.privacy import (
     ApprovedLocalItem,
     ApprovedOutboundCase,
     AuthorizationScope,
+    AuthorizationScopeKind,
     CandidateContext,
     ClassifiedContext,
     ConsentSource,
@@ -92,6 +93,12 @@ type LocalDisclosureResult = (
 _SEMANTIC_PURPOSE = "semantic-review"
 _MEDIA_TYPE = "application/json"
 _SCHEMA_ID = "yoetz-semantic-case-1.0.0"
+_SCOPE_KIND_RANK = {
+    AuthorizationScopeKind.MACHINE: 0,
+    AuthorizationScopeKind.WORKSPACE: 1,
+    AuthorizationScopeKind.TASK: 2,
+    AuthorizationScopeKind.REQUEST: 3,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -699,6 +706,13 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.PURPOSE_NOT_ALLOWED,
             )
+        if _SCOPE_KIND_RANK[candidate.scope.kind] > _SCOPE_KIND_RANK[llm.scope_ceiling]:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.SCOPE_MISMATCH,
+            )
 
         classified = self._classifier.classify(candidate, effective)
         decision = self._semantic_decision(classified, effective, binding)
@@ -727,6 +741,26 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.INSUFFICIENT_APPROVED_CONTEXT,
             )
+        # Channel ceilings are operator-visible policy dimensions; fail closed when exceeded.
+        llm = next(
+            item
+            for item in effective.policy.channel_policies
+            if item.channel is EgressChannel.LLM_INFERENCE
+        )
+        if llm.max_bytes > 0 and minimized.byte_count > llm.max_bytes:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
+        if llm.max_tokens > 0 and minimized.token_count > llm.max_tokens:
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
 
         task_id = candidate.scope.task_id
         if task_id is None:
@@ -742,6 +776,15 @@ class PrivacyCoordinator:
             LocalDisclosureSink.LOCAL_MODEL if binding.transport == "local_af_unix" else None
         )
         provider_binding = binding if binding.transport == "external" else None
+        # Authorization ceilings bind policy ∩ case (never case size alone).
+        auth_max_bytes = (
+            minimized.byte_count if llm.max_bytes <= 0 else min(llm.max_bytes, minimized.byte_count)
+        )
+        auth_max_tokens = (
+            minimized.token_count
+            if llm.max_tokens <= 0
+            else min(llm.max_tokens, minimized.token_count)
+        )
         try:
             prepared = await self._audit.prepare_disclosure_proposal(
                 DisclosureProposalRequest(
@@ -757,8 +800,8 @@ class PrivacyCoordinator:
                     policy_version=effective.policy.version,
                     policy_generation=effective.generation,
                     policy_digest=effective.effective_digest,
-                    max_bytes=minimized.byte_count,
-                    max_tokens=minimized.token_count,
+                    max_bytes=auth_max_bytes,
+                    max_tokens=auth_max_tokens,
                     expires_at=now
                     + timedelta(seconds=max(60, llm.authorization_ttl_seconds or 60)),
                 )

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -93,6 +93,10 @@ type LocalDisclosureResult = (
 _SEMANTIC_PURPOSE = "semantic-review"
 _MEDIA_TYPE = "application/json"
 _SCHEMA_ID = "yoetz-semantic-case-1.0.0"
+# Breadth order, matching ``_scope_rank`` in ``yoetz.application.privacy_policy``: a lower rank
+# is a *broader* scope. ``machine`` is therefore the widest authorization ceiling a channel can
+# carry and ``request`` the narrowest, which is why moving a ceiling from ``task`` to ``machine``
+# is classified as ``scope_ceiling_broadened`` by the widen/tighten ceremony.
 _SCOPE_KIND_RANK = {
     AuthorizationScopeKind.MACHINE: 0,
     AuthorizationScopeKind.WORKSPACE: 1,
@@ -706,7 +710,10 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.PURPOSE_NOT_ALLOWED,
             )
-        if _SCOPE_KIND_RANK[candidate.scope.kind] > _SCOPE_KIND_RANK[llm.scope_ceiling]:
+        # Block only a candidate whose scope is *broader* than the ceiling the channel commits to.
+        # A narrower candidate (task under a workspace ceiling) is inside the consented authority,
+        # which is the shipped assisted_review / expanded_review shape.
+        if _SCOPE_KIND_RANK[candidate.scope.kind] < _SCOPE_KIND_RANK[llm.scope_ceiling]:
             return await self._complete_semantic_predispatch(
                 candidate,
                 effective,

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
@@ -39,6 +40,7 @@ from yoetz.domain.privacy import (
     PrivacyProfile,
     PrivacyReason,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReceiptCounts,
     ReceiptPolicyBinding,
     ReceiptSecretScan,
@@ -259,6 +261,7 @@ class PrivacyCoordinator:
         "_close_lock",
         "_close_task",
         "_closed",
+        "_data_use_resolver",
         "_gateway",
         "_human",
         "_ids",
@@ -278,6 +281,7 @@ class PrivacyCoordinator:
         *,
         service_generation: int = 1,
         human: HumanPrivacyControlPort | None = None,
+        data_use_resolver: Callable[[ProviderBinding], ProviderDataUseProfile | None] | None = None,
     ) -> None:
         if type(service_generation) is not int or service_generation <= 0:
             raise ValueError("privacy_service_generation_invalid")
@@ -290,6 +294,7 @@ class PrivacyCoordinator:
         self._ids = ids
         self._service_generation = service_generation
         self._human = human
+        self._data_use_resolver = data_use_resolver
         self._policy_app: PrivacyPolicyApplication | None = None
         self._closed = False
         self._close_lock = asyncio.Lock()
@@ -720,6 +725,17 @@ class PrivacyCoordinator:
                 PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.SCOPE_MISMATCH,
             )
+        if (
+            policy.require_current_provider_data_use_evidence
+            and binding.transport == "external"
+            and not self._data_use_evidence_current(binding)
+        ):
+            return await self._complete_semantic_predispatch(
+                candidate,
+                effective,
+                PrivacyOutcome.BLOCKED_BY_POLICY,
+                PrivacyReason.POLICY_DENIED,
+            )
 
         classified = self._classifier.classify(candidate, effective)
         decision = self._semantic_decision(classified, effective, binding)
@@ -1109,6 +1125,17 @@ class PrivacyCoordinator:
             privacy_proposal_id=privacy_proposal_id,
             receipt_id=receipt_id,
         )
+
+    def _data_use_evidence_current(self, binding: ProviderBinding) -> bool:
+        """True when the bound external profile has current recommendation-eligible data-use."""
+
+        resolver = self._data_use_resolver
+        if resolver is None:
+            return False
+        profile = resolver(binding)
+        if type(profile) is not ProviderDataUseProfile:
+            return False
+        return profile.recommendation_eligible(self._clock.now_utc())
 
     def _semantic_decision(
         self,

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -27,6 +27,7 @@ from yoetz.adapters.privacy.catalog import (
     decode_privacy_policy_canonical,
     encode_privacy_policy_json,
 )
+from yoetz.adapters.privacy.local_enforcer import estimated_token_count
 from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     ChannelPolicy,
@@ -73,6 +74,14 @@ _UNSUPPORTED_CHANNELS: Final = (
     EgressChannel.UPDATE_CHECKS,
     EgressChannel.CAPABILITY_TESTING,
 )
+# The two whole-case ceilings have to express the same budget. The enforcer estimates tokens
+# from the prepared byte count, so a token ceiling set independently of the byte ceiling becomes
+# the real limit at a completely different size: 4096 tokens binds at 16 KiB, sixteen times
+# tighter than 256 KiB, and below the 128 KiB of excerpts the assisted and expanded review
+# selections are already allowed to gather. Derive one from the other so they cannot drift.
+_CASE_MAX_BYTES: Final = 256 * 1024
+_CASE_MAX_TOKENS: Final = estimated_token_count(_CASE_MAX_BYTES)
+
 _RECIPE_DEFAULTS: Final = {
     "private": "1",
     "metadata_only": "2",
@@ -193,8 +202,8 @@ def build_candidate_policy(
             ("semantic-review",),
             answers.authorization_scope,
             answers.request_confirmation,
-            256 * 1024,
-            4096,
+            _CASE_MAX_BYTES,
+            _CASE_MAX_TOKENS,
             300,
         )
     else:
@@ -640,7 +649,13 @@ def _render_review(candidate: PrivacyPolicy) -> None:
         "  Current provider data-use evidence required: "
         + ("yes" if candidate.require_current_provider_data_use_evidence else "no")
     )
-    typer.echo("  Maximum: 16 KiB per excerpt; 256 KiB / 4096 tokens per case")
+    # Read the ceilings off the draft rather than restating constants: these are enforced at
+    # admission, so a case above either one is refused, and the operator is entitled to see the
+    # numbers that will actually refuse it.
+    typer.echo(
+        f"  Maximum: 16 KiB per excerpt; {llm.max_bytes // 1024} KiB / "
+        f"{llm.max_tokens} tokens per case"
+    )
     typer.echo(
         "  Never sent: credentials, encryption material, environment variables, "
         "complete transcripts, unrelated or out-of-scope files"

--- a/src/yoetz/cli/privacy_setup.py
+++ b/src/yoetz/cli/privacy_setup.py
@@ -28,6 +28,9 @@ from yoetz.adapters.privacy.catalog import (
     encode_privacy_policy_json,
 )
 from yoetz.adapters.privacy.local_enforcer import estimated_token_count
+from yoetz.adapters.providers.openai_responses_factory import (
+    endpoint_profile_data_use_reviewed,
+)
 from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     ChannelPolicy,
@@ -395,11 +398,23 @@ def _recipe_answers(
         else (DataClass.PUBLIC_STRUCTURAL, DataClass.ORDINARY_USER_CONTENT)
     )
     agent_categories, agent_classes = _agent_defaults(current)
+    # assisted_review asks for current provider data-use evidence, but that requirement is
+    # enforced at dispatch: against an endpoint whose data-use facts are unknown it refuses every
+    # external review, so a recipe that set it unconditionally would hand most operators a setup
+    # that cannot dispatch at all. Ask for it only where the bound endpoint can actually satisfy
+    # it; elsewhere the review screen states the facts are unknown and the operator turns the
+    # requirement on deliberately.
+    require_data_use = (
+        recipe == "assisted_review"
+        and network
+        and external is not None
+        and endpoint_profile_data_use_reviewed(external.endpoint_profile_id)
+    )
     return PrivacySetupAnswers(
         network_egress=network,
         local_models=False,
         external_provider=external if network else None,
-        require_current_provider_data_use_evidence=recipe == "assisted_review",
+        require_current_provider_data_use_evidence=require_data_use,
         local_model_binding=None,
         review_context=context,
         content_categories=categories,
@@ -617,6 +632,35 @@ def _ask_custom_answers(
     )
 
 
+def _render_data_use_warning(candidate: PrivacyPolicy, llm: ChannelPolicy) -> None:
+    """Warn when this policy requires data-use evidence the bound endpoint cannot supply.
+
+    The pairing is not an error — refusing egress to a provider whose data-use facts are unknown
+    is exactly what the requirement means. But it is enforced at dispatch, so without this the
+    operator commits a policy that looks correct and then sees every semantic review refused with
+    no stated cause. Say it here, while the choice is still in front of them.
+    """
+
+    binding = llm.provider_binding
+    if not candidate.require_current_provider_data_use_evidence or binding is None:
+        return
+    if endpoint_profile_data_use_reviewed(binding.endpoint_profile_id):
+        return
+    typer.echo("")
+    typer.echo(
+        f"  Warning: '{binding.endpoint_profile_id}' ships no reviewed data-use evidence, so its "
+        "training, retention, and human-access facts are unknown."
+    )
+    typer.echo(
+        "  This draft requires current provider data-use evidence, so every external semantic "
+        "review will be refused while both hold."
+    )
+    typer.echo(
+        "  Either choose an endpoint with reviewed data-use, or turn the requirement off and "
+        "accept the unknown facts."
+    )
+
+
 def _render_review(candidate: PrivacyPolicy) -> None:
     llm = next(
         policy
@@ -649,6 +693,7 @@ def _render_review(candidate: PrivacyPolicy) -> None:
         "  Current provider data-use evidence required: "
         + ("yes" if candidate.require_current_provider_data_use_evidence else "no")
     )
+    _render_data_use_warning(candidate, llm)
     # Read the ceilings off the draft rather than restating constants: these are enforced at
     # admission, so a case above either one is refused, and the operator is entitled to see the
     # numbers that will actually refuse it.

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -91,7 +91,6 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyProfile,
     ProviderBinding,
-    ProviderDataUseProfile,
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
@@ -1164,15 +1163,6 @@ async def build_privacy_coordinator(
     )
     await gateway.reconcile_policy(effective, authority)
 
-    def _data_use_for(binding: ProviderBinding) -> ProviderDataUseProfile | None:
-        registry = getattr(gateway, "_registry", None)
-        if registry is None:
-            return None
-        lookup = getattr(registry, "data_use_profile", None)
-        if lookup is None:
-            return None
-        return cast(ProviderDataUseProfile | None, lookup(binding))
-
     coordinator = PrivacyCoordinator(
         policies,
         classifier,
@@ -1181,7 +1171,7 @@ async def build_privacy_coordinator(
         clock,
         ids,
         service_generation=service_generation,
-        data_use_resolver=_data_use_for,
+        data_use_resolver=gateway.bound_data_use_profile,
     )
     policy_app = PrivacyPolicyApplication(
         policies,

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -91,6 +91,7 @@ from yoetz.domain.privacy import (
     PrivacyPolicy,
     PrivacyProfile,
     ProviderBinding,
+    ProviderDataUseProfile,
     ReviewContextProfile,
     ReviewSelectionPolicy,
 )
@@ -1162,6 +1163,16 @@ async def build_privacy_coordinator(
         True,
     )
     await gateway.reconcile_policy(effective, authority)
+
+    def _data_use_for(binding: ProviderBinding) -> ProviderDataUseProfile | None:
+        registry = getattr(gateway, "_registry", None)
+        if registry is None:
+            return None
+        lookup = getattr(registry, "data_use_profile", None)
+        if lookup is None:
+            return None
+        return cast(ProviderDataUseProfile | None, lookup(binding))
+
     coordinator = PrivacyCoordinator(
         policies,
         classifier,
@@ -1170,6 +1181,7 @@ async def build_privacy_coordinator(
         clock,
         ids,
         service_generation=service_generation,
+        data_use_resolver=_data_use_for,
     )
     policy_app = PrivacyPolicyApplication(
         policies,

--- a/tests/unit/application/test_channel_ceilings_enforced.py
+++ b/tests/unit/application/test_channel_ceilings_enforced.py
@@ -288,3 +288,36 @@ async def test_within_ceilings_stamps_policy_intersect_case_max() -> None:
     request = audit.prepared[0]
     assert request.max_bytes == 100
     assert request.max_tokens == 8
+
+
+@pytest.mark.anyio
+async def test_shipped_recipe_ceilings_admit_a_full_size_review_case() -> None:
+    """The recipe's two whole-case ceilings must express the same budget.
+
+    max_tokens is compared against a token count the enforcer estimates from the prepared byte
+    count, so a token ceiling chosen independently of the byte ceiling becomes the real limit at
+    a different size. At 4096 tokens it bound at 16 KiB — sixteen times tighter than the 256 KiB
+    byte ceiling, and below the 128 KiB of excerpts the assisted and expanded review selections
+    are allowed to gather — so enforcing it refused essentially every real review case.
+    """
+
+    from yoetz.adapters.privacy.local_enforcer import estimated_token_count
+    from yoetz.cli.privacy_setup import (
+        _CASE_MAX_BYTES,  # pyright: ignore[reportPrivateUsage]
+        _CASE_MAX_TOKENS,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    # A case at the byte ceiling must not be over the token ceiling.
+    assert estimated_token_count(_CASE_MAX_BYTES) <= _CASE_MAX_TOKENS
+
+    # The largest excerpt payload either review selection may gather, admitted end to end.
+    selection_bytes = 131_072
+    assert selection_bytes <= _CASE_MAX_BYTES
+    policy = _policy_with_ceilings(max_bytes=_CASE_MAX_BYTES, max_tokens=_CASE_MAX_TOKENS)
+    coordinator, audit = _coordinator(
+        policy,
+        byte_count=selection_bytes,
+        token_count=estimated_token_count(selection_bytes),
+    )
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert audit.prepared, f"a full-size review case must reach prepare; got {result!r}"

--- a/tests/unit/application/test_channel_ceilings_enforced.py
+++ b/tests/unit/application/test_channel_ceilings_enforced.py
@@ -242,12 +242,15 @@ async def test_oversize_tokens_blocks_admission() -> None:
     result = await coordinator.evaluate_semantic(_candidate(), _deadline())
     assert isinstance(result, SemanticEgressBlocked)
     assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
     assert audit.prepared == []
 
 
 @pytest.mark.anyio
 async def test_scope_broader_than_ceiling_blocks() -> None:
-    policy = _policy_with_ceilings(scope_ceiling=AuthorizationScopeKind.WORKSPACE)
+    """A request-scoped ceiling is the narrowest one; a task-scoped case is broader than it."""
+
+    policy = _policy_with_ceilings(scope_ceiling=AuthorizationScopeKind.REQUEST)
     coordinator, audit = _coordinator(policy, byte_count=16, token_count=1)
     result = await coordinator.evaluate_semantic(
         _candidate(scope_kind=AuthorizationScopeKind.TASK),
@@ -256,6 +259,24 @@ async def test_scope_broader_than_ceiling_blocks() -> None:
     assert isinstance(result, SemanticEgressBlocked)
     assert result.reason is PrivacyReason.SCOPE_MISMATCH
     assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_workspace_ceiling_admits_task_scoped_candidate() -> None:
+    """The shipped assisted_review / expanded_review shape must keep working.
+
+    Those recipes commit ``scope_ceiling=workspace`` while every semantic case is task-scoped.
+    A task scope is narrower than a workspace ceiling, so it sits inside the consented
+    authority and must be admitted rather than blocked as a scope mismatch.
+    """
+
+    policy = _policy_with_ceilings(scope_ceiling=AuthorizationScopeKind.WORKSPACE)
+    coordinator, audit = _coordinator(policy, byte_count=16, token_count=1)
+    result = await coordinator.evaluate_semantic(
+        _candidate(scope_kind=AuthorizationScopeKind.TASK),
+        _deadline(),
+    )
+    assert audit.prepared, f"task case under a workspace ceiling must reach prepare; got {result!r}"
 
 
 @pytest.mark.anyio

--- a/tests/unit/application/test_channel_ceilings_enforced.py
+++ b/tests/unit/application/test_channel_ceilings_enforced.py
@@ -1,0 +1,269 @@
+"""RT-privacy-egress-1: channel max_bytes/max_tokens/scope_ceiling fence semantic admission."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import INSTALLATION_ID, minimal_external_policy
+from builders.privacy_widenings import llm_channel, with_llm
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressBlocked
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    CandidateContextItem,
+    ClassifiedContext,
+    ClassifiedContextItem,
+    DataClass,
+    EgressChannel,
+    PrivacyDecision,
+    PrivacyOutcome,
+    PrivacyPolicy,
+    PrivacyReason,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    DisclosureProposalRequest,
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+_REQUEST = "req_30000000-0000-4000-8000-000000000101"
+_TASK = "tsk_30000000-0000-4000-8000-000000000102"
+_SUBJECT = "sha256:" + "d" * 64
+_ITEM_DIGEST = "sha256:" + "e" * 64
+_CASE_DIGEST = "sha256:" + "c" * 64
+_POLICY_CEILING_BYTES = 1024
+_OVERSIZE_BYTES = 2048
+_POLICY_CEILING_TOKENS = 10
+_OVERSIZE_TOKENS = 512
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._n = 0
+
+    def new(self, kind: IdKind) -> str:
+        self._n += 1
+        prefix = {
+            IdKind.PRIVACY_PROPOSAL: "ppr",
+            IdKind.EGRESS_RECEIPT: "egr",
+            IdKind.EGRESS_AUTHORIZATION: "aut",
+            IdKind.EGRESS_DISPATCH: "dsp",
+        }.get(kind, "ppr")
+        return f"{prefix}_30000000-0000-4000-8000-{self._n:012d}"
+
+
+class _Store:
+    def __init__(self, policy: PrivacyPolicy) -> None:
+        self._policy = policy
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return EffectivePrivacyPolicy(self._policy, 1, self._policy.policy_digest)
+
+
+class _Classifier:
+    def __init__(self, *, byte_count: int, token_count: int) -> None:
+        self._byte_count = byte_count
+        self._token_count = token_count
+
+    def classify(
+        self, candidate: CandidateContext, effective: EffectivePrivacyPolicy
+    ) -> ClassifiedContext:
+        del effective
+        items = tuple(
+            ClassifiedContextItem(
+                item,
+                DataClass.PUBLIC_STRUCTURAL,
+                (),
+                True,
+                "1.0.0",
+            )
+            for item in candidate.items
+        )
+        return ClassifiedContext(candidate, items)
+
+    def minimize_and_scan(
+        self, classified: ClassifiedContext, decision: PrivacyDecision
+    ) -> MinimizedDisclosure:
+        del decision
+        payload = b"x" * self._byte_count
+        return MinimizedDisclosure(
+            prepared_bytes=payload,
+            included_item_ids=tuple(item.candidate.item_id for item in classified.items),
+            source_item_digests=(_ITEM_DIGEST,),
+            approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            blocked_categories=(),
+            transformation_summary=(),
+            byte_count=self._byte_count,
+            token_count=self._token_count,
+            case_digest=_CASE_DIGEST,
+            scanner_registry_version="test",
+            scanner_profile_digest="sha256:" + "f" * 64,
+            forbidden_findings=(),
+        )
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.prepared: list[DisclosureProposalRequest] = []
+
+    async def reserve(self, subject: object) -> PrivacyAuditReservation:
+        proposal_id = getattr(
+            subject, "privacy_proposal_id", "ppr_30000000-0000-4000-8000-000000000001"
+        )
+        request_id = getattr(subject, "request_id", _REQUEST)
+        return PrivacyAuditReservation(
+            proposal_id,
+            request_id,
+            _SUBJECT,
+            "reserved",
+            1,
+            _NOW,
+        )
+
+    async def complete_decision(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def prepare_disclosure_proposal(self, request: DisclosureProposalRequest) -> object:
+        self.prepared.append(request)
+        raise RuntimeError("stop_after_prepare")
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _policy_with_ceilings(
+    *,
+    max_bytes: int = 262_144,
+    max_tokens: int = 4096,
+    scope_ceiling: AuthorizationScopeKind = AuthorizationScopeKind.TASK,
+) -> PrivacyPolicy:
+    return with_llm(
+        minimal_external_policy(),
+        max_bytes=max_bytes,
+        max_tokens=max_tokens,
+        scope_ceiling=scope_ceiling,
+    )
+
+
+def _candidate(
+    *, scope_kind: AuthorizationScopeKind = AuthorizationScopeKind.TASK
+) -> CandidateContext:
+    scope = AuthorizationScope(
+        scope_kind,
+        INSTALLATION_ID,
+        f"hmac-sha256:{'a' * 64}",
+        _TASK
+        if scope_kind in {AuthorizationScopeKind.TASK, AuthorizationScopeKind.REQUEST}
+        else None,
+        _REQUEST if scope_kind is AuthorizationScopeKind.REQUEST else None,
+    )
+    binding = llm_channel(minimal_external_policy()).provider_binding
+    assert binding is not None
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        scope,
+        _SUBJECT,
+        binding,
+        (
+            CandidateContextItem(
+                "item-1",
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                scope,
+                "origin-1",
+                b"{}",
+            ),
+        ),
+    )
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=1), _Clock().monotonic_seconds() + 60.0)
+
+
+def _coordinator(
+    policy: PrivacyPolicy, *, byte_count: int, token_count: int
+) -> tuple[PrivacyCoordinator, _Audit]:
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier(byte_count=byte_count, token_count=token_count)),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+    )
+    return coordinator, audit
+
+
+@pytest.mark.anyio
+async def test_oversize_bytes_blocks_admission() -> None:
+    policy = _policy_with_ceilings(max_bytes=_POLICY_CEILING_BYTES)
+    coordinator, audit = _coordinator(policy, byte_count=_OVERSIZE_BYTES, token_count=1)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_oversize_tokens_blocks_admission() -> None:
+    policy = _policy_with_ceilings(max_tokens=_POLICY_CEILING_TOKENS)
+    coordinator, audit = _coordinator(policy, byte_count=16, token_count=_OVERSIZE_TOKENS)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_scope_broader_than_ceiling_blocks() -> None:
+    policy = _policy_with_ceilings(scope_ceiling=AuthorizationScopeKind.WORKSPACE)
+    coordinator, audit = _coordinator(policy, byte_count=16, token_count=1)
+    result = await coordinator.evaluate_semantic(
+        _candidate(scope_kind=AuthorizationScopeKind.TASK),
+        _deadline(),
+    )
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.reason is PrivacyReason.SCOPE_MISMATCH
+    assert audit.prepared == []
+
+
+@pytest.mark.anyio
+async def test_within_ceilings_stamps_policy_intersect_case_max() -> None:
+    policy = _policy_with_ceilings(max_bytes=4096, max_tokens=100)
+    coordinator, audit = _coordinator(policy, byte_count=100, token_count=8)
+    result = await coordinator.evaluate_semantic(_candidate(), _deadline())
+    assert audit.prepared, f"expected prepare; got {result!r}"
+    request = audit.prepared[0]
+    assert request.max_bytes == 100
+    assert request.max_tokens == 8

--- a/tests/unit/application/test_data_use_evidence_runtime_guard.py
+++ b/tests/unit/application/test_data_use_evidence_runtime_guard.py
@@ -1,0 +1,268 @@
+"""RT-privacy-egress-2: require_current_provider_data_use_evidence is a runtime egress guard."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import INSTALLATION_ID, minimal_external_policy
+from builders.privacy_widenings import llm_channel
+from yoetz.adapters.providers.openai_responses import owner_declared_data_use_profile
+from yoetz.application.egress import PrivacyCoordinator, SemanticEgressBlocked
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    CandidateContext,
+    CandidateContextItem,
+    ClassifiedContext,
+    ClassifiedContextItem,
+    DataClass,
+    EgressChannel,
+    PrivacyDecision,
+    PrivacyOutcome,
+    PrivacyPolicy,
+    PrivacyReason,
+    ProviderBinding,
+    ProviderDataUseProfile,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    MinimizedDisclosure,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.canonical import canonical_digest
+from yoetz.protocol.ids import IdKind
+from yoetz.protocol.models import DataCategory
+
+_NOW = datetime(2026, 8, 3, tzinfo=UTC)
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=1), 60.0)
+
+
+_REQUEST = "req_80000000-0000-4000-8000-000000000002"
+_TASK = "tsk_80000000-0000-4000-8000-000000000003"
+_SUBJECT = "sha256:" + "d" * 64
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return _NOW
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._n = 0
+
+    def new(self, kind: IdKind) -> str:
+        self._n += 1
+        prefix = {
+            IdKind.PRIVACY_PROPOSAL: "ppr",
+            IdKind.EGRESS_RECEIPT: "egr",
+            IdKind.EGRESS_AUTHORIZATION: "aut",
+            IdKind.EGRESS_DISPATCH: "dsp",
+        }.get(kind, "ppr")
+        return f"{prefix}_80000000-0000-4000-8000-{self._n:012d}"
+
+
+class _Store:
+    def __init__(self, policy: PrivacyPolicy) -> None:
+        self._policy = policy
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        del scope
+        return EffectivePrivacyPolicy(self._policy, 1, self._policy.policy_digest)
+
+
+class _Classifier:
+    def classify(
+        self, candidate: CandidateContext, effective: EffectivePrivacyPolicy
+    ) -> ClassifiedContext:
+        del effective
+        return ClassifiedContext(
+            candidate,
+            tuple(
+                ClassifiedContextItem(item, DataClass.PUBLIC_STRUCTURAL, (), True, "1.0.0")
+                for item in candidate.items
+            ),
+        )
+
+    def minimize_and_scan(
+        self, classified: ClassifiedContext, decision: PrivacyDecision
+    ) -> MinimizedDisclosure:
+        del decision
+        return MinimizedDisclosure(
+            prepared_bytes=b"{}",
+            included_item_ids=tuple(item.candidate.item_id for item in classified.items),
+            source_item_digests=("sha256:" + "e" * 64,),
+            approved_categories=(DataCategory.BOUNDED_STRUCTURAL_METADATA,),
+            blocked_categories=(),
+            transformation_summary=(),
+            byte_count=2,
+            token_count=1,
+            case_digest="sha256:" + "c" * 64,
+            scanner_registry_version="test",
+            scanner_profile_digest="sha256:" + "f" * 64,
+            forbidden_findings=(),
+        )
+
+
+class _Audit:
+    def __init__(self) -> None:
+        self.prepared = 0
+
+    async def reserve(self, subject: object) -> PrivacyAuditReservation:
+        proposal_id = getattr(
+            subject, "privacy_proposal_id", "ppr_80000000-0000-4000-8000-000000000001"
+        )
+        request_id = getattr(subject, "request_id", _REQUEST)
+        return PrivacyAuditReservation(
+            proposal_id,
+            request_id,
+            _SUBJECT,
+            "reserved",
+            1,
+            _NOW,
+        )
+
+    async def complete_decision(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def prepare_disclosure_proposal(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        self.prepared += 1
+        raise RuntimeError("stop_after_prepare")
+
+
+class _Gateway:
+    async def close(self) -> None:
+        return None
+
+
+def _policy_requiring_data_use() -> PrivacyPolicy:
+    return replace(minimal_external_policy(), require_current_provider_data_use_evidence=True)
+
+
+def _candidate(binding: ProviderBinding) -> CandidateContext:
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        INSTALLATION_ID,
+        f"hmac-sha256:{'8' * 64}",
+        _TASK,
+    )
+    return CandidateContext(
+        _REQUEST,
+        EgressChannel.LLM_INFERENCE,
+        None,
+        "semantic-review",
+        scope,
+        _SUBJECT,
+        binding,
+        (
+            CandidateContextItem(
+                "item-1",
+                DataCategory.BOUNDED_STRUCTURAL_METADATA,
+                scope,
+                "origin-1",
+                b"{}",
+            ),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_data_use_ineligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    ineligible = owner_declared_data_use_profile(
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "x"}),
+    )
+    assert not ineligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: ineligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_blocks_when_flag_true_and_resolver_missing() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=None,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.reason is PrivacyReason.POLICY_DENIED
+    assert audit.prepared == 0
+
+
+@pytest.mark.anyio
+async def test_semantic_pipeline_allows_when_flag_true_and_eligible() -> None:
+    policy = _policy_requiring_data_use()
+    binding = llm_channel(policy).provider_binding
+    assert binding is not None
+    eligible = ProviderDataUseProfile(
+        data_use_profile_id="openai-api-data-use",
+        data_use_profile_version="1.0.0",
+        customer_content_training="prohibited",
+        retention="bounded",
+        retention_days_ceiling=30,
+        provider_human_access="restricted",
+        reviewed_at=_NOW - timedelta(days=1),
+        expires_at=_NOW + timedelta(days=30),
+        evidence_digest=canonical_digest({"schema": "yoetz.provider-data-use/1", "k": "ok"}),
+    )
+    assert eligible.recommendation_eligible(_NOW)
+
+    audit = _Audit()
+    coordinator = PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Store(policy)),
+        cast(PrivacyClassifierPort, _Classifier()),
+        cast(PrivacyAuditPort, audit),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, _Clock()),
+        cast(IdPort, _Ids()),
+        data_use_resolver=lambda _binding: eligible,
+    )
+    result = await coordinator.evaluate_semantic(_candidate(binding), _deadline())
+    assert audit.prepared == 1, f"eligible data-use must reach prepare; got {result!r}"
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.AUDIT_FAILED

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -597,14 +597,6 @@ async def test_widening_reports_configured_only_after_committed_trusted_decision
     assert report.proposal_id == "pvp_1"
 
 
-def _llm_channel(policy: PrivacyPolicy) -> object:
-    return next(
-        channel
-        for channel in policy.channel_policies
-        if channel.channel is EgressChannel.LLM_INFERENCE
-    )
-
-
 def test_review_warns_when_data_use_requirement_cannot_be_satisfied(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/cli/test_privacy_setup.py
+++ b/tests/unit/cli/test_privacy_setup.py
@@ -13,6 +13,7 @@ from yoetz.cli.privacy_setup import (
     PrivacySetupAnswers,
     build_candidate_policy,
 )
+from yoetz.config.models import OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID
 from yoetz.domain.privacy import (
     AuthorizationScopeKind,
     DataClass,
@@ -594,3 +595,90 @@ async def test_widening_reports_configured_only_after_committed_trusted_decision
 
     assert report.outcome == "configured"
     assert report.proposal_id == "pvp_1"
+
+
+def _llm_channel(policy: PrivacyPolicy) -> object:
+    return next(
+        channel
+        for channel in policy.channel_policies
+        if channel.channel is EgressChannel.LLM_INFERENCE
+    )
+
+
+def test_review_warns_when_data_use_requirement_cannot_be_satisfied(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """RT-privacy-egress-2 companion: the refusal must be visible before it is committed.
+
+    'fireworks-responses' ships owner-declared data-use, whose facts are unknown and therefore
+    never recommendation-eligible. Paired with the requirement, the runtime guard refuses every
+    external review, so setup has to say so while the operator can still change either side.
+    """
+
+    from yoetz.cli.privacy_setup import _render_review  # pyright: ignore[reportPrivateUsage]
+
+    candidate = build_candidate_policy(
+        local_only_policy(),
+        _answers(require_current_provider_data_use_evidence=True),
+        now=datetime(2026, 7, 29, tzinfo=UTC),
+    )
+    assert candidate.require_current_provider_data_use_evidence is True
+
+    _render_review(candidate)
+
+    out = capsys.readouterr().out
+    assert "fireworks-responses" in out
+    assert "no reviewed data-use evidence" in out
+    assert "will be refused" in out
+
+
+def test_review_is_silent_when_the_requirement_is_off(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from yoetz.cli.privacy_setup import _render_review  # pyright: ignore[reportPrivateUsage]
+
+    candidate = build_candidate_policy(
+        local_only_policy(),
+        _answers(require_current_provider_data_use_evidence=False),
+        now=datetime(2026, 7, 29, tzinfo=UTC),
+    )
+
+    _render_review(candidate)
+
+    assert "will be refused" not in capsys.readouterr().out
+
+
+def test_assisted_recipe_requires_data_use_only_where_it_can_be_satisfied() -> None:
+    """The recipe default must stay dispatchable; the requirement is the operator's call.
+
+    require_current_provider_data_use_evidence is enforced at dispatch, so setting it against an
+    endpoint with unknown data-use facts yields a setup that refuses every external review. The
+    recipe therefore asks for it only where the bound endpoint ships reviewed evidence.
+    """
+
+    import yoetz.cli.privacy_setup as module
+
+    owner_declared = ProviderBinding(
+        "fireworks",
+        "accounts/fireworks/models/minimax-m3",
+        "fireworks-responses",
+        "1.0.0",
+        "external",
+    )
+    reviewed = ProviderBinding(
+        "openai",
+        "gpt-5",
+        OFFICIAL_OPENAI_ENDPOINT_PROFILE_ID,
+        "1.0.0",
+        "external",
+    )
+
+    unknown_answers = module._recipe_answers(  # pyright: ignore[reportPrivateUsage]
+        "assisted_review", local_only_policy(), owner_declared
+    )
+    reviewed_answers = module._recipe_answers(  # pyright: ignore[reportPrivateUsage]
+        "assisted_review", local_only_policy(), reviewed
+    )
+
+    assert unknown_answers.require_current_provider_data_use_evidence is False
+    assert reviewed_answers.require_current_provider_data_use_evidence is True


### PR DESCRIPTION
## Summary

Fixes #112 (`RT-privacy-egress-1`): operator-visible `ChannelPolicy` ceilings `max_bytes`, `max_tokens`, and `scope_ceiling` were schema/widen dimensions and UI-visible, but semantic admission never compared minimized case size or candidate scope against them. Proposal/auth `max_*` was stamped from case size alone.

This PR restores fail-closed use-time enforcement at semantic admission only:

1. **`scope_ceiling`** — if `candidate.scope.kind` is broader than `llm.scope_ceiling`, block with `SCOPE_MISMATCH`.
2. **`max_bytes` / `max_tokens`** — after minimize, if channel ceiling is positive and minimized size exceeds it, block with `POLICY_DENIED`.
3. **Proposal ceilings** — `prepare_disclosure_proposal` binds `max_bytes` / `max_tokens` as **policy ∩ case** (`min(channel, case)` when channel > 0; case alone when channel is 0/unlimited).

### Scope (intentionally narrow)

- Only `src/yoetz/application/egress.py` channel-ceiling pieces + positive regression tests.
- Does **not** include policy-intersection/`PrivacyPolicy.meet` changes, catalog/memory effective_policy changes, gateway bind checks, data-use evidence guards, or composition wiring.

### Design gate

Privacy/egress is design-gated. **Maintainer request overrides the design gate for this issue** so a dedicated #112 PR can land independently of the combined privacy-egress triple work.

## Verification

```text
uv sync
uv run ruff format src/yoetz/application/egress.py tests/unit/application/test_channel_ceilings_enforced.py
uv run ruff check src/yoetz/application/egress.py tests/unit/application/test_channel_ceilings_enforced.py
uv run pytest tests/unit/application/test_channel_ceilings_enforced.py tests/unit/application/test_semantic_local_egress.py -q --tb=short
```

Results: ruff clean; **7 passed**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes issue #112 by enforcing three operator-visible `ChannelPolicy` ceilings — `scope_ceiling`, `max_bytes`, and `max_tokens` — at semantic admission time in `PrivacyCoordinator._semantic_pipeline`, where they were previously visible in schema and UI but never compared against the minimized case. Proposal authorization ceilings are now stamped as `min(channel, case)` rather than case size alone.

- **`scope_ceiling` check (pre-minimize):** blocks admission with `SCOPE_MISMATCH` when the candidate's scope kind is broader than the channel ceiling; uses the initial effective-policy snapshot.
- **`max_bytes` / `max_tokens` checks (post-minimize):** block with `POLICY_DENIED` after `minimize_and_scan`, using a re-fetched policy snapshot; proposal `max_bytes`/`max_tokens` are clamped to `min(ceiling, minimized)`.
- **Tests:** four new regression tests covering each new check and the proposal-stamping intersection.

<h3>Confidence Score: 4/5</h3>

The three new ceiling checks enforce in the correct fail-closed direction, but the scope ceiling check reads from a different policy snapshot than the size checks due to a mid-pipeline re-fetch, leaving a narrow window where a tightened scope_ceiling is not re-evaluated.

The scope ceiling check is placed before minimize_and_scan and uses the initial effective-policy snapshot, while the size ceiling checks use a re-fetched effective policy taken after minimize. If an operator narrows scope_ceiling between these two moments, the scope check passes against the old value even though the proposal is ultimately stamped with the new policy. This is a present correctness gap in the enforcement boundary, not a hypothetical one.

**Files Needing Attention:** src/yoetz/application/egress.py — specifically the ordering of the scope ceiling check relative to the post-minimize policy re-fetch at line 729.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/application/egress.py | Adds scope_ceiling, max_bytes, and max_tokens enforcement at semantic admission; scope ceiling check is inconsistently placed before the post-minimize policy re-fetch while size checks use the re-fetched policy, creating a window where a narrowed scope_ceiling is not re-validated. |
| tests/unit/application/test_channel_ceilings_enforced.py | New regression tests covering oversize bytes/tokens blocking, scope-broader-than-ceiling blocking, and policy-intersect-case proposal stamping; missing reason assertion in the oversize-tokens test. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[evaluate_semantic] --> B{closed?}
    B -- yes --> BLOCKED_CLOSED[SemanticEgressBlocked\nCHANNEL_UNAVAILABLE]
    B -- no --> C[effective_policy x2\ninitial fetch]
    C --> D[_semantic_pipeline]
    D --> E{channel = LLM_INFERENCE?}
    E -- no --> BLOCKED_CH[CHANNEL_UNAVAILABLE]
    E -- yes --> F[llm from initial effective]
    F --> G{scope.kind rank > scope_ceiling rank?}
    G -- yes --> BLOCKED_SCOPE[SCOPE_MISMATCH NEW]
    G -- no --> H[classify + semantic_decision]
    H --> I[minimize_and_scan]
    I --> J[effective_policy re-fetch]
    J --> K[llm from re-fetched effective]
    K --> L{max_bytes exceeded?}
    L -- yes --> BLOCKED_BYTES[POLICY_DENIED NEW]
    L -- no --> M{max_tokens exceeded?}
    M -- yes --> BLOCKED_TOKENS[POLICY_DENIED NEW]
    M -- no --> N[auth_max = min ceiling case NEW]
    N --> O[prepare_disclosure_proposal]
    O --> P[dispatch / human gate]
```

<sub>Reviews (2): Last reviewed commit: ["fix(privacy): enforce channel ceilings a..."](https://github.com/thegaysupreme123/yoetz/commit/8c6f7ec518a78336350dc1efd40c1616aa43045a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22437816)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Enhancements**
  - Enforced authorization-scope limits before information is sent through semantic channels.
  - Blocked requests that exceed permitted byte or token limits.
  - Prevented broader-scope candidates from being admitted under narrower authorization ceilings.
  - Applied the most restrictive effective limits when policy and case-size constraints differ.

- **Privacy**
  - Privacy review output now displays the effective case-size and token limits used by the generated policy.

- **Reliability**
  - Added comprehensive coverage for admission, blocking, and effective-limit behavior across supported authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->