### PR TITLE
fix(mcp): make the registered route observable on the readiness surface (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,21 @@ describes behavior intended for the first release rather than a change from a pr
 - Public protocol documentation under [`docs/protocol/`](docs/protocol/) and the evidence-bound
   claim map at [`docs/public-claims.json`](docs/public-claims.json).
 
+- **The registered MCP route is now observable.** Both Yoetz-owned Codex serve commands classify as
+  `yoetz_owned`, so registration state alone reported a strict registration and a policy
+  registration identically — and `yoetz provider status` never looked at the route at all, letting
+  `semantic_ready: true` be read as "semantic review will run" on an agent route that cannot
+  dispatch it. `yoetz provider status` now also reports `mcp_route` (registered profile, configured
+  profile, and whether it was read) and a second, narrower `agent_route_semantic_ready` verdict;
+  `yoetz integrate codex mcp status` reports `route_profile`, and `yoetz setup status` rows carry
+  `registered_route_profile`. `semantic_ready` keeps its existing installation-local meaning and
+  the exit code is unchanged: a strict route is a process-local ceiling (ADR-018), so CLI and
+  terminal checks still dispatch, and it is reported as a blocker scoped to the agent route only.
+  Route observation is fail-soft and never changes the exit code. A new
+  [semantic dogfood runbook](docs/runbooks/semantic-dogfood.md) turns this into a preflight that
+  declares which claim a run may make, and a provenance gate that refuses to score semantic quality
+  when no provider attempt happened.
+
 ### Documentation and repository
 
 - User documentation: `docs/architecture.md` (topology, module map, honesty rules), `docs/usage/`

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2220,8 +2220,8 @@ the whole apply before a file is written. Setup separately reports
 `project_skill_installation`, structural plugin-source installation, MCP registration,
 hooks/consent, service routing, and semantic readiness; none of those fields implies another.
 MCP server registration is a sibling port, never an `IntegrationsPort` overload (ADR-012).
-`HarnessMcpPort` methods are `status_registration`, `preview_registration`, and
-`apply_registration`, each taking a `HarnessBinary` (harness ID, redacted-repr executable path,
+`HarnessMcpPort` methods are `status_registration`, `observe_registration`, `preview_registration`,
+and `apply_registration`, each taking a `HarnessBinary` (harness ID, redacted-repr executable path,
 optional reported version, `supported|untested` compatibility). Shared names are
 `MCP_SERVER_NAME` (exactly `yoetz`), `MCP_SERVE_COMMAND` (exactly `("yoetz", "mcp", "serve")`),
 `MCP_STRICT_SERVE_COMMAND` (exactly
@@ -2229,8 +2229,15 @@ optional reported version, `supported|untested` compatibility). Shared names are
 `McpRegistrationState` (`absent|yoetz_owned|foreign_present`), `McpRegistrationAction`
 (`register|reregister|noop`), `McpRegistrationReason` (`confirmation_required|preview_stale|
 harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_present`),
-`McpRegistrationPreview`, `McpRegistrationCommand`, `McpRegistrationResult`, and
-`McpRegistrationError`. `HarnessMcpService` owns confirmation
+`McpRegistrationPreview`, `McpRegistrationObservation`, `McpRegistrationCommand`,
+`McpRegistrationResult`, and
+`McpRegistrationError`. `McpRegistrationObservation` carries `harness_id`, `state`, and
+`route_profile` (`policy|strict|null`); `route_profile` is non-null only when the state is
+`yoetz_owned`, because a foreign or absent entry has no Yoetz route to describe.
+`observe_registration` reads exactly what `status_registration` reads, mutates nothing, and shares
+its `status` diagnostic phase — it exists because both owned serve commands classify as
+`yoetz_owned`, so state alone cannot distinguish a strict registration from a policy one.
+`HarnessMcpService` owns confirmation
 (`McpRegistrationConfirmation` with channel exactly `interactive|noninteractive_flag`) and
 diagnostics (`McpRegistrationDiagnostic`, `HarnessMcpDiagnosticSink`); every registration
 mutation is digest-bound to a freshly recomputed preview, a foreign same-name entry is
@@ -2242,6 +2249,21 @@ schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
 `yoetz.setup-status/1`, and `yoetz.mcp-registration-preview/1`; the marker lives at
 `state_dir()/setup-wizard.json` via `config.paths.setup_marker_path`. The CLI surfaces are
 `yoetz setup run|status` and `yoetz integrate <harness> mcp status|preview|install` (ADR-012).
+`setup status` rows carry `registration_state` and `registered_route_profile`; the
+`integrate <harness> mcp status` body carries `state` and `route_profile`.
+
+`yoetz provider status` emits the read-only `yoetz.provider-status/1` schema token. It reports two
+non-substitutable verdicts. `semantic_ready` is installation-local and unchanged by route posture:
+service ready and unlocked, `verification.semantic` not `disabled`, an endpoint bound, the bound
+provider's credential connected, and the `llm_inference` channel enabled. `agent_route_semantic_ready`
+is `semantic_ready` **and** `mcp_route.registered_profile == "policy"`, and describes only the
+registered Codex MCP route. The `mcp_route` object carries `registration_state`,
+`registered_profile`, `configured_profile`, and `observed`; `observed: false` means the route was
+not read, not that none is registered. A strict registered route adds a `mcp_route_profile` blocker
+with `scope: "agent_route"` and never moves `semantic_ready` or the exit code, because ADR-018
+decision 2 makes the route ceiling process-local — CLI and terminal checks still dispatch. Route
+observation is fail-soft by contract: no discovery failure, registration error, or unreadable entry
+may raise or change the exit code.
 
 Every `integration_preview` preview/status body and every `integration_execute` body carries an
 explicit required `harness` discriminator. Its frozen v0.1 schema value is exactly `codex`; omission,

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2257,9 +2257,15 @@ non-substitutable verdicts. `semantic_ready` is installation-local and unchanged
 service ready and unlocked, `verification.semantic` not `disabled`, an endpoint bound, the bound
 provider's credential connected, and the `llm_inference` channel enabled. `agent_route_semantic_ready`
 is `semantic_ready` **and** `mcp_route.registered_profile == "policy"`, and describes only the
-registered Codex MCP route. The `mcp_route` object carries `registration_state`,
-`registered_profile`, `configured_profile`, and `observed`; `observed: false` means the route was
-not read, not that none is registered. A strict registered route adds a `mcp_route_profile` blocker
+registered Codex MCP route; an unread route makes it `false`, because `registered_profile` is then
+`null` and an unobserved route is never treated as a policy route. The `mcp_route` object carries
+`registration_state`, `registered_profile`, `configured_profile`, and `observed`. `observed: false`
+means the route was not read, not that none is registered, and is the single reported state for
+every read failure — empty Codex discovery, any `McpRegistrationError` (`harness_unavailable`,
+`parse_failed`, `timeout`), and any `OSError`; `registration_state` and `registered_profile` are
+both `null` there. `registered_profile: null` with `observed: true` is the different fact that no
+Yoetz route is registered (`registration_state` is `absent` or `foreign_present`).
+A strict registered route adds a `mcp_route_profile` blocker
 with `scope: "agent_route"` and never moves `semantic_ready` or the exit code, because ADR-018
 decision 2 makes the route ceiling process-local — CLI and terminal checks still dispatch. Route
 observation is fail-soft by contract: no discovery failure, registration error, or unreadable entry

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ golden vectors under [`fixtures/`](../fixtures/) win over any prose, including t
 - [`docs/protocol/`](protocol/) — the technical protocol: compatibility, data egress and privacy,
   local service security, the privacy setup wizard.
 - [`docs/runbooks/`](runbooks/) — operational procedures: backup/restore, key recovery, migration
-  rollback, quarantine recovery, Codex integration.
+  rollback, quarantine recovery, Codex integration, semantic dogfood.
 - [`docs/public-claims.json`](public-claims.json) — every public claim bound to its requirements,
   surfaces, tests, and honest release status. Enforced by `tests/conformance/claims/`.
 - [`guidance/`](../guidance/) — agent-facing guidance, shipped byte-identically to every harness and

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -110,6 +110,14 @@ that Codex activated a plugin. Current Codex plugin activation has its own marke
 add trust flow; setup deliberately does not mutate that global surface. This distinction is why a
 successful setup report includes both project-skill presence and plugin-source presence.
 
+Registration also decides *which* route the agent gets. Both owned serve commands classify as
+`yoetz_owned`, so the state alone cannot tell a strict registration from a policy one. Read the
+route from `yoetz integrate codex mcp status --json` (`route_profile`) or from
+`yoetz provider status --json` (`mcp_route.registered_profile`). Before running a session that will
+report a finding about Yoetz's semantic behaviour, walk the
+[semantic dogfood runbook](semantic-dogfood.md) — it declares up front which claim the run is
+allowed to make, and refuses to score semantic quality when no provider attempt happened.
+
 If the host is configured with Yoetz as an optional server and it is unavailable, Codex work
 continues and the skill discloses no live ledger/check/receipt data. If configured as required,
 server failure blocks only the Codex surfaces that the tested capability profile proves are

--- a/docs/runbooks/semantic-dogfood.md
+++ b/docs/runbooks/semantic-dogfood.md
@@ -26,7 +26,12 @@ partway through has no single claim it can make.
 
 ### Profile A — strict / local-only
 
-**Precondition:** `registered_profile == "strict"`.
+**Preconditions:** `mcp_route.observed == true` **and** `registered_profile == "strict"`.
+
+Both halves are required. An unread route (`observed: false`) reports `registered_profile: null`,
+which is *unknown*, not *strict* — it is no basis for a zero-egress claim. Observation is also what
+separates a strict route from `absent` or `foreign_present`, which report `registered_profile: null`
+with `observed: true` and are likewise not Profile A.
 
 Claims this run may make:
 
@@ -81,10 +86,12 @@ Fields to record from `yoetz provider status --json`:
 
 `registered_profile != configured_profile` is registration drift: the registered entry no longer
 matches what this installation's configuration would produce. Record it and resolve it before
-starting, through a fresh digest-bound re-registration (ADR-018 decision 7). Do not assume the
-configured value is what the agent will get.
+starting, through a fresh digest-bound re-registration — `yoetz integrate codex mcp preview`, then
+`yoetz integrate codex mcp install --accept --preview-digest <digest>` (ADR-018 decision 7). Do not
+assume the configured value is what the agent will get.
 
-`mcp_route.observed: false` is disqualifying for Profile B. An unread route is not a policy route.
+`mcp_route.observed: false` is disqualifying for **both** profiles. An unread route is not a policy
+route, and it is not a strict route either — it is no route at all until it is read.
 
 `yoetz integrate codex mcp status --json` reports `route_profile` for the same reason, and is the
 narrower check when you only need the route.
@@ -93,8 +100,13 @@ narrower check when you only need the route.
 
 Whether a run may score semantic usefulness is derived from the check result, never asserted from
 configuration. The rule is protocol-enforced by `validate_semantic_provenance_binding`
-(`src/yoetz/protocol/models.py`) and its totality is locked by test, so
-`semantic_provenance == null` reliably means *no provider attempt was made*.
+(`src/yoetz/protocol/models.py`) and its totality is locked by test.
+
+**Read provenance together with `semantic_status` and `semantic_reason` — never alone.** Null
+provenance means *no provider attempt was made* only on the branches where the protocol forbids
+provenance (rows 1 and 3 below). `failed` is unconstrained: it may carry provenance or not, and
+either way the attempt is indeterminate. Nor does the converse hold — provenance being *present*
+proves an attempt happened, not that it was useful.
 
 | `semantic_status` | `semantic_provenance` | May score semantic usefulness |
 |---|---|---|

--- a/docs/runbooks/semantic-dogfood.md
+++ b/docs/runbooks/semantic-dogfood.md
@@ -1,0 +1,143 @@
+# Semantic dogfood runbook
+
+This runbook governs sessions that use Yoetz on Yoetz and then report a finding about it. Its
+purpose is to fix, **before** the first task action, which claim the run is allowed to make — so a
+result is never read as evidence for a question the run's configuration made unanswerable.
+
+It exists because of the 2026-08-03 postmortem
+([`docs/postmortems/2026-08-03-codex-testing-yoetz-schema-feedback-influence.md`](../postmortems/2026-08-03-codex-testing-yoetz-schema-feedback-influence.md)),
+which scored "did semantic feedback help?" against a session whose MCP route was `strict`. Yoetz
+behaved correctly and reported honestly — `semantic_status=blocked_by_policy`,
+`semantic_reason=route_semantic_ceiling`, `semantic_provenance: null`, zero egress. The run simply
+could never have measured semantic usefulness. Nothing in the tooling said so in advance.
+
+Three facts this runbook keeps apart:
+
+- **Registration is not activation.** A registered MCP entry says what Codex would launch, not that
+  it launched or that a model was shown anything.
+- **Availability is not usefulness.** A route that *can* dispatch semantic review is not evidence
+  that the review helped.
+- **A clean semantic judgment is not proof the implementation is correct.**
+
+## 1. Pick the profile before you start
+
+Choose one profile and record it. Do not switch profiles mid-run; a run that changes route posture
+partway through has no single claim it can make.
+
+### Profile A — strict / local-only
+
+**Precondition:** `registered_profile == "strict"`.
+
+Claims this run may make:
+
+- zero external semantic egress through the Yoetz agent route
+- deterministic-check behaviour
+- receipt honesty — that the refusal is recorded with the exact status/reason and no promoted
+  deterministic outcome
+
+Claims this run may **not** make: anything about semantic quality, usefulness, or influence.
+Record semantic usefulness as **not tested**. Never record it as "poor", "weak", or "absent" — the
+route declined to attempt it, which is not a measurement of it.
+
+### Profile B — policy-enabled
+
+**Preconditions, all three:**
+
+1. `registered_profile == "policy"`
+2. `agent_route_semantic_ready == true`
+3. human authorization obtained through the existing ceremony — the credential ceremony
+   (`yoetz provider credential set`) and privacy policy already in place before the run starts
+
+Claims this run may make: everything in Profile A, plus observations about semantic output, subject
+to the provenance gate in §3.
+
+Explicitly: previewing a registration change from inside the session is allowed
+(`yoetz integrate codex mcp preview`). **Widening privacy policy from the agent channel is not.**
+Policy widening is a human ceremony; if a run finds it needs wider policy, the run stops and is
+re-planned, it does not widen and continue.
+
+## 2. Preflight sequence
+
+Run all five before the first task action and record the output verbatim. Every command here is
+read-only and already exists — this runbook adds no command.
+
+```text
+yoetz version
+yoetz service status
+yoetz provider status --json
+yoetz integrate codex mcp status --json
+yoetz privacy show
+```
+
+Fields to record from `yoetz provider status --json`:
+
+| Field | What it settles |
+|---|---|
+| `semantic_ready` | Whether **this installation** can dispatch semantic review at all. Installation-local; unchanged by route posture. |
+| `mcp_route.registered_profile` | Which route the Codex agent actually gets: `policy`, `strict`, or `null` when unread. |
+| `mcp_route.configured_profile` | Which route setup would register now. |
+| `mcp_route.observed` | `false` means the route could not be read — **not** that none is registered. |
+| `agent_route_semantic_ready` | Whether the **registered Codex route** can dispatch semantic review. This is the field that selects the profile. |
+
+`registered_profile != configured_profile` is registration drift: the registered entry no longer
+matches what this installation's configuration would produce. Record it and resolve it before
+starting, through a fresh digest-bound re-registration (ADR-018 decision 7). Do not assume the
+configured value is what the agent will get.
+
+`mcp_route.observed: false` is disqualifying for Profile B. An unread route is not a policy route.
+
+`yoetz integrate codex mcp status --json` reports `route_profile` for the same reason, and is the
+narrower check when you only need the route.
+
+## 3. The provenance gate
+
+Whether a run may score semantic usefulness is derived from the check result, never asserted from
+configuration. The rule is protocol-enforced by `validate_semantic_provenance_binding`
+(`src/yoetz/protocol/models.py`) and its totality is locked by test, so
+`semantic_provenance == null` reliably means *no provider attempt was made*.
+
+| `semantic_status` | `semantic_provenance` | May score semantic usefulness |
+|---|---|---|
+| any pre-dispatch status — `not_requested`, `not_configured`, `blocked_by_policy` (incl. `route_semantic_ceiling`), `blocked_forbidden_data`, `classification_uncertain`, `awaiting_human`, `human_denied`, `approval_expired` | `null` (enforced) | **No** — not attempted |
+| `succeeded`, `refused`, `timeout`, `invalid`, `late`, `stale`; or `unavailable` with `transport_unavailable` / `provider_rate_limited` / `provider_quota_exhausted` | present (enforced) | Yes |
+| `unavailable` with `credential_unavailable`, `endpoint_profile_unavailable`, `retry_budget_exhausted`, `audit_reservation_unavailable`, `receipt_persistence_unknown` | `null` (enforced) | **No** — not attempted |
+| `failed` / `coordinator_failure` | either — unconstrained | **No** — attempt indeterminate |
+
+`failed` is the one status where provenance presence proves nothing in either direction. Record it
+as **attempt indeterminate**, never as "not attempted".
+
+Read the gate off the result, not off preflight. Passing preflight makes an attempt *possible*; only
+the result says whether one *happened*.
+
+## 4. What passing preflight does not prove
+
+- It does not prove a semantic review ran. That is the gate in §3.
+- It does not prove the review was useful. Availability is not usefulness.
+- It does not prove the implementation under review is correct. A clean semantic judgment is one
+  observation, not a verdict.
+- It does not measure whether feedback changed the agent's behaviour. Influence measurement is
+  [issue #133](https://github.com/TheGaySupreme123/yoetz/issues/133) and is out of scope here.
+
+## 5. Report hygiene
+
+A dogfood report is shared material. It carries:
+
+- credential state as **presence only** (`connected` / `not stored` / `unknown`) — never a value,
+  prefix, length, or any property of the stored secret
+- no absolute paths, usernames, or machine identifiers
+- no transcripts
+- no unredacted provider request or response payloads
+- versions, bounded status/reason tokens, digests, and structural state
+
+Report the declared profile, the preflight output, the resulting `semantic_status` /
+`semantic_reason` / provenance presence, and the gate row those land in. State the claim the run was
+authorized to make and stop there.
+
+## See also
+
+- [Codex integration runbook](codex-integration.md) — installing the skill and registering MCP.
+- [Privacy and semantic review](../usage/privacy-and-semantic-review.md) — the durable policy that
+  authorizes disclosure.
+- [Providers](../usage/providers.md) — the readiness conditions behind `semantic_ready`.
+- [ADR-018](../adr/ADR-018-host-declared-mcp-route-egress-ceiling.md) — why the strict route is a
+  process-local ceiling and not a privacy policy.

--- a/docs/usage/privacy-and-semantic-review.md
+++ b/docs/usage/privacy-and-semantic-review.md
@@ -133,8 +133,13 @@ evidence, and they are on your machine.
 
 When you are auditing a run rather than the installation, the
 [semantic dogfood runbook](../runbooks/semantic-dogfood.md) gives the preflight and the provenance
-gate: which route the agent actually got, and how to read `semantic_provenance` to tell "no provider
-attempt was made" apart from "an attempt was made and produced nothing useful".
+gate: which route the agent actually got, and how to read `semantic_provenance`.
+
+Read `semantic_provenance` together with `semantic_status` and `semantic_reason`, never on its own.
+The outcome is three-way, not two-way: on the statuses where the protocol forbids provenance, null
+means **no provider attempt was made**; where it requires provenance, an attempt happened (which is
+not the same as it being useful); and `failed`/`coordinator_failure` is unconstrained, so it is
+**indeterminate** — never read it as "not attempted".
 
 If you believe Yoetz disclosed, retained, or logged something these commitments forbid, treat it as
 a security report: [`SECURITY.md`](../../SECURITY.md), not a public issue.

--- a/docs/usage/privacy-and-semantic-review.md
+++ b/docs/usage/privacy-and-semantic-review.md
@@ -131,5 +131,10 @@ catalog keeps encrypted proposal objects and their structural sidecars enumerabl
 No control surface is required to trust a summary — the receipts, catalog, and policy file are the
 evidence, and they are on your machine.
 
+When you are auditing a run rather than the installation, the
+[semantic dogfood runbook](../runbooks/semantic-dogfood.md) gives the preflight and the provenance
+gate: which route the agent actually got, and how to read `semantic_provenance` to tell "no provider
+attempt was made" apart from "an attempt was made and produced nothing useful".
+
 If you believe Yoetz disclosed, retained, or logged something these commitments forbid, treat it as
 a security report: [`SECURITY.md`](../../SECURITY.md), not a public issue.

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -163,12 +163,20 @@ registration state alone cannot tell them apart. The report therefore names the 
 "agent_route_semantic_ready": false
 ```
 
-- `registered_profile` — what is actually registered: `policy`, `strict`, or `null` when unread.
-- `configured_profile` — what setup would register now. A mismatch is registration drift; fix it
-  with a fresh digest-bound re-registration (`yoetz integrate codex mcp preview`).
+- `registered_profile` — the observed Yoetz route: `policy`, `strict`, or `null`. **`null` has two
+  different meanings**, and `registration_state` plus `observed` are what tell them apart: with
+  `observed: true` it means no Yoetz route is registered (`registration_state` is `absent` or
+  `foreign_present`); with `observed: false` it means the route could not be read. Do not read a
+  missing or foreign registration as a probe failure.
+- `configured_profile` — what setup would register now. A mismatch is registration drift. Fixing it
+  takes both steps of the digest-bound ceremony: `yoetz integrate codex mcp preview` produces the
+  digest, then `yoetz integrate codex mcp install --accept --preview-digest <digest>` applies it.
+  Preview alone changes nothing.
 - `observed: false` — the route could not be read. That is *unknown*, not *absent*, and it is never
   reported as a blocker.
-- `agent_route_semantic_ready` — `semantic_ready` **and** `registered_profile == "policy"`.
+- `agent_route_semantic_ready` — `semantic_ready` **and** `registered_profile == "policy"`. An
+  unread route therefore makes it `false`: `registered_profile` is `null`, so an unobserved route
+  is never treated as a policy route.
 
 **A strict registration does not make this installation not-ready.** The strict route is a
 process-local ceiling (ADR-018): it stops that one MCP process from requesting semantic review. A

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -120,7 +120,8 @@ Before spending a run on semantic review, ask whether the five structural condit
 yoetz provider status --json
 ```
 
-The report names each condition and the exact next command when one is known to be unmet:
+The report names each condition and the exact next command when one is known to be unmet. Five of
+them are **installation** conditions; a sixth verdict describes the Codex agent route separately.
 
 1. the local service is running and unlocked
 2. `verification.semantic` is not `disabled`
@@ -143,6 +144,42 @@ or rejected, use `yoetz service auto-unlock repair`. The JSON field `readiness_d
 distinguishes a known not-ready state from one that cannot yet be read.
 
 `semantic_ready: true` is structural readiness only. It does not prove live provider dispatch.
+
+### The agent route is a separate verdict
+
+`semantic_ready` covers the five conditions above and nothing else. It says this **installation**
+can dispatch semantic review. It does not say the Codex agent gets a route that will.
+
+Yoetz registers Codex with one of two serve commands, and both classify as `yoetz_owned` — so
+registration state alone cannot tell them apart. The report therefore names the route directly:
+
+```json
+"mcp_route": {
+  "registration_state": "yoetz_owned",
+  "registered_profile": "strict",
+  "configured_profile": "policy",
+  "observed": true
+},
+"agent_route_semantic_ready": false
+```
+
+- `registered_profile` — what is actually registered: `policy`, `strict`, or `null` when unread.
+- `configured_profile` — what setup would register now. A mismatch is registration drift; fix it
+  with a fresh digest-bound re-registration (`yoetz integrate codex mcp preview`).
+- `observed: false` — the route could not be read. That is *unknown*, not *absent*, and it is never
+  reported as a blocker.
+- `agent_route_semantic_ready` — `semantic_ready` **and** `registered_profile == "policy"`.
+
+**A strict registration does not make this installation not-ready.** The strict route is a
+process-local ceiling (ADR-018): it stops that one MCP process from requesting semantic review. A
+`yoetz check` from the CLI, or a check from the terminal interface, still dispatches normally. So
+`semantic_ready: true` alongside a strict route is not a contradiction — it means CLI and terminal
+checks can dispatch while the Codex agent route cannot. A strict route adds a `mcp_route_profile`
+blocker marked `scope: "agent_route"`, and leaves the exit code alone.
+
+Neither verdict substitutes for the other. Reading `semantic_ready: true` and expecting semantic
+review through a strict agent route is exactly the conflation this field exists to prevent; see the
+[semantic dogfood runbook](../runbooks/semantic-dogfood.md) for the preflight that consumes it.
 
 ## The credential ceremony
 

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Final, Literal, cast
 
 from yoetz.ports.harness_mcp import (
@@ -21,6 +22,7 @@ from yoetz.ports.harness_mcp import (
     McpRegistrationAction,
     McpRegistrationCommand,
     McpRegistrationError,
+    McpRegistrationObservation,
     McpRegistrationPreview,
     McpRegistrationReason,
     McpRegistrationResult,
@@ -36,6 +38,10 @@ __all__ = [
 
 _COMMAND_TIMEOUT_SECONDS: Final = 10.0
 _OUTPUT_LIMIT_BYTES: Final = 65_536
+# The registered argv is the only durable evidence of which route the agent actually gets.
+_ROUTE_PROFILE_BY_COMMAND: Final[Mapping[tuple[str, ...], Literal["policy", "strict"]]] = (
+    MappingProxyType({MCP_SERVE_COMMAND: "policy", MCP_STRICT_SERVE_COMMAND: "strict"})
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,7 +136,9 @@ class CodexMcpAdapter:
         tokens = _entry_command_tokens(entry)
         for command in (MCP_STRICT_SERVE_COMMAND, MCP_SERVE_COMMAND):
             if tokens == command:
-                return McpRegistrationState.YOETZ_OWNED, tokens
+                # Return the matched constant, not the parsed tokens, so the route mapping below
+                # reads off one source of truth instead of re-comparing the argv.
+                return McpRegistrationState.YOETZ_OWNED, command
         # An unreadable or different command is preserved, never replaced.
         return McpRegistrationState.FOREIGN_PRESENT, None
 
@@ -139,6 +147,14 @@ class CodexMcpAdapter:
         return self._classify_get(
             self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
         )[0]
+
+    async def observe_registration(self, binary: HarnessBinary) -> McpRegistrationObservation:
+        self._require_codex(binary)
+        state, command = self._classify_get(
+            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
+        )
+        route_profile = None if command is None else _ROUTE_PROFILE_BY_COMMAND.get(command)
+        return McpRegistrationObservation(binary.harness_id, state, route_profile)
 
     @staticmethod
     def _require_codex(binary: HarnessBinary) -> None:

--- a/src/yoetz/application/harness_mcp.py
+++ b/src/yoetz/application/harness_mcp.py
@@ -11,6 +11,7 @@ from yoetz.ports.harness_mcp import (
     HarnessMcpPort,
     McpRegistrationCommand,
     McpRegistrationError,
+    McpRegistrationObservation,
     McpRegistrationPreview,
     McpRegistrationReason,
     McpRegistrationResult,
@@ -121,6 +122,37 @@ class HarnessMcpService:
             )
         )
         return state
+
+    async def observe(self, binary: HarnessBinary) -> McpRegistrationObservation:
+        """Read registration state *and* the registered route profile in one probe.
+
+        Shares the ``status`` phase because it reads exactly what ``status`` reads and mutates
+        nothing; the diagnostic shape is unchanged.
+        """
+
+        if type(binary) is not HarnessBinary:
+            raise _invalid("integration_request_invalid")
+        try:
+            observation = await self._port.observe_registration(binary)
+        except McpRegistrationError as exc:
+            self._diagnostics.record_mcp_registration(
+                McpRegistrationDiagnostic(
+                    binary.harness_id, "status", "failed", None, None, None, exc.reason
+                )
+            )
+            raise
+        self._diagnostics.record_mcp_registration(
+            McpRegistrationDiagnostic(
+                binary.harness_id,
+                "status",
+                "success",
+                observation.state,
+                observation.state,
+                None,
+                None,
+            )
+        )
+        return observation
 
     async def preview(self, binary: HarnessBinary) -> McpRegistrationPreview:
         if type(binary) is not HarnessBinary:

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -1,7 +1,9 @@
 """Read-only semantic readiness report for operator surfaces.
 
-Reports the four conditions that must all hold before external semantic review can
-dispatch, without claiming a live provider smoke or writing any state.
+Reports the installation-local conditions that must all hold before external semantic review can
+dispatch, without claiming a live provider smoke or writing any state. It separately reports the
+registered Codex MCP route, because a strict agent route cannot dispatch semantic review even
+when every installation condition holds.
 """
 
 from __future__ import annotations
@@ -56,6 +58,15 @@ def _emit(value: Mapping[str, JsonValue], *, json_output: bool) -> None:
     print(f"credential: {credential_human_display(value.get('credential_connected'))}")
     print(f"llm_inference_enabled: {value.get('llm_inference_enabled')}")
     print(f"semantic_ready: {value.get('semantic_ready')}")
+    route = value.get("mcp_route")
+    if isinstance(route, Mapping):
+        print(
+            "mcp_route: "
+            f"registered={route.get('registered_profile')} "
+            f"configured={route.get('configured_profile')} "
+            f"observed={route.get('observed')}"
+        )
+    print(f"agent_route_semantic_ready: {value.get('agent_route_semantic_ready')}")
     blockers = value.get("blockers")
     if isinstance(blockers, list | tuple) and blockers:
         print("blockers:")
@@ -119,6 +130,55 @@ def _mcp_local_composition(service_state: str | None, *, service_observed: bool)
     if service_state in {None, "service_unavailable"}:
         return "starts_on_demand"
     return "unknown"
+
+
+async def _mcp_route_observation() -> dict[str, JsonValue]:
+    """Report which Codex MCP route is registered, or say plainly that it was not read.
+
+    A strict registration and a policy registration are both ``yoetz_owned``, so registration
+    state alone cannot tell an operator whether the agent route can dispatch semantic review at
+    all. This probe adds the missing fact.
+
+    Fail-soft is deliberate and load-bearing: this report exists to stay readable when the
+    installation is broken, so an absent Codex, an unreadable entry, or any registration error
+    degrades to ``observed: false`` — the module's existing "unknown means unread" convention —
+    rather than raising or moving the exit code.
+    """
+
+    # Imported here: `yoetz.cli.setup` imports this module lazily, and the discovery/adapter
+    # stack is only needed on this one path.
+    from yoetz.adapters.integrations.codex_discovery import discover_codex_binaries
+    from yoetz.adapters.integrations.codex_mcp import CodexMcpAdapter
+    from yoetz.application.harness_mcp import HarnessMcpService
+    from yoetz.cli import setup as cli_setup
+
+    try:
+        # Sibling-module private on purpose: the registration-time authority stays owned by
+        # `setup`, so this reads it rather than growing a second answer to the same question.
+        configured: JsonValue = (
+            cli_setup._configured_mcp_route_profile()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        )
+    except Exception:
+        configured = None
+    unread: dict[str, JsonValue] = {
+        "registration_state": None,
+        "registered_profile": None,
+        "configured_profile": configured,
+        "observed": False,
+    }
+    try:
+        binaries = discover_codex_binaries()
+        if not binaries:
+            return unread
+        observation = await HarnessMcpService(CodexMcpAdapter()).observe(binaries[0])
+    except Exception:
+        return unread
+    return {
+        "registration_state": observation.state.value,
+        "registered_profile": observation.route_profile,
+        "configured_profile": configured,
+        "observed": True,
+    }
 
 
 def machine_scope_request() -> JsonObject:
@@ -199,6 +259,9 @@ async def provider_status_report() -> dict[str, JsonValue]:
         credential_connected = None
         llm_inference_enabled = None
 
+    mcp_route = await _mcp_route_observation()
+    registered_profile = mcp_route["registered_profile"]
+
     blockers: list[dict[str, JsonValue]] = []
     if service_state != "ready":
         if service_state_reason in {"auto_unlock_rejected", "auto_unlock_stale"}:
@@ -261,6 +324,18 @@ async def provider_status_report() -> dict[str, JsonValue]:
                 "next_command": "yoetz --privacy",
             }
         )
+    if registered_profile == "strict":
+        # Scoped to the agent route on purpose. ADR-018 decision 2 makes the route ceiling
+        # process-local, so a strict Codex registration does not stop a CLI or terminal check
+        # from dispatching semantic review — it is not an installation blocker.
+        blockers.append(
+            {
+                "condition": "mcp_route_profile",
+                "state": "strict",
+                "scope": "agent_route",
+                "next_command": "yoetz integrate codex mcp preview",
+            }
+        )
 
     readiness_determinable = (
         service_state == "ready"
@@ -293,6 +368,8 @@ async def provider_status_report() -> dict[str, JsonValue]:
         "service_state_reason": service_state_reason,
         "readiness_determinable": readiness_determinable,
         "semantic_ready": semantic_ready,
+        "mcp_route": mcp_route,
+        "agent_route_semantic_ready": semantic_ready and registered_profile == "policy",
         "blockers": tuple(blockers),
         "next_commands": next_commands,
         "notes": (
@@ -300,6 +377,11 @@ async def provider_status_report() -> dict[str, JsonValue]:
             "credential_connected reports the configured provider's credential, not any provider.",
             "A credential for a different provider than the bound endpoint does not count.",
             "unknown means the service could not be read, not that the step is incomplete.",
+            "agent_route_semantic_ready describes the registered Codex MCP route only; "
+            "semantic_ready describes this installation. Neither substitutes for the other.",
+            "A strict registered route does not make this installation not-ready: CLI and "
+            "terminal checks still dispatch, only the strict agent route cannot.",
+            "mcp_route.observed false means the route was not read, not that none is registered.",
         ),
     }
 

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -1815,10 +1815,13 @@ async def setup_status(*, json_output: bool) -> int:
     for binary in binaries:
         row = _binary_row(binary)
         try:
-            state = await HarnessMcpService(service_port).status(binary)
-            row["registration_state"] = state.value
+            observation = await HarnessMcpService(service_port).observe(binary)
+            row["registration_state"] = observation.state.value
+            # A strict and a policy registration are both yoetz_owned; only this distinguishes them.
+            row["registered_route_profile"] = observation.route_profile
         except McpRegistrationError as error:
             row["registration_state"] = None
+            row["registered_route_profile"] = None
             row["registration_error"] = error.reason.value
         rows.append(row)
     report: dict[str, JsonValue] = {
@@ -1867,8 +1870,15 @@ async def integrate_mcp(
     service = HarnessMcpService(_mcp_adapter())
     try:
         if action == "status":
-            state = await service.status(chosen)
-            _emit({"harness": harness, "state": state.value}, json_output=json_output)
+            observation = await service.observe(chosen)
+            _emit(
+                {
+                    "harness": harness,
+                    "route_profile": observation.route_profile,
+                    "state": observation.state.value,
+                },
+                json_output=json_output,
+            )
             return 0
         preview = await service.preview(chosen)
         if action == "preview":

--- a/src/yoetz/ports/harness_mcp.py
+++ b/src/yoetz/ports/harness_mcp.py
@@ -22,6 +22,7 @@ __all__ = [
     "McpRegistrationAction",
     "McpRegistrationCommand",
     "McpRegistrationError",
+    "McpRegistrationObservation",
     "McpRegistrationPreview",
     "McpRegistrationReason",
     "McpRegistrationResult",
@@ -142,6 +143,34 @@ class McpRegistrationPreview:
 
 
 @dataclass(frozen=True, slots=True)
+class McpRegistrationObservation:
+    """One read-only registration probe, including *which* Yoetz route is registered.
+
+    ``status_registration`` answers only "is this entry ours", which reads identically for a
+    policy and a strict registration. Reporting a route posture requires the extra fact, so it
+    is carried here rather than by widening the state enum. ``route_profile`` is non-null only
+    when the entry is Yoetz-owned; a foreign or absent entry has no Yoetz route to describe.
+    """
+
+    harness_id: HarnessId
+    state: McpRegistrationState
+    route_profile: Literal["policy", "strict"] | None
+
+    def __post_init__(self) -> None:
+        if type(self.harness_id) is not HarnessId:
+            raise _port_error("integration_harness_invalid")
+        if type(self.state) is not McpRegistrationState:
+            raise _port_error("integration_state_invalid")
+        if self.route_profile is None:
+            return
+        if (
+            self.route_profile not in {"policy", "strict"}
+            or self.state is not McpRegistrationState.YOETZ_OWNED
+        ):
+            raise _port_error("integration_value_invalid")
+
+
+@dataclass(frozen=True, slots=True)
 class McpRegistrationCommand:
     preview_digest: str
     explicitly_accepted: bool
@@ -197,6 +226,8 @@ class McpRegistrationError(Exception):
 
 class HarnessMcpPort(Protocol):
     async def status_registration(self, binary: HarnessBinary) -> McpRegistrationState: ...
+
+    async def observe_registration(self, binary: HarnessBinary) -> McpRegistrationObservation: ...
 
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview: ...
 

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -469,6 +469,8 @@ def test_setup_status_is_read_only(wizard_env: dict[str, object]) -> None:
     report = json.loads(result.stdout)
     assert report["schema"] == "yoetz.setup-status/1"
     assert report["discovered"][0]["registration_state"] == "yoetz_owned"
+    # `yoetz_owned` reads the same for both serve commands, so the row has to name the route.
+    assert report["discovered"][0]["registered_route_profile"] == "strict"
     assert report["marker_present"] is False
     assert report["service"]["reachable"] is False
     assert report["integration"] == {
@@ -533,7 +535,10 @@ def test_integrate_mcp_status_preview_install(wizard_env: dict[str, object]) -> 
     wizard_env["outputs"] = [CommandOutput(1, b"")]
     status = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "status", "--json"])
     assert status.exit_code == 0
-    assert json.loads(status.stdout)["state"] == "absent"
+    absent_status = json.loads(status.stdout)
+    assert absent_status["state"] == "absent"
+    # An absent entry has no Yoetz route to describe; the field is present and null, never guessed.
+    assert absent_status["route_profile"] is None
 
     wizard_env["outputs"] = [CommandOutput(1, b"")]
     preview = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview", "--json"])
@@ -563,6 +568,24 @@ def test_integrate_mcp_status_preview_install(wizard_env: dict[str, object]) -> 
     )
     assert install.exit_code == 0
     assert json.loads(install.stdout)["state_after"] == "yoetz_owned"
+
+
+def test_integrate_mcp_status_names_the_registered_route(
+    wizard_env: dict[str, object],
+) -> None:
+    """Status has to distinguish the two owned registrations, or #132's conflation stays.
+
+    Both serve commands classify as ``yoetz_owned``, so an operator reading only the state
+    cannot tell whether the agent route can request semantic review at all.
+    """
+
+    for route_profile in ("strict", "policy"):
+        wizard_env["outputs"] = [_yoetz_entry(route_profile)]
+        result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "status", "--json"])
+        assert result.exit_code == 0
+        body = json.loads(result.stdout)
+        assert body["state"] == "yoetz_owned"
+        assert body["route_profile"] == route_profile
 
 
 def test_integrate_mcp_install_without_accept_fails_closed(

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -91,6 +91,63 @@ def test_status_foreign_on_different_or_unreadable_command() -> None:
         assert state is McpRegistrationState.FOREIGN_PRESENT, payload
 
 
+def test_observe_reports_which_route_is_registered() -> None:
+    """`yoetz_owned` alone cannot answer "can the agent get semantic review".
+
+    Both serve commands classify as owned, so an operator reading only registration state sees a
+    strict route and a policy route as the same thing. The observation carries the difference.
+    """
+
+    for strict, expected in ((False, "policy"), (True, "strict")):
+        runner = _Runner([CommandOutput(0, _yoetz_entry(strict=strict))])
+        observation = anyio.run(lambda: CodexMcpAdapter(runner).observe_registration(_BINARY))
+        assert observation.state is McpRegistrationState.YOETZ_OWNED
+        assert observation.route_profile == expected
+        assert observation.harness_id is HarnessId.CODEX
+
+
+def test_observe_reports_no_route_when_the_entry_is_not_ours() -> None:
+    absent = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).observe_registration(_BINARY)
+    )
+    assert absent.state is McpRegistrationState.ABSENT
+    assert absent.route_profile is None
+
+    foreign_output = CommandOutput(0, json.dumps({"command": "other-server"}).encode("utf-8"))
+    foreign = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([foreign_output])).observe_registration(_BINARY)
+    )
+    assert foreign.state is McpRegistrationState.FOREIGN_PRESENT
+    assert foreign.route_profile is None
+
+
+def test_observe_does_not_depend_on_the_adapter_route_profile() -> None:
+    """The observation reports what is registered, never what this adapter would register."""
+
+    runner = _Runner([CommandOutput(0, _yoetz_entry(strict=True))])
+    observation = anyio.run(
+        lambda: CodexMcpAdapter(runner, route_profile="policy").observe_registration(_BINARY)
+    )
+    assert observation.route_profile == "strict"
+
+
+def test_observe_parse_failure_is_a_typed_error() -> None:
+    runner = _Runner([CommandOutput(0, b"not json")])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(lambda: CodexMcpAdapter(runner).observe_registration(_BINARY))
+    assert caught.value.reason is McpRegistrationReason.PARSE_FAILED
+
+
+def test_observe_rejects_a_non_codex_binary() -> None:
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(_Runner([])).observe_registration(
+                object()  # type: ignore[arg-type]
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+
+
 def test_status_parse_failure_is_a_typed_error() -> None:
     for stdout in (b"not json", b"[1,2]", b"\xff\xfe"):
         runner = _Runner([CommandOutput(0, stdout)])

--- a/tests/unit/application/test_harness_mcp_service.py
+++ b/tests/unit/application/test_harness_mcp_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import anyio
 import pytest
 
@@ -15,6 +17,7 @@ from yoetz.ports.harness_mcp import (
     McpRegistrationAction,
     McpRegistrationCommand,
     McpRegistrationError,
+    McpRegistrationObservation,
     McpRegistrationPreview,
     McpRegistrationReason,
     McpRegistrationResult,
@@ -55,6 +58,14 @@ class _Port:
             raise McpRegistrationError(self.fail_with, {})
         return self.state
 
+    async def observe_registration(self, binary: HarnessBinary) -> McpRegistrationObservation:
+        if self.fail_with is not None:
+            raise McpRegistrationError(self.fail_with, {})
+        route_profile: Literal["policy", "strict"] | None = (
+            "strict" if self.state is McpRegistrationState.YOETZ_OWNED else None
+        )
+        return McpRegistrationObservation(binary.harness_id, self.state, route_profile)
+
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         if self.fail_with is not None:
             raise McpRegistrationError(self.fail_with, {})
@@ -91,6 +102,44 @@ def test_status_and_preview_record_success_diagnostics() -> None:
     assert preview.preview_digest == _DIGEST
     assert [record.phase for record in sink.records] == ["status", "preview"]
     assert all(record.outcome == "success" for record in sink.records)
+
+
+def test_observe_records_a_status_phase_diagnostic_and_carries_the_route() -> None:
+    sink = _Sink()
+    service = HarnessMcpService(_Port(McpRegistrationState.YOETZ_OWNED), sink)
+    observation = anyio.run(lambda: service.observe(_BINARY))
+    assert observation.state is McpRegistrationState.YOETZ_OWNED
+    assert observation.route_profile == "strict"
+    # Observing reads exactly what status reads, so it shares the phase; the diagnostic shape
+    # is unchanged.
+    assert sink.records[-1].phase == "status"
+    assert sink.records[-1].outcome == "success"
+    assert sink.records[-1].state_before is McpRegistrationState.YOETZ_OWNED
+
+
+def test_observe_failure_is_recorded_and_reraised() -> None:
+    sink = _Sink()
+    service = HarnessMcpService(_Port(fail_with=McpRegistrationReason.PARSE_FAILED), sink)
+    with pytest.raises(McpRegistrationError):
+        anyio.run(lambda: service.observe(_BINARY))
+    assert sink.records[-1].phase == "status"
+    assert sink.records[-1].outcome == "failed"
+    assert sink.records[-1].reason is McpRegistrationReason.PARSE_FAILED
+
+
+def test_observe_rejects_an_invalid_binary() -> None:
+    service = HarnessMcpService(_Port())
+    with pytest.raises(ValueError):
+        anyio.run(lambda: service.observe(object()))  # type: ignore[arg-type]
+
+
+def test_a_route_profile_is_only_meaningful_for_a_yoetz_owned_entry() -> None:
+    """A foreign or absent entry has no Yoetz route, so claiming one is a construction error."""
+
+    with pytest.raises(ValueError):
+        McpRegistrationObservation(HarnessId.CODEX, McpRegistrationState.ABSENT, "policy")
+    with pytest.raises(ValueError):
+        McpRegistrationObservation(HarnessId.CODEX, McpRegistrationState.FOREIGN_PRESENT, "strict")
 
 
 def test_register_requires_explicit_acceptance() -> None:

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -17,10 +17,15 @@ from typing import Any, cast
 import pytest
 
 from yoetz.cli import provider_status as module
+from yoetz.cli import setup as cli_setup
 from yoetz.config.models import ProviderProfileConfig, VerificationConfig, YoetzConfig
 from yoetz.ports.control import ControlError
+from yoetz.ports.harness_mcp import McpRegistrationError, McpRegistrationReason
 
 pytestmark = pytest.mark.anyio
+
+# Captured before any test patches it, so the fail-soft test can exercise the real probe.
+_REAL_ROUTE_OBSERVATION = module._mcp_route_observation  # pyright: ignore[reportPrivateUsage]
 
 
 def _provider(provider_id: str = "openai") -> ProviderProfileConfig:
@@ -97,6 +102,7 @@ def _install(
     installation_state: str | None = None,
     service_state: str = "ready",
     service_state_reason: str = "none",
+    mcp_route: dict[str, object] | None = None,
 ) -> _Client:
     config = YoetzConfig(
         profile="strict-local" if provider is None else "local-openai",
@@ -129,7 +135,39 @@ def _install(
     if installation_state:
         (state / "installation-state.json").write_text(installation_state)
     monkeypatch.setattr(module, "state_dir", lambda: state)
+
+    # The route probe shells out to a discovered `codex`, so leaving it unpatched would make
+    # every test in this module depend on the developer's own registration. The default is the
+    # "could not read" answer, which is what a host without Codex actually produces.
+    observation = _UNREAD_ROUTE if mcp_route is None else mcp_route
+
+    async def _observe() -> dict[str, object]:
+        return dict(observation)
+
+    monkeypatch.setattr(module, "_mcp_route_observation", _observe)
     return client
+
+
+_UNREAD_ROUTE: dict[str, object] = {
+    "registration_state": None,
+    "registered_profile": None,
+    "configured_profile": None,
+    "observed": False,
+}
+
+
+def _route(
+    registered: str | None,
+    *,
+    configured: str | None = None,
+    state: str = "yoetz_owned",
+) -> dict[str, object]:
+    return {
+        "registration_state": state,
+        "registered_profile": registered,
+        "configured_profile": registered if configured is None else configured,
+        "observed": True,
+    }
 
 
 async def test_all_four_conditions_met_reports_ready(
@@ -371,6 +409,158 @@ async def test_rejected_auto_unlock_points_to_repair_first(
     blockers = cast(tuple[dict[str, object], ...], report["blockers"])
     assert blockers[0]["next_command"] == "yoetz service auto-unlock repair"
     assert report["next_commands"] == ("yoetz service auto-unlock repair",)
+
+
+async def test_strict_registered_route_is_not_ready_for_the_agent_but_leaves_the_install_ready(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The exact conflation #132 names: registration is not activation.
+
+    A strict Codex registration cannot dispatch semantic review, but ADR-018 decision 2 makes
+    that ceiling process-local — CLI and terminal checks on the same installation still can. So
+    the agent-route verdict flips and ``semantic_ready`` must not.
+    """
+
+    _install(monkeypatch, tmp_path, provider=_provider(), mcp_route=_route("strict"))
+
+    report = await module.provider_status_report()
+
+    assert report["semantic_ready"] is True
+    assert report["agent_route_semantic_ready"] is False
+    assert report["mcp_route"] == _route("strict")
+    blockers = cast(tuple[dict[str, object], ...], report["blockers"])
+    route = [item for item in blockers if item.get("condition") == "mcp_route_profile"]
+    assert len(route) == 1
+    assert route[0]["state"] == "strict"
+    # The scope marks this as an agent-route blocker, not an installation blocker.
+    assert route[0]["scope"] == "agent_route"
+    assert route[0]["next_command"] == "yoetz integrate codex mcp preview"
+
+
+async def test_strict_registered_route_does_not_change_the_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exit code stays driven by installation readiness, so existing callers keep their contract."""
+
+    _install(monkeypatch, tmp_path, provider=_provider(), mcp_route=_route("strict"))
+
+    assert await module.run_provider_status(json_output=True) == 0
+
+
+async def test_policy_registered_route_makes_both_verdicts_true(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch, tmp_path, provider=_provider(), mcp_route=_route("policy"))
+
+    report = await module.provider_status_report()
+
+    assert report["semantic_ready"] is True
+    assert report["agent_route_semantic_ready"] is True
+    blockers = cast(tuple[dict[str, object], ...], report["blockers"])
+    assert [item for item in blockers if item.get("condition") == "mcp_route_profile"] == []
+
+
+async def test_a_policy_route_on_an_unready_installation_is_not_agent_route_ready(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The agent-route verdict is a conjunction; a policy route alone never grants it."""
+
+    _install(
+        monkeypatch,
+        tmp_path,
+        provider=_provider(),
+        capabilities=(),
+        mcp_route=_route("policy"),
+    )
+
+    report = await module.provider_status_report()
+
+    assert report["semantic_ready"] is False
+    assert report["agent_route_semantic_ready"] is False
+
+
+async def test_unread_route_is_unknown_and_never_a_blocker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unobservable route reads as unread, matching how an unreadable credential is handled.
+
+    Failing soft here is the point: this report has to stay readable on a host with no Codex, a
+    broken Codex, or an unparseable registration entry.
+    """
+
+    _install(monkeypatch, tmp_path, provider=_provider())
+
+    report = await module.provider_status_report()
+
+    assert report["mcp_route"] == _UNREAD_ROUTE
+    assert report["agent_route_semantic_ready"] is False
+    assert report["semantic_ready"] is True
+    assert report["blockers"] == ()
+    assert await module.run_provider_status(json_output=True) == 0
+
+
+async def test_route_probe_failure_degrades_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The real probe, not a stub: discovery and registration errors must not reach the caller."""
+
+    _install(monkeypatch, tmp_path, provider=_provider())
+    monkeypatch.setattr(module, "_mcp_route_observation", _REAL_ROUTE_OBSERVATION)
+
+    def _explode() -> tuple[object, ...]:
+        raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
+
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.codex_discovery.discover_codex_binaries", _explode
+    )
+    monkeypatch.setattr(cli_setup, "_configured_mcp_route_profile", lambda: "policy")
+
+    report = await module.provider_status_report()
+
+    assert report["mcp_route"] == {
+        "registration_state": None,
+        "registered_profile": None,
+        # Configured profile is config-local, so it survives a failed probe.
+        "configured_profile": "policy",
+        "observed": False,
+    }
+    assert report["agent_route_semantic_ready"] is False
+
+
+async def test_registration_drift_from_configuration_is_visible(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`registered_profile != configured_profile` is the drift signal the runbook reads.
+
+    Setup would register a policy route now, but the live agent is still on the strict one. Only
+    reporting both facts makes that difference observable.
+    """
+
+    _install(
+        monkeypatch,
+        tmp_path,
+        provider=_provider(),
+        mcp_route=_route("strict", configured="policy"),
+    )
+
+    report = await module.provider_status_report()
+
+    route = cast(dict[str, object], report["mcp_route"])
+    assert route["registered_profile"] == "strict"
+    assert route["configured_profile"] == "policy"
+    assert report["agent_route_semantic_ready"] is False
+
+
+async def test_the_two_readiness_verdicts_are_documented_as_non_substitutable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _install(monkeypatch, tmp_path, provider=_provider(), mcp_route=_route("strict"))
+
+    report = await module.provider_status_report()
+
+    notes = " ".join(cast(tuple[str, ...], report["notes"]))
+    assert "Neither substitutes for the other." in notes
+    assert "does not make this installation not-ready" in notes
 
 
 async def test_uninitialized_vault_points_to_guided_setup(

--- a/tests/unit/protocol/test_models_and_schemas.py
+++ b/tests/unit/protocol/test_models_and_schemas.py
@@ -1536,6 +1536,81 @@ def test_check_semantic_status_reason_and_provenance_matrix() -> None:
     _assert_reason(exc_info, "invalid_semantic_provenance")
 
 
+def _binding_accepts(models: Any, status: Any, reason: Any, *, provenance: bool) -> bool:
+    try:
+        models.validate_semantic_provenance_binding(
+            status,
+            reason,
+            status if provenance else None,
+            reason if provenance else None,
+        )
+    except ProtocolValueError:
+        return False
+    return True
+
+
+def test_semantic_provenance_partition_is_total_over_every_status_and_reason() -> None:
+    """Every status/reason pair must land in exactly one provenance branch.
+
+    Reading ``semantic_provenance == null`` as "no provider attempt was made" is only sound
+    while the partition is total. A status added later that fell through every branch would
+    make null ambiguous and silently break that inference — which is the one fact the semantic
+    dogfood gate is built on (``docs/runbooks/semantic-dogfood.md``, issue #132).
+    """
+
+    models = _models_module()
+    classification: dict[tuple[Any, Any], str] = {}
+    for status in models.SemanticStatus:
+        reasons = models.VALID_SEMANTIC_REASONS[status]
+        assert reasons, f"{status.value} has no valid reason"
+        for reason in reasons:
+            absent_ok = _binding_accepts(models, status, reason, provenance=False)
+            present_ok = _binding_accepts(models, status, reason, provenance=True)
+            # Rejecting both forms means the pair fell out of the partition entirely.
+            assert absent_ok or present_ok, (status.value, reason.value)
+            classification[(status, reason)] = (
+                "unconstrained"
+                if absent_ok and present_ok
+                else ("forbidden" if absent_ok else "required")
+            )
+
+    unconstrained = {
+        status.value for (status, _), kind in classification.items() if kind == "unconstrained"
+    }
+    # `failed` is the one status where provenance presence proves nothing either way, so a
+    # dogfood run must record it as "attempt indeterminate", never as "not attempted".
+    assert unconstrained == {"failed"}
+
+    # A pre-dispatch block returns before any provider capability check, so provenance is
+    # forbidden — this is exactly the receipt the strict-route dogfood session produced.
+    assert (
+        classification[
+            (
+                models.SemanticStatus.BLOCKED_BY_POLICY,
+                models.SemanticReason.ROUTE_SEMANTIC_CEILING,
+            )
+        ]
+        == "forbidden"
+    )
+
+    unavailable = {
+        reason.value: kind
+        for (status, reason), kind in classification.items()
+        if status is models.SemanticStatus.UNAVAILABLE
+    }
+    # `unavailable` is the one status that splits on its reason, so each reason has to be
+    # classified individually and none may be left unconstrained.
+    assert set(unavailable.values()) <= {"required", "forbidden"}
+    assert {reason for reason, kind in unavailable.items() if kind == "required"} == {
+        "transport_unavailable",
+        "provider_rate_limited",
+        "provider_quota_exhausted",
+    }
+    assert set(unavailable) == {
+        reason.value for reason in models.VALID_SEMANTIC_REASONS[models.SemanticStatus.UNAVAILABLE]
+    }
+
+
 def test_frontier_model_enforces_genesis_cross_field_identity() -> None:
     models = _models_module()
     genesis = models.FrontierModel.model_validate({"sequence": "0", "head_digest": "genesis"})


### PR DESCRIPTION
## Issue

- Linked issue: `Fixes #132`
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated (privacy/egress + setup/registration). Acknowledged on the issue before this PR was opened: https://github.com/TheGaySupreme123/yoetz/issues/132#issuecomment-5182710243

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` §10 (`observe_registration`, `McpRegistrationObservation`, and the previously unregistered `yoetz.provider-status/1` schema token), `docs/usage/providers.md` (new "The agent route is a separate verdict"), `docs/usage/privacy-and-semantic-review.md`, `docs/runbooks/codex-integration.md`, `docs/README.md`, `CHANGELOG.md`, and the new `docs/runbooks/semantic-dogfood.md`. **No ADR change** — this reports the ceiling ADR-018 already defines and adds no behavior to it; confirmed nothing drifts from decisions 2 and 7.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit tests/subprocess tests/conformance
  -> 2171 passed

uv run ruff check . && uv run ruff format --check .
  -> All checks passed! / 516 files already formatted

npx --no-install pyright
  -> 0 errors, 0 warnings, 0 informations

uv run python scripts/scan_public_boundary.py --source-tree .
  -> PASS (837 files scanned)

uv run python scripts/generate_schemas.py --check
  -> PASS (58 schemas match)

uv run python scripts/verify_resource_manifest.py --check
  -> PASS (82 resources)
```

End-to-end against the local installation, and against a scratch `CODEX_HOME` carrying a strict
registration (removed afterward; the real config was never touched):

```text
# unregistered
yoetz integrate codex mcp status --json
  {"harness":"codex","route_profile":null,"state":"absent"}
yoetz provider status --json
  "mcp_route": {"configured_profile":"policy","observed":true,
                "registered_profile":null,"registration_state":"absent"}

# strict registration
yoetz integrate codex mcp status --json
  {"harness":"codex","route_profile":"strict","state":"yoetz_owned"}
yoetz provider status --json
  agent_route_semantic_ready: False
  mcp_route: {"configured_profile":"policy","observed":true,
              "registered_profile":"strict","registration_state":"yoetz_owned"}
  blocker: {"condition":"mcp_route_profile","scope":"agent_route","state":"strict",
            "next_command":"yoetz integrate codex mcp preview"}
  exit code 0 (unchanged)
```

Drift (`registered_profile: strict` vs `configured_profile: policy`) is visible in that run.
`semantic_ready` staying `true` under a strict route needs a running unlocked service, which this
machine does not have; that case is covered by
`test_a_strict_registered_route_scopes_its_blocker_to_the_agent_route`.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Yoetz could not tell you which route the agent is actually on. `_classify_get` matched the
registered argv against **both** owned serve commands and then discarded which one matched, so
`status_registration` returned only `yoetz_owned` — a strict registration and a policy registration
read identically. `yoetz provider status` derived `semantic_ready` from five installation-local
conditions and never looked at the route at all. An experimenter reading `semantic_ready: true`
reasonably concluded semantic review would run; under a strict registration it will not. That is
the conflation the 2026-08-03 postmortem scored against: *registration is not activation, and
availability is not usefulness.*

**Observe the route.** New `McpRegistrationObservation` and `HarnessMcpPort.observe_registration`
carry the matched command's profile. `route_profile` is non-null only when the state is
`yoetz_owned` — a foreign or absent entry has no Yoetz route to describe. `_classify_get`'s owned
branch now returns the matched constant so the mapping reads off one source of truth.
`status_registration` is deliberately unchanged, so setup and its tests keep their contract.
`HarnessMcpService.observe` mirrors `.status()` and shares its `status` diagnostic phase — it reads
exactly what status reads and mutates nothing, so the diagnostic shape is unchanged.

**Report it without overreaching.** `provider status` gains an `mcp_route` block
(`registration_state`, `registered_profile`, `configured_profile`, `observed`) and a second,
narrower `agent_route_semantic_ready` verdict. `setup status` rows carry
`registered_route_profile`; `integrate codex mcp status` emits `route_profile`.

**One deliberate refinement to the approved shape.** The approved preview flipped `semantic_ready`
to `false` under a strict registration. That would contradict ADR-018 decision 2 and its
"Alternatives considered": the route ceiling is *process-local*, and a route-local trust choice
must not silently tighten other CLI, UI, or MCP processes. A strict Codex registration does not
stop `yoetz check` from the CLI or the terminal interface from dispatching semantic review, so
reporting the installation as not-ready would be a new and wrong claim — and would break every
caller treating `semantic_ready` as installation state. So `semantic_ready` keeps its exact meaning
and the strict route is reported as a blocker scoped to `agent_route`, alongside the narrower
verdict. Same protection, no ceiling asserted that does not exist. `registered_profile !=
configured_profile` is itself the drift signal #132 asks for. Exit code stays driven by
`semantic_ready`.

**Fail-soft is load-bearing, not incidental.** This report exists to stay readable when the
installation is broken, so an absent Codex, an unreadable entry, or any registration error degrades
to `observed: false` — the module's existing "unknown means unread" convention — and never raises
or moves the exit code. An unobserved route is `unknown`, not a blocker, matching how
`credential_connected: None` is already handled.

**Lock the gate the runbook depends on.** The provenance rule is already protocol-enforced by
`validate_semantic_provenance_binding`; what was missing was proof the partition is *total*. A new
test asserts every `SemanticStatus`/reason pair lands in exactly one branch, that `unavailable`
splits correctly on its reason, and that `failed` is the one status where provenance presence is
unconstrained — so a future status cannot silently make `semantic_provenance == null` stop meaning
"no provider attempt was made". The runbook must read `failed` as *attempt indeterminate*, never
as *not attempted*.

**The runbook.** `docs/runbooks/semantic-dogfood.md` declares, before work starts, which claim a
run may make: Profile A (strict / local-only) may claim zero egress and receipt honesty and must
record semantic usefulness as **not tested** — never as "poor"; Profile B (policy-enabled) requires
a policy route, `agent_route_semantic_ready`, and human authorization through the existing
ceremony. Preview is allowed from the agent channel; widening policy is not. The preflight is five
existing read-only commands, and the provenance gate is a table derived from the check result.

**Non-goals:** no default policy widening, no change to the strict route, no new top-level CLI
command (the set is frozen by `tests/conformance/surfaces/test_cli_contract_matrix.py`), and no
claim that passing preflight proves semantic usefulness. Schema authorability (#128), nested
validation repair (#129), undeclared obligations (#130), typed evidence provenance (#131), and
influence measurement (#133) remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `yoetz provider status` to report installation readiness separately from agent-route semantic readiness.
  - Setup and integration status now show MCP registration state and detected route profile.
  - Added visibility into strict versus policy route configuration and related blockers.

- **Bug Fixes**
  - Route observation failures now degrade gracefully without changing installation readiness or exit codes.

- **Documentation**
  - Updated Codex integration guidance and added a semantic dogfood runbook covering preflight, provenance, and reporting requirements.

- **Tests**
  - Added coverage for route detection, readiness distinctions, unavailable registrations, and observation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the conflation between registration state and route posture that made a strict Codex MCP registration indistinguishable from a policy one. It introduces `McpRegistrationObservation` and `HarnessMcpPort.observe_registration`, wires them through the service layer, and surfaces the result as `mcp_route` and `agent_route_semantic_ready` in `yoetz provider status`.

- `_classify_get` now returns the matched constant (not re-parsed tokens), so `_ROUTE_PROFILE_BY_COMMAND` has a single source of truth; `observe_registration` delegates to it and wraps the result in the new dataclass.
- `semantic_ready` retains its installation-local meaning and the exit code is unchanged; a strict route adds only a scoped `mcp_route_profile` blocker under `agent_route`, consistent with ADR-018 decision 2.
- The new provenance-partition totality test locks the invariant that `semantic_provenance == null` reliably signals no provider attempt, which the semantic dogfood runbook depends on.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All new paths are read-only, fail-soft, and exit-code-neutral; the core semantic_ready invariant and its callers are unchanged.

The change is purely additive on the observable surface: new fields on existing outputs, a new read-only observe() method that records the same diagnostic phase as status(), and a scoped blocker that explicitly does not touch the exit code. Test coverage for the new paths is thorough, and the provenance-partition totality test closes the gap the runbook depends on. The one noted gap in McpRegistrationObservation validation cannot be triggered by the current production code path.

**Files Needing Attention:** src/yoetz/ports/harness_mcp.py — the McpRegistrationObservation validator is one direction short of the full invariant; worth tightening before _ROUTE_PROFILE_BY_COMMAND is extended.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/ports/harness_mcp.py | Adds McpRegistrationObservation dataclass and observe_registration to the Protocol; validation enforces route_profile implies state=YOETZ_OWNED but not the inverse |
| src/yoetz/adapters/integrations/codex_mcp.py | _classify_get now returns the matched constant; observe_registration uses _ROUTE_PROFILE_BY_COMMAND.get() which silently returns None for unknown commands |
| src/yoetz/application/harness_mcp.py | Adds observe() mirroring status() but returning McpRegistrationObservation; diagnostic phase stays status for backward compat |
| src/yoetz/cli/provider_status.py | Adds _mcp_route_observation (fail-soft), mcp_route block, and agent_route_semantic_ready verdict; strict route adds scoped blocker without moving exit code |
| src/yoetz/cli/setup.py | setup_status and integrate_mcp status now call observe() instead of status(), adding registered_route_profile to output |
| tests/unit/cli/test_provider_status.py | Comprehensive new tests for route observation, fail-soft, drift detection, and agent_route_semantic_ready |
| tests/unit/adapters/test_codex_mcp_registration.py | Adapter-level tests for observe_registration covering both profiles, absent/foreign entries, and decoupling from adapter route_profile |
| tests/unit/application/test_harness_mcp_service.py | Service-layer tests for observe(), including diagnostics, error reraise, and McpRegistrationObservation constructor invariants |
| tests/unit/protocol/test_models_and_schemas.py | New provenance partition totality test correctly pins the failed status as unconstrained |
| tests/subprocess/test_setup_wizard_cli.py | Subprocess tests correctly assert new route_profile and registered_route_profile fields in CLI output |
| docs/runbooks/semantic-dogfood.md | New runbook clearly separates Profile A/B claims, preflight sequence, and provenance gate |

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): make the registered route obse..."](https://github.com/thegaysupreme123/yoetz/commit/f73d7b05b4d1190db17ad0cbfa7b1f9f909cb420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22876367)</sub>

<!-- /greptile_comment -->