### PR TITLE
Terminalize failed checks without misclassifying semantic outcomes

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -916,9 +916,20 @@ deciding between the two, shared by the receipt and by compact status coverage.
 - `reclaim_operation(writer_id, operation_id, request_digest) -> OperationLease | PendingVerdict`;
 - `commit_check_if_current(frozen, findings, policy_executions, semantic_status, semantic_reason,
   semantic_provenance, request_id) -> CheckCommitResult`;
+- `fail_check_if_current(lease, failure) -> None` (last-resort terminalization for a bounded,
+  non-retryable post-admission failure; records no check event and advances no frontier; retryable
+  failures are rejected and remain pending);
 - `lookup_operation(writer_id, operation_id) -> OperationRecord | None`.
 
 The check orchestration methods are authority-bearing port methods, not SQLite extensions.
+Once `freeze_case` returns an `OperationLease`, an unexpected application/protocol-value failure is
+an internal failure, never caller-side `INVALID_REQUEST`. The application calls
+`fail_check_if_current` before returning `INTERNAL_ERROR`; the exact operation becomes
+`complete/terminal` with a durable bounded error result, same-request replay returns that error,
+and a fresh check identity remains admissible at the unchanged frontier. SQLite commits the
+in-memory oracle state and durable rows atomically: a failed persistence sync restores the prior
+oracle state. `awaiting_human` and retryable ownership conflicts remain pending and never use this
+terminalization path.
 `ports/ledger.py` owns the shared closed enums: `OperationKind` is
 `start|publish_work|check|respond|receipt`; `OperationState` is `pending|complete|quarantined`;
 `CheckPhase` is `reserved|local_ready|semantic_wait|ready_to_finalize|terminal`;

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -922,7 +922,8 @@ deciding between the two, shared by the receipt and by compact status coverage.
 - `lookup_operation(writer_id, operation_id) -> OperationRecord | None`.
 
 The check orchestration methods are authority-bearing port methods, not SQLite extensions.
-Once `freeze_case` returns an `OperationLease`, an unexpected application/protocol-value failure is
+Once `freeze_case` returns a `FrozenCase` whose `lease` field carries the `OperationLease`, an
+unexpected application/protocol-value failure is
 an internal failure, never caller-side `INVALID_REQUEST`. The application calls
 `fail_check_if_current` before returning `INTERNAL_ERROR`; the exact operation becomes
 `complete/terminal` with a durable bounded error result, same-request replay returns that error,

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -2453,3 +2453,50 @@ class MemoryLedgerAdapter:
             self._state.operations[key] = (terminal, None)
             self._state.check_results[key] = result
             return result
+
+    async def fail_check_if_current(
+        self, lease: OperationLease, failure: PublicOperationError
+    ) -> None:
+        """Terminalize an admitted check whose application pipeline failed unexpectedly.
+
+        This is the last-resort durability path: it records no check event and advances no
+        frontier, but it closes the exact operation so replay returns a stable terminal error
+        instead of waiting forever on a lease that no worker can resume safely.
+        """
+
+        if failure.retryable:
+            raise TypeError("retryable_check_failure_cannot_terminalize")
+        canonical = canonical_encode(
+            {
+                "code": failure.code.value,
+                "message": str(failure),
+                "retryable": failure.retryable,
+                "safe_details": dict(failure.safe_details),
+            }
+        )
+        key = (lease.writer_id, lease.operation_id)
+        async with self._lock:
+            current = self._state.operations.get(key)
+            if (
+                current is not None
+                and current[0].state is OperationState.COMPLETE
+                and key in self._state.check_errors
+            ):
+                return
+            record = self._require_lease(lease)
+            terminal = replace(
+                record,
+                state=OperationState.COMPLETE,
+                phase=CheckPhase.TERMINAL,
+                owner_generation=None,
+                lease_owner_id=None,
+                lease_generation=None,
+                lease_expires_at=None,
+                resume_object_ref=None,
+                result_canonical=canonical,
+                result_digest=f"sha256:{hashlib.sha256(canonical).hexdigest()}",
+                result_locator=None,
+                terminal_at=_now(self._clock),
+            )
+            self._state.operations[key] = (terminal, None)
+            self._state.check_errors[key] = failure

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -563,12 +563,16 @@ class SqliteLedger:
                     result_object_id,
                     terminal,
                 ) = operation_row
