### PR TITLE
fix: bind release evidence inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.value }}
       tag: ${{ steps.version.outputs.tag }}
+      commit: ${{ steps.version.outputs.commit }}
       is-prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - name: Reject a manual run not in dry_run=true mode
@@ -105,6 +106,7 @@ jobs:
           set -euo pipefail
           tag="${{ github.event.inputs.tag || github.ref_name }}"
           version="${tag#v}"
+          commit=$(git rev-parse HEAD)
           pkg_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           if [ "$version" != "$pkg_version" ]; then
             echo "::error::tag version ${version} does not equal pyproject.toml version ${pkg_version}"
@@ -114,6 +116,7 @@ jobs:
           case "$version" in *-*) is_pre=true ;; esac
           echo "value=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "commit=${commit}" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=${is_pre}" >> "$GITHUB_OUTPUT"
 
       - name: uv sync --locked (verify lockfiles are current)
@@ -232,7 +235,7 @@ jobs:
           json.dump({
               'tag': '${{ needs.validate-release-source.outputs.tag }}',
               'version': '${{ needs.validate-release-source.outputs.version }}',
-              'commit': '${{ github.sha }}',
+              'commit': '${{ needs.validate-release-source.outputs.commit }}',
               'digest': '${digest}',
               'runner': platform.platform(),
               'uv': '0.11.29',
@@ -513,19 +516,27 @@ jobs:
 
       - name: Build the release-inputs manifest for the evidence generator
         run: |
-          uv run --locked python -c "
-          import json
-          json.dump({
-              'tag': '${{ needs.validate-release-source.outputs.tag }}',
-              'version': '${{ needs.validate-release-source.outputs.version }}',
-              'candidate_digest': '${{ needs.build-candidate.outputs.candidate-digest }}',
-              'dry_run': '${{ env.DRY_RUN }}' == 'true',
-              'inputs_root': '${{ runner.temp }}/inputs',
-              'fault_manifest_digest': '${{ needs.fault-release-profile.outputs.manifest-digest }}',
-              'capability_manifest_digest': '${{ needs.capability-release-profile.outputs.manifest-digest }}',
-              'security_manifest_digest': '${{ needs.security-privacy-release.outputs.manifest-digest }}',
-          }, open('${{ runner.temp }}/release-inputs.json', 'w'), indent=2)
-          "
+          uv run --locked python scripts/build_release_inputs.py \
+            --candidate-version "${{ needs.validate-release-source.outputs.version }}" \
+            --candidate-tag "${{ needs.validate-release-source.outputs.tag }}" \
+            --candidate-commit "${{ needs.validate-release-source.outputs.commit }}" \
+            --artifact-root "${{ runner.temp }}/inputs/candidate-${{ needs.validate-release-source.outputs.version }}" \
+            --candidate-digest "sha256:${{ needs.build-candidate.outputs.candidate-digest }}" \
+            --support-matrix "${{ runner.temp }}/inputs/capability-matrix/capability-matrix.json" \
+            --known-limitations release/known-limitations.json \
+            --gate-record '{"name":"clean_source_identity","source_results":["${{ needs.validate-release-source.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}"]}' \
+            --gate-record '{"name":"artifact_checksums","source_results":["${{ needs.build-candidate.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}"]}' \
+            --gate-record '{"name":"resource_manifest_parity","source_results":["${{ needs.validate-release-source.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}"]}' \
+            --gate-record '{"name":"unit_tests","source_results":["${{ needs.security-privacy-release.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.security-privacy-release.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"property_tests","source_results":["${{ needs.fault-release-profile.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.fault-release-profile.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"integration_tests","source_results":["${{ needs.verify-linux-x86_64.result }}","${{ needs.verify-macos-arm64.result }}","${{ needs.fault-release-profile.result }}","${{ needs.capability-release-profile.result }}","${{ needs.security-privacy-release.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.fault-release-profile.outputs.manifest-digest }}","sha256:${{ needs.capability-release-profile.outputs.manifest-digest }}","sha256:${{ needs.security-privacy-release.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"conformance_tests","source_results":["${{ needs.verify-linux-x86_64.result }}","${{ needs.verify-macos-arm64.result }}","${{ needs.capability-release-profile.result }}","${{ needs.security-privacy-release.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.capability-release-profile.outputs.manifest-digest }}","sha256:${{ needs.security-privacy-release.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"packaging_tests","source_results":["${{ needs.verify-linux-x86_64.result }}","${{ needs.verify-macos-arm64.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}"]}' \
+            --gate-record '{"name":"security_privacy_scan","source_results":["${{ needs.security-privacy-release.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.security-privacy-release.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"capability_matrix","source_results":["${{ needs.capability-release-profile.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.capability-release-profile.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"dependency_vulnerability_license","source_results":["${{ needs.security-privacy-release.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}","sha256:${{ needs.security-privacy-release.outputs.manifest-digest }}"]}' \
+            --gate-record '{"name":"clean_install","source_results":["${{ needs.verify-linux-x86_64.result }}","${{ needs.verify-macos-arm64.result }}"],"input_digests":["sha256:${{ needs.build-candidate.outputs.candidate-digest }}"]}' \
+            --output "${{ runner.temp }}/release-inputs.json"
 
       - name: generate_release_evidence.py --write
         run: |

--- a/release/known-limitations.json
+++ b/release/known-limitations.json
@@ -1,0 +1,21 @@
+{
+  "schema": "yoetz.release-known-limitations/1",
+  "limitations": [
+    {
+      "code": "signature_not_provided",
+      "description": "Release artifacts provide SHA-256 checksums and provenance, but no cryptographic signature; Sigstore signing is deferred until a documented verification command exists."
+    },
+    {
+      "code": "native_service_manager_install_deferred",
+      "description": "Yoetz provides the foreground 'yoetz service run' entrypoint for a user-selected external supervisor; native launchd and systemd-user installer commands are deferred."
+    },
+    {
+      "code": "public_doctor_command_deferred",
+      "description": "Startup safety validation and 'yoetz version --json' are available; the public 'yoetz doctor' command is deferred to v0.2."
+    },
+    {
+      "code": "open_questions_ledger_not_automatically_enforced",
+      "description": "The E-001 through E-016 and R-001/R-002 decision ledger remains an owner-reviewed release record; this evidence bundle does not claim that every ledger item is automatically represented or enforced."
+    }
+  ]
+}

--- a/scripts/build_release_inputs.py
+++ b/scripts/build_release_inputs.py
@@ -142,7 +142,7 @@ def _artifacts(
             or name in declared
         ):
             raise ReleaseInputError("candidate_checksum_invalid")
-        declared[name] = f"sha256:{digest}"
+        declared[name] = _normalise_digest(digest, detail=name)
     if set(declared) != {path.name for path in found}:
         raise ReleaseInputError("candidate_checksum_invalid")
 

--- a/scripts/build_release_inputs.py
+++ b/scripts/build_release_inputs.py
@@ -1,0 +1,301 @@
+"""Build the typed input manifest consumed by ``generate_release_evidence.py``.
+
+The release workflow supplies candidate artifacts, reviewed support/limitation inputs, and one
+machine-result record for every required release gate.  This script is the single boundary that
+normalizes those inputs into the evidence generator's canonical manifest; it rejects ambiguity
+instead of letting an inline workflow snippet silently omit a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+_REQUIRED_GATES: tuple[str, ...] = (
+    "clean_source_identity",
+    "artifact_checksums",
+    "resource_manifest_parity",
+    "unit_tests",
+    "property_tests",
+    "integration_tests",
+    "conformance_tests",
+    "packaging_tests",
+    "security_privacy_scan",
+    "capability_matrix",
+    "dependency_vulnerability_license",
+    "clean_install",
+)
+_WORKFLOW_RESULTS = frozenset({"success", "failure", "cancelled", "skipped"})
+_SHA256 = re.compile(r"(?:sha256:)?[0-9a-f]{64}\Z")
+_COMMIT = re.compile(r"[0-9a-f]{40}\Z")
+
+
+class ReleaseInputError(Exception):
+    """A bounded input-construction failure suitable for a public workflow log."""
+
+    def __init__(self, reason: str, *, detail: str = "") -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.detail = detail
+
+
+@dataclass(frozen=True, slots=True)
+class GateRecord:
+    name: str
+    source_results: tuple[str, ...]
+    input_digests: tuple[str, ...]
+
+    def render(self) -> dict[str, object]:
+        if all(result == "success" for result in self.source_results):
+            status, reason = "pass", "all_sources_succeeded"
+        elif "failure" in self.source_results:
+            status, reason = "fail", "source_failure"
+        elif "cancelled" in self.source_results:
+            status, reason = "fail", "source_cancelled"
+        else:
+            status, reason = "incomplete", "source_skipped"
+        return {
+            "status": status,
+            "reason_code": reason,
+            "input_digests": list(self.input_digests),
+        }
+
+
+def _read_json(path: Path, *, expected_keys: frozenset[str] | None = None) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise ReleaseInputError("input_missing", detail=str(path))
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReleaseInputError("input_invalid_json", detail=str(path)) from exc
+    if not isinstance(value, dict):
+        raise ReleaseInputError("input_invalid_shape", detail=str(path))
+    document = cast(dict[str, object], value)
+    if expected_keys is not None and frozenset(document) != expected_keys:
+        raise ReleaseInputError("input_unknown_or_missing_field", detail=str(path))
+    return document
+
+
+def _normalise_digest(raw: str, *, detail: str) -> str:
+    if not _SHA256.fullmatch(raw):
+        raise ReleaseInputError("digest_invalid", detail=detail)
+    return raw if raw.startswith("sha256:") else f"sha256:{raw}"
+
+
+def _path_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _artifacts(artifact_root: Path, output_parent: Path) -> list[dict[str, str]]:
+    if artifact_root.is_symlink() or not artifact_root.is_dir():
+        raise ReleaseInputError("artifact_root_missing", detail=str(artifact_root))
+    if not _path_within(artifact_root, output_parent):
+        raise ReleaseInputError("artifact_root_outside_output_root", detail=str(artifact_root))
+
+    found = sorted(
+        (path for path in artifact_root.iterdir() if path.name.endswith((".whl", ".tar.gz"))),
+        key=lambda path: path.name.encode("utf-8"),
+    )
+    if not found:
+        raise ReleaseInputError("artifact_missing", detail=str(artifact_root))
+
+    entries: list[dict[str, str]] = []
+    for path in found:
+        if path.is_symlink() or not path.is_file() or not _path_within(path, artifact_root):
+            raise ReleaseInputError("artifact_invalid", detail=path.name)
+        entries.append(
+            {
+                "path": path.resolve().relative_to(output_parent.resolve()).as_posix(),
+                "sha256": _hash(path),
+            }
+        )
+    return entries
+
+
+def _gate_record(raw: str) -> GateRecord:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ReleaseInputError("gate_record_invalid_json") from exc
+    if not isinstance(value, dict):
+        raise ReleaseInputError("gate_record_invalid_shape")
+    fields = cast(dict[str, object], value)
+    if set(fields) != {"name", "source_results", "input_digests"}:
+        raise ReleaseInputError("gate_record_invalid_shape")
+    name = fields["name"]
+    source_results = fields["source_results"]
+    input_digests = fields["input_digests"]
+    if not isinstance(name, str) or name not in _REQUIRED_GATES:
+        raise ReleaseInputError("gate_record_unknown", detail=str(name))
+    if not isinstance(source_results, list) or not source_results:
+        raise ReleaseInputError("gate_record_result_invalid", detail=name)
+    results: list[str] = []
+    for result in cast(list[object], source_results):
+        if not isinstance(result, str) or result not in _WORKFLOW_RESULTS:
+            raise ReleaseInputError("gate_record_result_invalid", detail=name)
+        results.append(result)
+    if not isinstance(input_digests, list):
+        raise ReleaseInputError("gate_record_digest_invalid", detail=name)
+    digests: list[str] = []
+    for digest in cast(list[object], input_digests):
+        if not isinstance(digest, str):
+            raise ReleaseInputError("gate_record_digest_invalid", detail=name)
+        digests.append(_normalise_digest(digest, detail=name))
+    normalized = tuple(digests)
+    if len(set(normalized)) != len(normalized):
+        raise ReleaseInputError("gate_record_digest_duplicate", detail=name)
+    return GateRecord(name, tuple(results), normalized)
+
+
+def _gates(raw_records: Sequence[str]) -> dict[str, object]:
+    by_name: dict[str, GateRecord] = {}
+    for raw in raw_records:
+        record = _gate_record(raw)
+        if record.name in by_name:
+            raise ReleaseInputError("gate_record_duplicate", detail=record.name)
+        by_name[record.name] = record
+    missing = [name for name in _REQUIRED_GATES if name not in by_name]
+    if missing:
+        raise ReleaseInputError("gate_record_missing", detail=",".join(missing))
+    return {name: by_name[name].render() for name in _REQUIRED_GATES}
+
+
+def _support_cells(path: Path, candidate_digest: str) -> list[dict[str, object]]:
+    document = _read_json(path)
+    if document.get("schema") != "yoetz.capability-matrix/1":
+        raise ReleaseInputError("support_matrix_schema_invalid", detail=str(path))
+    if document.get("candidate_artifact_digest") != candidate_digest:
+        raise ReleaseInputError("support_matrix_candidate_digest_mismatch", detail=str(path))
+    cells = document.get("cells")
+    if not isinstance(cells, list):
+        raise ReleaseInputError("support_matrix_cells_invalid", detail=str(path))
+
+    rendered: list[dict[str, object]] = []
+    for cell in cast(list[object], cells):
+        if not isinstance(cell, dict):
+            raise ReleaseInputError("support_matrix_cell_invalid", detail=str(path))
+        fields = cast(dict[str, object], cell)
+        required = ("capability_family", "external_version", "platform", "requirement_id", "status")
+        if not all(isinstance(fields.get(key), str) and str(fields[key]) for key in required):
+            raise ReleaseInputError("support_matrix_cell_invalid", detail=str(path))
+        rendered.append(
+            {
+                "label": ":".join(str(fields[key]) for key in required[:-1]),
+                "status": str(fields["status"]),
+            }
+        )
+    return sorted(rendered, key=lambda cell: str(cell["label"]).encode("utf-8"))
+
+
+def _limitations(path: Path) -> list[dict[str, str]]:
+    document = _read_json(path, expected_keys=frozenset({"schema", "limitations"}))
+    if document["schema"] != "yoetz.release-known-limitations/1":
+        raise ReleaseInputError("limitations_schema_invalid", detail=str(path))
+    raw_items = document["limitations"]
+    if not isinstance(raw_items, list):
+        raise ReleaseInputError("limitations_invalid", detail=str(path))
+    items: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in cast(list[object], raw_items):
+        if not isinstance(item, dict):
+            raise ReleaseInputError("limitation_invalid", detail=str(path))
+        fields = cast(dict[str, object], item)
+        if set(fields) != {"code", "description"}:
+            raise ReleaseInputError("limitation_invalid", detail=str(path))
+        code, description = fields["code"], fields["description"]
+        if (
+            not isinstance(code, str)
+            or not code
+            or not isinstance(description, str)
+            or not description
+        ):
+            raise ReleaseInputError("limitation_invalid", detail=str(path))
+        if code in seen:
+            raise ReleaseInputError("limitation_duplicate", detail=code)
+        seen.add(code)
+        items.append({"code": code, "description": description})
+    return sorted(items, key=lambda item: item["code"].encode("utf-8"))
+
+
+def build_manifest(args: argparse.Namespace) -> dict[str, object]:
+    version = str(args.candidate_version)
+    tag = str(args.candidate_tag)
+    commit = str(args.candidate_commit)
+    if not version or tag != f"v{version}" or not _COMMIT.fullmatch(commit):
+        raise ReleaseInputError("candidate_identity_invalid")
+    candidate_digest = _normalise_digest(str(args.candidate_digest), detail="candidate")
+    output = cast(Path, args.output)
+    output_parent = output.parent.resolve()
+    return {
+        "candidate_version": version,
+        "candidate_tag": tag,
+        "candidate_commit": commit,
+        "artifacts": _artifacts(cast(Path, args.artifact_root), output_parent),
+        "gates": _gates(cast(list[str], args.gate_record)),
+        "support_matrix_cells": _support_cells(cast(Path, args.support_matrix), candidate_digest),
+        "known_limitations": _limitations(cast(Path, args.known_limitations)),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="build_release_inputs.py")
+    parser.add_argument("--candidate-version", required=True)
+    parser.add_argument("--candidate-tag", required=True)
+    parser.add_argument("--candidate-commit", required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--candidate-digest", required=True)
+    parser.add_argument("--support-matrix", type=Path, required=True)
+    parser.add_argument("--known-limitations", type=Path, required=True)
+    parser.add_argument("--gate-record", action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        manifest = build_manifest(args)
+        output = cast(Path, args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=output.parent, prefix=".release-inputs-", delete=False
+        ) as handle:
+            json.dump(manifest, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.replace(temporary, output)
+    except ReleaseInputError as exc:
+        print(f"build_release_inputs: FAIL ({exc.reason}) {exc.detail}", file=sys.stderr)
+        return 1
+    except OSError:
+        print("build_release_inputs: FAIL (io_error)", file=sys.stderr)
+        return 1
+    print("build_release_inputs: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_release_inputs.py
+++ b/scripts/build_release_inputs.py
@@ -280,9 +280,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
         "candidate_version": version,
         "candidate_tag": tag,
         "candidate_commit": commit,
-        "artifacts": _artifacts(
-            cast(Path, args.artifact_root), output_parent, candidate_digest
-        ),
+        "artifacts": _artifacts(cast(Path, args.artifact_root), output_parent, candidate_digest),
         "gates": _gates(cast(list[str], args.gate_record)),
         "support_matrix_cells": _support_cells(cast(Path, args.support_matrix), candidate_digest),
         "known_limitations": _limitations(cast(Path, args.known_limitations)),

--- a/scripts/build_release_inputs.py
+++ b/scripts/build_release_inputs.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import cast
 
 _REQUIRED_GATES: tuple[str, ...] = (
@@ -107,7 +107,9 @@ def _hash(path: Path) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
-def _artifacts(artifact_root: Path, output_parent: Path) -> list[dict[str, str]]:
+def _artifacts(
+    artifact_root: Path, output_parent: Path, candidate_digest: str
+) -> list[dict[str, str]]:
     if artifact_root.is_symlink() or not artifact_root.is_dir():
         raise ReleaseInputError("artifact_root_missing", detail=str(artifact_root))
     if not _path_within(artifact_root, output_parent):
@@ -120,14 +122,41 @@ def _artifacts(artifact_root: Path, output_parent: Path) -> list[dict[str, str]]
     if not found:
         raise ReleaseInputError("artifact_missing", detail=str(artifact_root))
 
+    checksum_path = artifact_root / "SHA256SUMS"
+    if checksum_path.is_symlink() or not checksum_path.is_file():
+        raise ReleaseInputError("candidate_checksum_missing")
+    if _hash(checksum_path) != candidate_digest:
+        raise ReleaseInputError("candidate_artifact_digest_mismatch")
+    try:
+        checksum_lines = checksum_path.read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ReleaseInputError("candidate_checksum_invalid") from exc
+    declared: dict[str, str] = {}
+    for line in checksum_lines:
+        digest, separator, source_path = line.partition("  ")
+        name = PurePosixPath(source_path).name
+        if (
+            separator != "  "
+            or not _SHA256.fullmatch(digest)
+            or not name.endswith((".whl", ".tar.gz"))
+            or name in declared
+        ):
+            raise ReleaseInputError("candidate_checksum_invalid")
+        declared[name] = f"sha256:{digest}"
+    if set(declared) != {path.name for path in found}:
+        raise ReleaseInputError("candidate_checksum_invalid")
+
     entries: list[dict[str, str]] = []
     for path in found:
         if path.is_symlink() or not path.is_file() or not _path_within(path, artifact_root):
             raise ReleaseInputError("artifact_invalid", detail=path.name)
+        artifact_digest = _hash(path)
+        if artifact_digest != declared[path.name]:
+            raise ReleaseInputError("candidate_artifact_digest_mismatch")
         entries.append(
             {
                 "path": path.resolve().relative_to(output_parent.resolve()).as_posix(),
-                "sha256": _hash(path),
+                "sha256": artifact_digest,
             }
         )
     return entries
@@ -155,7 +184,7 @@ def _gate_record(raw: str) -> GateRecord:
         if not isinstance(result, str) or result not in _WORKFLOW_RESULTS:
             raise ReleaseInputError("gate_record_result_invalid", detail=name)
         results.append(result)
-    if not isinstance(input_digests, list):
+    if not isinstance(input_digests, list) or not input_digests:
         raise ReleaseInputError("gate_record_digest_invalid", detail=name)
     digests: list[str] = []
     for digest in cast(list[object], input_digests):
@@ -251,7 +280,9 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
         "candidate_version": version,
         "candidate_tag": tag,
         "candidate_commit": commit,
-        "artifacts": _artifacts(cast(Path, args.artifact_root), output_parent),
+        "artifacts": _artifacts(
+            cast(Path, args.artifact_root), output_parent, candidate_digest
+        ),
         "gates": _gates(cast(list[str], args.gate_record)),
         "support_matrix_cells": _support_cells(cast(Path, args.support_matrix), candidate_digest),
         "known_limitations": _limitations(cast(Path, args.known_limitations)),

--- a/tests/conformance/claims/test_public_claim_map.py
+++ b/tests/conformance/claims/test_public_claim_map.py
@@ -1,6 +1,6 @@
 """Claims conformance: docs/public-claims.json binds every public statement to real evidence.
 
-Grounded entirely in the reviewed ``docs/public-claims.json`` claim map (29 claims, schema
+Grounded entirely in the reviewed ``docs/public-claims.json`` claim map (schema
 ``yoetz.public-claims/1``) plus the real ADR set and spec-tree requirement files it cites. Every
 claim must point to an existing ADR/spec requirement, an existing public surface document, and a
 plausibly typed test or fixture path, with at least one declared evidence kind actually backed by a
@@ -228,6 +228,3 @@ def test_skipped_or_unsupported_claims_are_flagged() -> None:
             # test/fixture paths must exist for real once it claims anything stronger.
             for test_path in cast(list[str], claim["tests"]):
                 assert (_REPO_ROOT / test_path).is_file(), (claim_id, test_path)
-
-    # v0.1 has not shipped a release yet -- today, every claim is honestly flagged unevidenced.
-    assert statuses == {"not_yet_evidenced"}

--- a/tests/packaging/test_build_release_inputs.py
+++ b/tests/packaging/test_build_release_inputs.py
@@ -1,0 +1,184 @@
+"""Contract tests for the workflow-owned typed release-input builder."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+_ROOT: Final = Path(__file__).resolve().parents[2]
+_BUILDER: Final = _ROOT / "scripts" / "build_release_inputs.py"
+_GENERATOR: Final = _ROOT / "scripts" / "generate_release_evidence.py"
+_GATES: Final = (
+    "clean_source_identity",
+    "artifact_checksums",
+    "resource_manifest_parity",
+    "unit_tests",
+    "property_tests",
+    "integration_tests",
+    "conformance_tests",
+    "packaging_tests",
+    "security_privacy_scan",
+    "capability_matrix",
+    "dependency_vulnerability_license",
+    "clean_install",
+)
+
+
+def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
+    root = tmp_path / "inputs"
+    artifacts = root / "candidate-0.1.0"
+    artifacts.mkdir(parents=True)
+    (artifacts / "yoetz-0.1.0.whl").write_bytes(b"wheel")
+    (artifacts / "yoetz-0.1.0.tar.gz").write_bytes(b"sdist")
+    digest = "a" * 64
+    matrix = root / "capability-matrix.json"
+    matrix.write_text(
+        json.dumps(
+            {
+                "schema": "yoetz.capability-matrix/1",
+                "candidate_artifact_digest": f"sha256:{digest}",
+                "cells": [
+                    {
+                        "capability_family": "mcp",
+                        "external_version": "1.28.1",
+                        "platform": "linux_x86_64",
+                        "requirement_id": "initialize",
+                        "status": "supported",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    limitations = root / "limitations.json"
+    limitations.write_text(
+        json.dumps(
+            {
+                "schema": "yoetz.release-known-limitations/1",
+                "limitations": [{"code": "L-001", "description": "test limitation"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return artifacts, matrix, limitations, digest
+
+
+def _run_builder(
+    tmp_path: Path, records: list[dict[str, object]], *, output: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    artifacts, matrix, limitations, digest = _inputs(tmp_path)
+    manifest = output or tmp_path / "release-inputs.json"
+    command = [
+        sys.executable,
+        str(_BUILDER),
+        "--candidate-version",
+        "0.1.0",
+        "--candidate-tag",
+        "v0.1.0",
+        "--candidate-commit",
+        "0" * 40,
+        "--artifact-root",
+        str(artifacts),
+        "--candidate-digest",
+        digest,
+        "--support-matrix",
+        str(matrix),
+        "--known-limitations",
+        str(limitations),
+    ]
+    for record in records:
+        command.extend(("--gate-record", json.dumps(record)))
+    command.extend(("--output", str(manifest)))
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(_ROOT / "src") + os.pathsep + environment.get("PYTHONPATH", "")
+    return subprocess.run(
+        command, cwd=_ROOT, env=environment, text=True, capture_output=True, check=False
+    )
+
+
+def _passing_records() -> list[dict[str, object]]:
+    return [
+        {
+            "name": name,
+            "source_results": ["success"],
+            "input_digests": ["sha256:" + name.encode().hex().ljust(64, "0")[:64]],
+        }
+        for name in _GATES
+    ]
+
+
+def test_builder_output_drives_the_real_evidence_generator(tmp_path: Path) -> None:
+    manifest = tmp_path / "release-inputs.json"
+    built = _run_builder(tmp_path, _passing_records(), output=manifest)
+    assert built.returncode == 0, built.stderr
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    assert set(document["gates"]) == set(_GATES)
+    assert document["support_matrix_cells"] == [
+        {"label": "mcp:1.28.1:linux_x86_64:initialize", "status": "supported"}
+    ]
+
+    generated = subprocess.run(
+        [
+            sys.executable,
+            str(_GENERATOR),
+            "--input-manifest",
+            str(manifest),
+            "--output-dir",
+            str(tmp_path / "evidence"),
+            "--write",
+        ],
+        cwd=_ROOT,
+        env={**os.environ, "PYTHONPATH": str(_ROOT / "src")},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert generated.returncode == 0, generated.stderr
+
+
+def test_one_incomplete_gate_causes_the_real_generator_to_fail(tmp_path: Path) -> None:
+    records = _passing_records()
+    records[-1]["source_results"] = ["skipped"]
+    manifest = tmp_path / "release-inputs.json"
+    built = _run_builder(tmp_path, records, output=manifest)
+    assert built.returncode == 0, built.stderr
+    generated = subprocess.run(
+        [
+            sys.executable,
+            str(_GENERATOR),
+            "--input-manifest",
+            str(manifest),
+            "--output-dir",
+            str(tmp_path / "evidence"),
+            "--write",
+        ],
+        cwd=_ROOT,
+        env={**os.environ, "PYTHONPATH": str(_ROOT / "src")},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert generated.returncode == 1
+    assert "one or more required gates did not pass" in generated.stderr
+
+
+def test_builder_rejects_missing_duplicate_and_unknown_gate_records(tmp_path: Path) -> None:
+    missing = _run_builder(tmp_path / "missing", _passing_records()[:-1])
+    assert missing.returncode == 1
+    assert "gate_record_missing" in missing.stderr
+
+    duplicate_records = _passing_records()
+    duplicate_records.append(duplicate_records[0])
+    duplicate = _run_builder(tmp_path / "duplicate", duplicate_records)
+    assert duplicate.returncode == 1
+    assert "gate_record_duplicate" in duplicate.stderr
+
+    unknown_records = _passing_records()
+    unknown_records[0]["name"] = "unknown_gate"
+    unknown = _run_builder(tmp_path / "unknown", unknown_records)
+    assert unknown.returncode == 1
+    assert "gate_record_unknown" in unknown.stderr

--- a/tests/packaging/test_build_release_inputs.py
+++ b/tests/packaging/test_build_release_inputs.py
@@ -29,7 +29,7 @@ _GATES: Final = (
 )
 
 
-def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
+def _inputs(tmp_path: Path, *, prefixed_checksums: bool = False) -> tuple[Path, Path, Path, str]:
     root = tmp_path / "inputs"
     artifacts = root / "candidate-0.1.0"
     artifacts.mkdir(parents=True)
@@ -38,7 +38,8 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
     checksum_lines: list[str] = []
     for path in sorted(artifacts.iterdir(), key=lambda item: item.name.encode("utf-8")):
         artifact_digest = hashlib.sha256(path.read_bytes()).hexdigest()
-        checksum_lines.append(f"{artifact_digest}  /build/dist/{path.name}\n")
+        prefix = "sha256:" if prefixed_checksums else ""
+        checksum_lines.append(f"{prefix}{artifact_digest}  /build/dist/{path.name}\n")
     checksum_bytes = "".join(checksum_lines).encode()
     (artifacts / "SHA256SUMS").write_bytes(checksum_bytes)
     digest = hashlib.sha256(checksum_bytes).hexdigest()
@@ -75,9 +76,15 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
 
 
 def _run_builder(
-    tmp_path: Path, records: list[dict[str, object]], *, output: Path | None = None
+    tmp_path: Path,
+    records: list[dict[str, object]],
+    *,
+    output: Path | None = None,
+    prefixed_checksums: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    artifacts, matrix, limitations, digest = _inputs(tmp_path)
+    artifacts, matrix, limitations, digest = _inputs(
+        tmp_path, prefixed_checksums=prefixed_checksums
+    )
     manifest = output or tmp_path / "release-inputs.json"
     command = [
         sys.executable,
@@ -145,6 +152,11 @@ def test_builder_output_drives_the_real_evidence_generator(tmp_path: Path) -> No
         check=False,
     )
     assert generated.returncode == 0, generated.stderr
+
+
+def test_builder_accepts_prefixed_checksum_digests(tmp_path: Path) -> None:
+    built = _run_builder(tmp_path, _passing_records(), prefixed_checksums=True)
+    assert built.returncode == 0, built.stderr
 
 
 def test_one_incomplete_gate_causes_the_real_generator_to_fail(tmp_path: Path) -> None:

--- a/tests/packaging/test_build_release_inputs.py
+++ b/tests/packaging/test_build_release_inputs.py
@@ -222,8 +222,6 @@ def test_builder_rejects_unbound_gate_and_substituted_candidate_artifact(tmp_pat
     for record in _passing_records():
         command.extend(("--gate-record", json.dumps(record)))
     command.extend(("--output", str(output)))
-    substituted = subprocess.run(
-        command, cwd=_ROOT, text=True, capture_output=True, check=False
-    )
+    substituted = subprocess.run(command, cwd=_ROOT, text=True, capture_output=True, check=False)
     assert substituted.returncode == 1
     assert "candidate_artifact_digest_mismatch" in substituted.stderr

--- a/tests/packaging/test_build_release_inputs.py
+++ b/tests/packaging/test_build_release_inputs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -34,7 +35,13 @@ def _inputs(tmp_path: Path) -> tuple[Path, Path, Path, str]:
     artifacts.mkdir(parents=True)
     (artifacts / "yoetz-0.1.0.whl").write_bytes(b"wheel")
     (artifacts / "yoetz-0.1.0.tar.gz").write_bytes(b"sdist")
-    digest = "a" * 64
+    checksum_lines: list[str] = []
+    for path in sorted(artifacts.iterdir(), key=lambda item: item.name.encode("utf-8")):
+        artifact_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        checksum_lines.append(f"{artifact_digest}  /build/dist/{path.name}\n")
+    checksum_bytes = "".join(checksum_lines).encode()
+    (artifacts / "SHA256SUMS").write_bytes(checksum_bytes)
+    digest = hashlib.sha256(checksum_bytes).hexdigest()
     matrix = root / "capability-matrix.json"
     matrix.write_text(
         json.dumps(
@@ -182,3 +189,41 @@ def test_builder_rejects_missing_duplicate_and_unknown_gate_records(tmp_path: Pa
     unknown = _run_builder(tmp_path / "unknown", unknown_records)
     assert unknown.returncode == 1
     assert "gate_record_unknown" in unknown.stderr
+
+
+def test_builder_rejects_unbound_gate_and_substituted_candidate_artifact(tmp_path: Path) -> None:
+    unbound_records = _passing_records()
+    unbound_records[0]["input_digests"] = []
+    unbound = _run_builder(tmp_path / "unbound", unbound_records)
+    assert unbound.returncode == 1
+    assert "gate_record_digest_invalid" in unbound.stderr
+
+    artifact_root, matrix, limitations, digest = _inputs(tmp_path / "substituted")
+    (artifact_root / "yoetz-0.1.0.whl").write_bytes(b"substituted-wheel")
+    output = tmp_path / "substituted" / "release-inputs.json"
+    command = [
+        sys.executable,
+        str(_BUILDER),
+        "--candidate-version",
+        "0.1.0",
+        "--candidate-tag",
+        "v0.1.0",
+        "--candidate-commit",
+        "0" * 40,
+        "--artifact-root",
+        str(artifact_root),
+        "--candidate-digest",
+        digest,
+        "--support-matrix",
+        str(matrix),
+        "--known-limitations",
+        str(limitations),
+    ]
+    for record in _passing_records():
+        command.extend(("--gate-record", json.dumps(record)))
+    command.extend(("--output", str(output)))
+    substituted = subprocess.run(
+        command, cwd=_ROOT, text=True, capture_output=True, check=False
+    )
+    assert substituted.returncode == 1
+    assert "candidate_artifact_digest_mismatch" in substituted.stderr

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -1,0 +1,58 @@
+"""Static contract coverage for the tagged release evidence assembly workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+_ROOT: Final = Path(__file__).resolve().parents[2]
+_WORKFLOW: Final = _ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_dry_run_retains_builder_backed_release_evidence_bundle() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    assembly = workflow.split("  assemble-release-evidence:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # approve-publication",
+        1,
+    )[0]
+
+    assert "workflow_dispatch:" in workflow
+    assert "DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}" in workflow
+    assert "workflow_dispatch is dry-run only; dry_run must be true" in workflow
+    assert "scripts/build_release_inputs.py" in assembly
+    assert "generate_release_evidence.py" in assembly
+    assert "python -c" not in assembly
+    assert "--candidate-commit" in assembly
+    assert (
+        '--artifact-root "${{ runner.temp }}/inputs/candidate-${{ needs.validate-release-source.outputs.version }}"'
+        in assembly
+    )
+    assert (
+        '--support-matrix "${{ runner.temp }}/inputs/capability-matrix/capability-matrix.json"'
+        in assembly
+    )
+    assert assembly.count("--gate-record") == 12
+    for gate in (
+        "clean_source_identity",
+        "artifact_checksums",
+        "resource_manifest_parity",
+        "unit_tests",
+        "property_tests",
+        "integration_tests",
+        "conformance_tests",
+        "packaging_tests",
+        "security_privacy_scan",
+        "capability_matrix",
+        "dependency_vulnerability_license",
+        "clean_install",
+    ):
+        assert f'"name":"{gate}"' in assembly
+
+    upload = assembly.split("      - name: Upload release evidence bundle\n", 1)[1]
+    upload = upload.split(
+        "\n  # ---------------------------------------------------------------------------------------------",
+        1,
+    )[0]
+    assert "if:" not in upload
+    assert "path: ${{ runner.temp }}/release-evidence" in upload
+    assert "retention-days: 90" in upload


### PR DESCRIPTION
Fixes #159

## Summary

- Replace the inline release-input manifest snippet with a typed, fail-closed builder.
- Bind the manifest to the tagged candidate commit, discovered artifact paths and SHA-256 digests, capability support cells, reviewed limitations, and all twelve named machine gates.
- Reject missing, duplicate, and unknown gate records before evidence generation, and retain the dry-run evidence artifact for 90 days.
- Remove the stale all-claims-unreleased assertion and hard-coded claim count.

## Why

The release workflow emitted a shape that `generate_release_evidence.py` could not load, so it failed before it could evaluate release gates. The new builder is the shared contract consumed by the workflow and direct integration tests.

## Verification

- `pytest -q tests/packaging/test_build_release_inputs.py tests/packaging/test_release_workflow_contract.py tests/packaging/test_checksums_sbom_and_provenance.py tests/conformance/claims/test_public_claim_map.py` — 22 passed
- `pytest -q tests/packaging -m 'not fault and not soak and not live' --timeout=900`
- `ruff check .`
- `pyright`
- `python scripts/scan_public_boundary.py --source-tree .`
- `python scripts/verify_resource_manifest.py --check`

## Design gate

#159 is the pre-existing release/packaging issue, opened by the repository owner. I searched related issues and PRs before this change; no duplicate implementation PR was open.

## Boundaries

- [x] No private drafting input is included.
- [x] Review comments will be dispositioned before merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix release evidence inputs by binding candidate commit and replacing inline Python with `build_release_inputs.py`
> - Adds a new [`scripts/build_release_inputs.py`](https://github.com/TheGaySupreme123/yoetz/pull/197/files#diff-793a4ea4288f4af3f96613ff5c0589f624f774e9e0d67bcdb1563cb937c1111a) CLI that validates and assembles the release-inputs manifest, verifying artifacts, SHA256 checksums, gate records, capability matrix, and known limitations before writing a normalized JSON output.
> - The release workflow now captures the Git commit SHA as a job output and passes it (along with other explicit arguments) to the new script instead of using an inline `python -c` snippet.
> - Adds [`release/known-limitations.json`](https://github.com/TheGaySupreme123/yoetz/pull/197/files#diff-d5a04bb75ae67236d3b320ebec37e2c371fe5b84aa8ed22e53dafd476faefc18) with four initial limitation entries.
> - New contract tests in [`tests/packaging/`](https://github.com/TheGaySupreme123/yoetz/pull/197/files#diff-40ad4d22fc350e25778626c766973929458fbecf4fc14610757e97cb477ca17b) assert that the workflow uses the checked-in script with the correct arguments and that the builder rejects malformed or incomplete inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e61e463.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->