### PR TITLE
Make ledger event reads task-scoped so receipt survives create_or_attach resume

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -907,7 +907,12 @@ deciding between the two, shared by the receipt and by compact status coverage.
 - `append_batch(command: AppendCommand) -> AppendResult`;
 - `load_frontier() -> Frontier` (task-ledger truth without requiring a pre-existing session;
   START resumed-event content and append CAS use this value);
-- `load_events(session_id, after=0, through=None) -> AsyncIterator[LedgerRecord]`;
+- `load_events(session_id, after=0, through=None) -> AsyncIterator[LedgerRecord]` (the task-scoped
+  ledger chain in `ingestion_sequence` order, bounded by `after`/`through`; `session_id` is an
+  authorization/membership argument, never a row filter, so a session attached to the task reads
+  the whole task chain and an unknown session reads nothing. The chain is task-global, and replay
+  is genesis-anchored, so a session-filtered row set would be a mid-chain suffix and no longer
+  replayable — the same membership rule that `load_projection` and `query_projection` apply);
 - `load_projection(session_id, view) -> StoredProjection | None` (cache/rebuild use);
 - `load_case_availability(session_id, frontier, projection) -> CaseAvailabilityFacts` (shared bounded
   event/captured-object availability snapshot for case construction);

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -1340,12 +1340,21 @@ class MemoryLedgerAdapter:
         ):
             raise _error(PublicErrorCode.INVALID_REQUEST)
         async with self._lock:
-            rows = tuple(
-                record
-                for record in self._state.records
-                if record.session_id == session_id
-                and record.ledger.ingestion_sequence > after
-                and (through is None or record.ledger.ingestion_sequence <= through)
+            records = self._state.records
+            # ``session_id`` is a membership check, not a row filter. The ingestion sequence and
+            # the digest chain are task-global, so every session attached to this task reads the
+            # whole task chain, exactly as ``load_projection`` and ``query_projection`` do.
+            # Filtering rows by session would hand replay — which is genesis-anchored — a
+            # mid-chain suffix as soon as a resumed session appended its own event.
+            rows = (
+                tuple(
+                    record
+                    for record in records
+                    if record.ledger.ingestion_sequence > after
+                    and (through is None or record.ledger.ingestion_sequence <= through)
+                )
+                if any(record.session_id == session_id for record in records)
+                else ()
             )
         for record in rows:
             yield record

--- a/src/yoetz/application/receipt.py
+++ b/src/yoetz/application/receipt.py
@@ -257,7 +257,12 @@ async def _records_through(runtime: TaskRuntime, frontier: Frontier) -> tuple[Le
             )
         ]
     )
-    projection = replay(records)
+    try:
+        projection = replay(records)
+    except ValueError as exc:
+        # Replay is genesis-anchored; a chain it rejects is a storage fact, not an engine bug, so
+        # it leaves here as a bounded public error rather than an unbounded internal one.
+        raise _error(PublicErrorCode.STORAGE_CORRUPT, "The task ledger is unreadable.") from exc
     if Frontier(projection.frontier, projection.head_digest) != frontier:
         raise _error(PublicErrorCode.FRONTIER_CONFLICT, "The receipt frontier is not current.")
     return records

--- a/src/yoetz/application/respond.py
+++ b/src/yoetz/application/respond.py
@@ -261,7 +261,12 @@ async def _records_through(runtime: TaskRuntime, frontier: Frontier) -> tuple[Le
             )
         ]
     )
-    projection = replay(records)
+    try:
+        projection = replay(records)
+    except ValueError as exc:
+        # Replay is genesis-anchored; a chain it rejects is a storage fact, not an engine bug, so
+        # it leaves here as a bounded public error rather than an unbounded internal one.
+        raise _error(PublicErrorCode.STORAGE_CORRUPT, "The task ledger is unreadable.") from exc
     if Frontier(projection.frontier, projection.head_digest) != frontier:
         raise _error(PublicErrorCode.FRONTIER_CONFLICT, "The response frontier is not current.")
     return records

--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -655,7 +655,12 @@ async def _candidate_page(
     )
     from yoetz.kernel.reducers import replay
 