-                structural = tuple(
-                    item[0]
-                    for item in self._db.execute(
-                        "SELECT event_id FROM events WHERE ingestion_seq BETWEEN ? AND ? "
-                        "ORDER BY event_id",
-                        (first, last),
+                structural = (
+                    ()
+                    if first is None or last is None
+                    else tuple(
+                        item[0]
+                        for item in self._db.execute(
+                            "SELECT event_id FROM events WHERE ingestion_seq BETWEEN ? AND ? "
+                            "ORDER BY event_id",
+                            (first, last),
+                        )
                     )
                 )
                 result_ref = (
@@ -580,7 +584,11 @@ class SqliteLedger:
                         "application/vnd.yoetz.receipt+json",
                     )
                 )
-                locator = OperationResultLocator(first, last, result_ref, structural)
+                locator = (
+                    None
+                    if first is None and last is None and result_ref is None
+                    else OperationResultLocator(first, last, result_ref, structural)
+                )
                 operation = OperationRecord(
                     writer_value,
                     operation_value,
@@ -601,6 +609,7 @@ class SqliteLedger:
                 )
                 append_result = None
                 check_result = None
+                check_error: PublicOperationError | None = None
                 if operation.operation_kind is not OperationKind.CHECK:
                     result_json = strict_json_parse(result_canonical)
                     result_map = cast(Mapping[str, object], result_json)
@@ -627,7 +636,7 @@ class SqliteLedger:
                             for value in cast(list[object], result_map["warnings"])
                         ),
                     )
-                else:
+                elif locator is not None:
                     operation_records = records[cast(int, first) - 1 : cast(int, last)]
                     check_event = next(
                         (
@@ -684,12 +693,51 @@ class SqliteLedger:
                                 ),
                             ),
                         )
+                else:
+                    try:
+                        failure_json = strict_json_parse(cast(bytes, result_canonical))
+                        if not isinstance(failure_json, Mapping):
+                            raise ValueError("check_terminal_error_invalid")
+                        if frozenset(failure_json) == frozenset(
+                            {"code", "message", "retryable", "safe_details"}
+                        ):
+                            retryable = failure_json["retryable"]
+                            if retryable is not False:
+                                raise ValueError("check_terminal_error_retryable")
+                            check_error = PublicOperationError(
+                                PublicErrorCode(cast(str, failure_json["code"])),
+                                cast(str, failure_json["message"]),
+                                retryable,
+                                safe_details=failure_json["safe_details"],
+                            )
+                        elif frozenset(failure_json) == frozenset(
+                            {"code", "reason_code", "sequence", "head_digest"}
+                        ):
+                            if (
+                                failure_json["code"] != PublicErrorCode.FRONTIER_CONFLICT.value
+                                or failure_json["reason_code"] != "frontier_changed"
+                            ):
+                                raise ValueError("check_terminal_error_invalid")
+                            check_error = _public_error(
+                                PublicErrorCode.FRONTIER_CONFLICT,
+                                retryable=True,
+                                reason_code="frontier_changed",
+                                sequence=cast(int, failure_json["sequence"]),
+                                head_digest=cast(str, failure_json["head_digest"]),
+                            )
+                        else:
+                            raise ValueError("check_terminal_error_invalid")
+                    except (TypeError, ValueError) as exc:
+                        raise _public_error(PublicErrorCode.STORAGE_CORRUPT) from exc
                 self._state.operations[(writer_value, operation_value)] = (
                     operation,
                     append_result,
                 )
                 if check_result is not None:
                     self._state.check_results[(writer_value, operation_value)] = check_result
+                if operation.operation_kind is OperationKind.CHECK and locator is None:
+                    assert check_error is not None
+                    self._state.check_errors[(writer_value, operation_value)] = check_error
             # Disclosure waits are durable but the oracle is in-memory, so a restart would
             # otherwise answer "no continuation" for a check that is genuinely still suspended —
             # exactly the unrecoverable state this work exists to remove.
@@ -1289,19 +1337,7 @@ class SqliteLedger:
                 if pending is not None:
                     raise _public_error(PublicErrorCode.OPERATION_PENDING, retryable=True)
 
-            clone = MemoryLedgerState(
-                records=self._state.records,
-                operations=dict(self._state.operations),
-                writers=dict(self._state.writers),
-                projection=self._state.projection,
-                frozen_cases=dict(self._state.frozen_cases),
-                check_results=dict(self._state.check_results),
-                check_errors=dict(self._state.check_errors),
-                jobs=dict(self._state.jobs),
-                job_by_case=dict(self._state.job_by_case),
-                attempts=dict(self._state.attempts),
-                object_refs=dict(self._state.object_refs),
-            )
+            clone = self._clone_state()
             shim = _SqliteImportShim()
             shim.reservation = reservation
             oracle = MemoryLedgerAdapter(
@@ -1372,19 +1408,40 @@ class SqliteLedger:
             objects=self._objects,
         )
 
+    def _clone_state(self) -> MemoryLedgerState:
+        """Copy the oracle state so a failed SQLite sync cannot leak an in-memory commit."""
+
+        return MemoryLedgerState(
+            records=self._state.records,
+            operations=dict(self._state.operations),
+            writers=dict(self._state.writers),
+            projection=self._state.projection,
+            frozen_cases=dict(self._state.frozen_cases),
+            check_results=dict(self._state.check_results),
+            check_errors=dict(self._state.check_errors),
+            jobs=dict(self._state.jobs),
+            job_by_case=dict(self._state.job_by_case),
+            attempts=dict(self._state.attempts),
+            disclosure_waits=dict(self._state.disclosure_waits),
+            object_refs=dict(self._state.object_refs),
+        )
+
+    def _sync_after_mutation_locked(self, new_records: tuple[LedgerRecord, ...] = ()) -> None:
+        self._db.execute("BEGIN IMMEDIATE")
+        try:
+            self._db.execute("PRAGMA defer_foreign_keys=ON")
+            self._verify_owner()
+            self._persist_derived_records(new_records)
+            self._sync_runtime_state()
+            self._db.execute("COMMIT")
+        except BaseException:
+            if self._db.get_autocommit() is False:
+                self._db.execute("ROLLBACK")
+            raise
+
     async def _sync_after_mutation(self, new_records: tuple[LedgerRecord, ...] = ()) -> None:
         async with self._lock:
-            self._db.execute("BEGIN IMMEDIATE")
-            try:
-                self._db.execute("PRAGMA defer_foreign_keys=ON")
-                self._verify_owner()
-                self._persist_derived_records(new_records)
-                self._sync_runtime_state()
-                self._db.execute("COMMIT")
-            except BaseException:
-                if self._db.get_autocommit() is False:
-                    self._db.execute("ROLLBACK")
-                raise
+            self._sync_after_mutation_locked(new_records)
 
     async def load_projection(
         self, session_id: str, view: ProjectionView
@@ -1553,22 +1610,72 @@ class SqliteLedger:
         request_id: str,
     ) -> CheckCommitResult:
         await self._ensure_recovered()
-        before = len(self._state.records)
-        try:
-            result = await self._oracle().commit_check_if_current(
-                frozen,
-                findings,
-                policy_executions,
-                semantic_status,
-                semantic_reason,
-                semantic_provenance,
-                request_id,
+        async with self._lock:
+            prior = self._state
+            clone = self._clone_state()
+            oracle = MemoryLedgerAdapter(
+                task_id=self._task_id,
+                ownership_fence=self._fence,
+                state=clone,
+                import_state=_SqliteImportShim(),
+                transaction_lock=asyncio.Lock(),
+                clock=self._clock,
+                ids=self._ids,
+                objects=self._objects,
             )
-        except PublicOperationError:
-            await self._sync_after_mutation()
-            raise
-        await self._sync_after_mutation(self._state.records[before:])
-        return result
+            try:
+                result = await oracle.commit_check_if_current(
+                    frozen,
+                    findings,
+                    policy_executions,
+                    semantic_status,
+                    semantic_reason,
+                    semantic_provenance,
+                    request_id,
+                )
+            except PublicOperationError:
+                # The memory oracle terminalizes a frontier conflict before raising it. Preserve
+                # that durable error transition just as the pre-clone implementation did.
+                self._state = clone
+                try:
+                    self._sync_after_mutation_locked()
+                except BaseException:
+                    self._state = prior
+                    raise
+                raise
+            new_records = clone.records[len(prior.records) :]
+            self._state = clone
+            try:
+                self._sync_after_mutation_locked(new_records)
+            except BaseException:
+                self._state = prior
+                raise
+            return result
+
+    async def fail_check_if_current(
+        self, lease: OperationLease, failure: PublicOperationError
+    ) -> None:
+        await self._ensure_recovered()
+        async with self._lock:
+            prior = self._state
+            clone = self._clone_state()
+            oracle = MemoryLedgerAdapter(
+                task_id=self._task_id,
+                ownership_fence=self._fence,
+                state=clone,
+                import_state=_SqliteImportShim(),
+                transaction_lock=asyncio.Lock(),
+                clock=self._clock,
+                ids=self._ids,
+                objects=self._objects,
+            )
+            await oracle.fail_check_if_current(lease, failure)
+            self._state = clone
+            try:
+                self._sync_after_mutation_locked()
+            except BaseException:
+                self._state = prior
+                raise
 
     async def run_passive_checkpoint(self, wal_page_threshold: int) -> CheckpointReport:
         await self._ensure_recovered()

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -85,7 +85,7 @@ from yoetz.protocol.coverage import (
     coverage_to_json,
     weakest,
 )
-from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
 from yoetz.protocol.models import (
     CheckRequest,
@@ -1195,6 +1195,7 @@ async def execute_check_commit(
             frozenset(required_capabilities),
         )
     )
+    frozen: FrozenCase | None = None
     try:
         if runtime.session_id != request.session_id or runtime.writer_id != request.writer_id:
             raise PublicOperationError(
@@ -1409,12 +1410,45 @@ async def execute_check_commit(
             semantic_result.provenance,
             request.request_id,
         )
-    except ProtocolValueError as exc:
-        raise PublicOperationError(
-            PublicErrorCode.INVALID_REQUEST,
-            "The check request is invalid.",
+    except PublicOperationError as exc:
+        if frozen is not None and not exc.retryable:
+            try:
+                await runtime.ledger.fail_check_if_current(frozen.lease, exc)
+            except Exception as terminalize_exc:
+                record_unexpected_exception_without_raising(
+                    terminalize_exc,
+                    component="check",
+                    operation="check_pipeline_terminalization_failed",
+                    request_id=request.request_id,
+                )
+        raise
+    except Exception as exc:
+        # The request is already a validated CheckRequest. Any protocol-value failure raised from
+        # this pipeline is therefore an implementation/storage defect, not malformed caller input.
+        # Close an admitted operation before surfacing the internal error so exact replay and
+        # status never wait forever on work this invocation has abandoned.
+        record_unexpected_exception_without_raising(
+            exc,
+            component="check",
+            operation="check_pipeline_failed",
+            request_id=request.request_id,
+        )
+        failure = PublicOperationError(
+            PublicErrorCode.INTERNAL_ERROR,
+            "The check failed internally.",
             False,
-        ) from exc
+        )
+        if frozen is not None:
+            try:
+                await runtime.ledger.fail_check_if_current(frozen.lease, failure)
+            except Exception as terminalize_exc:
+                record_unexpected_exception_without_raising(
+                    terminalize_exc,
+                    component="check",
+                    operation="check_pipeline_terminalization_failed",
+                    request_id=request.request_id,
+                )
+        raise failure from exc
     finally:
         await app.runtime.release(runtime)
 

--- a/src/yoetz/ports/ledger.py
+++ b/src/yoetz/ports/ledger.py
@@ -29,6 +29,7 @@ from yoetz.kernel.deterministic_checks import CaseAvailabilityFacts, Determinist
 from yoetz.kernel.projections import ProjectionState
 from yoetz.ports.objects import ObjectKind, ObjectRef
 from yoetz.protocol.coverage import Coverage, PublicationChannel
+from yoetz.protocol.errors import PublicOperationError
 from yoetz.protocol.ids import IdKind, validate_actor_id, validate_id
 from yoetz.protocol.models import (
     MAX_EVENTS_PER_BATCH,
@@ -1515,6 +1516,10 @@ class LedgerPort(Protocol):
         semantic_provenance: SemanticProvenance | None,
         request_id: str,
     ) -> CheckCommitResult: ...
+
+    async def fail_check_if_current(
+        self, lease: OperationLease, failure: PublicOperationError
+    ) -> None: ...
 
     async def lookup_operation(
         self, writer_id: str, operation_id: str

--- a/tests/conformance/adapters/test_ledger_port.py
+++ b/tests/conformance/adapters/test_ledger_port.py
@@ -20,7 +20,13 @@ from yoetz.adapters.memory.ledger import MemoryLedgerAdapter, MemoryLedgerState
 from yoetz.adapters.sqlite.migrations import initialize_bundle
 from yoetz.adapters.sqlite.repository import SqliteLedger
 from yoetz.domain.events import EventDraft, EventPayload, UnknownEvent
-from yoetz.domain.findings import CheckVerdict, RankedFindings
+from yoetz.domain.findings import (
+    CheckVerdict,
+    RankedFindings,
+    SemanticDispatchKind,
+    SemanticFailureClass,
+    SemanticProvenance,
+)
 from yoetz.domain.values import parse_rfc3339_millis
 from yoetz.ports.ledger import (
     AppendCommand,
@@ -46,6 +52,7 @@ from yoetz.ports.objects import (
     StagedObject,
 )
 from yoetz.ports.runtime import OwnershipFence
+from yoetz.ports.semantic import SamplingParams
 from yoetz.protocol.canonical import canonical_encode
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import PREFIX_BY_KIND, IdKind
@@ -561,6 +568,264 @@ async def test_commit_check_if_current_contract() -> None:
         assert result.outcome == "committed"
         results.append(result)
     assert results[0] == results[1]
+
+
+@pytest.mark.anyio
+async def test_invalid_semantic_outcome_commits_and_does_not_poison_later_checks() -> None:
+    """A designed provider-invalid outcome must be durable in both ledger adapters."""
+
+    command = ledger_command()
+    for adapter in (memory_ledger(command), sqlite_ledger(command)):
+        await adapter.append_batch(command)
+        frozen = await adapter.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            "req_00000000-0000-4000-8000-000000000038",
+            "sha256:" + "8" * 64,
+        )
+        assert type(frozen) is FrozenCase
+        lease = await adapter.advance_check_phase(
+            frozen.lease,
+            CheckPhase.RESERVED,
+            CheckPhase.LOCAL_READY,
+            await _local_result_ref(adapter, command),
+        )
+        lease = await adapter.advance_check_phase(
+            lease,
+            CheckPhase.LOCAL_READY,
+            CheckPhase.SEMANTIC_WAIT,
+        )
+        case_ref = await _object_ref(adapter, command, ObjectKind.SEMANTIC_CASE)
+        job = await adapter.enqueue_semantic_job(lease, "sha256:" + "7" * 64, case_ref)
+        handle = await adapter.claim_semantic_job(lease, job.job_id)
+        await adapter.record_attempt_outcome(
+            handle,
+            AttemptOutcome.FAILED,
+            terminal_code=SemanticReason.RESPONSE_CONTENT_INVALID,
+        )
+        lease = await adapter.renew_leases(lease)
+        lease = await adapter.advance_check_phase(
+            lease,
+            CheckPhase.SEMANTIC_WAIT,
+            CheckPhase.READY_TO_FINALIZE,
+        )
+        provenance = SemanticProvenance(
+            provider="fake",
+            endpoint_profile_id="fake",
+            endpoint_profile_version="1.0.0",
+            model="fake/model",
+            sdk_version="1.0.0",
+            prompt_digest="sha256:" + "1" * 64,
+            schema_digest="sha256:" + "2" * 64,
+            policy_digest="sha256:" + "3" * 64,
+            privacy_policy_digest="sha256:" + "4" * 64,
+            sampling_params=SamplingParams(128),
+            latency_ms=1,
+            semantic_attempt_id=handle.attempt_id,
+            dispatch_kind=SemanticDispatchKind.EXTERNAL,
+            privacy_receipt_id="egr_00000000-0000-4000-8000-000000000038",
+            status=SemanticStatus.INVALID,
+            reason=SemanticReason.RESPONSE_CONTENT_INVALID,
+            provider_request_id=handle.provider_request_id,
+            failure_class=SemanticFailureClass.RESPONSE_CONTENT,
+            egress_authorization_id="aut_00000000-0000-4000-8000-000000000038",
+            request_commitment="hmac-sha256:" + "5" * 64,
+        )
+        ranked = RankedFindings(
+            (),
+            0,
+            CheckVerdict.INCOMPLETE_CHECK,
+            command.entries[0].coverage,
+        )
+        result = await adapter.commit_check_if_current(
+            FrozenCase(frozen.case, lease),
+            ranked,
+            (CheckPolicyExecution("research-evidence", "0.1.0", "run", "completed"),),
+            SemanticStatus.INVALID,
+            SemanticReason.RESPONSE_CONTENT_INVALID,
+            provenance,
+            lease.operation_id,
+        )
+        assert result.semantic_status is SemanticStatus.INVALID
+        assert result.semantic_reason is SemanticReason.RESPONSE_CONTENT_INVALID
+        operation = await adapter.lookup_operation(command.writer_id, lease.operation_id)
+        assert operation is not None
+        assert operation.state.value == "complete"
+
+
+@pytest.mark.anyio
+async def test_failed_check_terminalization_replays_and_allows_a_fresh_check() -> None:
+    command = ledger_command()
+    for adapter in (memory_ledger(command), sqlite_ledger(command)):
+        await adapter.append_batch(command)
+        request_id = "req_00000000-0000-4000-8000-000000000058"
+        request_digest = "sha256:" + "8" * 64
+        frozen = await adapter.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            request_id,
+            request_digest,
+        )
+        assert type(frozen) is FrozenCase
+
+        await adapter.fail_check_if_current(
+            frozen.lease,
+            PublicOperationError(
+                PublicErrorCode.INTERNAL_ERROR,
+                "The check failed internally.",
+                False,
+            ),
+        )
+
+        operation = await adapter.lookup_operation(command.writer_id, request_id)
+        assert operation is not None
+        assert operation.state.value == "complete"
+        assert operation.phase is CheckPhase.TERMINAL
+        with pytest.raises(PublicOperationError) as replayed:
+            await adapter.freeze_case(
+                command.session_id,
+                command.writer_id,
+                1,
+                request_id,
+                request_digest,
+            )
+        assert replayed.value.code is PublicErrorCode.INTERNAL_ERROR
+        fresh = await adapter.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            "req_00000000-0000-4000-8000-000000000059",
+            "sha256:" + "9" * 64,
+        )
+        assert type(fresh) is FrozenCase
+
+
+@pytest.mark.anyio
+async def test_failed_check_terminalization_survives_sqlite_restart() -> None:
+    command = ledger_command()
+    first = sqlite_ledger(command)
+    await first.append_batch(command)
+    request_id = "req_00000000-0000-4000-8000-000000000068"
+    request_digest = "sha256:" + "8" * 64
+    frozen = await first.freeze_case(
+        command.session_id,
+        command.writer_id,
+        1,
+        request_id,
+        request_digest,
+    )
+    assert type(frozen) is FrozenCase
+    await first.fail_check_if_current(
+        frozen.lease,
+        PublicOperationError(
+            PublicErrorCode.INTERNAL_ERROR,
+            "The check failed internally.",
+            False,
+        ),
+    )
+
+    restarted = SqliteLedger(
+        db=first._db,  # pyright: ignore[reportPrivateUsage]
+        task_id=command.task_id,
+        ownership_fence=_fence(),
+        clock=first._clock,  # pyright: ignore[reportPrivateUsage]
+        ids=first._ids,  # pyright: ignore[reportPrivateUsage]
+        objects=first._objects,  # pyright: ignore[reportPrivateUsage]
+    )
+    with pytest.raises(PublicOperationError) as replayed:
+        await restarted.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            request_id,
+            request_digest,
+        )
+    assert replayed.value.code is PublicErrorCode.INTERNAL_ERROR
+
+
+@pytest.mark.anyio
+async def test_frontier_conflict_terminalization_survives_sqlite_restart() -> None:
+    command = ledger_command()
+    first = sqlite_ledger(command)
+    await first.append_batch(command)
+
+    async def ready(request_id: str, request_digest: str) -> FrozenCase:
+        frozen = await first.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            request_id,
+            request_digest,
+        )
+        assert type(frozen) is FrozenCase
+        lease = await first.advance_check_phase(
+            frozen.lease,
+            CheckPhase.RESERVED,
+            CheckPhase.LOCAL_READY,
+            await _local_result_ref(first, command),
+        )
+        lease = await first.advance_check_phase(
+            lease,
+            CheckPhase.LOCAL_READY,
+            CheckPhase.READY_TO_FINALIZE,
+        )
+        return FrozenCase(frozen.case, lease)
+
+    winning = await ready(
+        "req_00000000-0000-4000-8000-000000000078",
+        "sha256:" + "7" * 64,
+    )
+    stale = await ready(
+        "req_00000000-0000-4000-8000-000000000079",
+        "sha256:" + "8" * 64,
+    )
+    ranked = RankedFindings(
+        (),
+        0,
+        CheckVerdict.NO_ISSUE_DETECTED,
+        command.entries[0].coverage,
+    )
+    executions = (CheckPolicyExecution("research-evidence", "0.1.0", "run", "completed"),)
+    await first.commit_check_if_current(
+        winning,
+        ranked,
+        executions,
+        SemanticStatus.NOT_REQUESTED,
+        SemanticReason.DETERMINISTIC_MODE,
+        None,
+        winning.lease.operation_id,
+    )
+    with pytest.raises(PublicOperationError) as conflicted:
+        await first.commit_check_if_current(
+            stale,
+            ranked,
+            executions,
+            SemanticStatus.NOT_REQUESTED,
+            SemanticReason.DETERMINISTIC_MODE,
+            None,
+            stale.lease.operation_id,
+        )
+    assert conflicted.value.code is PublicErrorCode.FRONTIER_CONFLICT
+
+    restarted = SqliteLedger(
+        db=first._db,  # pyright: ignore[reportPrivateUsage]
+        task_id=command.task_id,
+        ownership_fence=_fence(),
+        clock=first._clock,  # pyright: ignore[reportPrivateUsage]
+        ids=first._ids,  # pyright: ignore[reportPrivateUsage]
+        objects=first._objects,  # pyright: ignore[reportPrivateUsage]
+    )
+    with pytest.raises(PublicOperationError) as replayed:
+        await restarted.freeze_case(
+            command.session_id,
+            command.writer_id,
+            1,
+            stale.lease.operation_id,
+            "sha256:" + "8" * 64,
+        )
+    assert replayed.value.code is PublicErrorCode.FRONTIER_CONFLICT
 
 
 @pytest.mark.anyio

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -68,7 +69,7 @@ from yoetz.ports.ledger import (
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef
 from yoetz.ports.runtime import BundleRuntimePort, OwnershipFence, RouteCommand, TaskRuntime
 from yoetz.ports.semantic import ReviewerChallenge, SamplingParams, SemanticJudgment
-from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
 from yoetz.protocol.models import CheckRequest, SemanticReason, SemanticStatus
 
@@ -139,6 +140,8 @@ class _Ledger:
         self.replay: CheckCommitResult | None = None
         self.failure: BaseException | None = None
         self.commit_count = 0
+        self.commit_failure: Exception | None = None
+        self.fail_count = 0
         self.phase_transitions: list[tuple[CheckPhase, CheckPhase]] = []
         self.last_ranked: RankedFindings | None = None
         self.last_executions: tuple[CheckPolicyExecution, ...] | None = None
@@ -228,6 +231,8 @@ class _Ledger:
         request_id: str,
     ) -> CheckCommitResult:
         assert frozen == self.frozen
