### PR TITLE
Fix composed setup credential failure reporting

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2406,6 +2406,17 @@ schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
 `yoetz.setup-status/1`, and `yoetz.mcp-registration-preview/1`; the marker lives at
 `state_dir()/setup-wizard.json` via `config.paths.setup_marker_path`. The CLI surfaces are
 `yoetz setup run|status` and `yoetz integrate <harness> mcp status|preview|install` (ADR-012).
+Standalone `yoetz provider endpoint` retains its explicit credential next command. When endpoint
+binding is embedded in the composed setup wizard, that standalone handoff is suppressed because
+the wizard still owns privacy consent and confidential ingress. Every visible yes/no prompt near
+credential setup says that API-key entry has not started and accepts only yes/no; a separate
+heading announces the hidden trusted-console ceremony. Invalid visible-prompt input is never
+reflected by Yoetz. Provider credential failure reasons cross the report boundary only through a
+fixed nonsecret allowlist, while provider binding, credential storage, repository privacy, service
+state, and semantic readiness remain independent report components. Recovery commands are derived
+from the read-only committed/live status when available, with component results used only as a
+state-equivalent fallback, so failure in a later component cannot rewrite an already committed
+privacy grant.
 `setup status` rows carry `registration_state` and `registered_route_profile`; the
 `integrate <harness> mcp status` body carries `state` and `route_profile`.
 

--- a/src/yoetz/cli/provider_binding.py
+++ b/src/yoetz/cli/provider_binding.py
@@ -119,8 +119,17 @@ def prompt_provider_model(choice: str) -> str | None:
     return None
 
 
-def prompt_provider_endpoint_binding(*, path: Path | None = None) -> Path | None:
-    """Prompt for a reviewed provider preset or custom origin; never asks for secrets."""
+def prompt_provider_endpoint_binding(
+    *,
+    path: Path | None = None,
+    show_standalone_next_step: bool = True,
+) -> Path | None:
+    """Prompt for a reviewed provider preset or custom origin; never asks for secrets.
+
+    ``show_standalone_next_step`` is false only when a composed setup flow owns the next
+    transition. Standalone endpoint setup keeps the repair command, while the wizard avoids
+    implying that it stopped before its policy and confidential-credential phases.
+    """
 
     typer.echo("")
     typer.echo("LLM endpoint (nonsecret)")
@@ -184,5 +193,6 @@ def prompt_provider_endpoint_binding(*, path: Path | None = None) -> Path | None
             "  note: owner-declared hosts use unknown data-use posture and never inherit "
             "the assisted recommendation badge"
         )
-    typer.echo(f"  next: {NEXT_CREDENTIAL}")
+    if show_standalone_next_step:
+        typer.echo(f"  next: {NEXT_CREDENTIAL}")
     return written

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -88,6 +88,204 @@ _NEXT_CREDENTIAL: Final = (
     "provider credential through the confidential ceremony"
 )
 _NEXT_RESTART: Final = "restart the Yoetz service so the configured semantic evaluator is composed"
+_PROVIDER_SETUP_DIRECT_REASONS: Final = frozenset(
+    {
+        "cancelled",
+        "confirmation_mismatch",
+        "credential_setup_failed",
+        "empty_input",
+        "eof",
+        "input_invalid",
+        "interrupted",
+        "model_selection_invalid",
+        "preview_invalid",
+        "privacy_setup_incomplete",
+        "provider_binding_invalid",
+        "repository_privacy_scope_unavailable",
+        "result_invalid",
+        "service_not_ready",
+        "stored_result_recovered",
+        "trusted_console_required",
+    }
+)
+_PROVIDER_SETUP_CONFIG_REASONS: Final = frozenset(
+    {
+        "config_value_invalid",
+        "https_origin_invalid",
+        "owner_declared_endpoint_forbidden",
+        "owner_declared_endpoint_required",
+        "provider_required_for_semantic",
+        "secret_in_config",
+        "unknown_config_key",
+    }
+)
+_PROVIDER_SETUP_AUTO_UNLOCK_REASONS: Final = frozenset(
+    {
+        "ambiguous_write",
+        "authority_mismatch",
+        "correlation_mismatch",
+        "entry_exists",
+        "entry_invalid",
+        "human_authority_unavailable",
+        "locked",
+        "migration_not_proven",
+        "missing",
+        "readback_failed",
+        "unsupported",
+        "unverified",
+    }
+)
+_PROVIDER_SETUP_CONFIDENTIAL_REASONS: Final = frozenset(
+    {
+        "ambiguous",
+        "cancelled",
+        "ceremony_unsupported",
+        "correlation_mismatch",
+        "kind_forbidden",
+        "peer_untrusted",
+        "pending_not_actionable",
+        "pending_unavailable",
+        "protocol_error",
+        "response_bytes",
+        "secret_rejected",
+        "service_unavailable",
+        "session_busy",
+        "session_closed",
+        "stale_generation",
+        "state_forbidden",
+        "timeout",
+    }
+)
+
+
+def _allowlisted_provider_setup_reason(reason: object) -> str:
+    """Return one reviewed nonsecret provider-setup reason, never caller text."""
+
+    if type(reason) is not str:
+        return "credential_setup_failed"
+    if reason in _PROVIDER_SETUP_DIRECT_REASONS or reason in _PROVIDER_SETUP_CONFIG_REASONS:
+        return reason
+    if reason.startswith("credential_"):
+        confidential_reason = reason.removeprefix("credential_")
+        if confidential_reason in _PROVIDER_SETUP_CONFIDENTIAL_REASONS:
+            return reason
+    if reason.startswith("auto_unlock_"):
+        auto_unlock_reason = reason.removeprefix("auto_unlock_")
+        if auto_unlock_reason in _PROVIDER_SETUP_AUTO_UNLOCK_REASONS:
+            return reason
+    return "credential_setup_failed"
+
+
+def _provider_setup_result(
+    service: dict[str, JsonValue],
+    report: dict[str, JsonValue],
+) -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+    """Finalize a provider component report through the public reason allowlist."""
+
+    if "credential_reason" in report:
+        report["credential_reason"] = _allowlisted_provider_setup_reason(
+            report.get("credential_reason")
+        )
+    return service, report
+
+
+def _prompt_yes_no_before_credential(
+    prompt: str,
+    *,
+    default: bool,
+) -> bool:
+    """Read one visible yes/no choice without ever reflecting an invalid response."""
+
+    typer.echo("  This is a visible yes/no prompt. API-key entry has not started.")
+    typer.echo("  Enter only yes or no. A separate heading will announce hidden secret input.")
+    default_text = "Y" if default else "N"
+    suffix = "Y/n" if default else "y/N"
+    while True:
+        raw = typer.prompt(
+            f"{prompt} [{suffix}]",
+            default=default_text,
+            show_default=False,
+        )
+        answer = raw.strip().casefold()
+        if answer in {"y", "yes"}:
+            return True
+        if answer in {"n", "no"}:
+            return False
+        typer.echo(
+            "Not accepted: this was a yes/no consent prompt, not credential entry. "
+            "No API key was read or stored; enter only yes or no.",
+            err=True,
+        )
+
+
+def _prompt_credential_probe_authorization() -> bool:
+    """Collect credential-probe consent before the separately labelled hidden ceremony."""
+
+    typer.echo("")
+    typer.echo("Privacy and credential-verification consent")
+    return _prompt_yes_no_before_credential(
+        "After storage, permit one fixed, content-free request to verify this API key?",
+        default=True,
+    )
+
+
+def _emit_hidden_credential_transition() -> None:
+    """Make the first confidential-input boundary unmistakable."""
+
+    typer.echo("")
+    typer.echo("Hidden credential ceremony begins now")
+    typer.echo(
+        "  Secret prompts from this point use the trusted local terminal with input echo disabled."
+    )
+    typer.echo(
+        "  The ceremony may request vault reauthentication first. Enter the API key only at "
+        "the hidden 'Provider credential:' prompt."
+    )
+
+
+def _append_next_step(next_steps: list[JsonValue], step: str) -> None:
+    if step not in next_steps:
+        next_steps.append(step)
+
+
+def _semantic_status_next_steps(status: Mapping[str, object]) -> tuple[str, ...]:
+    """Translate authoritative provider-status blockers into wizard recovery guidance."""
+
+    steps: list[str] = []
+    blockers = status.get("blockers")
+    if isinstance(blockers, (list, tuple)):
+        for blocker in blockers:
+            if not isinstance(blocker, Mapping):
+                continue
+            condition = blocker.get("condition")
+            if condition == "provider_credential":
+                if blocker.get("state") == "not_connected":
+                    steps.append(_NEXT_CREDENTIAL)
+            elif condition == "provider_endpoint":
+                steps.append(_NEXT_PROVIDER_TOML)
+            elif condition in {"llm_inference_channel", "repository_privacy_grant"}:
+                if blocker.get("state") in {"disabled", "missing"}:
+                    steps.append(_NEXT_PRIVACY)
+            elif condition == "verification.semantic":
+                command = blocker.get("next_command")
+                if type(command) is str:
+                    steps.append(command)
+            elif condition == "mcp_route_profile":
+                steps.append(
+                    "run 'yoetz integrate codex mcp preview' and explicitly accept "
+                    "re-registration if you want the policy route to permit configured "
+                    "semantic review"
+                )
+    else:
+        if status.get("endpoint_bound") is False:
+            steps.append(_NEXT_PROVIDER_TOML)
+        if status.get("credential_connected") is False:
+            steps.append(_NEXT_CREDENTIAL)
+        if status.get("llm_inference_enabled") is False:
+            steps.append(_NEXT_PRIVACY)
+        if status.get("repository_grant_state") == "missing":
+            steps.append(_NEXT_PRIVACY)
+    return tuple(dict.fromkeys(steps))
 
 
 def _stdout_json(value: JsonValue) -> None:
@@ -1162,7 +1360,7 @@ async def _interactive_provider_setup(
                                 "Restore credential-store access, then rerun 'yoetz setup'.",
                                 err=True,
                             )
-                        return service, provider_report
+                        return _provider_setup_result(service, provider_report)
                     typer.echo("Platform credential store unavailable; choose a vault passphrase")
                     typer.echo("Secure vault setup (hidden local-terminal input)")
                     await initialize_passphrase_vault()
@@ -1198,27 +1396,27 @@ async def _interactive_provider_setup(
             if not selected_model:
                 provider_report["credential_reason"] = "model_selection_invalid"
                 wipe_auto_passphrase()
-                return service, provider_report
+                return _provider_setup_result(service, provider_report)
             written, _provider = apply_provider_endpoint_choice(choice, model=selected_model)
         except (ConfigError, OSError, ValueError) as error:
             provider_report["credential_reason"] = getattr(
                 error, "reason_code", "provider_binding_invalid"
             )
             wipe_auto_passphrase()
-            return service, provider_report
+            return _provider_setup_result(service, provider_report)
         typer.echo(f"{preset.provider_id} model: {selected_model}")
     else:
-        written = prompt_provider_endpoint_binding()
+        written = prompt_provider_endpoint_binding(show_standalone_next_step=False)
     if written is None:
         wipe_auto_passphrase()
-        return service, provider_report
+        return _provider_setup_result(service, provider_report)
     provider_report["binding"] = "configured"
     config = load_config({}, {}, written)
     provider = config.provider
     if provider is None or service.get("state") != "ready":
         provider_report.setdefault("credential_reason", "service_not_ready")
         wipe_auto_passphrase()
-        return service, provider_report
+        return _provider_setup_result(service, provider_report)
 
     # The service snapshots its configured provider and credential capability at composition
     # time. Refresh it after writing the binding before deciding whether this exact profile
@@ -1228,7 +1426,7 @@ async def _interactive_provider_setup(
     if before_credential is not None and not await before_credential():
         provider_report["credential_reason"] = "privacy_setup_incomplete"
         wipe_auto_passphrase()
-        return service, provider_report
+        return _provider_setup_result(service, provider_report)
     credential_before: bool | None = None
     if service.get("state") == "ready":
         from yoetz.cli.provider_status import provider_status_report
@@ -1243,11 +1441,14 @@ async def _interactive_provider_setup(
         from yoetz.cli.provider_status import credential_human_display
 
         typer.echo(f"  Credential: {credential_human_display(True)} (already stored)")
-        if typer.confirm("Use the stored credential for this provider and model?", default=True):
+        if _prompt_yes_no_before_credential(
+            "Use the stored credential for this provider and model?",
+            default=True,
+        ):
             provider_report["credential"] = "stored"
             provider_report["credential_display"] = credential_human_display(True)
             wipe_auto_passphrase()
-            return service, provider_report
+            return _provider_setup_result(service, provider_report)
         replacing_stored_credential = True
         typer.echo("Enter a new credential to replace the stored value.")
 
@@ -1275,7 +1476,7 @@ async def _interactive_provider_setup(
     if type(repository_commitment) is not str:
         provider_report["credential_reason"] = "repository_privacy_scope_unavailable"
         wipe_auto_passphrase()
-        return service, provider_report
+        return _provider_setup_result(service, provider_report)
     target = ProviderCredentialTarget(
         action="set",
         provider_id=storage.provider_id,
@@ -1287,8 +1488,7 @@ async def _interactive_provider_setup(
         purpose_digest=storage.purpose_digest,
         repository_privacy_commitment=repository_commitment,
     )
-    typer.echo("")
-    typer.echo("Provider API key (hidden local-terminal input; stored only in the Yoetz vault)")
+    _emit_hidden_credential_transition()
     try:
         result = await set_provider_credential(
             target,
@@ -1307,7 +1507,7 @@ async def _interactive_provider_setup(
             # from a committed replacement. Preserve that uncertainty instead of claiming success.
             provider_report["credential"] = "failed"
             provider_report["credential_reason"] = f"credential_{error.reason}"
-            return await _service_reachability(), provider_report
+            return _provider_setup_result(await _service_reachability(), provider_report)
         service = await _restart_service_for_semantic_composition()
         credential_after: bool | None = None
         if service.get("state") == "ready":
@@ -1336,7 +1536,7 @@ async def _interactive_provider_setup(
             provider_report["credential_display"] = credential_human_display(True)
     finally:
         wipe_auto_passphrase()
-    return await _service_reachability(), provider_report
+    return _provider_setup_result(await _service_reachability(), provider_report)
 
 
 def _semantic_openai_extra_state() -> str:
@@ -1409,10 +1609,7 @@ async def run_provider_setup(
 
         typer.echo("")
         typer.echo("Choose the exact disclosure policy before the API key can be tested.")
-        credential_probe_authorized = typer.confirm(
-            "After storage, permit one fixed, content-free request to verify this API key?",
-            default=True,
-        )
+        credential_probe_authorized = _prompt_credential_probe_authorization()
         try:
             privacy_result = await run_privacy_setup(
                 recipe_hint="assisted_review",
@@ -1430,6 +1627,7 @@ async def run_provider_setup(
         model=model,
         before_credential=authorize_provider_channel,
     )
+    service, provider_report = _provider_setup_result(service, provider_report)
     binding = provider_report.get("binding")
     credential = provider_report.get("credential")
     typer.echo("")
@@ -1620,10 +1818,7 @@ async def run_setup_wizard(
             from yoetz.cli.unlock import HumanCeremonyCliError
             from yoetz.ports.control import ControlError
 
-            credential_probe_authorized = typer.confirm(
-                "After storage, permit one fixed, content-free request to verify this API key?",
-                default=True,
-            )
+            credential_probe_authorized = _prompt_credential_probe_authorization()
             try:
                 privacy_result = await run_privacy_setup(
                     recipe_hint="assisted_review",
@@ -1661,46 +1856,65 @@ async def run_setup_wizard(
             service,
             before_credential=authorize_provider_channel,
         )
-        if (
-            service.get("state") == "ready"
-            and provider.get("binding") == "configured"
-            and provider.get("credential") == "stored"
-        ):
-            service = await _restart_service_for_semantic_composition()
+        service, provider = _provider_setup_result(service, provider)
+        if service.get("state") == "ready" and provider.get("binding") == "configured":
+            if provider.get("credential") == "stored":
+                service = await _restart_service_for_semantic_composition()
             if service.get("state") == "ready":
                 from yoetz.cli.provider_status import provider_status_report
+                from yoetz.ports.control import ControlError
 
-                semantic_status = await provider_status_report()
-        else:
-            privacy = {
-                "outcome": "failed",
-                "profile": "unknown",
-                "reason": "provider_setup_incomplete",
-            }
+                # This is a read-only structural status read. It never probes the provider or
+                # dispatches semantic work, and it supplies authoritative blockers after a
+                # credential ceremony fails or returns an ambiguous result.
+                try:
+                    semantic_status = await provider_status_report()
+                except ControlError, OSError, ValueError:
+                    semantic_status = None
 
     next_steps: list[JsonValue] = []
-    if not service["reachable"]:
-        next_steps.append(_NEXT_SERVICE)
+    if not service.get("reachable"):
+        _append_next_step(next_steps, _NEXT_SERVICE)
     if service.get("state") != "ready":
-        next_steps.append(_NEXT_UNLOCK)
-    if review_mode == "semantic" and (
-        semantic_status is None or semantic_status.get("semantic_ready") is not True
-    ):
-        next_steps.append(_NEXT_RESTART)
-    if privacy.get("outcome") not in {"configured", "unchanged", "not_changed"}:
-        next_steps.append(_NEXT_PRIVACY)
-    if review_mode != "local_only" and provider.get("binding") != "configured":
-        next_steps.append(_NEXT_PROVIDER_TOML)
-    if review_mode != "local_only" and provider.get("credential") != "stored":
-        next_steps.append(_NEXT_CREDENTIAL)
+        _append_next_step(next_steps, _NEXT_UNLOCK)
+    if review_mode == "semantic":
+        status_steps = (
+            _semantic_status_next_steps(cast(Mapping[str, object], semantic_status))
+            if semantic_status is not None
+            else ()
+        )
+        for step in status_steps:
+            _append_next_step(next_steps, step)
+        if semantic_status is None or (
+            semantic_status.get("semantic_ready") is not True and not status_steps
+        ):
+            # Fall back only to component results that this run committed or directly observed.
+            # A missing credential cannot be repaired by restarting a ready service, and a
+            # successful privacy result must stay successful even when the next component fails.
+            if privacy.get("outcome") not in {"configured", "unchanged", "not_changed"}:
+                _append_next_step(next_steps, _NEXT_PRIVACY)
+            if provider.get("binding") != "configured":
+                _append_next_step(next_steps, _NEXT_PROVIDER_TOML)
+            if provider.get("credential") != "stored":
+                _append_next_step(next_steps, _NEXT_CREDENTIAL)
+            elif provider.get("binding") == "configured":
+                _append_next_step(next_steps, _NEXT_RESTART)
+    elif review_mode != "local_only":
+        if privacy.get("outcome") not in {"configured", "unchanged", "not_changed"}:
+            _append_next_step(next_steps, _NEXT_PRIVACY)
+        if provider.get("binding") != "configured":
+            _append_next_step(next_steps, _NEXT_PROVIDER_TOML)
+        if provider.get("credential") != "stored":
+            _append_next_step(next_steps, _NEXT_CREDENTIAL)
     if (
         chosen is not None
         and provider.get("binding") == "configured"
         and registration.get("route_profile") == "strict"
     ):
-        next_steps.append(
+        _append_next_step(
+            next_steps,
             "run 'yoetz integrate codex mcp preview' and explicitly accept re-registration "
-            "if you want the policy route to permit configured semantic review"
+            "if you want the policy route to permit configured semantic review",
         )
 
     mutating_run = interactive or accept
@@ -1887,10 +2101,16 @@ def _emit_human_report(report: dict[str, JsonValue]) -> None:
                 True if credential == "stored" else (False if credential == "failed" else None)
             )
         )
+        credential_reason = provider.get("credential_reason")
+        if type(credential_reason) is str:
+            typer.echo(f"  Credential reason: {credential_reason}")
     if isinstance(privacy, dict):
         line = f"  Privacy: {privacy.get('outcome')} ({privacy.get('profile')})"
+        grant_state = privacy.get("grant_state")
+        if type(grant_state) is str:
+            line += f"; repository grant: {grant_state}"
         if privacy.get("reason"):
-            line += f" — {privacy.get('reason')}"
+            line += f"; reason: {privacy.get('reason')}"
         typer.echo(line)
     steps = report["next_steps"]
     if isinstance(steps, list) and steps:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -254,9 +254,10 @@ def _semantic_status_next_steps(status: Mapping[str, object]) -> tuple[str, ...]
     steps: list[str] = []
     blockers = status.get("blockers")
     if isinstance(blockers, (list, tuple)):
-        for blocker in blockers:
-            if not isinstance(blocker, Mapping):
+        for blocker_value in cast(list[object] | tuple[object, ...], blockers):
+            if not isinstance(blocker_value, Mapping):
                 continue
+            blocker = cast(Mapping[str, object], blocker_value)
             condition = blocker.get("condition")
             if condition == "provider_credential":
                 if blocker.get("state") == "not_connected":

--- a/src/yoetz/cli/trusted_console.py
+++ b/src/yoetz/cli/trusted_console.py
@@ -18,6 +18,8 @@ _ERROR_REASONS: Final = frozenset(
     {
         _TRUST_FAILURE,
         "cancelled",
+        "empty_input",
+        "eof",
         "input_invalid",
         "interrupted",
     }
@@ -137,14 +139,14 @@ class _PosixConsoleAdapter:
                 finally:
                     view.release()
                 if count <= 0:
-                    raise TrustedConsoleError("input_invalid")
+                    raise TrustedConsoleError("eof")
                 used += count
                 if storage[used - 1] == 10:
                     break
             if used == 0 or storage[used - 1] != 10:
                 raise TrustedConsoleError("input_invalid")
             if used == 1:
-                raise TrustedConsoleError("input_invalid")
+                raise TrustedConsoleError("empty_input")
             storage[used - 1] = 0
             for index in range(used, len(storage)):
                 storage[index] = 0
@@ -334,12 +336,12 @@ class _CtypesWindowsConsoleApi:
                 ctypes.byref(read),
                 None,
             ):
-                raise TrustedConsoleError("input_invalid")
+                raise TrustedConsoleError("eof")
             used = int(read.value)
             while used > 0 and buffer[used - 1] in {"\r", "\n"}:
                 used -= 1
             if used <= 0:
-                raise TrustedConsoleError("input_invalid")
+                raise TrustedConsoleError("empty_input")
             encoded_size = int(
                 self._kernel32.WideCharToMultiByte(
                     self._CP_UTF8,
@@ -445,7 +447,10 @@ class _WindowsConsoleAdapter:
         encoded = self._api.read_line(self._input, maximum, hidden=hidden)
         if hidden:
             self.write("\n")
-        if not encoded or len(encoded) > maximum:
+        if not encoded:
+            _overwrite(encoded)
+            raise TrustedConsoleError("empty_input")
+        if len(encoded) > maximum:
             _overwrite(encoded)
             raise TrustedConsoleError("input_invalid")
         return encoded

--- a/src/yoetz/cli/unlock.py
+++ b/src/yoetz/cli/unlock.py
@@ -76,6 +76,8 @@ _FIXED_ERROR_REASONS: Final = frozenset(
     {
         "cancelled",
         "confirmation_mismatch",
+        "empty_input",
+        "eof",
         "input_invalid",
         "interrupted",
         "preview_invalid",

--- a/tests/subprocess/test_provider_endpoint_cli.py
+++ b/tests/subprocess/test_provider_endpoint_cli.py
@@ -389,3 +389,30 @@ def test_interactive_menu_choice_6_writes_grok_preset(
     assert "xai" in joined
     assert "xai-openai-chat-completions" in joined
     assert "Custom model ID" in joined
+    assert "next: run 'yoetz provider credential set'" in joined
+
+
+def test_composed_endpoint_binding_suppresses_standalone_next_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "config.toml"
+    answers = iter(("2", "1"))
+    echoes: list[str] = []
+
+    def fake_prompt(*_args: object, **_kwargs: object) -> str:
+        return next(answers)
+
+    def fake_echo(value: object = "", **_kwargs: object) -> None:
+        echoes.append(str(value))
+
+    monkeypatch.setattr(provider_binding.typer, "prompt", fake_prompt)
+    monkeypatch.setattr(provider_binding.typer, "echo", fake_echo)
+
+    written = provider_binding.prompt_provider_endpoint_binding(
+        path=target,
+        show_standalone_next_step=False,
+    )
+
+    assert written == target
+    assert target.is_file()
+    assert all("next: run 'yoetz provider credential set'" not in line for line in echoes)

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -213,6 +213,146 @@ def wizard_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, obj
     return state
 
 
+def _wire_composed_provider_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    credential_outcome: Literal["stored", "failed"],
+    credential_reason: str = "empty_input",
+) -> dict[str, object]:
+    """Keep the real composed wizard/provider flow and fake only external boundaries."""
+
+    import yoetz.cli.privacy_setup as privacy_setup_module
+    import yoetz.cli.provider_binding as provider_binding_module
+    import yoetz.cli.provider_status as provider_status_module
+    import yoetz.cli.setup as setup_module
+    import yoetz.cli.unlock as unlock_module
+    import yoetz.config.load as config_module
+
+    provider = SimpleNamespace(
+        provider_id="fireworks",
+        model="accounts/fireworks/models/minimax-m3",
+        endpoint_profile_id="fireworks-responses",
+        endpoint_profile_version="1.0.0",
+    )
+    config_path = tmp_path / "config.toml"
+    state: dict[str, object] = {
+        "binding_embedded_flags": [],
+        "credential_targets": [],
+        "privacy_calls": [],
+        "reports": [],
+        "restart_calls": 0,
+        "status_reads": 0,
+        "stored": False,
+    }
+
+    async def ready(*, start_if_absent: bool = False) -> dict[str, object]:
+        del start_if_absent
+        return {"reachable": True, "state": "ready", "vault_mode": "os_managed"}
+
+    async def restart() -> dict[str, object]:
+        state["restart_calls"] = cast(int, state["restart_calls"]) + 1
+        return {"reachable": True, "state": "ready", "vault_mode": "os_managed"}
+
+    def prompt_binding(
+        *,
+        path: Path | None = None,
+        show_standalone_next_step: bool = True,
+    ) -> Path:
+        del path
+        cast(list[bool], state["binding_embedded_flags"]).append(show_standalone_next_step)
+        config_path.write_text("[provider]\n", encoding="utf-8")
+        return config_path
+
+    def load_config(*_args: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            storage=SimpleNamespace(data_dir=tmp_path),
+            provider=provider,
+        )
+
+    async def privacy_setup(
+        *,
+        recipe_hint: str | None = None,
+        offer_recommended: bool = False,
+        credential_probe_authorized: bool = False,
+    ) -> SimpleNamespace:
+        cast(list[tuple[str | None, bool, bool]], state["privacy_calls"]).append(
+            (recipe_hint, offer_recommended, credential_probe_authorized)
+        )
+        return SimpleNamespace(
+            outcome="configured",
+            profile="trusted_provider",
+            proposal_id="pvp_issue_165",
+            grant_state="granted",
+            migration_state="not_applicable",
+            reason=None,
+        )
+
+    async def provider_status() -> dict[str, object]:
+        state["status_reads"] = cast(int, state["status_reads"]) + 1
+        if state["status_reads"] == 1:
+            return {"credential_connected": False}
+        stored = state["stored"] is True
+        blockers: tuple[dict[str, object], ...] = ()
+        if not stored:
+            blockers = (
+                {
+                    "condition": "provider_credential",
+                    "state": "not_connected",
+                    "next_command": "yoetz provider credential set",
+                },
+            )
+        return {
+            "semantic_ready": stored,
+            "endpoint_bound": True,
+            "credential_connected": stored,
+            "llm_inference_enabled": True,
+            "repository_grant_state": "granted",
+            "blockers": blockers,
+        }
+
+    async def set_credential(
+        target: object,
+        credential: bytearray | None,
+        reauthentication: bytearray | None,
+    ) -> SimpleNamespace:
+        assert credential is None
+        assert reauthentication is None
+        cast(list[object], state["credential_targets"]).append(target)
+        if credential_outcome == "failed":
+            raise unlock_module.HumanCeremonyCliError(credential_reason)
+        state["stored"] = True
+        return SimpleNamespace(activation_status="stored")
+
+    original_emit_human_report = setup_module._emit_human_report
+
+    def capture_report(report: dict[str, object]) -> None:
+        cast(list[dict[str, object]], state["reports"]).append(
+            cast(dict[str, object], json.loads(json.dumps(report)))
+        )
+        original_emit_human_report(cast(dict[str, object], report))
+
+    monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
+    monkeypatch.setattr(setup_module, "_service_reachability", ready)
+    monkeypatch.setattr(setup_module, "_restart_service_for_semantic_composition", restart)
+    monkeypatch.setattr(setup_module, "_emit_human_report", capture_report)
+    monkeypatch.setattr(
+        provider_binding_module,
+        "prompt_provider_endpoint_binding",
+        prompt_binding,
+    )
+    monkeypatch.setattr(config_module, "load_config", load_config)
+    monkeypatch.setattr(privacy_setup_module, "run_privacy_setup", privacy_setup)
+    monkeypatch.setattr(
+        privacy_setup_module,
+        "get_privacy_setup_snapshot",
+        _fake_repository_privacy_snapshot,
+    )
+    monkeypatch.setattr(provider_status_module, "provider_status_report", provider_status)
+    monkeypatch.setattr(unlock_module, "set_provider_credential", set_credential)
+    return state
+
+
 def test_non_interactive_without_accept_is_a_dry_run(wizard_env: dict[str, object]) -> None:
     result = _RUNNER.invoke(cli.app, ["setup", "run", "--non-interactive", "--json"])
     assert result.exit_code == 0
@@ -421,7 +561,9 @@ def test_interactive_wizard_selects_harness_then_installation_and_requires_y_or_
     import yoetz.cli.setup as setup_module
 
     monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
-    monkeypatch.setattr(provider_binding, "prompt_provider_endpoint_binding", lambda: None)
+    monkeypatch.setattr(
+        provider_binding, "prompt_provider_endpoint_binding", lambda **_kwargs: None
+    )
 
     # harness 1, installation 2, review mode 2 (local only), a rejected y/n, then confirm.
     result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n2\n2\nmaybe\nY\n")
@@ -458,7 +600,9 @@ def test_interactive_registration_n_declines_without_mutation(
     import yoetz.cli.setup as setup_module
 
     monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
-    monkeypatch.setattr(provider_binding, "prompt_provider_endpoint_binding", lambda: None)
+    monkeypatch.setattr(
+        provider_binding, "prompt_provider_endpoint_binding", lambda **_kwargs: None
+    )
 
     result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n1\nN\n")
 
@@ -534,6 +678,213 @@ def test_semantic_first_run_suggests_and_selects_assisted_privacy_draft(
     assert result.exit_code == 0
     assert privacy_calls == [("assisted_review", True, True)]
     assert "Privacy: configured (confirm_every_request)" in result.stdout
+
+
+def test_visible_consent_prompt_never_reflects_credential_shaped_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.cli.setup as setup_module
+
+    fake_credential = "sk-fake-issue-165-never-repeat"
+    answers = iter((fake_credential, "yes"))
+    emitted: list[str] = []
+
+    def prompt(*_args: object, **_kwargs: object) -> str:
+        return next(answers)
+
+    def echo(value: object = "", **_kwargs: object) -> None:
+        emitted.append(str(value))
+
+    monkeypatch.setattr(setup_module.typer, "prompt", prompt)
+    monkeypatch.setattr(setup_module.typer, "echo", echo)
+
+    assert (
+        setup_module._prompt_yes_no_before_credential(  # pyright: ignore[reportPrivateUsage]
+            "Consent?",
+            default=True,
+        )
+        is True
+    )
+    rendered = "\n".join(emitted)
+    assert fake_credential not in rendered
+    assert "not credential entry" in rendered
+    assert "No API key was read or stored" in rendered
+
+    _service, sanitized = setup_module._provider_setup_result(  # pyright: ignore[reportPrivateUsage]
+        {"reachable": True, "state": "ready"},
+        {
+            "binding": "configured",
+            "credential": "failed",
+            "credential_reason": fake_credential,
+        },
+    )
+    assert sanitized["credential_reason"] == "credential_setup_failed"
+    assert fake_credential not in json.dumps(sanitized)
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("cancelled", "cancelled"),
+        ("empty_input", "empty_input"),
+        ("eof", "eof"),
+        ("confirmation_mismatch", "confirmation_mismatch"),
+        ("credential_ambiguous", "credential_ambiguous"),
+        ("credential_secret_rejected", "credential_secret_rejected"),
+        ("credential_service_unavailable", "credential_service_unavailable"),
+        ("secret-shaped-caller-text", "credential_setup_failed"),
+    ],
+)
+def test_provider_setup_reason_is_bounded_and_allowlisted(reason: str, expected: str) -> None:
+    import yoetz.cli.setup as setup_module
+
+    assert (
+        setup_module._allowlisted_provider_setup_reason(  # pyright: ignore[reportPrivateUsage]
+            reason
+        )
+        == expected
+    )
+
+
+def test_composed_wizard_preserves_privacy_when_hidden_credential_input_is_empty(
+    wizard_env: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import yoetz.cli.setup as setup_module
+
+    fake_credential = "sk-fake-issue-165-must-never-appear"
+    wizard_env["outputs"] = [
+        CommandOutput(1, b""),
+        CommandOutput(1, b""),
+        CommandOutput(0, b""),
+        _yoetz_entry("policy"),
+    ]
+    state = _wire_composed_provider_setup(
+        monkeypatch,
+        tmp_path,
+        credential_outcome="failed",
+        credential_reason="empty_input",
+    )
+    original_prompt = setup_module.typer.prompt
+    probe_answers = iter((fake_credential, "yes"))
+
+    def route_visible_prompts(prompt: str, *args: object, **kwargs: object) -> object:
+        if prompt.startswith("After storage, permit one fixed"):
+            return next(probe_answers)
+        return original_prompt(prompt, *args, **kwargs)
+
+    monkeypatch.setattr(setup_module.typer, "prompt", route_visible_prompts)
+
+    result = _RUNNER.invoke(
+        cli.app,
+        ["setup", "run"],
+        input="1\n1\nY\n",
+    )
+
+    assert result.exit_code == 0
+    reports = cast(list[dict[str, object]], state["reports"])
+    assert len(reports) == 1
+    report = reports[0]
+    assert report["privacy"] == {
+        "outcome": "configured",
+        "profile": "trusted_provider",
+        "proposal_id": "pvp_issue_165",
+        "grant_state": "granted",
+        "migration_state": "not_applicable",
+        "reason": None,
+    }
+    assert report["provider"] == {
+        "binding": "configured",
+        "credential": "failed",
+        "credential_reason": "empty_input",
+    }
+    assert report["service"] == {
+        "reachable": True,
+        "state": "ready",
+        "vault_mode": "os_managed",
+    }
+    assert report["next_steps"] == [setup_module._NEXT_CREDENTIAL]  # pyright: ignore[reportPrivateUsage]
+    semantic_status = cast(dict[str, object], report["semantic_status"])
+    assert semantic_status["semantic_ready"] is False
+    assert semantic_status["repository_grant_state"] == "granted"
+    assert report["marker_written"] is False
+    assert state["binding_embedded_flags"] == [False]
+    assert state["privacy_calls"] == [("assisted_review", True, True)]
+    assert state["status_reads"] == 2
+    assert state["restart_calls"] == 1
+    assert state["stored"] is False
+    assert len(cast(list[object], state["credential_targets"])) == 1
+
+    assert "Privacy and credential-verification consent" in result.stdout
+    assert "API-key entry has not started" in result.stdout
+    assert "not credential entry" in result.stderr
+    assert "Hidden credential ceremony begins now" in result.stdout
+    assert "Privacy: configured (trusted_provider)" in result.stdout
+    assert "repository grant: granted" in result.stdout
+    assert "Credential: not stored" in result.stdout
+    assert "Credential reason: empty_input" in result.stdout
+    assert "next: run 'yoetz provider credential set'" not in result.stdout
+    assert "restart the Yoetz service" not in " ".join(cast(list[str], report["next_steps"]))
+    assert "yoetz --privacy" not in " ".join(cast(list[str], report["next_steps"]))
+    assert fake_credential not in result.output
+    assert fake_credential not in json.dumps(report)
+    secret_bytes = fake_credential.encode("utf-8")
+    for candidate in tmp_path.rglob("*"):
+        if candidate.is_file():
+            assert secret_bytes not in candidate.read_bytes()
+
+
+def test_composed_wizard_reaches_semantic_readiness_after_hidden_credential_storage(
+    wizard_env: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wizard_env["outputs"] = [
+        CommandOutput(1, b""),
+        CommandOutput(1, b""),
+        CommandOutput(0, b""),
+        _yoetz_entry("policy"),
+    ]
+    state = _wire_composed_provider_setup(
+        monkeypatch,
+        tmp_path,
+        credential_outcome="stored",
+    )
+
+    result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n1\nY\nY\n")
+
+    assert result.exit_code == 0
+    reports = cast(list[dict[str, object]], state["reports"])
+    assert len(reports) == 1
+    report = reports[0]
+    assert report["privacy"] == {
+        "outcome": "configured",
+        "profile": "trusted_provider",
+        "proposal_id": "pvp_issue_165",
+        "grant_state": "granted",
+        "migration_state": "not_applicable",
+        "reason": None,
+    }
+    assert report["provider"] == {
+        "binding": "configured",
+        "credential": "stored",
+        "credential_display": "********",
+    }
+    assert cast(dict[str, object], report["semantic_status"])["semantic_ready"] is True
+    assert report["next_steps"] == []
+    assert report["marker_written"] is True
+    assert state["binding_embedded_flags"] == [False]
+    assert state["privacy_calls"] == [("assisted_review", True, True)]
+    assert state["status_reads"] == 2
+    assert state["restart_calls"] == 2
+    assert state["stored"] is True
+    targets = cast(list[object], state["credential_targets"])
+    assert len(targets) == 1
+    assert getattr(targets[0], "repository_privacy_commitment") == "hmac-sha256:" + "7" * 64
+    assert "Hidden credential ceremony begins now" in result.stdout
+    assert "Credential: ********" in result.stdout
+    assert "Semantic-advice readiness: ready" in result.stdout
 
 
 def test_no_codex_found_still_completes_with_guidance(wizard_env: dict[str, object]) -> None:
@@ -951,7 +1302,7 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
         fake_create_for_initialization,
     )
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
-    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda: None)
+    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda **_kwargs: None)
     monkeypatch.setattr(config_module, "load_config", fake_load_config)
     monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
     monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
@@ -1039,7 +1390,7 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
 
     monkeypatch.setattr(keyring_module, "AutoUnlockPassphraseStore", fake_store)
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
-    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda: None)
+    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda **_kwargs: None)
     monkeypatch.setattr(config_module, "load_config", fake_load_config)
     monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
     monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
@@ -1282,7 +1633,7 @@ def test_existing_bound_credential_can_be_reused_without_requesting_it_again(
     def reuse(*_args: object, **_kwargs: object) -> bool:
         return True
 
-    monkeypatch.setattr(setup_module.typer, "confirm", reuse)
+    monkeypatch.setattr(setup_module, "_prompt_yes_no_before_credential", reuse)
 
     _service, report = asyncio.run(
         setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]
@@ -1364,7 +1715,7 @@ def test_existing_bound_credential_replacement_does_not_inherit_old_presence(
     def replace_stored(*_args: object, **_kwargs: object) -> bool:
         return False
 
-    monkeypatch.setattr(setup_module.typer, "confirm", replace_stored)
+    monkeypatch.setattr(setup_module, "_prompt_yes_no_before_credential", replace_stored)
 
     _service, report = asyncio.run(
         setup_module._interactive_provider_setup(  # pyright: ignore[reportPrivateUsage]

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -27,6 +27,7 @@ from yoetz.ports.integrations import (
     IntegrationTarget,
     SkillSource,
 )
+from yoetz.protocol.canonical import JsonValue
 from yoetz.service.client import ServiceClient
 
 _RUNNER = CliRunner()
@@ -37,6 +38,10 @@ def _plain(text: str) -> str:
     """Strip ANSI SGR sequences so Rich usage panels stay assertable."""
 
     return _ANSI_ESCAPE.sub("", text)
+
+
+def _skip_provider_binding(**_kwargs: object) -> None:
+    """Stand in for the interactive endpoint prompt without an untyped lambda."""
 
 
 async def _fake_repository_privacy_snapshot(*_args: object) -> SimpleNamespace:
@@ -324,13 +329,13 @@ def _wire_composed_provider_setup(
         state["stored"] = True
         return SimpleNamespace(activation_status="stored")
 
-    original_emit_human_report = setup_module._emit_human_report
+    original_emit_human_report = setup_module._emit_human_report  # pyright: ignore[reportPrivateUsage]
 
-    def capture_report(report: dict[str, object]) -> None:
+    def capture_report(report: dict[str, JsonValue]) -> None:
         cast(list[dict[str, object]], state["reports"]).append(
             cast(dict[str, object], json.loads(json.dumps(report)))
         )
-        original_emit_human_report(cast(dict[str, object], report))
+        original_emit_human_report(report)
 
     monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
     monkeypatch.setattr(setup_module, "_service_reachability", ready)
@@ -562,7 +567,7 @@ def test_interactive_wizard_selects_harness_then_installation_and_requires_y_or_
 
     monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
     monkeypatch.setattr(
-        provider_binding, "prompt_provider_endpoint_binding", lambda **_kwargs: None
+        provider_binding, "prompt_provider_endpoint_binding", _skip_provider_binding
     )
 
     # harness 1, installation 2, review mode 2 (local only), a rejected y/n, then confirm.
@@ -601,7 +606,7 @@ def test_interactive_registration_n_declines_without_mutation(
 
     monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
     monkeypatch.setattr(
-        provider_binding, "prompt_provider_endpoint_binding", lambda **_kwargs: None
+        provider_binding, "prompt_provider_endpoint_binding", _skip_provider_binding
     )
 
     result = _RUNNER.invoke(cli.app, ["setup", "run"], input="1\n1\nN\n")
@@ -766,7 +771,7 @@ def test_composed_wizard_preserves_privacy_when_hidden_credential_input_is_empty
         credential_outcome="failed",
         credential_reason="empty_input",
     )
-    original_prompt = setup_module.typer.prompt
+    original_prompt = cast(Callable[..., object], setup_module.typer.prompt)
     probe_answers = iter((fake_credential, "yes"))
 
     def route_visible_prompts(prompt: str, *args: object, **kwargs: object) -> object:
@@ -1302,7 +1307,7 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
         fake_create_for_initialization,
     )
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
-    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda **_kwargs: None)
+    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", _skip_provider_binding)
     monkeypatch.setattr(config_module, "load_config", fake_load_config)
     monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
     monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)
@@ -1390,7 +1395,7 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
 
     monkeypatch.setattr(keyring_module, "AutoUnlockPassphraseStore", fake_store)
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
-    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", lambda **_kwargs: None)
+    monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", _skip_provider_binding)
     monkeypatch.setattr(config_module, "load_config", fake_load_config)
     monkeypatch.setattr(paths_module, "bundle_root", fake_bundle_root)
     monkeypatch.setattr(setup_module, "_service_reachability", fake_reachability)

--- a/tests/unit/adapters/providers/test_openai_responses_request_shape.py
+++ b/tests/unit/adapters/providers/test_openai_responses_request_shape.py
@@ -37,9 +37,11 @@ _JUDGMENT = '{"conclusion":"no_material_discrepancy","reviewer_challenges":[]}'
 class _CaptureTransport(httpx.AsyncBaseTransport):
     def __init__(self) -> None:
         self.request_body: bytes | None = None
+        self.authorization: str | None = None
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.request_body = await request.aread()
+        self.authorization = request.headers.get("authorization")
         return httpx.Response(
             200,
             request=request,
@@ -343,6 +345,8 @@ async def test_evaluator_dispatches_the_audited_rendered_body_verbatim() -> None
 
     assert type(result) is SemanticResultSuccess
     assert capture.request_body == rendered.body
+    assert capture.authorization == "Bearer nonsecret-test-credential"
+    assert "yoetz-fixed-nonsecret-sentinel" not in capture.authorization
     # The adapter reports the policy that authorized the dispatch, never a minted placeholder.
     assert result.provenance.policy_digest == case.policy_digest
     assert result.provenance.privacy_policy_digest == case.policy_digest

--- a/tests/unit/cli/test_trusted_console.py
+++ b/tests/unit/cli/test_trusted_console.py
@@ -73,7 +73,21 @@ def test_posix_empty_line_is_rejected() -> None:
     ):
         with pytest.raises(TrustedConsoleError) as exc:
             adapter.read_line("Secret: ", 64, hidden=False)
-    assert exc.value.reason == "input_invalid"
+    assert exc.value.reason == "empty_input"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX terminal checks are unavailable")
+def test_posix_eof_is_distinct_from_empty_input() -> None:
+    adapter = trusted_console._PosixConsoleAdapter()  # pyright: ignore[reportPrivateUsage]
+    adapter._fd = 9  # pyright: ignore[reportPrivateUsage]
+
+    with (
+        patch("yoetz.cli.trusted_console._PosixConsoleAdapter.write"),
+        patch("yoetz.cli.trusted_console.os.readv", return_value=0),
+    ):
+        with pytest.raises(TrustedConsoleError) as exc:
+            adapter.read_line("Secret: ", 64, hidden=False)
+    assert exc.value.reason == "eof"
 
 
 class _WindowsApi:
@@ -154,6 +168,36 @@ def test_windows_reads_secrets_without_echo_through_console_api() -> None:
     assert api.hidden_reads == [True]
     assert api.writes == ["Secret: ", "\n"]
     assert api.closed == [202, 101]
+
+
+def test_windows_empty_input_is_distinct_and_bounded() -> None:
+    api = _WindowsApi()
+    api.read_line = lambda *_args, **_kwargs: bytearray()  # type: ignore[method-assign]
+    adapter = trusted_console._WindowsConsoleAdapter(api)  # pyright: ignore[reportPrivateUsage]
+    adapter.open()
+    try:
+        with pytest.raises(TrustedConsoleError) as exc:
+            adapter.read_line("Secret: ", 64, hidden=True)
+    finally:
+        adapter.close()
+    assert exc.value.reason == "empty_input"
+
+
+def test_windows_eof_reason_is_not_collapsed() -> None:
+    api = _WindowsApi()
+
+    def eof(*_args: object, **_kwargs: object) -> bytearray:
+        raise TrustedConsoleError("eof")
+
+    api.read_line = eof  # type: ignore[method-assign]
+    adapter = trusted_console._WindowsConsoleAdapter(api)  # pyright: ignore[reportPrivateUsage]
+    adapter.open()
+    try:
+        with pytest.raises(TrustedConsoleError) as exc:
+            adapter.read_line("Secret: ", 64, hidden=True)
+    finally:
+        adapter.close()
+    assert exc.value.reason == "eof"
 
 
 def test_windows_ambiguous_console_error_is_bounded() -> None:


### PR DESCRIPTION
## Summary

- separates visible consent prompts from the hidden credential ceremony and never reflects invalid credential-shaped input
- preserves committed privacy and grant state when credential storage fails
- exposes only allowlisted, nonsecret credential failure reasons
- derives recovery commands from live provider-status blockers and committed component state
- suppresses the standalone endpoint-binding handoff inside the composed setup wizard
- adds full partial-success and success regressions for the real composed wizard path

Addresses #165.

## Root cause

The composed wizard reused standalone endpoint-binding copy, then presented an ordinary echoing confirmation before confidential credential ingress. When credential storage later failed, setup replaced the already-committed privacy result with a synthetic failure and inferred recovery from that fabricated report state instead of live provider status.

## Fake credential verification

The test suite verifies the storage and transport boundaries independently:

- a local vault test stores and replaces a fake credential, retrieves the exact replacement for one authorized attempt, and rejects a second use
- mocked provider transport receives `Authorization: Bearer nonsecret-test-credential`, while the SDK sentinel credential is absent
- failed composed setup asserts that credential-shaped test input is absent from CLI output, the JSON report, and temporary persisted files
- failed credential storage performs no credential probe or semantic provider dispatch

I also ran a direct local vault-to-transport proof using the real encrypted vault and production `OneAttemptCredentialTransport`, with a mocked final HTTP boundary and no live network access. It verified:

```text
vault_reports_stored: true
plaintext_credential_on_disk: false
production_transport_received_exact_fake_credential: true
sdk_sentinel_replaced: true
request_body_preserved: true
credential_handle_second_use_rejected: true
mock_network_calls: 1
live_network_calls: 0
```

## Local verification

```text
133 passed
  tests/subprocess/test_provider_endpoint_cli.py
  tests/subprocess/test_setup_wizard_cli.py
  tests/unit/cli/test_trusted_console.py
  tests/unit/service/test_vault_state.py
  tests/unit/adapters/providers/test_openai_responses_request_shape.py

316 passed
  tests/unit/cli
  tests/unit/config
  tests/unit/adapters/providers

172 passed
  tests/unit/service

290 passed
  tests/unit/application
```

Additional checks passed:

```text
uv run ruff format --check .
uv run ruff check .
npx --no-install pyright
uv run python scripts/generate_schemas.py --check
uv run python scripts/sync_check_continuation_schemas.py --check
uv run python scripts/verify_resource_manifest.py --check
uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Local validation used Python 3.14.6, uv 0.11.29, the repository's frozen dependency environment, isolated filesystem state, and fake credentials only.

## Branching and CI note

This PR now targets `main` and contains two commits across nine changed files. The initial required `format-lint-type` job exposed strict Pyright errors in the new blocker traversal and test doubles; commit `bcc06a4` fixes those types without changing the issue #165 behavior. The exact locked format/lint/type commands and the focused 133-test setup/credential slice pass locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects composed setup reporting when credential storage fails while preserving already committed privacy state.
- Separates visible consent from hidden credential entry and bounds reported credential-failure reasons.
- Derives recovery guidance from live provider status with component-state fallback.
- Suppresses standalone endpoint handoff text inside the composed wizard.
- Adds composed-flow regressions for partial success, successful storage, output secrecy, and platform-specific console reasons.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/cli/setup.py | Adds bounded credential reporting, explicit consent and secret-input transitions, preserved component state, and status-derived recovery guidance. |
| src/yoetz/cli/provider_binding.py | Allows composed setup to suppress the standalone credential handoff while retaining standalone behavior by default. |
| src/yoetz/cli/trusted_console.py | Distinguishes empty input from EOF across POSIX and Windows trusted-console implementations. |
| src/yoetz/cli/unlock.py | Extends the fixed public ceremony-reason set for the new empty-input and EOF outcomes. |
| tests/subprocess/test_setup_wizard_cli.py | Exercises composed setup success and credential-storage failure while checking privacy preservation, bounded output, and recovery commands. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Composed setup wizard] --> B[Visible verification consent]
  B --> C[Commit privacy and repository grant]
  C --> D[Hidden credential ceremony]
  D -->|Stored| E[Restart semantic service]
  D -->|Failed or ambiguous| F[Preserve privacy result]
  E --> G[Read provider status]
  F --> G
  G --> H[Derive bounded recovery steps]
  H --> I[Emit sanitized setup report]
```

<sub>Reviews (2): Last reviewed commit: ["Fix composed setup credential reporting"](https://github.com/thegaysupreme123/yoetz/commit/979a6387e0af022f45b8dbd0de4920cada06fa15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=23773656)</sub>

<!-- /greptile_comment -->