-    projection = replay(records)
+    try:
+        projection = replay(records)
+    except ValueError as exc:
+        # Replay is genesis-anchored; a chain it rejects is a storage fact, not an engine bug, so
+        # it leaves here as a bounded public error rather than an unbounded internal one.
+        raise _error(PublicErrorCode.STORAGE_CORRUPT, "The task ledger is unreadable.") from exc
     if Frontier(projection.frontier, projection.head_digest) != frontier:
         raise _error(PublicErrorCode.STORAGE_CORRUPT, "The status frontier is inconsistent.")
     availability = await runtime.ledger.load_case_availability(

--- a/tests/conformance/adapters/test_ledger_port.py
+++ b/tests/conformance/adapters/test_ledger_port.py
@@ -146,10 +146,20 @@ def _fence() -> OwnershipFence:
     )
 
 
-def ledger_command(*, request_suffix: str = "1", unknown: bool = False) -> AppendCommand:
+def ledger_command(
+    *,
+    request_suffix: str = "1",
+    unknown: bool = False,
+    index: int = 0,
+    session_id: str | None = None,
+    writer_id: str | None = None,
+    expected_frontier: int = 0,
+) -> AppendCommand:
     vector = "unknown-schema" if unknown else "projection-rebuild"
     records = replay_records(vector)
-    record = next(row for row in records if type(row) is UnknownEvent) if unknown else records[0]
+    record = (
+        next(row for row in records if type(row) is UnknownEvent) if unknown else records[index]
+    )
     assert record.payload is not None
     operation_id = f"req_00000000-0000-4000-8000-00000000000{request_suffix}"
     draft = EventDraft(
@@ -189,12 +199,12 @@ def ledger_command(*, request_suffix: str = "1", unknown: bool = False) -> Appen
     )
     return AppendCommand(
         record.task_id,
-        record.session_id,
-        record.writer.writer_id,
+        record.session_id if session_id is None else session_id,
+        record.writer.writer_id if writer_id is None else writer_id,
         operation_id,
         OperationKind.PUBLISH_WORK,
         "sha256:" + "2" * 64,
-        0,
+        expected_frontier,
         (entry,),
     )
 
@@ -260,6 +270,46 @@ async def test_load_and_freeze_contract() -> None:
     for adapter in adapters:
         await adapter.append_batch(command)
         loaded.append(tuple([row async for row in adapter.load_events(command.session_id)]))
+    assert loaded[0] == loaded[1]
+
+
+@pytest.mark.anyio
+async def test_load_events_gives_every_attached_session_the_whole_task_chain() -> None:
+    """``session_id`` scopes membership, not rows (issue #200).
+
+    A task's ingestion sequence and digest chain are task-global: a second session appending to
+    the same task continues one chain rather than starting its own. Both adapters therefore hand
+    either session the full chain, and hand a session that never appended here nothing at all.
+    """
+
+    first = ledger_command()
+    second = ledger_command(
+        request_suffix="3",
+        index=1,
+        session_id="ses_20000007-0000-4000-8000-000000000012",
+        writer_id="wri_20000007-0000-4000-8000-000000000013",
+        expected_frontier=1,
+    )
+    stranger = "ses_20000007-0000-4000-8000-000000000099"
+    loaded: list[tuple[object, ...]] = []
+    for adapter in (memory_ledger(first), sqlite_ledger(first)):
+        await adapter.append_batch(first)
+        await adapter.append_batch(second)
+        resumed = tuple([row async for row in adapter.load_events(second.session_id)])
+        assert tuple(row.ledger.ingestion_sequence for row in resumed) == (1, 2)
+        assert tuple(str(row.session_id) for row in resumed) == (
+            first.session_id,
+            second.session_id,
+        )
+        original = tuple([row async for row in adapter.load_events(first.session_id)])
+        assert original == resumed
+        # ``after``/``through`` still bound the window, and they count task ingestion sequence.
+        windowed = tuple(
+            [row async for row in adapter.load_events(second.session_id, after=1, through=2)]
+        )
+        assert windowed == resumed[1:]
+        assert [row async for row in adapter.load_events(stranger)] == []
+        loaded.append(resumed)
     assert loaded[0] == loaded[1]
 
 