+        if self.commit_failure is not None:
+            raise self.commit_failure
         self.commit_count += 1
         self.last_ranked = ranked
         self.last_executions = executions
@@ -253,6 +258,28 @@ class _Ledger:
                 "0.1.0",
                 ("research-evidence/0.1.0", "work-integrity/0.1.0"),
             ),
+        )
+
+    async def fail_check_if_current(
+        self, lease: OperationLease, failure: PublicOperationError
+    ) -> None:
+        assert lease == self.frozen.lease
+        assert failure.code is PublicErrorCode.INTERNAL_ERROR
+        assert self.operation is not None
+        self.fail_count += 1
+        result_canonical = b'{"code":"INTERNAL_ERROR"}'
+        self.operation = replace(
+            self.operation,
+            state=OperationState.COMPLETE,
+            phase=CheckPhase.TERMINAL,
+            owner_generation=None,
+            lease_owner_id=None,
+            lease_generation=None,
+            lease_expires_at=None,
+            resume_object_ref=None,
+            result_canonical=result_canonical,
+            result_digest=f"sha256:{hashlib.sha256(result_canonical).hexdigest()}",
+            terminal_at=datetime(2026, 1, 1, tzinfo=UTC),
         )
 
 
@@ -364,6 +391,25 @@ async def test_deterministic_check_freezes_ranks_commits_and_releases() -> None:
         (CheckPhase.RESERVED, CheckPhase.LOCAL_READY),
         (CheckPhase.LOCAL_READY, CheckPhase.READY_TO_FINALIZE),
     ]
