### PR TITLE
fix: re-open the vault after soft locks without a human prompt

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1328,6 +1328,11 @@ Passphrase startup with no scoped entry reports `passphrase_required`; a validly
 does not authenticate the current envelope reports `auto_unlock_stale`; structural platform access
 or entry failures use the two other `auto_unlock_*` reasons. None reveals entry bytes, paths, or
 credential/policy state.
+After a soft lock (`idle_relock`, `user_session_locked`, `system_suspend`, `monitor_lost`), the
+service may re-read the same scoped entry (or retry OS keyring) once before denying ordinary
+control with `vault_locked`. `explicit_lock` and hard `auto_unlock_*` / `passphrase_required`
+reasons do not take that path. The trusted unlock helper may submit the scoped entry through the
+confidential unlock ceremony without a TTY prompt when the entry is present.
 `ServiceStatus.state_reason=human_authority_unavailable` has exactly two valid combinations:
 `state=locked,vault_mode=uninitialized` when pristine setup was blocked before keyring mutation,
 rendered as setup required; and `state=ready,vault_mode=os_keyring` for an existing vault whose

--- a/docs/adr/ADR-008-local-service-vault-trust-boundary.md
+++ b/docs/adr/ADR-008-local-service-vault-trust-boundary.md
@@ -86,6 +86,19 @@ remain locked and surface bounded `passphrase_required`,
 service logs one structural outcome/reason and never the entry, bundle path, or derived material.
 Foreign bundle entries are neither read nor deleted.
 
+**2026-08 soft-lock re-ready amendment.** The same trusted-service-only auto-unlock path may run
+again after a *soft* lock that cleared in-process keys but did not revoke the installation's
+scoped platform entry: `idle_relock`, `user_session_locked`, `system_suspend`, and `monitor_lost`.
+On the next ordinary control admission while still locked for one of those reasons, the service
+attempts one scoped passphrase load (or OS-keyring retry) and, on success, rebuilds the ready
+generation. This keeps MCP/CLI usable after idle or session soft locks without a human prompt when
+setup already provisioned auto-unlock. It does **not** unlock after `explicit_lock`, does not run
+for hard reasons (`passphrase_required`, `auto_unlock_*`, `vault_uninitialized`, `unlock_failed`,
+`keyring_locked` when the backend will not load), and never accepts a secret from MCP, ordinary
+control, argv, env, config, or stdin. The trusted foreground helper may also submit the scoped
+entry through the existing unlock ceremony so `yoetz service unlock` stays silent when that entry
+is valid.
+
 For an existing human-passphrase vault, `service auto-unlock enable|repair` requires the ordinary
 trusted foreground-TTY unlock ceremony first. Only the exact passphrase that successfully unlocks
 the current envelope is then saved under the scoped platform entry, and every mutable helper buffer
@@ -308,7 +321,10 @@ vault before first release is the one materially stronger containment choice sti
   admitted shielded database commits reach a definite bounded outcome, closes provider and
   decrypted-state handles, and returns to `locked`. MCP does not expose this method.
 - An advertised platform session-lock or system-suspend event takes the same path. Wake or user
-  session unlock never changes the service to `ready`; the human/keyring ceremony runs again.
+  session unlock never itself flips the service to `ready`. After those soft locks (and idle
+  relock), the service may re-apply the scoped auto-unlock or OS-keyring load on the next ordinary
+  control admission, or the human may run the unlock ceremony; explicit lock still requires the
+  human/keyring ceremony.
 - Idle relock is enabled by default only when there are no connected clients, in-flight requests,
   queued commits, leases, or provider calls for the complete configured interval. It never counts
   a long-running operation as idle. The default is 900 seconds. The only v0.1 mutation path is a
@@ -324,9 +340,10 @@ vault before first release is the one materially stronger containment choice sti
   bound to the exact proposed policy digest and expiry. MCP/LLMs may request more context but
   cannot mint or relay that proof.
 - If the service is absent, normal CLI reports `service_unavailable` and MCP returns a sanitized
-  structured unavailability result; neither starts a hidden runtime. If it is locked, both report
-  `vault_locked` and direct the local human to the separate unlock surface without accepting a
-  secret.
+  structured unavailability result; neither starts a hidden runtime. If it is soft-locked and
+  scoped auto-unlock (or keyring load) succeeds, ordinary methods proceed without a human prompt.
+  If it remains hard-locked, both report `vault_locked` and direct the local human to the separate
+  unlock surface without accepting a secret.
 
 ## Consequences
 
@@ -334,7 +351,8 @@ Persistent local service, control protocol, client library, vault state machine,
 and their crash/secret-boundary tests move into v0.1. Native launchd/systemd-user convenience and a
 generic passphrase transport remain separate future decisions; neither may be approximated by
 client-side direct access or a secret in argv/env/config/stdin. The reviewed bundle-scoped platform
-auto-unlock exception above is the only passphrase restart path.
+auto-unlock exception above is the only passphrase path that may open the vault without a human
+ceremony (restart and soft-lock re-ready).
 The v0.1 helper also owns the explicit first-install passphrase initialization ceremony: two local
 no-echo entries, one transmitted `vault_initialize` secret, atomic vault commit, and fail-closed
 crash recovery.

--- a/docs/adr/ADR-008-local-service-vault-trust-boundary.md
+++ b/docs/adr/ADR-008-local-service-vault-trust-boundary.md
@@ -352,7 +352,7 @@ and their crash/secret-boundary tests move into v0.1. Native launchd/systemd-use
 generic passphrase transport remain separate future decisions; neither may be approximated by
 client-side direct access or a secret in argv/env/config/stdin. The reviewed bundle-scoped platform
 auto-unlock exception above is the only passphrase path that may open the vault without a human