--- a/tests/integration/application/test_respond_status_receipt.py
+++ b/tests/integration/application/test_respond_status_receipt.py
@@ -45,17 +45,20 @@ from yoetz.ports.ledger import CheckCommitResult
 from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
 from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
 from yoetz.ports.semantic import SamplingParams, SemanticJudgment
-from yoetz.protocol.canonical import JsonValue
+from yoetz.protocol.canonical import JsonValue, canonical_encode
 from yoetz.protocol.coverage import CheckType
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.models import (
     CheckRequest,
     FrontierModel,
+    PublishWorkDryRunModel,
     PublishWorkRequest,
+    PublishWorkResult,
     ReceiptRequest,
     RespondRequest,
     SemanticReason,
     SemanticStatus,
+    StatusCandidateFindingsPageModel,
     StatusCompactPageModel,
     StatusEvidencePageModel,
     StatusFindingsPageModel,
@@ -301,6 +304,7 @@ async def _bootstrap_finding(
     *,
     seed: int,
     mode: str = "deterministic_only",
+    refs: bool = False,
 ) -> tuple[StartInternalResult, CheckCommitResult, str]:
     """Publish one open obligation plus an unsupported completion claim about it, then check.
 
@@ -309,7 +313,9 @@ async def _bootstrap_finding(
     themselves are not re-derived here.
     """
 
-    started = await app.start(start_request(seed, title="Respond/status/receipt exercise"))
+    started = await app.start(
+        start_request(seed, title="Respond/status/receipt exercise", refs=refs)
+    )
     obligation_id = protocol_id("obl_", seed + 1)
     obligation_event_id = protocol_id("evt_", seed + 2)
     publish_wire: dict[str, JsonValue] = {
@@ -1246,3 +1252,248 @@ async def test_check_respond_recheck_reaches_a_fixed_point() -> None:
     # material change, so nothing demands another cycle.
     assert item.unresolved_finding_count == "0"
     assert item.freshness != "stale_after_material_change"
+
+
+def _receipt_wire(
+    request_seed: int,
+    *,
+    task_id: str,
+    session: str,
+    writer: str,
+    frontier: Frontier | FrontierModel,
+) -> dict[str, JsonValue]:
+    return {
+        **_request_base(protocol_id("req_", request_seed)),
+        "task_id": task_id,
+        "session_id": session,
+        "writer_id": writer,
+        "expected_frontier": _frontier(frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+
+
+async def test_receipt_survives_reattach_through_create_or_attach() -> None:
+    """Regression for issue #200.
+
+    ``start mode=create_or_attach`` mints a fresh session for an existing task and appends one
+    ordinary ``session_resumed`` event to the task-global ingestion/digest chain. Reading the
+    ledger back through the attached session must therefore still yield the whole task chain: a
+    session-filtered slice would start mid-chain and replay, which is genesis-anchored, would
+    reject it as a corrupt projection.
+    """
+
+    app, _runtime, _ = _build_app(seed_offset=12)
+    started, checked, obligation = await _bootstrap_finding(app, seed=1900, refs=True)
+
+    before = await app.receipt(
+        ReceiptRequest.model_validate(
+            _receipt_wire(
+                1910,
+                task_id=started.task_id,
+                session=started.session_id,
+                writer=started.writer_id,
+                frontier=checked.result_frontier,
+            )
+        )
+    )
+    assert before.subject_frontier == checked.result_frontier
+    assert before.conclusion == "unresolved_findings_remain"
+
+    attached = await app.start(
+        start_request(1920, title="Respond/status/receipt exercise", refs=True)
+    )
+    assert attached.outcome == "attached"
+    assert attached.task_id == started.task_id
+    assert attached.session_id != started.session_id
+    assert attached.writer_id != started.writer_id
+
+    after = await app.receipt(
+        ReceiptRequest.model_validate(
+            _receipt_wire(
+                1930,
+                task_id=attached.task_id,
+                session=attached.session_id,
+                writer=attached.writer_id,
+                frontier=attached.frontier,
+            )
+        )
+    )
+
+    # The receipt covers the whole task ledger, not the suffix this session authored: its subject
+    # frontier is the attached head, which is strictly beyond the pre-resume receipt's.
+    assert _frontier(after.subject_frontier) == _frontier(attached.frontier)
+    assert after.subject_frontier.sequence > before.subject_frontier.sequence
+    assert after.receipt_id != before.receipt_id
+
+    # It also still reports the work published before the resume: the same unresolved conclusion,
+    # from the same pre-resume check, over the same obligation.
+    assert after.conclusion == before.conclusion
+    assert after.suppressed_finding_count == before.suppressed_finding_count
+    assert after.versions == before.versions
+    document = cast(Mapping[str, JsonValue], after.document)
+    assert obligation in canonical_encode(document).decode()
+
+    # ``status view=candidate_findings`` reads the ledger the same way and was equally broken.
+    candidates = await app.status(
+        StatusRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 1940)),
+                "session_id": attached.session_id,
+                "writer_id": attached.writer_id,
+                "view": "candidate_findings",
+                "limit": "10",
+                "at_frontier": str(after.result_frontier.sequence),
+            }
+        )
+    )
+    candidate_page = cast(StatusCandidateFindingsPageModel, candidates.page)
+    assert candidate_page.items
+    assert any(obligation in item.subject_refs for item in candidate_page.items)
+
+    # The ordinary findings view is task-wide from the attached session too: the finding the
+    # pre-resume check returned is still the finding on the record.
+    findings = await app.status(
+        StatusRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 1950)),
+                "session_id": attached.session_id,
+                "writer_id": attached.writer_id,
+                "view": "findings",
+                "limit": "10",
+                "at_frontier": str(after.result_frontier.sequence),
+            }
+        )
+    )
+    findings_page = cast(StatusFindingsPageModel, findings.page)
+    assert tuple(item.finding_id for item in findings_page.items) == tuple(
+        item.finding_id for item in checked.findings
+    )
+
+
+async def test_dry_run_publish_survives_reattach_through_create_or_attach() -> None:
+    """The dry-run preflight replays the task ledger too (issue #200).
+
+    ``publish_work dry_run=true`` proves a batch would reduce by replaying the existing records
+    with the provisional ones appended, and it converts any replay ``ValueError`` into
+    ``EVENT_INVALID``. Reading a session-filtered slice therefore turned every dry run on a
+    resumed task into an invalid batch, and made a draft citing a pre-resume event look like a
+    missing causal parent rather than the valid reference it is.
+    """
+
+    app, _runtime, _ = _build_app(seed_offset=14)
+    started, _checked, _obligation = await _bootstrap_finding(app, seed=2100, refs=True)
+    # The obligation event ``_bootstrap_finding`` publishes, named the same way it names it.
+    obligation_event_id = protocol_id("evt_", 2102)
+
+    attached = await app.start(
+        start_request(2120, title="Respond/status/receipt exercise", refs=True)
+    )
+    assert attached.outcome == "attached"
+    assert attached.task_id == started.task_id
+    assert attached.session_id != started.session_id
+
+    action_event_id = protocol_id("evt_", 2131)
+    preview = await app.publish_work(
+        PublishWorkRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 2130)),
+                "session_id": attached.session_id,
+                "writer_id": attached.writer_id,
+                "expected_frontier": _frontier(attached.frontier),
+                "dry_run": True,
+                "event_drafts": (
+                    {
+                        "event_id": action_event_id,
+                        "schema": {"name": "action_recorded", "version": "1.0.0"},
+                        "occurred_at": "2026-07-19T12:00:02.000Z",
+                        # Published before the resume, so the attached session can only cite it if
+                        # the preflight reads the whole task chain.
+                        "causal_parents": (obligation_event_id,),
+                        "payload": {
+                            "action_id": protocol_id("act_", 2132),
+                            "action_kind": "other",
+                            "description": "Continue the exercise from the attached session.",
+                        },
+                        "artifact_refs": (),
+                        "evidence_refs": (),
+                    },
+                ),
+            }
+        )
+    )
+
+    assert type(preview) is PublishWorkResult, f"unexpected publish result: {type(preview)}"
+    assert preview.ok is True
+    assert preview.outcome == "dry_run"
+    assert preview.subject_frontier.sequence == attached.frontier.sequence
+    assert preview.result_frontier == preview.subject_frontier
+    root = cast(PublishWorkDryRunModel, preview.root)
+    assert root.evidential is False
+    assert len(root.would_accept) == 1
+    assert root.would_accept[0].event_id == action_event_id
+    assert root.would_accept[0].causal_parents == (obligation_event_id,)
+
+    # Duplicate detection stays task-wide as well: re-drafting a pre-resume event id is still an
+    # invalid batch, so widening the read did not turn the preflight into a false positive.
+    with pytest.raises(PublicOperationError) as caught:
+        await app.publish_work(
+            PublishWorkRequest.model_validate(
+                {
+                    **_request_base(protocol_id("req_", 2140)),
+                    "session_id": attached.session_id,
+                    "writer_id": attached.writer_id,
+                    "expected_frontier": _frontier(attached.frontier),
+                    "dry_run": True,
+                    "event_drafts": (
+                        {
+                            "event_id": obligation_event_id,
+                            "schema": {"name": "action_recorded", "version": "1.0.0"},
+                            "occurred_at": "2026-07-19T12:00:03.000Z",
+                            "causal_parents": (),
+                            "payload": {
+                                "action_id": protocol_id("act_", 2141),
+                                "action_kind": "other",
+                                "description": "Reuse an event id already on the task ledger.",
+                            },
+                            "artifact_refs": (),
+                            "evidence_refs": (),
+                        },
+                    ),
+                }
+            )
+        )
+    assert caught.value.code is PublicErrorCode.EVENT_INVALID
+
+
+async def test_reattach_detaches_the_prior_session_from_the_task_route() -> None:
+    """The prior session stops being routable when a new one attaches (issue #200).
+
+    Membership in the ledger is what ``load_events`` checks; *authority* to act on the task is a
+    route question, and that is what a resumed START moves. This locks the contract that the fix
+    for #200 must not weaken: widening the ledger read does not keep a superseded session
+    routable.
+    """
+
+    app, _runtime, _ = _build_app(seed_offset=13)
+    started, _checked, _obligation = await _bootstrap_finding(app, seed=2000, refs=True)
+
+    assert await app.start_catalog.resolve_route(started.session_id) is not None
+
+    attached = await app.start(
+        start_request(2020, title="Respond/status/receipt exercise", refs=True)
+    )
+    assert attached.outcome == "attached"
+
+    # Bounded, not an internal error: the superseded session no longer resolves to a route, which
+    # is the fact the real bundle runtime turns into SESSION_NOT_FOUND before any ledger read.
+    assert await app.start_catalog.resolve_route(started.session_id) is None
+    resumed_route = await app.start_catalog.resolve_route(attached.session_id)
+    assert resumed_route is not None
+    assert resumed_route.task_id == attached.task_id
+
+    # A session that never touched this task reads nothing from its ledger.
+    ledger, _objects = _runtime.resources[attached.task_id]
+    stranger = protocol_id("ses_", 2099)
+    assert [record async for record in ledger.load_events(stranger)] == []