+    assert cast(_Runtime, app.runtime).release_count == 1
+
+
+@pytest.mark.anyio
+async def test_post_admission_protocol_failure_is_internal_and_terminalizes_operation() -> None:
+    """An internal value failure cannot masquerade as bad input or leave CHECK pending."""
+
+    app = _App()
+    app.ledger.commit_failure = ProtocolValueError("invalid_event_value_type")
+
+    with pytest.raises(PublicOperationError) as caught:
+        await execute_check_commit(app, _request())
+
+    assert caught.value.code is PublicErrorCode.INTERNAL_ERROR
+    assert caught.value.retryable is False
+    assert app.ledger.fail_count == 1
+    assert app.ledger.operation is not None
+    assert app.ledger.operation.state is OperationState.COMPLETE
+    assert app.ledger.operation.phase is CheckPhase.TERMINAL
     assert cast(_Runtime, app.runtime).release_count == 1
 
 
@@ -723,6 +769,33 @@ def _succeeded(judgment: SemanticJudgment) -> FinalSemanticEvaluation:
             request_commitment="hmac-sha256:" + "b" * 64,
         ),
     )
+
+
+@pytest.mark.anyio
+async def test_response_content_invalid_is_a_committed_semantic_outcome() -> None:
+    app = _App(semantic=True)
+    succeeded = _succeeded(SemanticJudgment("no_material_discrepancy", ()))
+    assert succeeded.provenance is not None
+    app.semantic_result = replace(
+        succeeded,
+        status=SemanticStatus.INVALID,
+        reason=SemanticReason.RESPONSE_CONTENT_INVALID,
+        judgment=None,
+        provenance=replace(
+            succeeded.provenance,
+            status=SemanticStatus.INVALID,
+            reason=SemanticReason.RESPONSE_CONTENT_INVALID,
+        ),
+    )
+
+    result = await execute_check_commit(app, _request("semantic_if_configured"))
+
+    assert result.outcome == "committed"
+    assert result.semantic_status is SemanticStatus.INVALID
+    assert result.semantic_reason is SemanticReason.RESPONSE_CONTENT_INVALID
+    assert result.coverage.known_gaps
+    assert app.ledger.commit_count == 1
+    assert app.ledger.fail_count == 0
 
 
 def _reviewer_challenge(ref: str, *, summary: str = "Evidence gap") -> ReviewerChallenge:

--- a/tests/integration/application/test_full_workflow.py
+++ b/tests/integration/application/test_full_workflow.py
@@ -46,11 +46,17 @@ from yoetz.domain.values import Frontier, session_id
 from yoetz.ports.control import ControlClientKind, ControlMethod
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
-from yoetz.ports.ledger import CheckCommitResult, CheckPhase, OperationLease
+from yoetz.ports.ledger import (
+    CheckCommitResult,
+    CheckPhase,
+    OperationLease,
+    OperationState,
+)
 from yoetz.ports.objects import ObjectKind, ObjectRef
 from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
 from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
 from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.models import (
     CheckRequest,
     FrontierModel,
@@ -311,9 +317,22 @@ async def test_full_workflow_uses_one_final_client_projection(
         return await advance(lease, expected_phase, next_phase, durable_object_ref)
 
     monkeypatch.setattr(ledger, "advance_check_phase", crash_after_deterministic_result)
-    with pytest.raises(RuntimeError, match="simulated_post_deterministic_publish_crash"):
+    with pytest.raises(PublicOperationError) as first_failure:
         await app.check(check_request)
-    clock.advance(61)
+    assert first_failure.value.code is PublicErrorCode.INTERNAL_ERROR
+    failed_operation = await ledger.lookup_operation(started.writer_id, check_request.request_id)
+    assert failed_operation is not None
+    assert failed_operation.state is OperationState.COMPLETE
+    assert failed_operation.phase is CheckPhase.TERMINAL
+    with pytest.raises(PublicOperationError) as exact_replay:
+        await app.check(check_request)
+    assert exact_replay.value.code is PublicErrorCode.INTERNAL_ERROR
+
+    recovery_wire = {
+        **first_check_wire,
+        "request_id": protocol_id("req_", 822),
+    }
+    recovery_request = CheckRequest.model_validate(recovery_wire)
 
     crash_after_local_ready = True
 
@@ -331,11 +350,14 @@ async def test_full_workflow_uses_one_final_client_projection(
         return replacement
 
     monkeypatch.setattr(ledger, "advance_check_phase", crash_before_finalization)
-    with pytest.raises(RuntimeError, match="simulated_post_local_ready_crash"):
-        await app.check(check_request)
+    with pytest.raises(PublicOperationError) as second_failure:
+        await app.check(recovery_request)
+    assert second_failure.value.code is PublicErrorCode.INTERNAL_ERROR
     deterministic_refs = objects.refs_for_kind(ObjectKind.DETERMINISTIC_RESULT)
     assert len(deterministic_refs) == 2
-    durable_operation = await ledger.lookup_operation(started.writer_id, check_request.request_id)
+    durable_operation = await ledger.lookup_operation(
+        started.writer_id, recovery_request.request_id
+    )
     assert durable_operation is not None
     assert durable_operation.phase is CheckPhase.LOCAL_READY
     assert durable_operation.resume_object_ref == deterministic_refs[-1]
@@ -343,7 +365,7 @@ async def test_full_workflow_uses_one_final_client_projection(
     clock.advance(61)
     monkeypatch.setattr(ledger, "advance_check_phase", advance)
 
-    checked = await app.check(check_request)
+    checked = await app.check(recovery_request)
     assert type(checked) is CheckCommitResult, f"unexpected nonterminal check: {type(checked)}"
     assert checked.findings
     assert len(objects.refs_for_kind(ObjectKind.DETERMINISTIC_RESULT)) == 2
@@ -447,4 +469,4 @@ async def test_full_workflow_uses_one_final_client_projection(
     assert responded.subject_frontier == checked.result_frontier
     assert rechecked.subject_frontier == responded.result_frontier
     assert receipt.subject_frontier == rechecked.result_frontier
-    assert runtime.release_count == 9
+    assert runtime.release_count == 10

--- a/tests/unit/application/test_error_mapping.py
+++ b/tests/unit/application/test_error_mapping.py
@@ -117,7 +117,7 @@ _MODULE_CODE_INVENTORY: dict[str, frozenset[PublicErrorCode]] = {
     ),
     "check.py": frozenset(
         {
-            PublicErrorCode.INVALID_REQUEST,
+            PublicErrorCode.INTERNAL_ERROR,
             PublicErrorCode.OPERATION_PENDING,
             PublicErrorCode.SESSION_CONFLICT,
             PublicErrorCode.STORAGE_CORRUPT,
@@ -220,11 +220,11 @@ def test_known_failure_families_map_to_expected_public_codes() -> None:
     assert exit_code_for("success") == 0
     assert exit_code_for("cancelled") == 130
 
-    # Each six-operation module raises only codes drawn from validation/frontier/storage; a
-    # provider or cancellation code appearing here would mean a module invented a new mapping
+    # Each six-operation module raises only codes drawn from validation/frontier/storage/fallback;
+    # a provider or cancellation code appearing here would mean a module invented a new mapping
     # instead of degrading gracefully (semantic failure folds into ``incomplete_check`` and never
     # becomes a public error; cancellation propagates as ``asyncio.CancelledError``, not a code).
-    allowed = _VALIDATION_CODES | _FRONTIER_CODES | _STORAGE_CODES
+    allowed = _VALIDATION_CODES | _FRONTIER_CODES | _STORAGE_CODES | _FALLBACK_CODES
     for name, expected_codes in _MODULE_CODE_INVENTORY.items():
         actual_codes = _referenced_codes(_application_source(name))
         assert actual_codes == expected_codes, name


### PR DESCRIPTION
## Summary

- preserve `response_content_invalid` as a committed semantic outcome with an explicit coverage gap
- replace the post-validation `ProtocolValueError -> INVALID_REQUEST` mapping with bounded `INTERNAL_ERROR` handling
- durably terminalize non-retryable post-admission failures so exact replay is stable and fresh checks remain admissible
- make SQLite check commits and terminal-error persistence atomic with the in-memory oracle, including restart recovery
- retain pending semantics for retryable ownership conflicts and the existing lease-reclaim fallback for ambiguous phase transitions

## Verification

- `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv sync --locked`
- 69 focused application, ledger-conformance, SQLite restart, adapter-parity, semantic-attempt, and workflow tests passed
- `npx --no-install pyright`
- `uv run ruff format --check .`
- `uv run ruff check .`

Fixes #189
Fixes #190

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Terminalize failed checks with durable errors instead of leaving operations pending
> - Adds `fail_check_if_current` to `LedgerPort`, `MemoryLedgerAdapter`, and `SqliteLedger` to record a non-retryable terminal error on a pending check, transitioning it to `COMPLETE/TERMINAL` without advancing the frontier.
> - Updates `execute_check_commit` in [check.py](https://github.com/TheGaySupreme123/yoetz/pull/193/files#diff-18cd5d49653d75df67f35a0c81ce5a4c16b61994a18d612ca738bf3205cff1b7) so that post-admission protocol/value failures are treated as `INTERNAL_ERROR` and the check is terminalized before re-raising; non-retryable `PublicOperationError` also triggers terminalization.
> - Exact replay of a terminalized operation returns the durable error rather than leaving the operation pending or raising unexpectedly.
> - SQLite-backed ledger persists terminal check errors across restarts by encoding them in `result_canonical` and replaying them during state rebuild when no locator is present.
> - Behavioral Change: `ProtocolValueError` raised after case admission no longer maps to `INVALID_REQUEST`; it now maps to `INTERNAL_ERROR` and terminalizes the operation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 376862c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->