### PR TITLE
fix: diagnose unavailable passphrase KDF

### DIFF
--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -28,13 +28,14 @@ manifests, the packaging/capability suites, and the release workflows under `.gi
 6. **Keys, semantic readiness, and compatibility extras:** the certified standard install includes
    direct pinned
    `cryptography` (AES-GCM, RFC 3394 AES Key Wrap, HKDF/HMAC) and `keyring` plus the approved
-   macOS/Linux secure-backend dependencies because object/vault crypto and OS-keyring-first service
-   startup are v0.1 core behavior. Founder-authorized amendment (2026-07-29): `argon2-cffi`,
-   `httpx`, and `openai` are also standard direct dependencies because first run offers both
-   passphrase storage and semantic review and must not offer a path the installed artifact cannot
-   execute. `semantic-openai` and `portable-recovery` remain compatibility extras for existing
-   install commands, with the same exact pins; they add no dependency absent from the standard
-   install. A malformed or incomplete environment still fails closed rather than downgrading.
+   macOS/Linux secure-backend dependencies because object/vault crypto, the Cryptography Argon2id
+   passphrase KDF, and OS-keyring-first service startup are v0.1 core behavior.
+   Founder-authorized amendment (2026-07-29): `argon2-cffi`, `httpx`, and `openai` are also standard
+   direct dependencies because first run offers both passphrase storage and semantic review and must
+   not offer a path the installed artifact cannot execute. `semantic-openai` and
+   `portable-recovery` remain compatibility extras for existing install commands, with the same
+   exact pins; they add no dependency absent from the standard install. A malformed or incomplete
+   environment still fails closed rather than downgrading.
 7. **Type/lint stack and npm boundary:** Ruff `0.15.22` (format+lint, line length 100), official
    npm Pyright `1.1.411` via a development-only private `package.json`, strict mode. The locked
    contributor/CI toolchain is Node `26.5.0` with npm `12.0.1`; `npm ci --ignore-scripts` followed

--- a/docs/protocol/local-service-security.md
+++ b/docs/protocol/local-service-security.md
@@ -71,6 +71,11 @@ existing-vault user experiencing a missing keyring entry, a wrong passphrase, or
 is never told to run initialization; that failure routes to
 [`../runbooks/key-recovery.md`](../runbooks/key-recovery.md) instead.
 
+The installed Cryptography Argon2id implementation is required before a passphrase-vault service
+can start. If that exact packaged KDF module is unavailable, `yoetz service run` fails closed before
+opening retained state, with `passphrase_kdf_unavailable` and the remedy to reinstall Yoetz. It does
+not substitute another KDF, initialize a replacement vault, or remove retained data.
+
 ### Existing-keyring vaults are a distinct case
 
 An already-committed keyring-backed vault created by an earlier release, or restored through a

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -700,7 +700,20 @@ service_app.command("stop")(_service_command("stop"))
 def service_run() -> None:
     """Run the persistent service in the foreground."""
 
-    from yoetz.service.daemon import main as daemon_main
+    try:
+        from yoetz.service.daemon import main as daemon_main
+    except ModuleNotFoundError as error:
+        # A passphrase vault is part of the supported base installation.  The
+        # daemon imports its Argon2 implementation while composing the vault,
+        # so recognize only that exact absent module here rather than turning
+        # an arbitrary broken import into an operator-facing dependency claim.
+        if error.name != "cryptography.hazmat.primitives.kdf.argon2":
+            raise
+        _stderr(
+            "passphrase_kdf_unavailable: reinstall this Yoetz package before starting "
+            "a passphrase vault"
+        )
+        raise typer.Exit(exit_code_for(PublicErrorCode.SERVICE_UNAVAILABLE)) from None
 
     daemon_main()
 

--- a/tests/packaging/test_missing_kdf_startup.py
+++ b/tests/packaging/test_missing_kdf_startup.py
@@ -1,0 +1,68 @@
+"""Installed-wheel fail-closed coverage for the passphrase KDF dependency."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Final
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+
+
+def test_missing_installed_argon2_kdf_reports_a_bounded_startup_remedy(tmp_path: Path) -> None:
+    """Fault only the disposable wheel install, never the developer environment."""
+
+    root = tmp_path / "issue157"
+    dist = root / "dist"
+    env = {
+        **os.environ,
+        "HOME": str(root / "home"),
+        "UV_CACHE_DIR": str(root / "cache"),
+        "UV_TOOL_BIN_DIR": str(root / "bin"),
+        "UV_TOOL_DIR": str(root / "tool"),
+        "YOETZ_STORAGE_DATA_DIR": str(root / "data"),
+    }
+    build = subprocess.run(
+        ["uv", "build", "--no-sources", "-o", str(dist), str(_REPO_ROOT)],
+        capture_output=True,
+        timeout=180,
+        env=env,
+        check=False,
+    )
+    assert build.returncode == 0, build.stderr.decode("utf-8", errors="replace")
+    assert any(dist.glob("*.whl")), "expected a real wheel artifact"
+    install = subprocess.run(
+        [
+            "uv",
+            "tool",
+            "install",
+            "--python",
+            "3.14.6",
+            "--find-links",
+            str(dist),
+            "yoetz==0.1.0",
+        ],
+        capture_output=True,
+        timeout=180,
+        env=env,
+        check=False,
+    )
+    assert install.returncode == 0, install.stderr.decode("utf-8", errors="replace")
+
+    executable = Path(env["UV_TOOL_BIN_DIR"]) / "yoetz"
+    argon2 = next((root / "tool" / "yoetz").rglob("cryptography/hazmat/primitives/kdf/argon2.py"))
+    argon2.rename(argon2.with_suffix(".py.hidden"))
+
+    startup = subprocess.run(
+        [str(executable), "service", "run"],
+        capture_output=True,
+        timeout=15,
+        env=env,
+        check=False,
+    )
+    assert startup.returncode == 20
+    assert b"passphrase_kdf_unavailable" in startup.stderr
+    assert b"reinstall this Yoetz package" in startup.stderr
+    assert b"Traceback (most recent call last)" not in startup.stderr
+    assert not (root / "data").exists(), "missing KDF must fail before any retained-state write"


### PR DESCRIPTION
## Scope

Partial, evidence-backed follow-up for #157. This PR does **not** close #157.

It makes the confirmed installed-wheel failure mode actionable: if the exact Cryptography Argon2id module required for passphrase vaults is missing, `yoetz service run` exits 20 with `passphrase_kdf_unavailable` before it writes retained state.

## Evidence

- Built a real wheel and installed it into an isolated UV tool/cache/home/data root.
- Renamed only that installed `cryptography/hazmat/primitives/kdf/argon2.py`; startup previously returned generic `internal_error` (70).
- The new installed-artifact regression proves exit 20, the bounded reinstall remedy, no traceback, and no data-root creation.
- Focused verification: `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/packaging/test_missing_kdf_startup.py tests/packaging/test_uninstall_and_data_retention.py -q` (7 passed); Ruff and Pyright passed.

## Remaining #157 gap

The requested real controlling-PTY initialize/unlock/reinstall proof remains open. During the isolated live trial, the vault reached `ready`, but the foreground PTY ceremony client did not return within the bounded window. That behavior needs its own diagnosis before the full retained-vault proof can be honestly added. No issue-closing keyword is used here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service startup now fails safely when the required Argon2id passphrase protection is unavailable.
  * Displays a clear recovery message and avoids opening or modifying retained vault data.
  * Prevents misleading fallback behavior, replacement vault creation, and data deletion.

* **Documentation**
  * Clarified core encryption, dependency, packaging, and secure-startup requirements.

* **Tests**
  * Added coverage verifying safe startup behavior in an installed package with the required protection unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a bounded startup diagnosis for an installed Cryptography Argon2id module that is unavailable, before retained service state is opened.
- Maps the exact missing-module failure to exit code 20 and `passphrase_kdf_unavailable`.
- Adds an installed-wheel regression test covering the remedy, traceback suppression, and absence of data-root creation.
- Documents the passphrase KDF packaging and fail-closed startup contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/cli/app.py | Converts the exact missing Cryptography Argon2id module during daemon import into a bounded service-unavailable response. |
| tests/packaging/test_missing_kdf_startup.py | Builds and installs a real wheel, removes only the installed Argon2id module, and verifies bounded failure before data-root creation. |
| docs/protocol/local-service-security.md | Documents the fail-closed behavior and reinstall remedy when the packaged passphrase KDF is unavailable. |
| docs/adr/ADR-007-packaging-platform-release.md | Clarifies that the Cryptography Argon2id implementation is part of the core installed dependency contract. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant CLI as yoetz service run
    participant D as Service daemon import
    participant KDF as Cryptography Argon2id
    U->>CLI: Start foreground service
    CLI->>D: Import daemon entrypoint
    D->>KDF: Import required KDF module
    alt KDF module available
        KDF-->>D: Argon2id
        D-->>CLI: Start daemon
    else Exact KDF module unavailable
        KDF--xCLI: ModuleNotFoundError
        CLI-->>U: passphrase_kdf_unavailable (exit 20)
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix: diagnose unavailable passphrase KDF"](https://github.com/thegaysupreme123/yoetz/commit/8227b97dca09062a90b1bea81d434365e0543bf5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=23595050)</sub>

<!-- /greptile_comment -->