--- a/tests/unit/kernel/test_reducers_each_family.py
+++ b/tests/unit/kernel/test_reducers_each_family.py
@@ -190,6 +190,22 @@ def test_session_events_advance_frontier_only() -> None:
     assert state.freshness.value == "current"
 
 
+def test_replay_rejects_a_mid_chain_suffix_as_corrupt() -> None:
+    """Replay is genesis-anchored by contract (issue #200).
+
+    A suffix that starts past the genesis anchor is a corrupt projection, not a partial one, so a
+    caller that reads only part of a task's chain — for example by filtering rows to one session —
+    has to be fixed at the record-loading layer. Loosening this check instead would let a
+    projection be built from an unverified chain.
+    """
+
+    records = _records("all-event-families")
+    with pytest.raises(ValueError, match="projection_corrupt"):
+        replay(records[1:])
+    with pytest.raises(ValueError, match="projection_corrupt"):
+        replay(records[3:5])
+
+
 def test_plan_and_obligation_supersession() -> None:
     records = _records("supersession-redaction")
     state = replay(records)


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #200
- I searched existing issues and PRs for duplicates before opening this PR. Closest prior art is #126 (closed), which is a different defect in `service/ready_composition` ownership fencing; #172/#34 concern receipt coverage content, not dispatch. #192 (respond frontier) is plausibly the same root cause and should be re-tested against this branch.
- Design-gated (storage/durability + protocol error surface): opened on maintainer instruction — the repo owner requested the fix and PR for #200 directly.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` LedgerPort entry — `load_events` now documented as returning the task-scoped chain in `ingestion_sequence` order, with `session_id` as an authorization/membership argument, never a row filter.

