### PR TITLE
Fix provider credential readiness status

### DIFF
--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -2249,6 +2249,17 @@ async def provide_service_ready_context(
     def binding_not_connected(_binding: ProviderBinding) -> bool:
         return False
 
+    async def configured_provider_credential_present() -> bool:
+        if candidate_binding is None:
+            return False
+        credential_binding = provider_credential_profile_binding(
+            candidate_binding.provider_id,
+            candidate_binding.model_id,
+            candidate_binding.endpoint_profile_id,
+            candidate_binding.endpoint_profile_version,
+        )
+        return await vault.has_provider_credential(credential_binding)
+
     async def resolve_provider_binding() -> ProviderBinding | None:
         if candidate_binding is None:
             return None
@@ -2258,21 +2269,15 @@ async def provide_service_ready_context(
         )
         if binding_connected(candidate_binding) is not True:
             return None
-        credential_binding = provider_credential_profile_binding(
-            candidate_binding.provider_id,
-            candidate_binding.model_id,
-            candidate_binding.endpoint_profile_id,
-            candidate_binding.endpoint_profile_version,
-        )
-        if not await vault.has_provider_credential(credential_binding):
+        if not await configured_provider_credential_present():
             return None
         return candidate_binding
 
-    # Repository authority is session-specific, so ready-time composition cannot truthfully claim
-    # a connected external provider or inspect its credential. Those facts are resolved only after
-    # a task route supplies its trusted repository commitment.
+    # Repository authority is session-specific, so ready-time composition cannot activate a
+    # provider binding or claim semantic readiness. Exact configured-credential presence is a
+    # separate structural vault fact: it neither decrypts the record nor grants dispatch authority.
     provider_binding: ProviderBinding | None = None
-    provider_credential_connected = False
+    provider_credential_connected = await configured_provider_credential_present()
     semantic_ready = False
     capabilities = {
         RuntimeCapability.STRUCTURAL_READ,

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -1354,6 +1354,94 @@ async def test_ready_factory_deterministic_check_records_semantic_not_requested_
 
 
 @pytest.mark.anyio
+async def test_ready_composition_reports_exact_configured_credential_presence(
+    tmp_path: Path,
+) -> None:
+    """Status can read exact vault presence without inventing repository authority."""
+
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "d" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    await lifecycle.acquire_singleton()
+    await lifecycle.transition(ServiceState.LOCKED)
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "e" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "f" * 64)
+    provider = fireworks_provider(model="accounts/fireworks/models/minimax-m3")
+    config = YoetzConfig(profile="local-openai", provider=provider)
+
+    def application_factory(provider_config: YoetzConfig):
+        return build_ready_application_factory(
+            lifecycle=lifecycle,
+            vault=vault,
+            config=provider_config,
+            paths=_Paths(tmp_path),
+            clock=clock,
+            secret_memory=memory,
+            diagnostics=_Diagnostics(),
+        )
+
+    app = None
+    try:
+        app = await application_factory(config)(1, vault.generation)
+        assert app.provider_credential_connected is False
+        await app.close()
+        app = None
+
+        credential_binding = provider_credential_profile_binding(
+            provider.provider_id,
+            provider.model,
+            provider.endpoint_profile_id,
+            provider.endpoint_profile_version,
+        )
+        proof = HumanAuthorizationProof(
+            "provider-proof-before-recomposition",
+            "provider_credential_set",
+            credential_binding.target_digest("set"),
+            1,
+            vault.generation,
+            None,
+            1.0,
+            60.0,
+        )
+        credential = memory.capture(
+            SecretPurpose.PROVIDER_CREDENTIAL,
+            bytearray(b"test-provider-token-for-status"),
+        )
+        await vault.store_provider_credential("set", credential_binding, credential, proof, 2.0)
+
+        app = await application_factory(config)(1, vault.generation)
+        assert app.provider_credential_connected is True
+        await app.close()
+        app = None
+
+        other_provider = fireworks_provider(model="accounts/fireworks/models/a-different-model")
+        other_config = YoetzConfig(profile="local-openai", provider=other_provider)
+        app = await application_factory(other_config)(1, vault.generation)
+        assert app.provider_credential_connected is False
+    finally:
+        if app is not None:
+            await app.close()
+        await vault.close()
+        memory.close()
+        await lifecycle.close()
+
+
+@pytest.mark.anyio
 async def test_ready_check_never_activates_provider_from_machine_policy_without_repository_grant(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #171

## Summary
- derive `provider_credential_connected` from the vault's exact configured provider/model/endpoint binding instead of hard-coding `false`
- keep structural credential presence separate from repository authority, provider activation, and semantic dispatch readiness
- add a real encrypted-vault regression covering status before storage, after storing a fake credential, and for a different configured model

## Root cause
Ready-time composition intentionally avoids claiming repository-scoped dispatch authority, but it incorrectly treated that as a reason not to report the separately safe structural fact that the exact configured credential record exists. That left `provider_credential_connected` permanently false even after successful setup.

## Verification
- red-before/green-after: the new exact-binding regression failed on the old hard-coded value, then passed with this change
- wizard/status slice: `98 passed`
  - `tests/integration/service/test_ready_composition.py`
  - `tests/unit/cli/test_provider_status.py`
  - `tests/subprocess/test_setup_wizard_cli.py`
- scripted fake-provider dispatch suite: `5 passed`
- full standalone-clone suite: `3295 passed, 17 skipped, 4 xfailed`
- Ruff check and format check: passed
- pinned Pyright: `0 errors, 0 warnings`
- exact wheel build: passed

The composed wizard's successful hidden-credential path was exercised with fake/simulated credential storage, and the new regression stores fake credential bytes in the real encrypted vault. I also attempted an installed-wheel clean-room wizard run; it reached the privacy/provider ceremony, but macOS SecurityAgent user-presence blocked unattended Keychain retrieval after restart, so I am not counting that partial manual run as a successful end-to-end credential ceremony.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates exact configured credential-record presence from provider activation and semantic dispatch readiness.
- Derives `provider_credential_connected` from the encrypted vault’s exact configured provider/model/profile binding.
- Reuses the structural presence check when resolving an active provider binding.
- Adds an encrypted-vault regression covering absent, matching, and different-model credentials.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/yoetz/service/ready_composition.py | Replaces the hard-coded disconnected status with an exact structural vault lookup while preserving separate activation and semantic-readiness gates. |
| tests/integration/service/test_ready_composition.py | Adds integration coverage proving status changes only for a credential matching the configured provider binding. |

<sub>Reviews (2): Last reviewed commit: ["Fix provider credential readiness status"](https://github.com/thegaysupreme123/yoetz/commit/84bdfd87fb106ede6086161410316e6b4437a993) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=23943340)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ready status now accurately reflects whether credentials for the configured provider are stored.
  * Credentials are only recognized when they match the exact configured provider profile.
  * Existing connectivity and missing-credential validation remains enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->