### PR TITLE
Measure Yoetz-to-agent intervention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,13 @@ describes behavior intended for the first release rather than a change from a pr
   declares which claim a run may make, and a provenance gate that refuses to score semantic quality
   when no provider attempt happened.
 
+- **Influence dogfood protocol (docs/test-only).** A new
+  [influence dogfood runbook](docs/runbooks/influence-dogfood.md) measures Yoetz-to-agent intervention
+  without conflating operational health, authoring UX, semantic quality, and work-product influence.
+  Offline unit tests lock classification rules (activation vs registration, strict-route Stream C as
+  `not_tested`, early publication gate, miss taxonomy, honesty vs work-product influence, forbidden
+  summary). No protocol, privacy, storage, or MCP surface change.
+
 ### Documentation and repository
 
 - User documentation: `docs/architecture.md` (topology, module map, honesty rules), `docs/usage/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ golden vectors under [`fixtures/`](../fixtures/) win over any prose, including t
 - [`docs/protocol/`](protocol/) — the technical protocol: compatibility, data egress and privacy,
   local service security, the privacy setup wizard.
 - [`docs/runbooks/`](runbooks/) — operational procedures: backup/restore, key recovery, migration
-  rollback, quarantine recovery, Codex integration, semantic dogfood.
+  rollback, quarantine recovery, Codex integration, semantic dogfood, influence dogfood.
 - [`docs/public-claims.json`](public-claims.json) — every public claim bound to its requirements,
   surfaces, tests, and honest release status. Enforced by `tests/conformance/claims/`.
 - [`guidance/`](../guidance/) — agent-facing guidance, shipped byte-identically to every harness and

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -116,7 +116,9 @@ route from `yoetz integrate codex mcp status --json` (`route_profile`) or from
 `yoetz provider status --json` (`mcp_route.registered_profile`). Before running a session that will
 report a finding about Yoetz's semantic behaviour, walk the
 [semantic dogfood runbook](semantic-dogfood.md) — it declares up front which claim the run is
-allowed to make, and refuses to score semantic quality when no provider attempt happened.
+allowed to make, and refuses to score semantic quality when no provider attempt happened. To measure
+whether feedback **changed the work product** (not merely whether Yoetz was healthy or authorable),
+use the [influence dogfood runbook](influence-dogfood.md).
 
 If the host is configured with Yoetz as an optional server and it is unavailable, Codex work
 continues and the skill discloses no live ledger/check/receipt data. If configured as required,

--- a/docs/runbooks/influence-dogfood.md
+++ b/docs/runbooks/influence-dogfood.md
@@ -1,0 +1,311 @@
+# Influence dogfood runbook
+
+This runbook governs sessions that measure whether Yoetz **changed the agent's work product**, not
+merely whether Yoetz was healthy, authorable, or able to emit feedback. Its purpose is to force four
+questions to be answered **separately**, so a zero-influence run with a healthy service and an honest
+receipt is never summarized as “Yoetz improved the agent.”
+
+It exists because of the 2026-08-03 postmortem
+([`docs/postmortems/2026-08-03-codex-testing-yoetz-schema-feedback-influence.md`](../postmortems/2026-08-03-codex-testing-yoetz-schema-feedback-influence.md)),
+which recorded operational health and receipt honesty while demonstrating little attributable work
+revision. The postmortem's P1.6–P1.8 remediation items (policy-enabled qualitative route, seeded
+defect, intervention timing) are the experiment contract this runbook operationalizes.
+
+Semantic eligibility and the provenance gate stay in the
+[semantic dogfood runbook](semantic-dogfood.md) (#132). This runbook **consumes** that profile and
+gate; it does not redefine them.
+
+**Issue:** [#133](https://github.com/TheGaySupreme123/yoetz/issues/133).  
+**Design gate:** docs/test-only evaluation protocol — no public runtime behavior change.  
+**Out of scope here:** product fixes owned by #128–#132 (schema authorability, nested errors,
+undeclared scope, evidence provenance, semantic route preflight).
+
+---
+
+## 1. Purpose and non-conflation rules
+
+Record and score these as **independent** claims. Do not collapse them into one “Yoetz helped”
+sentence.
+
+| Claim class | Must not be inferred from |
+|---|---|
+| Operational health | Tool listing, registration alone, or a successful dry-run |
+| Authoring / corrective UX | Service uptime without first-call success or public repair |
+| Semantic quality | A strict route that never attempted review; availability without a scored attempt |
+| Work-product influence | Receipt wording, honesty-only rewrites, registration, or zero findings |
+
+Hard rules:
+
+1. **Registration / tool listing is never activation or influence.** A registered MCP entry or a
+   successful `tools/list` says what the host *could* launch, not that the agent used Yoetz, that a
+   model was shown anything, or that any work changed.
+2. **Operational health ≠ authoring UX ≠ semantic quality ≠ work-product influence.** Score each
+   stream on its own evidence. A pass on A does not raise D.
+3. **Receipt-wording changes are honesty influence (Stream A / integrity), never Stream D.**
+   Softening a conclusion to match weakest coverage is integrity success, not proof the
+   implementation improved.
+4. **Strict-route runs mark Stream C semantic quality `not_tested` (privacy pass), never “poor
+   semantic feedback.”** The route declined to attempt review; that is not a measurement of review
+   quality. See [semantic dogfood](semantic-dogfood.md) Profile A and §3 provenance gate.
+5. **A zero-influence run with healthy service and honest receipt must not be summarized as “Yoetz
+   improved the agent.”** Enforce the forbidden-summary check in §5.
+
+Closed vocabulary for stream scores (use only these tokens):
+
+| Token | Meaning |
+|---|---|
+| `pass` | Evidence supports success for that stream's question |
+| `fail` | Evidence shows the stream's question was answerable and failed |
+| `not_demonstrated` | No positive evidence of success (default for Stream D without attribution) |
+| `not_tested` | Configuration or design made the question unanswerable (e.g. Stream C on strict) |
+| `indeterminate` | Attempt happened but outcome cannot be scored honestly |
+
+For Stream D work-product influence specifically, prefer `demonstrated` | `not_demonstrated` on the
+boolean metric `work_product_influence`, and keep stream score aligned (`pass` only when
+`demonstrated`).
+
+---
+
+## 2. Four evidence streams (required report sections)
+
+Every influence dogfood report **must** contain four separately scored sections. Do not merge scores.
+
+| Stream | Question | Counts as success only when… |
+|---|---|---|
+| **A Operational health** | Was Yoetz healthy? | Service completed intended ops honestly: listing/registration posture recorded, six tools visible when expected, start/attach, write accept/reject, dry-run non-evidential, status/check/receipt, latency/errors within experiment bounds |
+| **B Authoring / corrective UX** | Could the agent use it efficiently? | First-call success where required, rejection rate (excluding resource reads), identical structural retries bounded, source-inspection detours recorded, repair from **public** feedback alone, time-to-valid-plan / first obligation |
+| **C Semantic availability & quality** | Did the reviewer produce valid feedback? | **Only when** the [provenance gate](semantic-dogfood.md#3-the-provenance-gate) says an attempt happened: eligibility/preflight, dispatch + status/reason, packet coverage, finding specificity/actionability, FP/miss |
+| **D Agent influence** | Did that feedback **materially improve** the work? | Attributable work-product revision bound to a Yoetz output (finding, status frontier, or deterministic check outcome), with before→after action + evidence + recheck — or explicit `not_demonstrated` |
+
+### Stream A detail
+
+Record that the service did what the experiment asked without lying about coverage. Typical
+checklist: attach/start, publication accept and reject paths exercised as designed, dry-run not
+treated as evidence, status/check/receipt available, structural errors and latencies noted.
+Registration alone does **not** pass Stream A as “agent used Yoetz”; it only establishes that a
+route *could* exist.
+
+### Stream B detail
+
+Authoring UX is about the public surface (descriptors, examples, rejection messages), not about the
+agent reading product source. Count resource reads separately from write rejections. Identical
+retries on the same structural error are a UX failure signal. Time-to-valid-plan and
+time-to-first-obligation are primary timing metrics (see §4).
+
+### Stream C detail
+
+Follow semantic dogfood profiles:
+
+- **Profile A (strict):** Stream C = `not_tested`. Do not score quality.
+- **Profile B (policy):** Stream C is eligible only after the provenance gate allows scoring. A
+  `blocked_by_policy` / null provenance result is not a quality failure.
+
+### Stream D detail
+
+Work-product influence requires a **causal attribution record** (§3 step 5). Without it, Stream D is
+`not_demonstrated` even if findings exist. Findings the agent ignored are Stream D
+`not_demonstrated` with miss class `agent_response_miss` when a seeded defect was in play.
+Honesty-only receipt rewrites never promote Stream D.
+
+---
+
+## 3. Experiment design (must-do steps)
+
+Execute in order. If a step fails, record the failure class and continue only if the remaining
+streams remain answerable; do not reframe the run to claim Stream D success after an early gate fail.
+
+### 3.1 Control or recording-only arm
+
+Where feasible, run a **control** (no Yoetz, or Yoetz recording-only without mid-work checks) on the
+same seeded task. If a control is not run, state that limitation explicitly in the report metrics
+(`control_run: not_run`) and do not invent incremental cost/time deltas.
+
+### 3.2 Seed one known qualitative defect
+
+Seed **one** known qualitative defect **unknown to the working agent**. Examples (from the
+postmortem / issue):
+
+- uncovered UI string or evidence source kind;
+- claim broader than tests support;
+- open obligation left undeclared when a coherent outcome needs one.
+
+Record the seed id and intended miss class if not remediated. Do not use an uncontrolled historical
+task as the sole basis for causal certainty.
+
+### 3.3 Early structured publication gate (before first source edit)
+
+Before the first source edit of the work product under test, require:
+
+1. a **valid plan**;
+2. **≥1 bounded obligation per coherent outcome**, **or** a typed `no_obligations_reason` (product
+   already supports `no_obligations_declared` + typed empty-scope reasons — the protocol must *use*
+   it, not re-implement it);
+3. requested items + evidence expectations;
+4. experiment profile + semantic eligibility (link the [semantic dogfood](semantic-dogfood.md)
+   preflight and profile A/B).
+
+If authoring prevents this gate → record **`authoring_early_publication_gate: failed`** (Stream B
+fail contribution). **Do not** silently switch to end-of-task publication and still claim Stream D
+success. End-of-task-only publication may still inform Streams A/C and honesty, but Stream D remains
+`not_demonstrated` for “mid-work assistance” claims unless the run **explicitly** declares a
+terminal-review-only design (§3.4).
+
+Boolean metric (required): `plan_and_obligation_before_first_source_edit: true | false`.
+
+### 3.4 Meaningful mid-work check
+
+While revision is still possible, run at least one check (unless the run **explicitly** tests
+terminal-review-only). Record check timing relative to first source edit and first attributable
+revision. Terminal-review-only runs must say so in established facts; they may score honesty and
+late findings but cannot claim mid-work Stream D assistance.
+
+### 3.5 Causal attribution record (per claimed influence)
+
+For **each** claimed work-product influence, record:
+
+| Field | Content |
+|---|---|
+| `yoetz_output_ref` | Finding id, status frontier, check id, or other bounded token (no freeform transcript) |
+| `agent_decision_before` | Closed token or short enum of the pre-finding state (e.g. `no_revision_planned`) |
+| `bounded_action_after` | What changed (obligation respond, source revision, evidence republish) |
+| `new_evidence_ref` | Digest-bound evidence id if any |
+| `counterfactual` | `would_have_happened_without_yoetz`: `yes` \| `no` \| `uncertain` |
+| `recheck_result` | `passed` \| `failed` \| `not_run` \| `not_applicable` |
+
+Without this record, do not mark `work_product_influence: demonstrated`.
+
+### 3.6 Miss taxonomy (mandatory when seeded defect not remediated by influence)
+
+When the seeded defect is **not** remediated via attributable Yoetz influence, classify exactly one:
+
+| Class | Meaning |
+|---|---|
+| `case_construction_miss` | Defect absent from the published/selected case (experiment built the wrong case) |
+| `checker_or_reviewer_miss` | Defect present in the case, but no rule/finding surfaced it |
+| `agent_response_miss` | Valid finding existed; agent ignored it |
+
+Do not invent other miss classes in shared reports. If the defect **was** remediated with attribution
+and recheck, record `seeded_defect_outcome: remediated` and leave miss class null/omitted.
+
+---
+
+## 4. Required metrics (closed fields)
+
+Reproduce metrics from **bounded artifacts only**: operation results, status snapshots, finding ids,
+digests, enums, integers, booleans. **No** full transcripts, prompts, secrets, absolute paths,
+usernames, machine identifiers, or unredacted provider payloads.
+
+Include at least:
+
+| Field | Type / notes |
+|---|---|
+| `op_counts` | Per-op integers (`start`, `publish_work`, `check`, `respond`, `status`, `receipt`, …) |
+| `resource_read_count` | Integer; exclude from rejection rate denominator |
+| `write_rejection_rate` | Rational or pair `(rejects, write_attempts)` excluding resource reads |
+| `identical_structural_retries` | Integer |
+| `wall_ms_start_to_valid_plan` | Integer ms or `null` if never |
+| `wall_ms_start_to_first_obligation` | Integer ms or `null` |
+| `wall_ms_start_to_first_evidence` | Integer ms or `null` |
+| `wall_ms_start_to_first_check` | Integer ms or `null` |
+| `wall_ms_start_to_first_finding` | Integer ms or `null` |
+| `wall_ms_start_to_first_attributable_revision` | Integer ms or `null` |
+| `wall_ms_start_to_receipt` | Integer ms or `null` |
+| `plan_and_obligation_before_first_source_edit` | Boolean |
+| `authoring_early_publication_gate` | `passed` \| `failed` \| `not_applicable` |
+| `findings_deterministic_count` | Integer |
+| `findings_semantic_count` | Integer (score only if Stream C eligible) |
+| `findings_accepted` / `disputed` / `ignored` / `false_positive` | Integers |
+| `material_revisions_attributable_to_yoetz` | Integer |
+| `material_revisions_rechecked` | Integer |
+| `seeded_defect_outcome` | `remediated` \| `missed` \| `not_seeded` |
+| `seeded_defect_miss_class` | Miss taxonomy token or `null` |
+| `receipt_conclusion` | Bounded token from receipt |
+| `weakest_coverage` | Bounded coverage token |
+| `control_run` | `run` \| `not_run` |
+| `incremental_wall_ms_vs_control` | Integer or `null` if control not run |
+| `incremental_tool_calls_vs_control` | Integer or `null` if control not run |
+| `work_product_influence` | `demonstrated` \| `not_demonstrated` |
+| `honesty_influence` | `yes` \| `no` |
+| `stream_a` … `stream_d` | Closed stream score tokens from §1 |
+| `experiment_profile` | `strict` \| `policy` (semantic dogfood Profile A/B) |
+| `semantic_scoring_eligible` | Boolean from provenance gate |
+| `activation` | `none` \| `tools_listed` \| `registered_only` \| `session_ops` — registration/list alone is not session use |
+
+---
+
+## 5. Report template
+
+Required final report shape:
+
+```text
+1. Established facts
+2. Inferences
+3. Unresolved hypotheses
+4. Stream A…D scores (separate)
+5. Forbidden summary check: if Stream D = not_demonstrated (or work_product_influence =
+   not_demonstrated), final prose must not say Yoetz improved work quality / agent quality /
+   implementation quality
+```
+
+### 5.1 Section rules
+
+1. **Established facts** — only what bounded artifacts support (ops, timings, findings counts,
+   gate outcomes, attribution records present/absent).
+2. **Inferences** — labeled as such; never presented as facts.
+3. **Unresolved hypotheses** — including counterfactuals left `uncertain`.
+4. **Stream scores** — four lines or a four-row table; no combined “overall success” that hides D.
+5. **Forbidden summary check** — boolean `forbidden_summary_violation`. Set `true` if final prose
+   claims work-product improvement while `work_product_influence` is `not_demonstrated`. A
+   violation fails the dogfood report even when Streams A–C pass.
+
+### 5.2 Privacy hygiene
+
+Copy the semantic dogfood report hygiene (§5 there). A dogfood report is shared material. It carries:
+
+- credential state as **presence only** (`connected` / `not stored` / `unknown`) — never a value,
+  prefix, length, or any property of the stored secret;
+- no absolute paths, usernames, or machine identifiers;
+- no transcripts;
+- no unredacted provider request or response payloads;
+- versions, bounded status/reason tokens, digests, and structural state only.
+
+---
+
+## 6. Relationship to semantic dogfood
+
+| Semantic profile | Stream C | Stream D |
+|---|---|---|
+| **A — strict / local-only** | `not_tested` (privacy pass; never “poor”) | May still score from **deterministic** findings, status frontiers, and closure — never from semantic review |
+| **B — policy-enabled** | Eligible only after provenance gate | May cite semantic findings only when the gate allows scoring those findings |
+
+Influence dogfood always runs the semantic preflight when Stream C or semantic-cited Stream D is in
+scope. For strict Profile A runs that only care about deterministic influence, still record
+`experiment_profile: strict` and `stream_c: not_tested`.
+
+Retained negative-control shape (historical reference task
+`019fc915-a0bd-7803-b5d9-d8cbb9c65981`): start early, plan after first edit, zero obligations,
+terminal-only completion graph, deterministic zero findings, semantic blocked by strict route,
+honesty-only final wording — Stream D `not_demonstrated`, Stream C `not_tested`, forbidden summary
+if prose claims improvement.
+
+---
+
+## 7. Explicit non-goals
+
+- No protocol field, ADR, privacy, storage, or MCP surface changes in the name of this protocol.
+- No requirement that every task use Yoetz.
+- No live dogfood execution required to merge the protocol (operator live run is optional follow-up).
+- No claim of causal certainty from one uncontrolled historical postmortem.
+- Do not re-implement #128–#132 product work under this runbook.
+
+---
+
+## See also
+
+- [Semantic dogfood runbook](semantic-dogfood.md) — profiles A/B, preflight, provenance gate.
+- [Codex integration runbook](codex-integration.md) — skill install, MCP registration, route profile.
+- [Privacy and semantic review](../usage/privacy-and-semantic-review.md) — durable policy that
+  authorizes disclosure.
+- Postmortem
+  [`2026-08-03-codex-testing-yoetz-schema-feedback-influence.md`](../postmortems/2026-08-03-codex-testing-yoetz-schema-feedback-influence.md)
+  — root evidence and P1.6–P1.8.

--- a/docs/runbooks/semantic-dogfood.md
+++ b/docs/runbooks/semantic-dogfood.md
@@ -128,7 +128,10 @@ the result says whether one *happened*.
 - It does not prove the implementation under review is correct. A clean semantic judgment is one
   observation, not a verdict.
 - It does not measure whether feedback changed the agent's behaviour. Influence measurement is
-  [issue #133](https://github.com/TheGaySupreme123/yoetz/issues/133) and is out of scope here.
+  governed by the [influence dogfood runbook](influence-dogfood.md) (issue
+  [#133](https://github.com/TheGaySupreme123/yoetz/issues/133)): four separate evidence streams,
+  seeded-defect and miss taxonomy, and a forbidden-summary rule so zero influence cannot be sold as
+  improvement.
 
 ## 5. Report hygiene
 

--- a/tests/unit/dogfood/__init__.py
+++ b/tests/unit/dogfood/__init__.py
@@ -1,0 +1,5 @@
+"""Offline dogfood protocol classification helpers (test-local only).
+
+These modules lock report-classification rules for evaluation runbooks. They are not part of the
+product runtime, protocol surface, or packaged CLI/MCP.
+"""

--- a/tests/unit/dogfood/influence_report.py
+++ b/tests/unit/dogfood/influence_report.py
@@ -1,0 +1,438 @@
+"""Pure classification rules for the influence dogfood report (issue #133).
+
+Test-local only: closed enums, integers, booleans. No transcripts, paths, secrets, or freeform
+provider payloads. Not imported by product runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal, TypedDict, cast
+
+StreamScore = Literal["pass", "fail", "not_demonstrated", "not_tested", "indeterminate"]
+WorkProductInfluence = Literal["demonstrated", "not_demonstrated"]
+HonestyInfluence = Literal["yes", "no"]
+MissClass = Literal[
+    "case_construction_miss",
+    "checker_or_reviewer_miss",
+    "agent_response_miss",
+]
+SeededDefectOutcome = Literal["remediated", "missed", "not_seeded"]
+EarlyPublicationGate = Literal["passed", "failed", "not_applicable"]
+ExperimentProfile = Literal["strict", "policy"]
+Activation = Literal["none", "tools_listed", "registered_only", "session_ops"]
+SemanticStatus = Literal[
+    "not_requested",
+    "not_configured",
+    "blocked_by_policy",
+    "succeeded",
+    "refused",
+    "failed",
+    "unavailable",
+    "not_applicable",
+]
+
+STREAM_SCORES: Final = frozenset(
+    {"pass", "fail", "not_demonstrated", "not_tested", "indeterminate"}
+)
+MISS_CLASSES: Final = frozenset(
+    {"case_construction_miss", "checker_or_reviewer_miss", "agent_response_miss"}
+)
+
+# Phrases that, if present in final prose while work_product_influence is not_demonstrated,
+# constitute a forbidden-summary violation. Matched case-insensitively as substrings.
+_FORBIDDEN_IMPROVEMENT_PHRASES: Final = (
+    "yoetz improved work quality",
+    "yoetz improved the agent",
+    "yoetz improved agent quality",
+    "yoetz improved the implementation",
+    "yoetz improved implementation quality",
+    "yoetz improved work-product",
+    "yoetz improved the work product",
+    "feedback improved the work",
+    "feedback improved work quality",
+    "semantic feedback improved",
+)
+
+
+class AttributionRecord(TypedDict, total=False):
+    """One attributable revision bound to a Yoetz output."""
+
+    yoetz_output_ref: str
+    agent_decision_before: str
+    bounded_action_after: str
+    new_evidence_ref: str
+    counterfactual: Literal["yes", "no", "uncertain"]
+    recheck_result: Literal["passed", "failed", "not_run", "not_applicable"]
+
+
+class InfluenceTimeline(TypedDict, total=False):
+    """Synthetic bounded timeline / report inputs for classification.
+
+    All fields optional at construction; ``classify_influence_report`` applies defaults and
+    closed-vocabulary checks. Freeform transcript fields are intentionally absent.
+    """
+
+    activation: Activation
+    experiment_profile: ExperimentProfile
+    semantic_status: SemanticStatus
+    semantic_provenance_present: bool
+    semantic_scoring_eligible: bool
+    plan_before_first_source_edit: bool
+    obligation_before_first_source_edit: bool
+    first_source_edit_ms: int | None
+    valid_plan_ms: int | None
+    first_obligation_ms: int | None
+    ops_completed_honestly: bool
+    write_attempts: int
+    write_rejects: int
+    identical_structural_retries: int
+    findings_deterministic: int
+    findings_semantic: int
+    findings_ignored: int
+    findings_false_positive: int
+    findings_accepted: int
+    attributions: list[AttributionRecord]
+    receipt_wording_changed_for_honesty: bool
+    seeded_defect_in_case: bool | None
+    seeded_defect_finding_present: bool | None
+    seeded_defect_agent_acted: bool | None
+    seeded_defect_seeded: bool
+    final_prose: str
+    terminal_review_only: bool
+    control_run: Literal["run", "not_run"]
+
+
+class InfluenceReport(TypedDict):
+    """Closed classification result for an influence dogfood report."""
+
+    activation: Activation
+    is_activation: bool
+    experiment_profile: ExperimentProfile
+    stream_a: StreamScore
+    stream_b: StreamScore
+    stream_c: StreamScore
+    stream_d: StreamScore
+    authoring_early_publication_gate: EarlyPublicationGate
+    plan_and_obligation_before_first_source_edit: bool
+    work_product_influence: WorkProductInfluence
+    honesty_influence: HonestyInfluence
+    seeded_defect_outcome: SeededDefectOutcome
+    seeded_defect_miss_class: MissClass | None
+    material_revisions_attributable_to_yoetz: int
+    material_revisions_rechecked: int
+    semantic_scoring_eligible: bool
+    forbidden_summary_violation: bool
+    control_run: Literal["run", "not_run"]
+
+
+def _token(value: object, allowed: frozenset[str], default: str) -> str:
+    if type(value) is str and value in allowed:
+        return value
+    return default
+
+
+def _bool(value: object, default: bool = False) -> bool:
+    return value if type(value) is bool else default
+
+
+def _nonneg_int(value: object, default: int = 0) -> int:
+    if type(value) is int and not isinstance(value, bool) and 0 <= value <= 2**31 - 1:
+        return value
+    return default
+
+
+def semantic_scoring_eligible(
+    *,
+    experiment_profile: ExperimentProfile,
+    semantic_status: SemanticStatus,
+    semantic_provenance_present: bool,
+) -> bool:
+    """Mirror the semantic dogfood provenance gate for Stream C scoring eligibility.
+
+    Strict profile never scores semantic quality. On policy profile, only statuses that represent
+    a real provider attempt with enforced provenance may score. ``failed`` is indeterminate.
+    """
+
+    if experiment_profile == "strict":
+        return False
+    if semantic_status in {
+        "not_requested",
+        "not_configured",
+        "blocked_by_policy",
+        "not_applicable",
+    }:
+        return False
+    if semantic_status == "failed":
+        return False
+    if semantic_status in {"succeeded", "refused", "unavailable"}:
+        return semantic_provenance_present
+    return False
+
+
+def classify_stream_c(
+    *,
+    experiment_profile: ExperimentProfile,
+    semantic_status: SemanticStatus,
+    semantic_provenance_present: bool,
+    findings_semantic: int,
+) -> tuple[StreamScore, bool]:
+    """Return (stream_c score, scoring_eligible).
+
+    Strict or pre-dispatch blocked → ``not_tested``, never ``fail`` for “poor semantic feedback”.
+    """
+
+    eligible = semantic_scoring_eligible(
+        experiment_profile=experiment_profile,
+        semantic_status=semantic_status,
+        semantic_provenance_present=semantic_provenance_present,
+    )
+    if experiment_profile == "strict":
+        return "not_tested", False
+    if semantic_status in {
+        "not_requested",
+        "not_configured",
+        "blocked_by_policy",
+        "not_applicable",
+    }:
+        return "not_tested", False
+    if semantic_status == "failed":
+        return "indeterminate", False
+    if not eligible:
+        return "not_tested", False
+    # Attempt scored: presence of semantic findings is observational, not a quality rubric here.
+    # Quality pass/fail is left to human report; classifier only marks eligibility and non-fail
+    # for blocked routes. A scorable attempt with zero findings is still ``pass`` for availability.
+    _ = findings_semantic
+    return "pass", True
+
+
+def classify_early_publication_gate(
+    *,
+    plan_before_first_source_edit: bool,
+    obligation_before_first_source_edit: bool,
+    valid_plan_ms: int | None,
+    first_obligation_ms: int | None,
+    first_source_edit_ms: int | None,
+    terminal_review_only: bool,
+) -> tuple[EarlyPublicationGate, bool]:
+    """Early structured publication gate: plan + obligation before first source edit."""
+
+    plan_before = plan_before_first_source_edit
+    obligation_before = obligation_before_first_source_edit
+    if first_source_edit_ms is not None:
+        if valid_plan_ms is not None and valid_plan_ms > first_source_edit_ms:
+            plan_before = False
+        if first_obligation_ms is not None and first_obligation_ms > first_source_edit_ms:
+            obligation_before = False
+        if valid_plan_ms is None:
+            plan_before = False
+        if first_obligation_ms is None:
+            obligation_before = False
+
+    both = plan_before and obligation_before
+    if terminal_review_only and not both:
+        # Explicit terminal-review design: gate is N/A for mid-work claims; still record the boolean.
+        return "not_applicable", both
+    if both:
+        return "passed", True
+    return "failed", False
+
+
+def classify_miss(
+    *,
+    seeded: bool,
+    defect_in_case: bool | None,
+    finding_present: bool | None,
+    agent_acted: bool | None,
+) -> tuple[SeededDefectOutcome, MissClass | None]:
+    """Mandatory miss taxonomy when a seeded defect is not remediated by influence."""
+
+    if not seeded:
+        return "not_seeded", None
+    if agent_acted is True and finding_present is True:
+        return "remediated", None
+    if defect_in_case is False:
+        return "missed", "case_construction_miss"
+    if defect_in_case is True and finding_present is not True:
+        return "missed", "checker_or_reviewer_miss"
+    if finding_present is True and agent_acted is not True:
+        return "missed", "agent_response_miss"
+    # Seeded but insufficient observation to place the miss — treat as case construction uncertainty
+    # only when presence in case is unknown; otherwise checker miss.
+    if defect_in_case is None:
+        return "missed", "case_construction_miss"
+    return "missed", "checker_or_reviewer_miss"
+
+
+def classify_work_product_influence(
+    attributions: list[AttributionRecord],
+) -> tuple[WorkProductInfluence, int, int]:
+    """Stream D requires attributable revision; recheck is counted separately."""
+
+    material = 0
+    rechecked = 0
+    for row in attributions:
+        ref = row.get("yoetz_output_ref")
+        action = row.get("bounded_action_after")
+        if type(ref) is not str or not ref or type(action) is not str or not action:
+            continue
+        # Honesty-only / no work change tokens do not count.
+        if action in {"receipt_wording_only", "none", "ignored"}:
+            continue
+        material += 1
+        if row.get("recheck_result") in {"passed", "failed"}:
+            rechecked += 1
+    if material > 0:
+        return "demonstrated", material, rechecked
+    return "not_demonstrated", 0, rechecked
+
+
+def forbidden_summary_violation(
+    *,
+    work_product_influence: WorkProductInfluence,
+    final_prose: str,
+) -> bool:
+    """True when prose claims work-quality improvement without demonstrated influence."""
+
+    if work_product_influence == "demonstrated":
+        return False
+    text = final_prose.casefold()
+    return any(phrase in text for phrase in _FORBIDDEN_IMPROVEMENT_PHRASES)
+
+
+def classify_influence_report(timeline: InfluenceTimeline) -> InfluenceReport:
+    """Classify a synthetic influence timeline into the closed report shape."""
+
+    activation = cast(
+        Activation,
+        _token(
+            timeline.get("activation"),
+            frozenset({"none", "tools_listed", "registered_only", "session_ops"}),
+            "none",
+        ),
+    )
+    is_activation = activation == "session_ops"
+
+    experiment_profile = cast(
+        ExperimentProfile,
+        _token(timeline.get("experiment_profile"), frozenset({"strict", "policy"}), "strict"),
+    )
+    semantic_status = cast(
+        SemanticStatus,
+        _token(
+            timeline.get("semantic_status"),
+            frozenset(
+                {
+                    "not_requested",
+                    "not_configured",
+                    "blocked_by_policy",
+                    "succeeded",
+                    "refused",
+                    "failed",
+                    "unavailable",
+                    "not_applicable",
+                }
+            ),
+            "not_applicable",
+        ),
+    )
+    provenance = _bool(timeline.get("semantic_provenance_present"), False)
+
+    stream_c, eligible = classify_stream_c(
+        experiment_profile=experiment_profile,
+        semantic_status=semantic_status,
+        semantic_provenance_present=provenance,
+        findings_semantic=_nonneg_int(timeline.get("findings_semantic"), 0),
+    )
+
+    gate, plan_and_obligation_before = classify_early_publication_gate(
+        plan_before_first_source_edit=_bool(timeline.get("plan_before_first_source_edit"), False),
+        obligation_before_first_source_edit=_bool(
+            timeline.get("obligation_before_first_source_edit"), False
+        ),
+        valid_plan_ms=timeline.get("valid_plan_ms"),  # type: ignore[arg-type]
+        first_obligation_ms=timeline.get("first_obligation_ms"),  # type: ignore[arg-type]
+        first_source_edit_ms=timeline.get("first_source_edit_ms"),  # type: ignore[arg-type]
+        terminal_review_only=_bool(timeline.get("terminal_review_only"), False),
+    )
+
+    attributions_raw = timeline.get("attributions")
+    attributions: list[AttributionRecord] = (
+        list(attributions_raw) if type(attributions_raw) is list else []
+    )
+    work_product, material, rechecked = classify_work_product_influence(attributions)
+
+    # Registration / list-only never demonstrates influence.
+    if activation in {"none", "tools_listed", "registered_only"}:
+        work_product = "not_demonstrated"
+        material = 0
+        rechecked = 0
+
+    honesty: HonestyInfluence = (
+        "yes" if _bool(timeline.get("receipt_wording_changed_for_honesty"), False) else "no"
+    )
+
+    seeded = _bool(timeline.get("seeded_defect_seeded"), False)
+    outcome, miss = classify_miss(
+        seeded=seeded,
+        defect_in_case=timeline.get("seeded_defect_in_case"),  # type: ignore[arg-type]
+        finding_present=timeline.get("seeded_defect_finding_present"),  # type: ignore[arg-type]
+        agent_acted=timeline.get("seeded_defect_agent_acted"),  # type: ignore[arg-type]
+    )
+    if miss is not None and miss not in MISS_CLASSES:
+        miss = None
+
+    # Stream A: operational honesty of completed session ops. Registration/list alone is not session use.
+    ops_ok = _bool(timeline.get("ops_completed_honestly"), False)
+    if activation in {"none", "tools_listed", "registered_only"}:
+        stream_a: StreamScore = "not_demonstrated"
+    else:
+        stream_a = "pass" if ops_ok else "fail"
+
+    # Stream B: early publication gate is the primary offline lock.
+    if gate == "failed":
+        stream_b: StreamScore = "fail"
+    elif gate == "passed":
+        retries = _nonneg_int(timeline.get("identical_structural_retries"), 0)
+        stream_b = "fail" if retries > 3 else "pass"
+    else:
+        stream_b = "not_tested"
+
+    # Stream D: demonstrated only with attribution; honesty alone never promotes D.
+    if work_product == "demonstrated":
+        stream_d: StreamScore = "pass"
+    else:
+        stream_d = "not_demonstrated"
+
+    prose = timeline.get("final_prose")
+    final_prose = prose if type(prose) is str else ""
+    forbidden = forbidden_summary_violation(
+        work_product_influence=work_product,
+        final_prose=final_prose,
+    )
+
+    control = cast(
+        Literal["run", "not_run"],
+        _token(timeline.get("control_run"), frozenset({"run", "not_run"}), "not_run"),
+    )
+
+    return InfluenceReport(
+        activation=activation,
+        is_activation=is_activation,
+        experiment_profile=experiment_profile,
+        stream_a=stream_a,
+        stream_b=stream_b,
+        stream_c=stream_c,
+        stream_d=stream_d,
+        authoring_early_publication_gate=gate,
+        plan_and_obligation_before_first_source_edit=plan_and_obligation_before,
+        work_product_influence=work_product,
+        honesty_influence=honesty,
+        seeded_defect_outcome=outcome,
+        seeded_defect_miss_class=miss,
+        material_revisions_attributable_to_yoetz=material,
+        material_revisions_rechecked=rechecked,
+        semantic_scoring_eligible=eligible,
+        forbidden_summary_violation=forbidden,
+        control_run=control,
+    )

--- a/tests/unit/dogfood/influence_report.py
+++ b/tests/unit/dogfood/influence_report.py
@@ -390,11 +390,16 @@ def classify_influence_report(timeline: InfluenceTimeline) -> InfluenceReport:
         stream_a = "pass" if ops_ok else "fail"
 
     # Stream B: early publication gate is the primary offline lock.
+    # Identical structural retries are a UX failure signal even when the early-publication
+    # gate is not_applicable (terminal-review-only design per runbook §2 Stream B / §3.4).
+    retries = _nonneg_int(timeline.get("identical_structural_retries"), 0)
     if gate == "failed":
         stream_b: StreamScore = "fail"
     elif gate == "passed":
-        retries = _nonneg_int(timeline.get("identical_structural_retries"), 0)
         stream_b = "fail" if retries > 3 else "pass"
+    elif retries > 3:
+        # not_applicable (or other non-pass/fail gate): still fail on retry thrash.
+        stream_b = "fail"
     else:
         stream_b = "not_tested"
 

--- a/tests/unit/dogfood/test_influence_report_rules.py
+++ b/tests/unit/dogfood/test_influence_report_rules.py
@@ -1,0 +1,274 @@
+"""Offline classification locks for the influence dogfood protocol (issue #133).
+
+No live Codex, no network. Synthetic timeline dicts only. Validator is test-local
+(``tests.unit.dogfood.influence_report``), not product runtime.
+"""
+
+from __future__ import annotations
+
+from tests.unit.dogfood.influence_report import (
+    AttributionRecord,
+    InfluenceTimeline,
+    classify_influence_report,
+)
+
+
+def test_healthy_zero_findings_honesty_only_not_demonstrated_influence() -> None:
+    """Healthy service + zero findings + honesty-only wording + no revision → D not demonstrated."""
+
+    timeline: InfluenceTimeline = {
+        "activation": "session_ops",
+        "experiment_profile": "strict",
+        "semantic_status": "blocked_by_policy",
+        "semantic_provenance_present": False,
+        "ops_completed_honestly": True,
+        "plan_before_first_source_edit": True,
+        "obligation_before_first_source_edit": True,
+        "valid_plan_ms": 100,
+        "first_obligation_ms": 200,
+        "first_source_edit_ms": 1000,
+        "findings_deterministic": 0,
+        "findings_semantic": 0,
+        "attributions": [],
+        "receipt_wording_changed_for_honesty": True,
+        "seeded_defect_seeded": False,
+        "final_prose": (
+            "Service completed ops honestly; receipt conclusion matched weakest coverage. "
+            "No material work revision occurred."
+        ),
+        "control_run": "not_run",
+    }
+    report = classify_influence_report(timeline)
+    assert report["stream_a"] == "pass"
+    assert report["stream_d"] == "not_demonstrated"
+    assert report["work_product_influence"] == "not_demonstrated"
+    assert report["honesty_influence"] == "yes"
+    assert report["forbidden_summary_violation"] is False
+
+    # Claiming improvement without demonstration violates the forbidden-summary rule.
+    bad: InfluenceTimeline = {
+        **timeline,
+        "final_prose": "Yoetz improved the agent despite zero findings.",
+    }
+    bad_report = classify_influence_report(bad)
+    assert bad_report["work_product_influence"] == "not_demonstrated"
+    assert bad_report["forbidden_summary_violation"] is True
+
+
+def test_registration_only_is_not_activation_or_influence() -> None:
+    timeline: InfluenceTimeline = {
+        "activation": "registered_only",
+        "experiment_profile": "strict",
+        "ops_completed_honestly": False,
+        "attributions": [
+            {
+                "yoetz_output_ref": "finding-should-not-count",
+                "bounded_action_after": "source_revision",
+                "recheck_result": "passed",
+                "counterfactual": "uncertain",
+            }
+        ],
+        "final_prose": "MCP registered; tools listed.",
+    }
+    report = classify_influence_report(timeline)
+    assert report["is_activation"] is False
+    assert report["activation"] == "registered_only"
+    assert report["work_product_influence"] == "not_demonstrated"
+    assert report["stream_d"] == "not_demonstrated"
+    assert report["material_revisions_attributable_to_yoetz"] == 0
+
+
+def test_tools_list_only_is_not_activation() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "tools_listed",
+            "experiment_profile": "policy",
+            "final_prose": "tools/list returned six tools",
+        }
+    )
+    assert report["is_activation"] is False
+    assert report["stream_d"] == "not_demonstrated"
+    assert report["stream_a"] == "not_demonstrated"
+
+
+def test_strict_route_semantic_blocked_is_not_tested_not_fail() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "semantic_status": "blocked_by_policy",
+            "semantic_provenance_present": False,
+            "ops_completed_honestly": True,
+            "findings_semantic": 0,
+            "final_prose": "semantic_status=blocked_by_policy; usefulness not tested",
+        }
+    )
+    assert report["stream_c"] == "not_tested"
+    assert report["semantic_scoring_eligible"] is False
+    assert report["stream_c"] != "fail"
+
+
+def test_plan_after_first_edit_fails_early_publication_gate() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "plan_before_first_source_edit": False,
+            "obligation_before_first_source_edit": False,
+            "first_source_edit_ms": 100,
+            "valid_plan_ms": 500,
+            "first_obligation_ms": 600,
+            "final_prose": "plan published after first source edit",
+        }
+    )
+    assert report["authoring_early_publication_gate"] == "failed"
+    assert report["plan_and_obligation_before_first_source_edit"] is False
+    assert report["stream_b"] == "fail"
+
+
+def test_finding_revision_recheck_demonstrates_influence() -> None:
+    attribution: AttributionRecord = {
+        "yoetz_output_ref": "finding_det_1",
+        "agent_decision_before": "no_revision_planned",
+        "bounded_action_after": "source_revision",
+        "new_evidence_ref": "sha256:" + ("a" * 64),
+        "counterfactual": "uncertain",
+        "recheck_result": "passed",
+    }
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "policy",
+            "semantic_status": "succeeded",
+            "semantic_provenance_present": True,
+            "ops_completed_honestly": True,
+            "plan_before_first_source_edit": True,
+            "obligation_before_first_source_edit": True,
+            "valid_plan_ms": 50,
+            "first_obligation_ms": 80,
+            "first_source_edit_ms": 200,
+            "findings_deterministic": 1,
+            "findings_accepted": 1,
+            "attributions": [attribution],
+            "seeded_defect_seeded": True,
+            "seeded_defect_in_case": True,
+            "seeded_defect_finding_present": True,
+            "seeded_defect_agent_acted": True,
+            "final_prose": "Agent revised source after finding_det_1; recheck passed.",
+            "control_run": "run",
+        }
+    )
+    assert report["work_product_influence"] == "demonstrated"
+    assert report["stream_d"] == "pass"
+    assert report["material_revisions_attributable_to_yoetz"] == 1
+    assert report["material_revisions_rechecked"] == 1
+    assert report["seeded_defect_outcome"] == "remediated"
+    assert report["seeded_defect_miss_class"] is None
+    assert report["forbidden_summary_violation"] is False
+    assert report["stream_c"] == "pass"
+    assert report["semantic_scoring_eligible"] is True
+
+
+def test_seeded_defect_absent_from_case_is_case_construction_miss() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "seeded_defect_seeded": True,
+            "seeded_defect_in_case": False,
+            "seeded_defect_finding_present": False,
+            "seeded_defect_agent_acted": False,
+            "final_prose": "seeded defect never appeared in published case",
+        }
+    )
+    assert report["seeded_defect_outcome"] == "missed"
+    assert report["seeded_defect_miss_class"] == "case_construction_miss"
+
+
+def test_defect_in_case_no_finding_is_checker_or_reviewer_miss() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "policy",
+            "semantic_status": "succeeded",
+            "semantic_provenance_present": True,
+            "ops_completed_honestly": True,
+            "seeded_defect_seeded": True,
+            "seeded_defect_in_case": True,
+            "seeded_defect_finding_present": False,
+            "seeded_defect_agent_acted": False,
+            "final_prose": "defect present; no finding",
+        }
+    )
+    assert report["seeded_defect_outcome"] == "missed"
+    assert report["seeded_defect_miss_class"] == "checker_or_reviewer_miss"
+
+
+def test_finding_present_no_agent_action_is_agent_response_miss() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "findings_deterministic": 1,
+            "findings_ignored": 1,
+            "seeded_defect_seeded": True,
+            "seeded_defect_in_case": True,
+            "seeded_defect_finding_present": True,
+            "seeded_defect_agent_acted": False,
+            "attributions": [],
+            "final_prose": "valid finding; agent ignored it",
+        }
+    )
+    assert report["seeded_defect_outcome"] == "missed"
+    assert report["seeded_defect_miss_class"] == "agent_response_miss"
+    assert report["work_product_influence"] == "not_demonstrated"
+    assert report["stream_d"] == "not_demonstrated"
+
+
+def test_receipt_wording_change_only_is_honesty_influence_not_stream_d() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "plan_before_first_source_edit": True,
+            "obligation_before_first_source_edit": True,
+            "valid_plan_ms": 10,
+            "first_obligation_ms": 20,
+            "first_source_edit_ms": 100,
+            "receipt_wording_changed_for_honesty": True,
+            "attributions": [
+                {
+                    "yoetz_output_ref": "receipt_1",
+                    "agent_decision_before": "overclaimed_coverage",
+                    "bounded_action_after": "receipt_wording_only",
+                    "recheck_result": "not_applicable",
+                    "counterfactual": "no",
+                }
+            ],
+            "final_prose": "Receipt wording adjusted for honesty; work product unchanged.",
+        }
+    )
+    assert report["honesty_influence"] == "yes"
+    assert report["work_product_influence"] == "not_demonstrated"
+    assert report["stream_d"] == "not_demonstrated"
+    assert report["material_revisions_attributable_to_yoetz"] == 0
+    assert report["forbidden_summary_violation"] is False
+
+
+def test_policy_failed_semantic_is_indeterminate_not_poor_quality() -> None:
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "policy",
+            "semantic_status": "failed",
+            "semantic_provenance_present": True,
+            "ops_completed_honestly": True,
+            "final_prose": "semantic attempt indeterminate",
+        }
+    )
+    assert report["stream_c"] == "indeterminate"
+    assert report["semantic_scoring_eligible"] is False

--- a/tests/unit/dogfood/test_influence_report_rules.py
+++ b/tests/unit/dogfood/test_influence_report_rules.py
@@ -127,6 +127,40 @@ def test_plan_after_first_edit_fails_early_publication_gate() -> None:
     assert report["stream_b"] == "fail"
 
 
+def test_terminal_review_only_not_applicable_gate_is_not_tested_without_retry_thrash() -> None:
+    """Terminal-review-only: gate N/A; Stream B stays not_tested when retries are low."""
+
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "terminal_review_only": True,
+            "identical_structural_retries": 2,
+            "final_prose": "terminal-review-only; early gate not applicable",
+        }
+    )
+    assert report["authoring_early_publication_gate"] == "not_applicable"
+    assert report["stream_b"] == "not_tested"
+
+
+def test_terminal_review_only_not_applicable_gate_fails_on_identical_retry_thrash() -> None:
+    """Terminal-review-only still fails Stream B when identical structural retries > 3."""
+
+    report = classify_influence_report(
+        {
+            "activation": "session_ops",
+            "experiment_profile": "strict",
+            "ops_completed_honestly": True,
+            "terminal_review_only": True,
+            "identical_structural_retries": 4,
+            "final_prose": "terminal-review-only but agent thrashed on structural rejects",
+        }
+    )
+    assert report["authoring_early_publication_gate"] == "not_applicable"
+    assert report["stream_b"] == "fail"
+
+
 def test_finding_revision_recheck_demonstrates_influence() -> None:
     attribution: AttributionRecord = {
         "yoetz_output_ref": "finding_det_1",


### PR DESCRIPTION
## Summary

Docs/test-only influence dogfood protocol for measuring Yoetz-to-agent intervention (#133).

**What:** Adds a runbook that scores operational health, authoring UX, semantic quality, and work-product influence as four non-conflated streams, with a miss taxonomy, early-publication gate, strict Stream C `not_tested` handling, and a forbidden-summary rule so zero influence cannot be sold as improvement. Offline unit tests lock classification on synthetic timelines. Cross-links from semantic dogfood and Codex integration; changelog entry.

**Why:** We need a disciplined way to measure whether Yoetz actually changes agent work product without conflating it with ops health or UX. This is protocol/runbook + tests only — no runtime or protocol surface change.

**Plan / issue:** https://github.com/TheGaySupreme123/yoetz/issues/133

## Test plan

- [x] `uv run pytest tests/unit/dogfood/ -q` → 11 passed
- [x] `uv run ruff check tests/unit/dogfood/` → clean
- [x] `npx --no-install pyright tests/unit/dogfood/` → 0 errors

Fixes #133

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a docs/test-only protocol for measuring Yoetz-to-agent work-product influence as four independently scored streams (operational health, authoring UX, semantic quality, and agent influence), with offline unit tests that lock the classification rules.

- **New runbook** (`docs/runbooks/influence-dogfood.md`): defines causal attribution records, a miss taxonomy, an early-publication gate, strict Stream C `not_tested` handling for strict-route runs, and a forbidden-summary check to prevent zero-influence sessions from being reported as improvements.
- **New classifier** (`tests/unit/dogfood/influence_report.py`) and **11 unit tests** (`test_influence_report_rules.py`): lock each classification rule offline using synthetic timeline dicts; no live network or runtime surface change.
- **Cross-links** added to `codex-integration.md`, `semantic-dogfood.md`, `docs/README.md`, and `CHANGELOG.md`; no protocol, privacy, storage, or MCP surface changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no runtime, protocol, or MCP surface changes; the classifier logic gap affects only offline evaluation reports.

The Stream B classifier unconditionally returns `not_tested` for terminal-review-only sessions without inspecting `identical_structural_retries`, which the runbook treats as an always-active UX failure signal. A session with excessive structural retries under that code path would be misclassified, producing a silently incorrect dogfood report. This defect is confined to test-local evaluation code with no runtime impact.

**Files Needing Attention:** tests/unit/dogfood/influence_report.py — Stream B classification branch for the `not_applicable` gate case, and the forbidden-phrase coverage in `_FORBIDDEN_IMPROVEMENT_PHRASES`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/unit/dogfood/influence_report.py | New 439-line classification engine for the influence dogfood protocol; contains a logic gap where Stream B structural-retry check is skipped for terminal-review-only (`not_applicable`) gate runs, and a narrow forbidden-phrase list that can be bypassed by paraphrasing. |
| tests/unit/dogfood/test_influence_report_rules.py | 11 offline classification tests covering activation, registration, strict-route Stream C, early-publication gate, influence attribution, miss taxonomy, and honesty vs. work-product influence; the terminal-review-only (not_applicable gate) + retries path is untested. |
| docs/runbooks/influence-dogfood.md | New 311-line runbook defining four non-conflated evidence streams, causal attribution records, miss taxonomy, early-publication gate, and forbidden-summary rule; well-structured and internally consistent with the Python classifier. |
| tests/unit/dogfood/__init__.py | Minimal package init with a clarifying docstring; no logic. |
| CHANGELOG.md | Changelog entry accurately describes the scope of the influence dogfood protocol addition (docs/test-only, no runtime change). |
| docs/README.md | One-line update adding "influence dogfood" to the runbooks list description; correct. |
| docs/runbooks/codex-integration.md | Three-line cross-link addition pointing readers to the influence dogfood runbook; accurate and non-breaking. |
| docs/runbooks/semantic-dogfood.md | Updated the "influence measurement is out of scope" note to link to the new runbook; correct and complete. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InfluenceTimeline input] --> B{activation?}
    B -- none / tools_listed / registered_only --> C[stream_a = not_demonstrated\nwork_product = not_demonstrated]
    B -- session_ops --> D[stream_a = pass/fail\nbased on ops_completed_honestly]

    A --> E{experiment_profile?}
    E -- strict --> F[stream_c = not_tested\nsemantic_scoring_eligible = false]
    E -- policy --> G{semantic_status?}
    G -- blocked / not_configured\n/ not_applicable --> F
    G -- failed --> H[stream_c = indeterminate]
    G -- succeeded / refused / unavailable --> I{semantic_provenance_present?}
    I -- false --> F
    I -- true --> J[stream_c = pass]

    A --> K[classify_early_publication_gate]
    K --> L{gate result?}
    L -- failed --> M[stream_b = fail]
    L -- passed --> N{retries > 3?}
    N -- yes --> O[stream_b = fail]
    N -- no --> P[stream_b = pass]
    L -- not_applicable --> Q[stream_b = not_tested — retries NOT checked]

    A --> R[classify_work_product_influence]
    R --> S{material revisions > 0?}
    S -- yes --> T[stream_d = pass]
    S -- no --> U[stream_d = not_demonstrated]
    U --> W{forbidden phrase in prose?}
    W -- yes --> X[forbidden_summary_violation = true]
    W -- no --> Y[forbidden_summary_violation = false]
```

<sub>Reviews (2): Last reviewed commit: ["docs(test): influence dogfood protocol f..."](https://github.com/thegaysupreme123/yoetz/commit/f635764a1b98866bd02d78e4b97fc3ef013795ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22879741)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->