## Verification

Commands run (paste):

```text
uv sync --locked --all-extras --group dev
uv run --locked ruff format --check .                                     # 544 files clean
uv run --locked ruff check .                                              # pass
npm ci --ignore-scripts && npx --no-install pyright                       # 0 errors
uv run --locked pytest tests/integration/application -m "not fault and not soak and not live" -q --timeout=180
PYTHONHASHSEED=0 uv run --locked pytest tests/unit/protocol tests/unit/kernel -m "not fault and not soak and not live" -q --timeout=120
PYTHONHASHSEED=1 uv run --locked pytest tests/unit/protocol tests/unit/kernel -m "not fault and not soak and not live" -q --timeout=120
PYTHONHASHSEED=0 YOETZ_DENY_NETWORK=1 uv run --locked pytest tests/unit tests/property tests/conformance -m "not fault and not soak and not live" -q --timeout=120   # 2276 passed
YOETZ_DENY_NETWORK=1 uv run --locked pytest tests/integration/storage tests/integration/objects tests/integration/application tests/integration/privacy -m "not fault and not kill_matrix and not soak and not live" -q --timeout=180
uv run --locked python scripts/generate_schemas.py --check                # 69 match
uv run --locked python scripts/sync_check_continuation_schemas.py --check
uv run --locked python scripts/verify_resource_manifest.py --check        # 96 resources
uv run --locked python scripts/scan_public_boundary.py --source-tree .    # 900 files
```