-ceremony (restart and soft-lock re-ready).
+ceremony (restart, soft-lock re-ready, and the trusted helper's silent `service unlock`).
 The v0.1 helper also owns the explicit first-install passphrase initialization ceremony: two local
 no-echo entries, one transmitted `vault_initialize` secret, atomic vault commit, and fail-closed
 crash recovery.

--- a/docs/protocol/local-service-security.md
+++ b/docs/protocol/local-service-security.md
@@ -160,9 +160,9 @@ policy — it is not a logging or support-bundle mode that exists today.
 |---|---|---|---|
 | Fresh install stays locked with setup required | `human_authority_unavailable` | Keyring works but presence evidence is missing/stale/unavailable | Not keyring corruption; not a bug |
 | Existing vault reachable without presence prompt | (no error — `ready`, activation fenced) | Existing keyring data may load for local work | Not full external authority |
-| Vault locked after restart | (expected) | No valid scoped auto-unlock entry was available; keyring mode retries automatically | MCP cannot unlock it for you |
+| Vault locked after restart | (expected) | No valid scoped auto-unlock entry was available; keyring mode loads at restart when usable | MCP cannot unlock it for you |
 | Idle-relocked mid-session | (expected) | Default 900s idle timer elapsed with no active work; next ordinary call re-applies scoped auto-unlock when provisioned | Not a crash; not a permanent lock when auto-unlock is healthy |
-| Hard-locked after soft lock | `passphrase_required` / `auto_unlock_*` / `explicit_lock` | Auto-unlock missing, stale, or human locked the service | Run `yoetz service unlock` or `yoetz service auto-unlock repair` on a local terminal |
+| Hard-locked after soft lock | `passphrase_required` / `auto_unlock_*` / `keyring_locked` / `explicit_lock` | Auto-unlock missing, stale, keyring load refused, or human locked the service | Run `yoetz service unlock` or `yoetz service auto-unlock repair` on a local terminal |
 
 Troubleshooting always uses these bounded reason codes — never a raw file path, account name, or
 internal exception string.

--- a/docs/protocol/local-service-security.md
+++ b/docs/protocol/local-service-security.md
@@ -87,8 +87,11 @@ The service relocks on an explicit `service lock`, an advertised platform sessio
 system-suspend event, and on idle timeout. The default idle-relock interval is 900 seconds and
 applies only when there are no connected clients, in-flight requests, queued commits, leases, or
 provider calls for the complete interval — a long-running operation is never counted as idle. Wake
-or session unlock never itself changes the service back to `ready`; the human/keyring ceremony runs
-again.
+or session unlock never itself changes the service back to `ready`. After idle, session-lock,
+suspend, or monitor-loss soft locks, the trusted service may re-apply the same scoped platform
+auto-unlock entry (passphrase mode) or OS-keyring load that restart uses, on the next ordinary
+control admission. Explicit `service lock` and hard unlock failures still require the human/keyring
+ceremony (`yoetz service unlock`), which prefers the scoped platform entry when provisioned.
 
 The **only** way to change the idle interval (to 60–86400 seconds) or disable it entirely is an
 exact, foreground `idle_relock_policy_change` ceremony over the human-control channel, followed by
@@ -158,7 +161,8 @@ policy — it is not a logging or support-bundle mode that exists today.
 | Fresh install stays locked with setup required | `human_authority_unavailable` | Keyring works but presence evidence is missing/stale/unavailable | Not keyring corruption; not a bug |
 | Existing vault reachable without presence prompt | (no error — `ready`, activation fenced) | Existing keyring data may load for local work | Not full external authority |
 | Vault locked after restart | (expected) | No valid scoped auto-unlock entry was available; keyring mode retries automatically | MCP cannot unlock it for you |
-| Idle-relocked mid-session | (expected) | Default 900s idle timer elapsed with no active work | Not a crash |
+| Idle-relocked mid-session | (expected) | Default 900s idle timer elapsed with no active work; next ordinary call re-applies scoped auto-unlock when provisioned | Not a crash; not a permanent lock when auto-unlock is healthy |
+| Hard-locked after soft lock | `passphrase_required` / `auto_unlock_*` / `explicit_lock` | Auto-unlock missing, stale, or human locked the service | Run `yoetz service unlock` or `yoetz service auto-unlock repair` on a local terminal |
 
 Troubleshooting always uses these bounded reason codes — never a raw file path, account name, or
 internal exception string.

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -250,9 +250,11 @@ def _control_failure(error: ControlError) -> int:
     code = public_error_code_for_control_reason(error.reason)
     guidance = {
         PublicErrorCode.VAULT_LOCKED: (
-            "vault_locked: unlock from a local terminal "
-            "(`yoetz service unlock`); if uninitialized with no TTY, "
-            "prepare `vault_initialize`, then run `yoetz consent review` on a trusted console"
+            "vault_locked: run `yoetz service unlock` on a local terminal "
+            "(uses the platform credential store when setup provisioned auto-unlock); "
+            "if auto-unlock is stale, run `yoetz service auto-unlock repair`; "
+            "if uninitialized with no TTY, prepare `vault_initialize`, then "
+            "`yoetz consent review` on a trusted console"
         ),
         PublicErrorCode.SERVICE_UNAVAILABLE: (
             "service_unavailable: run 'yoetz service run' under your selected user supervisor"

--- a/src/yoetz/cli/menu.py
+++ b/src/yoetz/cli/menu.py
@@ -51,7 +51,8 @@ def _control_guidance(error: ControlError) -> str:
     return {
         PublicErrorCode.VAULT_LOCKED: (
             "vault_locked: unlock from this menu (Service -> Unlock vault) "
-            "or run 'yoetz service unlock'"
+            "or run 'yoetz service unlock' "
+            "(uses the platform credential store when auto-unlock is provisioned)"
         ),
         PublicErrorCode.SERVICE_UNAVAILABLE: (
             "service_unavailable: run 'yoetz service run' under your selected user supervisor"

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -908,8 +908,30 @@ def _load_scoped_auto_unlock_passphrase() -> bytearray | None:
     from yoetz.config.load import load_config
     from yoetz.config.paths import bundle_root
 
-    config = load_config({}, os.environ, None)
-    return AutoUnlockPassphraseStore(bundle_root(_data_dir=config.storage.data_dir)).load()
+    try:
+        config = load_config({}, os.environ, None)
+        return AutoUnlockPassphraseStore(bundle_root(_data_dir=config.storage.data_dir)).load()
+    except Exception:
+        # Convenience path must never block the interactive unlock ceremony.
+        return None
+
+
+async def _service_reports_unusable_auto_unlock() -> bool:
+    """True when the daemon already knows the scoped entry cannot unlock this vault."""
+
+    try:
+        from yoetz.ports.control import ControlClientKind
+        from yoetz.service.client import connect_service
+
+        client = await connect_service(ControlClientKind.CLI)
+        try:
+            status = await client.service_status()
+        finally:
+            await client.close()
+    except Exception:
+        return False
+    reason = getattr(status, "state_reason", None)
+    return reason in {"auto_unlock_stale", "auto_unlock_rejected"}
 
 
 async def unlock_vault(passphrase: bytearray | None = None) -> VaultStateResult:
@@ -928,21 +950,22 @@ async def unlock_vault(passphrase: bytearray | None = None) -> VaultStateResult:
             passphrase=passphrase,
         )
         return cast(VaultStateResult, result)
-    stored = _load_scoped_auto_unlock_passphrase()
-    if stored is not None:
-        try:
-            result = cast(
-                VaultStateResult,
-                await run_human_ceremony(
-                    HumanCeremonyKind.VAULT_UNLOCK,
-                    target,
-                    passphrase=stored,
-                ),
-            )
-            if getattr(result, "state", None) == "ready":
-                return result
-        except HumanCeremonyCliError:
-            pass
+    if not await _service_reports_unusable_auto_unlock():
+        stored = _load_scoped_auto_unlock_passphrase()
+        if stored is not None:
+            try:
+                result = cast(
+                    VaultStateResult,
+                    await run_human_ceremony(
+                        HumanCeremonyKind.VAULT_UNLOCK,
+                        target,
+                        passphrase=stored,
+                    ),
+                )
+                if getattr(result, "state", None) == "ready":
+                    return result
+            except HumanCeremonyCliError:
+                pass
     result = await run_human_ceremony(HumanCeremonyKind.VAULT_UNLOCK, target)
     return cast(VaultStateResult, result)
 

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -899,12 +899,51 @@ async def initialize_passphrase_vault(passphrase: bytearray | None = None) -> Va
     return cast(VaultStateResult, result)
 
 
+def _load_scoped_auto_unlock_passphrase() -> bytearray | None:
+    """Load the bundle-scoped platform entry when present; never invent a secret."""
+
+    import os
+
+    from yoetz.adapters.keys.os_keyring import AutoUnlockPassphraseStore
+    from yoetz.config.load import load_config
+    from yoetz.config.paths import bundle_root
+
+    config = load_config({}, os.environ, None)
+    return AutoUnlockPassphraseStore(bundle_root(_data_dir=config.storage.data_dir)).load()
+
+
 async def unlock_vault(passphrase: bytearray | None = None) -> VaultStateResult:
-    result = await run_human_ceremony(
-        HumanCeremonyKind.VAULT_UNLOCK,
-        EmptyVaultTarget(expected_mode="passphrase"),
-        passphrase=passphrase,
-    )
+    """Unlock the passphrase vault, preferring the scoped platform entry when available.
+
+    Setup often provisions a generated passphrase the human never types. When that entry
+    is present, submit it through the ordinary confidential ceremony with no TTY prompt.
+    Only fall back to interactive entry when no usable entry exists or silent unlock fails.
+    """
+
+    target = EmptyVaultTarget(expected_mode="passphrase")
+    if passphrase is not None:
+        result = await run_human_ceremony(
+            HumanCeremonyKind.VAULT_UNLOCK,
+            target,
+            passphrase=passphrase,
+        )
+        return cast(VaultStateResult, result)
+    stored = _load_scoped_auto_unlock_passphrase()
+    if stored is not None:
+        try:
+            result = cast(
+                VaultStateResult,
+                await run_human_ceremony(
+                    HumanCeremonyKind.VAULT_UNLOCK,
+                    target,
+                    passphrase=stored,
+                ),
+            )
+            if getattr(result, "state", None) == "ready":
+                return result
+        except HumanCeremonyCliError:
+            pass
+    result = await run_human_ceremony(HumanCeremonyKind.VAULT_UNLOCK, target)
     return cast(VaultStateResult, result)
 
 

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -323,10 +323,13 @@ def _control_error_result(
         return structured_error_result(
             PublicErrorCode.VAULT_LOCKED,
             (
-                "The local service vault is locked or uninitialized. Unlock from a local "
-                "terminal (`yoetz service unlock`). If the vault is still uninitialized and no "
-                "user-owned TTY is available, prepare `vault_initialize` via "
-                "`yoetz consent catalog` / `prepare` (ADR-015); never send secrets over MCP."
+                "The local service vault is locked or uninitialized. After trusted setup with "
+                "platform auto-unlock, soft locks (idle/session) re-open automatically; this "
+                "error means a hard lock or missing setup. On a local terminal run "
+                "`yoetz service unlock` (uses the platform credential store when provisioned) "
+                "or `yoetz service auto-unlock repair` if that entry is stale. If still "
+                "uninitialized, run `yoetz setup` or prepare `vault_initialize` via "
+                "`yoetz consent catalog` / `prepare` (ADR-015). Never send secrets over MCP."
             ),
             request_id=request_id,
             correlation_id=service_correlation_id,

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -777,14 +777,7 @@ class ServiceDaemon:
             await self._close_ready_locked()
             self._state_reason = (
                 reason
-                if reason
-                in {
-                    "explicit_lock",
-                    "idle_relock",
-                    "user_session_locked",
-                    "system_suspend",
-                    "monitor_lost",
-                }
+                if reason in _SOFT_LOCK_AUTO_READY_REASONS or reason == "explicit_lock"
                 else "explicit_lock"
             )
 
@@ -1314,8 +1307,9 @@ class ServiceDaemon:
                     reason="unlock_failed",
                 )
                 try:
-                    if vault.ready:
-                        await vault.lock()
+                    # Always best-effort lock: unlock may have left transient store state
+                    # even when ready is still false.
+                    await vault.lock()
                 except Exception:
                     pass
                 await self._return_to_locked_after_soft_unlock()
@@ -1347,17 +1341,15 @@ class ServiceDaemon:
             self._state_reason = "auto_unlock_backend_unavailable"
             self._auto_unlock_reason = "auto_unlock_backend_unavailable"
             return False
-        auto_passphrase, load_reason = AutoUnlockPassphraseStore(bundle).load_with_reason()
+
+        def _load_scoped_entry() -> tuple[bytearray | None, str]:
+            return AutoUnlockPassphraseStore(bundle).load_with_reason()
+
+        auto_passphrase, load_reason = await asyncio.to_thread(_load_scoped_entry)
         if auto_passphrase is None:
             reason = (
-                "passphrase_required"
-                if load_reason == "auto_unlock_absent"
-                else load_reason
-                if load_reason
-                in {
-                    "auto_unlock_backend_unavailable",
-                    "auto_unlock_rejected",
-                }
+                load_reason
+                if load_reason in {"auto_unlock_backend_unavailable", "auto_unlock_rejected"}
                 else "passphrase_required"
             )
             self._state_reason = reason

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -175,6 +175,16 @@ _CONTROL_HANDSHAKE_DEADLINE_SECONDS: Final = 5.0
 # After handshake, a session with no active calls may stay silent for at most this long
 # before the stream is closed and the listener admission slot is released.
 _CONTROL_INACTIVE_SESSION_DEADLINE_SECONDS: Final = 300.0
+# Soft locks may re-apply the same scoped auto-unlock / keyring load the service already uses at
+# restart. Explicit human lock and hard unlock failures stay locked until a trusted ceremony.
+_SOFT_LOCK_AUTO_READY_REASONS: Final = frozenset(
+    {
+        "idle_relock",
+        "user_session_locked",
+        "system_suspend",
+        "monitor_lost",
+    }
+)
 # Response-frame send must complete within this wall-clock window. A stalled peer that stops
 # reading cannot retain an in-flight entry in ``calls`` (and thus the inactive-session exemption)
 # indefinitely via write backpressure on sock_sendall.
@@ -468,6 +478,7 @@ class ServiceComposition:
     ready_close_relay: _ReadyCloseRelay | None = None
     privacy_policy_app_relay: _PrivacyPolicyAppRelay | None = None
     auto_unlock_reason: str = "none"
+    auto_unlock_bundle: Path | None = None
 
     def __repr__(self) -> str:
         return "ServiceComposition(<redacted>)"
@@ -500,6 +511,9 @@ class ServiceDaemon:
         self._closed = False
         self._stopping = False
         self._state_reason = "none"
+        # Composition is frozen; keep the live auto-unlock reason on the daemon so soft-lock
+        # re-ready can update it without replacing the composition object.
+        self._auto_unlock_reason = _composition.auto_unlock_reason
         self._monitor_state = "unavailable"
         self._stop_event = asyncio.Event()
         self._start_lock = asyncio.Lock()
@@ -568,60 +582,68 @@ class ServiceDaemon:
     ) -> None:
         """Construct and publish one generation-bound ready application."""
 
-        partial: _ReadyApplication | None = None
         async with self._activation_lock:
-            lifecycle = self._composition.lifecycle
-            try:
-                if (
-                    type(service_generation) is not int
-                    or type(vault_generation) is not int
-                    or service_generation <= 0
-                    or vault_generation <= 0
-                    or lifecycle.state is not ServiceState.UNLOCKING
-                    or lifecycle.instance.generation != service_generation
-                    or not self._composition.vault.ready
-                    or self._composition.vault.generation != vault_generation
-                    or self._application is not None
-                ):
-                    raise LifecycleError("invalid_transition")
-                factory = self._composition.ready_application_factory
-                if factory is None:
-                    raise LifecycleError("invalid_transition")
-                partial = await factory(service_generation, vault_generation)
-                if not _is_ready_application(partial):
-                    raise TypeError("ready_application_invalid")
-                if (
-                    lifecycle.state is not ServiceState.UNLOCKING
-                    or lifecycle.instance.generation != service_generation
-                    or not self._composition.vault.ready
-                    or self._composition.vault.generation != vault_generation
-                ):
-                    raise LifecycleError("invalid_transition")
-                self._application = partial
-                await lifecycle.transition(
-                    ServiceState.READY,
-                    vault_generation=vault_generation,
-                )
-                self._state_reason = "none"
-            except BaseException:
-                if self._application is partial:
-                    self._application = None
-                if partial is not None:
-                    try:
-                        await partial.close()
-                    except Exception:
-                        pass
+            await self._activate_ready_application_locked(service_generation, vault_generation)
+
+    async def _activate_ready_application_locked(
+        self, service_generation: int, vault_generation: int
+    ) -> None:
+        """Install ready composition while the caller already holds ``_activation_lock``."""
+
+        partial: _ReadyApplication | None = None
+        lifecycle = self._composition.lifecycle
+        try:
+            if (
+                type(service_generation) is not int
+                or type(vault_generation) is not int
+                or service_generation <= 0
+                or vault_generation <= 0
+                or lifecycle.state is not ServiceState.UNLOCKING
+                or lifecycle.instance.generation != service_generation
+                or not self._composition.vault.ready
+                or self._composition.vault.generation != vault_generation
+                or self._application is not None
+            ):
+                raise LifecycleError("invalid_transition")
+            factory = self._composition.ready_application_factory
+            if factory is None:
+                raise LifecycleError("invalid_transition")
+            partial = await factory(service_generation, vault_generation)
+            if not _is_ready_application(partial):
+                raise TypeError("ready_application_invalid")
+            if (
+                lifecycle.state is not ServiceState.UNLOCKING
+                or lifecycle.instance.generation != service_generation
+                or not self._composition.vault.ready
+                or self._composition.vault.generation != vault_generation
+            ):
+                raise LifecycleError("invalid_transition")
+            self._application = partial
+            await lifecycle.transition(
+                ServiceState.READY,
+                vault_generation=vault_generation,
+            )
+            self._state_reason = "none"
+            self._auto_unlock_reason = "none"
+        except BaseException:
+            if self._application is partial:
+                self._application = None
+            if partial is not None:
                 try:
-                    await self._composition.vault.lock()
+                    await partial.close()
                 except Exception:
                     pass
-                if lifecycle.state is ServiceState.UNLOCKING:
-                    try:
-                        await lifecycle.transition(ServiceState.LOCKED)
-                    except Exception:
-                        pass
-                self._state_reason = "unlock_failed"
-                raise
+            try:
+                await self._composition.vault.lock()
+            except Exception:
+                pass
+            if lifecycle.state is ServiceState.UNLOCKING:
+                try:
+                    await lifecycle.transition(ServiceState.LOCKED)
+                except Exception:
+                    pass
+            self._state_reason = "unlock_failed"
+            raise
 
     async def serve(self) -> None:
         """Serve authenticated ordinary and human-control clients in foreground."""
@@ -829,6 +851,9 @@ class ServiceDaemon:
         self, projection_context: ClientProjectionContext, request: ControlCallRequest
     ) -> object:
         application = self._application
+        if application is None:
+            if await self._try_soft_lock_auto_ready():
+                application = self._application
         if application is None:
             raise ControlError("vault_locked", retryable=True)
         admission: Admission | None = None
@@ -1230,11 +1255,155 @@ class ServiceDaemon:
             await self._close_ready_locked()
 
     async def _close_ready_locked(self) -> None:
+        # Lifecycle idle drain closes ready without calling ``daemon.lock``, so publish the
+        # soft-lock reason here when no stronger reason was already set.
+        if self._application is not None and self._state_reason == "none":
+            self._state_reason = "idle_relock"
         application, self._application = self._application, None
         if application is not None:
             await application.close()
         if self._composition.vault.ready:
             await self._composition.vault.lock()
+
+    async def _try_soft_lock_auto_ready(self) -> bool:
+        """Re-apply scoped auto-unlock after idle/session soft lock; never after explicit lock."""
+
+        if self._application is not None or not self._started or self._closed:
+            return self._application is not None
+        if self._state_reason not in _SOFT_LOCK_AUTO_READY_REASONS:
+            return False
+        lifecycle = self._composition.lifecycle
+        if lifecycle.state is not ServiceState.LOCKED:
+            return False
+        async with self._activation_lock:
+            if self._application is not None:
+                return True
+            if (
+                self._state_reason not in _SOFT_LOCK_AUTO_READY_REASONS
+                or lifecycle.state is not ServiceState.LOCKED
+            ):
+                return False
+            vault = self._composition.vault
+            mode = getattr(vault.mode, "value", vault.mode)
+            try:
+                await lifecycle.transition(ServiceState.UNLOCKING)
+            except LifecycleError:
+                return False
+            unlocked = False
+            try:
+                if mode == "passphrase":
+                    unlocked = await self._soft_unlock_passphrase_locked()
+                elif mode == "os_keyring":
+                    await cast(VaultService, vault).retry_keyring(None)
+                    unlocked = vault.ready
+                    if not unlocked:
+                        self._state_reason = "keyring_locked"
+                else:
+                    unlocked = False
+                if not unlocked:
+                    await self._return_to_locked_after_soft_unlock()
+                    return False
+                await self._activate_ready_application_locked(
+                    lifecycle.instance.generation,
+                    vault.generation,
+                )
+            except Exception:
+                get_logger("service.daemon").warning(
+                    "auto_unlock",
+                    outcome="failed",
+                    reason="unlock_failed",
+                )
+                try:
+                    if vault.ready:
+                        await vault.lock()
+                except Exception:
+                    pass
+                await self._return_to_locked_after_soft_unlock()
+                if (
+                    self._state_reason in _SOFT_LOCK_AUTO_READY_REASONS
+                    or self._state_reason == "none"
+                ):
+                    self._state_reason = "unlock_failed"
+                return False
+            return self._application is not None
+
+    async def _return_to_locked_after_soft_unlock(self) -> None:
+        """Best-effort LOCKED transition after a failed soft auto-ready attempt."""
+
+        lifecycle = self._composition.lifecycle
+        try:
+            if lifecycle.state is ServiceState.UNLOCKING:
+                await lifecycle.transition(ServiceState.LOCKED)
+        except LifecycleError:
+            pass
+
+    async def _soft_unlock_passphrase_locked(self) -> bool:
+        """Unlock passphrase vault from the bundle-scoped platform entry under activation lock."""
+
+        bundle = self._composition.auto_unlock_bundle
+        memory = self._composition.secret_memory
+        vault = cast(VaultService, self._composition.vault)
+        if bundle is None or memory is None or not hasattr(memory, "capture"):
+            self._state_reason = "auto_unlock_backend_unavailable"
+            self._auto_unlock_reason = "auto_unlock_backend_unavailable"
+            return False
+        auto_passphrase, load_reason = AutoUnlockPassphraseStore(bundle).load_with_reason()
+        if auto_passphrase is None:
+            reason = (
+                "passphrase_required"
+                if load_reason == "auto_unlock_absent"
+                else load_reason
+                if load_reason
+                in {
+                    "auto_unlock_backend_unavailable",
+                    "auto_unlock_rejected",
+                }
+                else "passphrase_required"
+            )
+            self._state_reason = reason
+            self._auto_unlock_reason = load_reason
+            get_logger("service.daemon").warning(
+                "auto_unlock",
+                outcome="skipped" if load_reason == "auto_unlock_absent" else "failed",
+                reason=load_reason,
+            )
+            return False
+        try:
+            handle = cast(LocalSecretMemory, memory).capture(
+                SecretPurpose.VAULT_UNLOCK, auto_passphrase
+            )
+            await vault.unlock(handle)
+        except VaultError:
+            self._state_reason = "auto_unlock_stale"
+            self._auto_unlock_reason = "auto_unlock_stale"
+            get_logger("service.daemon").warning(
+                "auto_unlock",
+                outcome="failed",
+                reason="auto_unlock_stale",
+            )
+            return False
+        except Exception:
+            self._state_reason = "auto_unlock_rejected"
+            self._auto_unlock_reason = "auto_unlock_rejected"
+            get_logger("service.daemon").warning(
+                "auto_unlock",
+                outcome="failed",
+                reason="auto_unlock_rejected",
+            )
+            return False
+        finally:
+            for index in range(len(auto_passphrase)):
+                auto_passphrase[index] = 0
+        if not vault.ready:
+            self._state_reason = "unlock_failed"
+            return False
+        self._auto_unlock_reason = "none"
+        get_logger("service.daemon").info(
+            "auto_unlock",
+            outcome="succeeded",
+            reason="soft_lock_reready",
+        )
+        return True
 
     async def _close_components(self) -> None:
         await self._close_ready()
@@ -1282,7 +1451,7 @@ class ServiceDaemon:
             return "vault_uninitialized"
         if mode == "os_keyring":
             return "keyring_locked"
-        reason = self._composition.auto_unlock_reason
+        reason = self._auto_unlock_reason
         if reason in {
             "auto_unlock_backend_unavailable",
             "auto_unlock_rejected",
@@ -2217,6 +2386,7 @@ async def _production_composition(
             ready_close_relay=ready_close_relay,
             privacy_policy_app_relay=privacy_relay,
             auto_unlock_reason=auto_unlock_reason,
+            auto_unlock_bundle=paths.bundle,
         )
     except BaseException:
         await listeners.close()

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -977,6 +977,168 @@ async def test_shutdown_is_idempotent_and_closes_owned_listener() -> None:
     assert vault.close_count == 1
 
 
+class _PassphraseVault:
+    mode = VaultMode.PASSPHRASE
+    generation = 3
+    ready = False
+
+    def __init__(self) -> None:
+        self.lock_count = 0
+        self.close_count = 0
+        self.unlock_count = 0
+        self._secret: bytes | None = None
+
+    def expect_secret(self, value: bytes) -> None:
+        self._secret = value
+
+    async def unlock(self, handle: object) -> None:
+        del handle
+        self.unlock_count += 1
+        self.ready = True
+        self.generation += 1
+
+    async def lock(self) -> None:
+        self.lock_count += 1
+        self.ready = False
+
+    async def close(self) -> None:
+        self.close_count += 1
+        self.ready = False
+
+
+class _SecretMemory:
+    def capture(self, purpose: object, secret: bytearray) -> object:
+        del purpose
+        return bytes(secret)
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.anyio
+async def test_soft_lock_auto_ready_reopens_on_next_ordinary_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    application = _Application()
+    vault = _PassphraseVault()
+    secret = b"correct horse battery staple!!"
+    vault.expect_secret(secret)
+
+    async def factory(service_generation: int, vault_generation: int) -> _Application:
+        assert service_generation == 7
+        assert vault_generation == vault.generation
+        return application
+
+    class _Store:
+        def load_with_reason(self) -> tuple[bytearray | None, str]:
+            return bytearray(secret), "none"
+
+    monkeypatch.setattr(daemon_module, "AutoUnlockPassphraseStore", lambda _bundle: _Store())
+
+    lifecycle = ServiceLifecycle(
+        _Clock(),
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "4" * 64,
+        instance_id=_INSTANCE_ID,
+        singleton_lock_path=tmp_path / "service.lock",
+    )
+    composition = ServiceComposition(
+        lifecycle=lifecycle,
+        control_listener=_Listener(),  # pyright: ignore[reportArgumentType]
+        secret_ingress_listener=None,
+        human_control_listener=None,
+        human_control_service=None,
+        session_monitor=None,
+        vault=vault,  # pyright: ignore[reportArgumentType]
+        ready_application_factory=factory,  # pyright: ignore[reportArgumentType]
+        secret_memory=_SecretMemory(),  # pyright: ignore[reportArgumentType]
+        auto_unlock_bundle=tmp_path,
+    )
+    daemon = ServiceDaemon(_composition=composition)
+    await daemon.start()
+    assert daemon.status().state is ServiceState.LOCKED
+    daemon._state_reason = "idle_relock"  # pyright: ignore[reportPrivateUsage]
+
+    result = await daemon.dispatch(
+        ControlClientKind.MCP_BRIDGE,
+        _request(daemon, ControlMethod.START, _start_body()),
+    )
+
+    assert result.outcome == "ok"
+    assert vault.unlock_count == 1
+    assert daemon.status().state is ServiceState.READY
+    assert daemon.status().state_reason == "none"
+    assert application.start_calls == 1
+    await daemon.close()
+
+
+@pytest.mark.anyio
+async def test_explicit_lock_does_not_auto_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    application = _Application()
+    vault = _PassphraseVault()
+
+    async def factory(service_generation: int, vault_generation: int) -> _Application:
+        del service_generation, vault_generation
+        return application
+
+    class _Store:
+        def load_with_reason(self) -> tuple[bytearray | None, str]:
+            return bytearray(b"correct horse battery staple!!"), "none"
+
+    monkeypatch.setattr(daemon_module, "AutoUnlockPassphraseStore", lambda _bundle: _Store())
+
+    lifecycle = ServiceLifecycle(
+        _Clock(),
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "5" * 64,
+        instance_id=_INSTANCE_ID,
+        singleton_lock_path=tmp_path / "service.lock",
+    )
+    composition = ServiceComposition(
+        lifecycle=lifecycle,
+        control_listener=_Listener(),  # pyright: ignore[reportArgumentType]
+        secret_ingress_listener=None,
+        human_control_listener=None,
+        human_control_service=None,
+        session_monitor=None,
+        vault=vault,  # pyright: ignore[reportArgumentType]
+        ready_application_factory=factory,  # pyright: ignore[reportArgumentType]
+        secret_memory=_SecretMemory(),  # pyright: ignore[reportArgumentType]
+        auto_unlock_bundle=tmp_path,
+    )
+    daemon = ServiceDaemon(_composition=composition)
+    await daemon.start()
+    daemon._state_reason = "explicit_lock"  # pyright: ignore[reportPrivateUsage]
+
+    rejected = await daemon.dispatch(
+        ControlClientKind.MCP_BRIDGE,
+        _request(daemon, ControlMethod.START, _start_body()),
+    )
+
+    assert rejected.outcome == "error"
+    assert isinstance(rejected.body, ControlError)
+    assert rejected.body.reason == "vault_locked"
+    assert vault.unlock_count == 0
+    assert daemon.status().state is ServiceState.LOCKED
+    await daemon.close()
+
+
+@pytest.mark.anyio
+async def test_idle_close_publishes_idle_relock_reason() -> None:
+    daemon, application, vault, _listener = _daemon()
+    await daemon.start()
+    assert daemon.status().state_reason == "none"
+    # Lifecycle idle drain closes ready without daemon.lock; the close path must publish
+    # idle_relock so soft auto-ready can recognize the reason.
+    await daemon._close_ready_locked()  # pyright: ignore[reportPrivateUsage]
+    assert application.close_count == 1
+    assert vault.lock_count >= 1
+    assert daemon.status().state_reason == "idle_relock"
+    await daemon.close()
+
+
 @pytest.mark.anyio
 async def test_unlock_activation_constructs_exact_generation_once(tmp_path: Path) -> None:
     application = _Application()

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -992,7 +992,8 @@ class _PassphraseVault:
         self._secret = value
 
     async def unlock(self, handle: object) -> None:
-        del handle
+        if self._secret is not None and handle != self._secret:
+            raise AssertionError("unexpected unlock secret")
         self.unlock_count += 1
         self.ready = True
         self.generation += 1
@@ -1015,26 +1016,29 @@ class _SecretMemory:
         return None
 
 
-@pytest.mark.anyio
-async def test_soft_lock_auto_ready_reopens_on_next_ordinary_dispatch(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def _patch_auto_unlock_store(
+    monkeypatch: pytest.MonkeyPatch,
+    secret: bytes | None,
+    reason: str = "none",
 ) -> None:
-    application = _Application()
-    vault = _PassphraseVault()
-    secret = b"correct horse battery staple!!"
-    vault.expect_secret(secret)
-
-    async def factory(service_generation: int, vault_generation: int) -> _Application:
-        assert service_generation == 7
-        assert vault_generation == vault.generation
-        return application
-
     class _Store:
         def load_with_reason(self) -> tuple[bytearray | None, str]:
-            return bytearray(secret), "none"
+            if secret is None:
+                return None, reason
+            return bytearray(secret), reason
 
-    monkeypatch.setattr(daemon_module, "AutoUnlockPassphraseStore", lambda _bundle: _Store())
+    def _factory(_bundle: Path) -> _Store:
+        return _Store()
 
+    monkeypatch.setattr(daemon_module, "AutoUnlockPassphraseStore", _factory)
+
+
+def _soft_lock_daemon(
+    tmp_path: Path,
+    *,
+    factory: object,
+    vault: _PassphraseVault,
+) -> ServiceDaemon:
     lifecycle = ServiceLifecycle(
         _Clock(),
         generation_store=_GenerationStore(),
@@ -1054,7 +1058,25 @@ async def test_soft_lock_auto_ready_reopens_on_next_ordinary_dispatch(
         secret_memory=_SecretMemory(),  # pyright: ignore[reportArgumentType]
         auto_unlock_bundle=tmp_path,
     )
-    daemon = ServiceDaemon(_composition=composition)
+    return ServiceDaemon(_composition=composition)
+
+
+@pytest.mark.anyio
+async def test_soft_lock_auto_ready_reopens_on_next_ordinary_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    application = _Application()
+    vault = _PassphraseVault()
+    secret = b"correct horse battery staple!!"
+    vault.expect_secret(secret)
+
+    async def factory(service_generation: int, vault_generation: int) -> _Application:
+        assert service_generation == 7
+        assert vault_generation == 4
+        return application
+
+    _patch_auto_unlock_store(monkeypatch, secret)
+    daemon = _soft_lock_daemon(tmp_path, factory=factory, vault=vault)
     await daemon.start()
     assert daemon.status().state is ServiceState.LOCKED
     daemon._state_reason = "idle_relock"  # pyright: ignore[reportPrivateUsage]
@@ -1083,32 +1105,8 @@ async def test_explicit_lock_does_not_auto_ready(
         del service_generation, vault_generation
         return application
 
-    class _Store:
-        def load_with_reason(self) -> tuple[bytearray | None, str]:
-            return bytearray(b"correct horse battery staple!!"), "none"
-
-    monkeypatch.setattr(daemon_module, "AutoUnlockPassphraseStore", lambda _bundle: _Store())
-
-    lifecycle = ServiceLifecycle(
-        _Clock(),
-        generation_store=_GenerationStore(),
-        process_start_identity_commitment="sha256:" + "5" * 64,
-        instance_id=_INSTANCE_ID,
-        singleton_lock_path=tmp_path / "service.lock",
-    )
-    composition = ServiceComposition(
-        lifecycle=lifecycle,
-        control_listener=_Listener(),  # pyright: ignore[reportArgumentType]
-        secret_ingress_listener=None,
-        human_control_listener=None,
-        human_control_service=None,
-        session_monitor=None,
-        vault=vault,  # pyright: ignore[reportArgumentType]
-        ready_application_factory=factory,  # pyright: ignore[reportArgumentType]
-        secret_memory=_SecretMemory(),  # pyright: ignore[reportArgumentType]
-        auto_unlock_bundle=tmp_path,
-    )
-    daemon = ServiceDaemon(_composition=composition)
+    _patch_auto_unlock_store(monkeypatch, b"correct horse battery staple!!")
+    daemon = _soft_lock_daemon(tmp_path, factory=factory, vault=vault)
     await daemon.start()
     daemon._state_reason = "explicit_lock"  # pyright: ignore[reportPrivateUsage]
 
@@ -1122,6 +1120,41 @@ async def test_explicit_lock_does_not_auto_ready(
     assert rejected.body.reason == "vault_locked"
     assert vault.unlock_count == 0
     assert daemon.status().state is ServiceState.LOCKED
+    await daemon.close()
+
+
+@pytest.mark.anyio
+async def test_soft_lock_absent_auto_unlock_stays_hard_locked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    application = _Application()
+    vault = _PassphraseVault()
+
+    async def factory(service_generation: int, vault_generation: int) -> _Application:
+        del service_generation, vault_generation
+        return application
+
+    _patch_auto_unlock_store(monkeypatch, None, "auto_unlock_absent")
+    daemon = _soft_lock_daemon(tmp_path, factory=factory, vault=vault)
+    await daemon.start()
+    daemon._state_reason = "idle_relock"  # pyright: ignore[reportPrivateUsage]
+
+    rejected = await daemon.dispatch(
+        ControlClientKind.MCP_BRIDGE,
+        _request(daemon, ControlMethod.START, _start_body()),
+    )
+    assert rejected.outcome == "error"
+    assert isinstance(rejected.body, ControlError)
+    assert rejected.body.reason == "vault_locked"
+    assert vault.unlock_count == 0
+    assert daemon.status().state_reason == "passphrase_required"
+
+    again = await daemon.dispatch(
+        ControlClientKind.MCP_BRIDGE,
+        _request(daemon, ControlMethod.START, _start_body()),
+    )
+    assert again.outcome == "error"
+    assert vault.unlock_count == 0
     await daemon.close()
 
 

--- a/tests/unit/cli/test_auto_unlock.py
+++ b/tests/unit/cli/test_auto_unlock.py
@@ -243,6 +243,10 @@ async def test_unlock_vault_prefers_scoped_platform_entry_without_prompt(
         seen.append(None if passphrase is None else bytearray(passphrase))
         return SimpleNamespace(state="ready")
 
+    async def not_stale() -> bool:
+        return False
+
+    monkeypatch.setattr(unlock_module, "_service_reports_unusable_auto_unlock", not_stale)
     monkeypatch.setattr(
         unlock_module,
         "_load_scoped_auto_unlock_passphrase",
@@ -271,11 +275,84 @@ async def test_unlock_vault_falls_back_to_interactive_when_store_absent(
         seen.append(passphrase is None)
         return SimpleNamespace(state="ready")
 
+    async def not_stale() -> bool:
+        return False
+
+    monkeypatch.setattr(unlock_module, "_service_reports_unusable_auto_unlock", not_stale)
     monkeypatch.setattr(unlock_module, "_load_scoped_auto_unlock_passphrase", lambda: None)
     monkeypatch.setattr(unlock_module, "run_human_ceremony", ceremony)
 
     result = await unlock_module.unlock_vault()
     assert result.state == "ready"
+    assert seen == [True]
+
+
+@pytest.mark.anyio
+async def test_unlock_vault_falls_back_when_silent_ceremony_stays_locked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = bytearray(b"correct horse battery staple!!")
+    seen: list[bool] = []
+    calls = 0
+
+    async def ceremony(
+        kind: object,
+        target: object,
+        passphrase: bytearray | None = None,
+        **_kwargs: object,
+    ) -> Any:
+        del kind, target
+        nonlocal calls
+        calls += 1
+        seen.append(passphrase is None)
+        if calls == 1:
+            return SimpleNamespace(state="locked")
+        return SimpleNamespace(state="ready")
+
+    async def not_stale() -> bool:
+        return False
+
+    monkeypatch.setattr(unlock_module, "_service_reports_unusable_auto_unlock", not_stale)
+    monkeypatch.setattr(unlock_module, "_load_scoped_auto_unlock_passphrase", lambda: secret)
+    monkeypatch.setattr(unlock_module, "run_human_ceremony", ceremony)
+
+    result = await unlock_module.unlock_vault()
+    assert result.state == "ready"
+    assert seen == [False, True]
+
+
+@pytest.mark.anyio
+async def test_unlock_vault_skips_stored_entry_when_service_reports_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[bool] = []
+    loads = 0
+
+    async def ceremony(
+        kind: object,
+        target: object,
+        passphrase: bytearray | None = None,
+        **_kwargs: object,
+    ) -> Any:
+        del kind, target
+        seen.append(passphrase is None)
+        return SimpleNamespace(state="ready")
+
+    async def stale() -> bool:
+        return True
+
+    def load() -> bytearray | None:
+        nonlocal loads
+        loads += 1
+        return bytearray(b"correct horse battery staple!!")
+
+    monkeypatch.setattr(unlock_module, "_service_reports_unusable_auto_unlock", stale)
+    monkeypatch.setattr(unlock_module, "_load_scoped_auto_unlock_passphrase", load)
+    monkeypatch.setattr(unlock_module, "run_human_ceremony", ceremony)
+
+    result = await unlock_module.unlock_vault()
+    assert result.state == "ready"
+    assert loads == 0
     assert seen == [True]
 
 

--- a/tests/unit/cli/test_auto_unlock.py
+++ b/tests/unit/cli/test_auto_unlock.py
@@ -226,5 +226,58 @@ def test_foreground_terminal_accepts_macos_controlling_tty_alias(
     assert closed == [9]
 
 
+@pytest.mark.anyio
+async def test_unlock_vault_prefers_scoped_platform_entry_without_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = bytearray(b"correct horse battery staple!!")
+    seen: list[bytearray | None] = []
+
+    async def ceremony(
+        kind: object,
+        target: object,
+        passphrase: bytearray | None = None,
+        **_kwargs: object,
+    ) -> Any:
+        del kind, target
+        seen.append(None if passphrase is None else bytearray(passphrase))
+        return SimpleNamespace(state="ready")
+
+    monkeypatch.setattr(
+        unlock_module,
+        "_load_scoped_auto_unlock_passphrase",
+        lambda: secret,
+    )
+    monkeypatch.setattr(unlock_module, "run_human_ceremony", ceremony)
+
+    result = await unlock_module.unlock_vault()
+    assert result.state == "ready"
+    assert seen == [bytearray(b"correct horse battery staple!!")]
+
+
+@pytest.mark.anyio
+async def test_unlock_vault_falls_back_to_interactive_when_store_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[bool] = []
+
+    async def ceremony(
+        kind: object,
+        target: object,
+        passphrase: bytearray | None = None,
+        **_kwargs: object,
+    ) -> Any:
+        del kind, target
+        seen.append(passphrase is None)
+        return SimpleNamespace(state="ready")
+
+    monkeypatch.setattr(unlock_module, "_load_scoped_auto_unlock_passphrase", lambda: None)
+    monkeypatch.setattr(unlock_module, "run_human_ceremony", ceremony)
+
+    result = await unlock_module.unlock_vault()
+    assert result.state == "ready"
+    assert seen == [True]
+
+
 async def _async_value(value: Any) -> Any:
     return value


### PR DESCRIPTION
## Summary

- After idle/session/suspend soft locks, the trusted service re-applies scoped platform auto-unlock (or OS keyring) on the next ordinary control/MCP admission so the vault feels continuously open when setup already provisioned Keychain.
- `yoetz service unlock` / TUI unlock prefer the scoped platform entry before any passphrase prompt (setup often generates a secret the human never sees).
- Explicit `service lock` and hard unlock failures stay locked; MCP/CLI hard-lock copy points at unlock/repair, never agent-side secrets.
- ADR-008 soft-lock re-ready amendment plus interfaces/security docs; idle drain now publishes `idle_relock`.

## Test plan

- [x] `uv run pytest tests/integration/service/test_daemon_clients.py::test_soft_lock_auto_ready_reopens_on_next_ordinary_dispatch tests/integration/service/test_daemon_clients.py::test_explicit_lock_does_not_auto_ready tests/integration/service/test_daemon_clients.py::test_idle_close_publishes_idle_relock_reason tests/unit/cli/test_auto_unlock.py tests/conformance/claims/test_local_service_security_doc.py -q`
- [x] ruff + pyright on touched modules
- [ ] Dogfood: setup with auto-unlock → idle/sleep → MCP call succeeds without terminal unlock; `yoetz service lock` still requires human unlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Soft-locked vaults can automatically reopen after idle, session, suspend, or monitor-loss relocks.
  * Service unlock can use securely stored credentials without prompting when configured.
  * Added recovery guidance for unavailable or stale automatic unlock credentials.
* **Bug Fixes**
  * Explicit locks and hard-lock states remain protected and require the normal unlock process.
  * Improved locked-vault messages distinguish recoverable locks from setup or unlock failures.
* **Documentation**
  * Clarified soft-lock recovery, automatic unlock behavior, troubleshooting, and trusted-console consent flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic vault reactivation after idle, session, suspend, and monitor-loss soft locks while preserving explicit locks as hard boundaries.
- Adds daemon-side scoped passphrase and OS-keyring reactivation before ordinary request admission.
- Makes CLI unlock prefer the provisioned platform credential before prompting.
- Updates MCP/CLI guidance, lifecycle documentation, and focused integration/unit tests.

<h3>Confidence Score: 4/5</h3>

The failed soft-unlock cleanup must be fixed before merging because an unexpected unlock exception can leave the vault in an inconsistent transient state.

The new daemon path restores the lifecycle to locked after an unexpected unlock failure but conditionally skips vault cleanup whenever the vault is `UNLOCKING`, allowing partial vault resources and state to survive.

**Files Needing Attention:** src/yoetz/service/daemon.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/service/daemon.py | Adds soft-lock auto-ready orchestration, but unexpected passphrase-unlock exceptions can leave the vault in `UNLOCKING`. |
| src/yoetz/cli/unlock.py | Prefers the bundle-scoped platform passphrase and safely falls back to the interactive ceremony. |
| src/yoetz/mcp/server.py | Updates bounded locked-vault remediation text without changing MCP authority. |
| tests/integration/service/test_daemon_clients.py | Covers successful soft reactivation, explicit-lock exclusion, and idle reason publication, but not unexpected unlock cleanup. |
| tests/unit/cli/test_auto_unlock.py | Covers silent stored-entry unlock and interactive fallback behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Ordinary control request] --> B{Application ready?}
    B -- Yes --> C[Admit and dispatch]
    B -- No --> D{Soft-lock reason?}
    D -- No --> E[Return vault_locked]
    D -- Yes --> F[Transition lifecycle to unlocking]
    F --> G{Vault mode}
    G -- Passphrase --> H[Load scoped platform entry]
    G -- OS keyring --> I[Retry keyring]
    H --> J{Unlock succeeded?}
    I --> J
    J -- Yes --> K[Build ready application]
    K --> C
    J -- No --> L[Clean vault and lifecycle to locked]
    L --> E
```

<sub>Reviews (1): Last reviewed commit: ["fix: re-open the vault after soft locks ..."](https://github.com/thegaysupreme123/yoetz/commit/34d15b8cfd64d231bb5d5c91f51c5dc684a9331b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=22993257)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->