Red/green: each regression test was run against the pre-fix `_iter_events` (stash) and fails with the exact issue signature — `ValueError: projection_corrupt` at `kernel/reducers.py:156` for receipt, `EVENT_INVALID / invalid_event_value_type` for the dry run — then passes with the fix.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

### Root cause

`start mode=create_or_attach` on an existing task mints a **new** `session_id` and appends one ordinary `session_resumed` event to the task-global ingestion/digest chain. `MemoryLedgerAdapter._iter_events` filtered ledger rows by `record.session_id == session_id`, so any operation that replays from `load_events` in a resumed session received a **mid-chain suffix**. Replay is genesis-anchored by design, so `_next_record` correctly rejected the suffix as `projection_corrupt` — the ledger was never corrupt; the reader was handing replay a truncated input. The bare `ValueError` then escaped to the daemon catch-all and surfaced as unbounded `internal_error` (exit 70).

The `session_resumed` event itself, the reducer no-op fold, and the genesis-anchored contiguity check are all correct and unchanged.

### The fix

`load_events`' `session_id` is now a membership guard, never a row filter — a session attached to the task reads the whole task chain; an unknown session reads nothing. This is the same rule `load_projection`, `query_projection`, `load_case_availability`, and `append_batch`'s internal replay already applied; `load_events` was the last session-row-filtered read. The SQLite adapter inherits the fix through the shared memory oracle, and a new conformance test asserts memory/SQLite parity for the two-session case.

Defense-in-depth: the three application-layer `replay()` calls (`receipt._records_through`, `respond._records_through`, `status._candidate_page`) now map replay `ValueError` to bounded public `STORAGE_CORRUPT` (exit 40) instead of unbounded `internal_error`, matching the append-path precedent in `memory/ledger.py` and the issue's fallback ask.

### User-visible symptoms repaired (all deterministic on any resumed task)

1. **`receipt` → `internal_error` exit 70** (the reported bug) — now succeeds, covering the whole task ledger including pre-resume work.
2. **`status view=candidate_findings` → `internal_error`** — same broken read pattern.
3. **`publish_work --dry-run` → `EVENT_INVALID / invalid_event_value_type`** — a valid batch was misreported as a malformed payload: the session-filtered `seen` set omitted every pre-resume event, so valid `causal_parents` references were rejected and the preview replay saw the same truncated chain. Dry-run now matches real-append acceptance, as its docstring already claimed.
4. **`status --at_frontier <pre-resume seq>` → spurious `FRONTIER_CONFLICT`**, and `respond` on a resumed task (plausibly #192) — same pattern, now consistent.
5. `import_review` cooperative/artifact-evidence counts are now task-wide rather than current-session-only — identical for single-session tasks, corrected for resumed ones.

### Tests added

- `test_receipt_survives_reattach_through_create_or_attach` — end-to-end: start → publish → check → receipt → re-attach → receipt succeeds, covers pre-resume work, and candidate-findings/findings views agree across the resume.
- `test_dry_run_publish_survives_reattach_through_create_or_attach` — dry run from the attached session accepts a pre-resume `causal_parent`, and duplicate-event-id detection still rejects a redrafted pre-resume event id (no false negatives from the widened read).
- `test_reattach_detaches_the_prior_session_from_the_task_route` — contract lock: the superseded session stops resolving to a route (the fact the runtime turns into `SESSION_NOT_FOUND`), and a never-attached session reads nothing.
- `test_load_events_gives_every_attached_session_the_whole_task_chain` — adapter conformance, memory + SQLite parity, windowing (`after`/`through`) preserved.
- `test_replay_rejects_a_mid_chain_suffix_as_corrupt` — pins that replay is genesis-anchored by contract, so any future regression must be fixed at the record-loading layer, not by loosening the reducer.

### Known follow-ups deliberately not in this PR

- `PublicOperationError` is a frozen slots dataclass; CPython's `contextlib` re-raise path assigns `exc.__traceback__`, so any bounded error propagating through a `@contextmanager` (e.g. `adapters/privacy/catalog.py:574`, `adapters/privacy/gateway.py:965`, `adapters/mcp_stdio.py:303`) is destroyed into `FrozenInstanceError` → unbounded `internal_error`. Pre-existing, reproduced during review; undermines the bounded-error contract generally and deserves its own issue.
- `MemoryLedgerAdapter.query_projection` still calls `replay()` unwrapped — same unbounded-on-genuine-corruption surface this PR closes elsewhere, unreachable via #200.
- Daemon `_READ_ONLY_METHODS` omits `RECEIPT`; a receipt that fails before its append is as retryable as a status read. Classification question left open.
- `receipt.py`/`respond.py` re-replay the tuple `_records_through` already replayed (pure, so harmless, but wasted work on long chains) — cleanup candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make ledger event reads task-scoped so receipt survives `create_or_attach` resume
> - `MemoryLedgerAdapter._iter_events` now returns the full task ledger (bounded by `after`/`through`) for any session attached to the task, rather than filtering rows by `session_id`; sessions not attached to the task receive no events.
> - Integration tests confirm that after reattaching via `start(create_or_attach)`, receipt, candidate findings, and findings views all reflect the pre-resume ledger from the new session.
> - `replay()` failures in `receipt`, `respond`, and `status` are now caught and surfaced as a public `STORAGE_CORRUPT` error instead of an unbounded internal `ValueError`.
> - Behavioral Change: `session_id` in `load_events` is now a membership check rather than a row filter; any session attached to the task reads the entire task chain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bfc8b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task history now replays as a complete, ingestion-ordered event chain across attached sessions.
  - Unknown sessions return no task history.
  - Corrupted or unreadable task ledgers now produce a clear `STORAGE_CORRUPT` error instead of an unexpected failure.
  - Replay correctly rejects incomplete event-chain suffixes.

- **Documentation**
  - Clarified task-wide event replay, authorization, ordering, and range behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->