### PR TITLE
Fix local service starvation and bound MCP deadlines

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1349,6 +1349,17 @@ cancelled solely for lack of a subsequent frame. Each control-result write is al
 bounded (**5 minutes**): a peer that stops reading cannot retain an in-flight call entry (and
 thus the inactive-session exemption) indefinitely via send backpressure.
 
+The ordinary client independently bounds each connect-plus-handshake attempt to **5 seconds** and
+closes a half-open stream on expiry. On-demand startup has one **30-second** monotonic budget that
+includes its initial attempt, spawn, and polling; an accepted but silent existing endpoint is
+reported unavailable rather than causing a second daemon to be spawned. The MCP bridge supplies a
+**30-second** call deadline for `start`, `publish_work`, `respond`, `status`, and `receipt`, and a
+**300-second** deadline for `check`; these use the existing private `deadline_ms` envelope field and
+do not change the public six-tool schemas. A timed-out write has an unknown outcome: the bridge
+must preserve its retryable failure shape, say that it may already have committed, and direct the
+caller to retry with the same `request_id` (and operation status where applicable). A timed-out
+read may simply be repeated.
+
 The private `ControlCallRequest` envelope may carry `route_profile=policy|strict` only for `check`
 and `status`. It is set by the MCP bridge from its immutable process profile, is absent from public
 operation request models, and is rejected on every other control method. `strict` prevents
@@ -2317,7 +2328,13 @@ across workspace sessions under a nonblocking per-workspace lease; within one pa
 `mapping_missing` rejection retires that session's remaining rows (stamped with the shared cause),
 and workspace-global rejections (`vault_locked`, disabled, paused) end the pass. A
 `service_unavailable` rejection is row-scoped: later rows are still attempted, and the pass yields
-after three consecutive such rejections. Quarantined detail is bounded by count, by the state byte
+after three consecutive such rejections. `observation_storage_corrupt` is terminal for its Codex
+session in the current READY generation: the coordinator remembers that session after the first
+bundle `STORAGE_CORRUPT`, later ingests are rejected without reopening the bundle, and the sweeper
+atomically moves that session's pending backlog to quarantine while healthy lanes continue. A new
+READY generation clears the in-memory suppression and permits one recovery probe. A successful
+probe removes that session from the local corruption set and resolves the workspace corruption gap
+only when no affected session remains. Quarantined detail is bounded by count, by the state byte
 budget, and by a 14-day age measured from a store-authored
 quarantined-at time behind the trusted-clock epoch fence; an operator can drop it explicitly with
 `yoetz observe reclaim`. Every drop — cap, age, or reclaim — retains aggregate commitment, count

--- a/docs/adr/ADR-003-storage-sqlite-durability.md
+++ b/docs/adr/ADR-003-storage-sqlite-durability.md
@@ -39,7 +39,13 @@ fault/contention matrix on both advertised platforms.
    canonical event bytes never rewritten by migration; newer unknown write-schema fails closed.
 8. **Corruption response:** integrity failure quarantines the bundle (writes disabled,
    `STORAGE_CORRUPT`), preserves originals under `quarantine/`, and directs to
-   backup/restore. Projection-only corruption is repaired by generation replay.
+   backup/restore. Projection-only corruption is repaired by generation replay. Recovery of an
+   existing bundle must remain cooperative with the trusted local service: decoding yields in
+   bounded batches and the pure CPU replay reducer runs outside the service event loop, so one
+   large or corrupt task cannot monopolize ordinary control. An observation route that encounters
+   `STORAGE_CORRUPT` does not reinterpret the bundle as healthy or retry indefinitely; ADR-010's
+   terminal observation quarantine contains that delivery lane while preserving the original
+   storage recovery contract.
 
 ## Consequences
 

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -160,6 +160,15 @@ count, byte budget, and a clock-fenced 14-day age with an explicit operator recl
 retains aggregate commitment/count/time range plus a loss gap, with involuntary evictions and
 operator reclaims counted separately.
 
+An observation route that encounters bundle `STORAGE_CORRUPT` records the exact terminal
+`observation_storage_corrupt` gap and quarantines that Codex session's pending delivery backlog.
+The READY-generation coordinator suppresses further recovery attempts for that Codex session so a
+poisoned mapped task cannot starve healthy sessions or ordinary control. The suppression is not a
+durable claim that repair is impossible: composing a new READY generation clears it and permits one
+fresh recovery probe after operator repair or restart. A successful probe clears that session's
+current corruption condition; the workspace gap heals only after no affected session remains.
+Maintenance re-sweeps always yield to the event loop before repeating.
+
 After every completed tool action, ready-service composition captures a descriptor-safe structural
 workspace digest. Real state change enqueues exact-policy verification; unchanged state does not.
 Approved checks never execute inside the hook RPC budget. A generation-fenced

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -334,6 +334,7 @@ class _WorkspaceState:
     # quarantine, never the (possibly much older) envelope receipt time.
     quarantine: list[tuple[str, ObservationEnvelope, str, Timestamp]] | None = None
     codex_session_bindings: dict[str, str] | None = None
+    storage_corrupt_sessions: set[str] | None = None
     ended_sessions: set[str] | None = None
     session_generations: dict[str, int] | None = None
     ended_session_generations: dict[str, int] | None = None
@@ -372,6 +373,8 @@ class _WorkspaceState:
             self.quarantine = []
         if self.codex_session_bindings is None:
             self.codex_session_bindings = {}
+        if self.storage_corrupt_sessions is None:
+            self.storage_corrupt_sessions = set()
         if self.ended_sessions is None:
             self.ended_sessions = set()
         if self.session_generations is None:
@@ -429,6 +432,7 @@ def _copy_state(state: _WorkspaceState) -> _WorkspaceState:
         pending_outbox=list(state.pending_outbox or ()),
         quarantine=list(state.quarantine or ()),
         codex_session_bindings=dict(state.codex_session_bindings or {}),
+        storage_corrupt_sessions=set(state.storage_corrupt_sessions or ()),
         ended_sessions=set(state.ended_sessions or ()),
         session_generations=dict(state.session_generations or {}),
         ended_session_generations=dict(state.ended_session_generations or {}),
@@ -1244,6 +1248,56 @@ class LocalObservationStore:
             self._save(workspace, state)
             return True
 
+    def quarantine_outbox_session(self, workspace: str, codex_session_id: str, reason: str) -> int:
+        """Atomically quarantine every pending row for one terminally failed session."""
+
+        if type(codex_session_id) is not str or not codex_session_id:
+            raise ProtocolValueError("invalid_event_value_type")
+        if type(reason) is not str or _OUTBOX_REASON_RE.fullmatch(reason) is None:
+            raise ProtocolValueError("invalid_event_value_type")
+        with self._lock:
+            state = self._load(workspace)
+            assert state.pending_outbox is not None
+            assert state.quarantine is not None
+            assert state.gaps is not None
+            assert state.storage_corrupt_sessions is not None
+            pending: list[ObservationOutboxRow] = []
+            moved: list[ObservationOutboxRow] = []
+            for row in state.pending_outbox:
+                (moved if row.codex_session_id == codex_session_id else pending).append(row)
+            if not moved:
+                return 0
+            state.pending_outbox[:] = pending
+            stamp = self._wall_timestamp()
+            existing = {
+                (
+                    entry[0],
+                    entry[1].source_identity,
+                    canonical_digest(observation_envelope_to_json(entry[1])),
+                )
+                for entry in state.quarantine
+            }
+            for row in moved:
+                identity = (
+                    codex_session_id,
+                    row.envelope.source_identity,
+                    canonical_digest(observation_envelope_to_json(row.envelope)),
+                )
+                if identity in existing:
+                    continue
+                state.quarantine.append((codex_session_id, row.envelope, reason, stamp))
+                existing.add(identity)
+            while len(state.quarantine) > _MAX_QUARANTINE:
+                evicted = state.quarantine.pop(0)
+                self._record_quarantine_eviction(state, evicted[0], evicted[1], evicted[2])
+            if reason in {gap.value for gap in ObservationGapCode}:
+                self._note_gap_state(state, reason)
+            if reason == ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value:
+                state.storage_corrupt_sessions.add(codex_session_id)
+            self._note_gap_state(state, ObservationGapCode.OUTBOX_QUARANTINED.value)
+            self._save(workspace, state)
+            return len(moved)
+
     def quarantined_count(self, workspace: str) -> int:
         with self._lock:
             state = self._load(workspace)
@@ -1481,6 +1535,16 @@ class LocalObservationStore:
             self._resolve_gap_state(state, ObservationGapCode.CURSOR_STALE.value)
             if envelope.content_object_refs:
                 self._resolve_gap_state(state, ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value)
+            assert state.codex_session_bindings is not None
+            assert state.storage_corrupt_sessions is not None
+            repaired_sessions = {
+                codex_session_id
+                for codex_session_id, commitment in state.codex_session_bindings.items()
+                if commitment == envelope.session_commitment
+            }
+            state.storage_corrupt_sessions.difference_update(repaired_sessions)
+            if not state.storage_corrupt_sessions:
+                self._resolve_gap_state(state, ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
             for gap in envelope.gap_codes:
                 self._note_gap_state(state, gap)
             if ObservationGapCode.UNSUPPORTED_EVENT.value in envelope.gap_codes:
@@ -1916,11 +1980,11 @@ class LocalObservationStore:
                     "paused": consent.paused,
                 }
             )
-        return {
-            # /3 adds quarantined_at per quarantine entry and the reclaimed
-            # counter; readers of every version tolerate both directions
-            # (unknown keys ignored, missing keys defaulted).
-            "schema": "yoetz.observation-local/4",
+        payload: dict[str, JsonValue] = {
+            # /5 adds terminal corruption-session tracking. /3 added quarantined_at per
+            # quarantine entry and the reclaimed counter. Readers tolerate both directions:
+            # unknown keys are ignored and missing keys default safely.
+            "schema": "yoetz.observation-local/5",
             "workspace_commitment": workspace,
             "consent": consent_json,
             "session_workspaces": JsonObject(
@@ -2066,6 +2130,11 @@ class LocalObservationStore:
                 {key: value for key, value in sorted(state.codex_session_bindings.items())}
             ),
         }
+        if state.storage_corrupt_sessions:
+            payload["storage_corrupt_sessions"] = tuple(
+                sorted(state.storage_corrupt_sessions, key=str.encode)
+            )
+        return payload
 
     def _state_from_json(self, raw: Mapping[str, JsonValue]) -> _WorkspaceState:
         consent_raw = raw.get("consent")
@@ -2185,6 +2254,14 @@ class LocalObservationStore:
             for key, value in cast(
                 Mapping[str, JsonValue], raw.get("codex_session_bindings") or {}
             ).items()
+        }
+        storage_corrupt_sessions = {
+            str(value)
+            for value in cast(
+                tuple[JsonValue, ...] | list[JsonValue],
+                raw.get("storage_corrupt_sessions") or (),
+            )
+            if type(value) is str and value
         }
         open_pre = {
             str(key): str(value)
@@ -2348,6 +2425,7 @@ class LocalObservationStore:
             trusted_policy_digest=cast(str | None, raw.get("trusted_policy_digest")),
             trusted_policy_mac=cast(str | None, raw.get("trusted_policy_mac")),
             codex_session_bindings=bindings,
+            storage_corrupt_sessions=storage_corrupt_sessions,
         )
 
 

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -297,6 +297,7 @@ class SqliteLedger:
         self._lock = asyncio.Lock()
         self._state = MemoryLedgerState()
         self._requires_recovery = _head(db).sequence != 0
+        self._recovery_task: asyncio.Task[None] | None = None
 
     def open_observation_store(self) -> SqliteObservationStore:
         """Public durable-observation seam over this bundle's connection.
@@ -449,6 +450,21 @@ class SqliteLedger:
     async def _ensure_recovered(self) -> None:
         if not self._requires_recovery:
             return
+        task = self._recovery_task
+        if task is None:
+            task = asyncio.create_task(self._recover_once())
+            self._recovery_task = task
+        try:
+            await asyncio.shield(task)
+        finally:
+            if task.done() and self._recovery_task is task:
+                self._recovery_task = None
+
+    async def _recover_once(self) -> None:
+        """Rebuild one shared projection without duplicating work on caller cancellation."""
+
+        if not self._requires_recovery:
+            return
         async with self._lock:
             if not self._requires_recovery:
                 return
@@ -461,9 +477,17 @@ class SqliteLedger:
                     "ORDER BY e.ingestion_seq"
                 ).fetchall(),
             )
-            records = tuple([await self._decode_durable_record(row) for row in rows])
+            decoded_records: list[LedgerRecord] = []
+            for index, row in enumerate(rows, start=1):
+                decoded_records.append(await self._decode_durable_record(row))
+                if index % 32 == 0:
+                    await asyncio.sleep(0)
+            records = tuple(decoded_records)
             try:
-                projection = replay(records)
+                # Reducer replay is pure but can be CPU-heavy for a mature ledger.  Keep it off
+                # the service daemon's event loop so recovery of one task cannot starve control
+                # handshakes or unrelated task routes.
+                projection = await asyncio.to_thread(replay, records)
             except ValueError as exc:
                 raise _public_error(PublicErrorCode.STORAGE_CORRUPT) from exc
             for (
@@ -549,6 +573,7 @@ class SqliteLedger:
                 key = (operation.writer_id, operation.operation_id)
                 self._state.frozen_cases[key] = case
                 self._state.operations[key] = (operation, None)
+                await asyncio.sleep(0)
             for operation_row in self._db.execute(
                 "SELECT writer_id,operation_id,operation_kind,request_digest,state,phase,"
                 "result_canonical,result_digest,first_ingestion_seq,last_ingestion_seq,"

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -167,6 +167,10 @@ def _empty_advice_event_ref_cache() -> dict[tuple[str, str], tuple[str, ...]]:
     return {}
 
 
+def _empty_storage_corrupt_sessions() -> set[str]:
+    return set()
+
+
 @dataclass
 class ObservationCoordinator:
     """Resolve Codex session → mapped task SQLite observation store + ledger."""
@@ -185,6 +189,9 @@ class ObservationCoordinator:
     observation_enabled: bool = True
     _advice_event_ref_cache: dict[tuple[str, str], tuple[str, ...]] = field(
         default_factory=_empty_advice_event_ref_cache, init=False, repr=False
+    )
+    _storage_corrupt_sessions: set[str] = field(
+        default_factory=_empty_storage_corrupt_sessions, init=False, repr=False
     )
 
     def __post_init__(self) -> None:
@@ -331,6 +338,8 @@ class ObservationCoordinator:
         expected = session_commitment_from_codex_id(self.local.key_material(), codex_session_id)
         if request.envelope.session_commitment != expected:
             return _reject(ObservationGapCode.CONSENT_MISSING.value)
+        if codex_session_id in self._storage_corrupt_sessions:
+            return _reject(ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
 
         mapping = self.mapping_loader(codex_session_id, _state=self.state_root)
         if mapping is None:
@@ -353,6 +362,8 @@ class ObservationCoordinator:
             return _reject(reason)
 
         async with self._lock:
+            if codex_session_id in self._storage_corrupt_sessions:
+                return _reject(ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
             runtime: TaskRuntime | None = None
             stage = "runtime_route"
             try:
@@ -449,6 +460,9 @@ class ObservationCoordinator:
                 )
                 if exc.code is PublicErrorCode.VAULT_LOCKED:
                     return _reject(ObservationGapCode.VAULT_LOCKED.value)
+                if exc.code is PublicErrorCode.STORAGE_CORRUPT:
+                    self._storage_corrupt_sessions.add(codex_session_id)
+                    return _reject(ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
                 if exc.code in {
                     PublicErrorCode.SERVICE_UNAVAILABLE,
                     PublicErrorCode.BUNDLE_BUSY,

--- a/src/yoetz/application/observation_drain.py
+++ b/src/yoetz/application/observation_drain.py
@@ -111,6 +111,7 @@ class ObservationOutboxSweeper:
         retry_pending = 0
         quarantined = 0
         reasons: dict[str, int] = {}
+        retired_sessions: set[tuple[str, str]] = set()
 
         workspaces = tuple(dict.fromkeys(workspace for workspace, _row in rows))
         for workspace in workspaces:
@@ -120,6 +121,9 @@ class ObservationOutboxSweeper:
                 pending_rows = frozenset(self.local.list_pending_outbox_rows(workspace))
                 for selected_workspace, row in rows:
                     if selected_workspace != workspace or row not in pending_rows:
+                        continue
+                    session_key = (workspace, row.codex_session_id)
+                    if session_key in retired_sessions:
                         continue
                     attempted += 1
                     request = ObservationIngestRequest(
@@ -150,6 +154,14 @@ class ObservationOutboxSweeper:
                         retry_pending += 1
                         continue
                     if decision.action is ObservationDrainAction.QUARANTINE:
+                        if decision.reason == ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value:
+                            retired_sessions.add(session_key)
+                            quarantined += self.local.quarantine_outbox_session(
+                                workspace,
+                                row.codex_session_id,
+                                decision.reason,
+                            )
+                            continue
                         if self.local.quarantine_outbox_row(
                             workspace,
                             attempted_row,

--- a/src/yoetz/domain/observation.py
+++ b/src/yoetz/domain/observation.py
@@ -195,6 +195,7 @@ class ObservationGapCode(str, Enum):  # noqa: UP042 - exact durable wire enum
     MAPPING_MISSING = "mapping_missing"
     OUTBOX_OVERFLOW = "outbox_overflow"
     OUTBOX_QUARANTINED = "outbox_quarantined"
+    OBSERVATION_STORAGE_CORRUPT = "observation_storage_corrupt"
     QUARANTINE_DETAIL_EVICTED = "quarantine_detail_evicted"
     CONTENT_CAPTURE_UNAVAILABLE = "content_capture_unavailable"
     CONTENT_REDACTED = "content_redacted"

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -100,6 +100,8 @@ __all__ = [
 ]
 
 _SERVER_NAME: Final = "yoetz"
+_WORKFLOW_RPC_DEADLINE_MS: Final = 30_000
+_SEMANTIC_CHECK_RPC_DEADLINE_MS: Final = 300_000
 _REGISTERED_TOOL_NAMES: Final = frozenset(
     {"start", "publish_work", "check", "respond", "status", "receipt"}
 )
@@ -132,6 +134,7 @@ _OPERATION_RECOVERY_UNAVAILABLE_MESSAGE: Final = (
     "correct the named authoring fields and resubmit with the intended request identity."
 )
 _OPERATION_RECOVERY_UNAVAILABLE_DETAILS: Final = {"reason_code": "operation_recovery_unavailable"}
+_WRITE_OPERATIONS: Final = frozenset({"start", "publish_work", "check", "respond", "receipt"})
 _REQUEST_TEMPLATES_GUIDANCE_URI: Final = "yoetz://guidance/request-templates.md"
 _GUIDANCE_BY_OPERATION: Final = MappingProxyType(
     {
@@ -443,7 +446,27 @@ def _control_error_result(
             operation=operation,
             safe_details={"reason_code": "privacy_projection_unavailable"},
         )
-    if error.reason in {"service_unavailable", "service_draining", "request_timeout"}:
+    if error.reason == "request_timeout":
+        if operation in _WRITE_OPERATIONS:
+            message = (
+                "The local operation timed out and may still have committed. Retry with the same "
+                "request_id to recover the stored outcome; for an existing Yoetz session, status "
+                "view=operation can inspect that request_id."
+            )
+        else:
+            message = (
+                "The local status read timed out and requested no write. Repeat the read with a "
+                "new request_id."
+            )
+        return structured_error_result(
+            PublicErrorCode.SERVICE_UNAVAILABLE,
+            message,
+            retryable=True,
+            request_id=request_id,
+            correlation_id=service_correlation_id,
+            operation=operation,
+        )
+    if error.reason in {"service_unavailable", "service_draining"}:
         return structured_error_result(
             PublicErrorCode.SERVICE_UNAVAILABLE,
             "The local service is unavailable; retry after it is ready.",
@@ -613,7 +636,7 @@ async def dispatch_start(
         arguments,
         StartRequest,
         StartResult,
-        lambda client, request: client.start(request),
+        lambda client, request: client.start(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
         runtime,
         "start",
     )
@@ -754,7 +777,7 @@ async def _publish_recovery_from_envelope(
         status_result = await _invoke_with_reconnect(
             runtime,
             status_request,
-            lambda service, request: service.status(request),
+            lambda service, request: service.status(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
         )
     except PublicOperationError as exc:
         # A nested public failure (session conflict, projection, etc.) does not prove the
@@ -885,7 +908,7 @@ async def dispatch_publish_work(
         arguments,
         PublishWorkRequest,
         PublishWorkResult,
-        lambda client, request: client.publish_work(request),
+        lambda client, request: client.publish_work(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
         runtime,
         "publish_work",
     )
@@ -898,7 +921,11 @@ async def dispatch_check(
         arguments,
         CheckRequest,
         CheckResult,
-        lambda client, request: client.check(request, route_profile=runtime.route_profile),
+        lambda client, request: client.check(
+            request,
+            deadline_ms=_SEMANTIC_CHECK_RPC_DEADLINE_MS,
+            route_profile=runtime.route_profile,
+        ),
         runtime,
         "check",
     )
@@ -911,7 +938,7 @@ async def dispatch_respond(
         arguments,
         RespondRequest,
         RespondResult,
-        lambda client, request: client.respond(request),
+        lambda client, request: client.respond(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
         runtime,
         "respond",
     )
@@ -924,7 +951,11 @@ async def dispatch_status(
         arguments,
         StatusRequest,
         StatusResult,
-        lambda client, request: client.status(request, route_profile=runtime.route_profile),
+        lambda client, request: client.status(
+            request,
+            deadline_ms=_WORKFLOW_RPC_DEADLINE_MS,
+            route_profile=runtime.route_profile,
+        ),
         runtime,
         "status",
     )
@@ -937,7 +968,7 @@ async def dispatch_receipt(
         arguments,
         ReceiptRequest,
         ReceiptResult,
-        lambda client, request: client.receipt(request),
+        lambda client, request: client.receipt(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
         runtime,
         "receipt",
     )

--- a/src/yoetz/service/client.py
+++ b/src/yoetz/service/client.py
@@ -727,15 +727,15 @@ class ServiceClient(ControlClientPort):
             or request.service_generation != self._session.service_generation
         ):
             raise ControlError("service_unavailable", retryable=True)
-        if (
-            request.rpc_id in self._pending
-            or request.rpc_id in self._retired_rpc_ids
-            or len(self._pending) + len(self._retired_rpc_ids) >= _MAX_IN_FLIGHT
-        ):
+        if request.rpc_id in self._pending or request.rpc_id in self._retired_rpc_ids:
+            raise ControlError("service_unavailable", retryable=True)
+        if len(self._pending) + len(self._retired_rpc_ids) >= _MAX_IN_FLIGHT:
+            await self._fail_connection(ControlError("service_unavailable", retryable=True))
             raise ControlError("service_unavailable", retryable=True)
 
         future = asyncio.get_running_loop().create_future()
         self._pending[request.rpc_id] = future
+        sent = False
         try:
             try:
                 self._session.admit(request)
@@ -743,19 +743,31 @@ class ServiceClient(ControlClientPort):
                 raise ControlError("frame_invalid") from exc
             if request.deadline_ms is None:
                 await self._send(request)
+                sent = True
                 result = await future
             else:
                 try:
                     async with asyncio.timeout(request.deadline_ms / 1_000):
                         await self._send(request)
+                        sent = True
                         result = await asyncio.shield(future)
                 except TimeoutError as exc:
-                    self._retire_call(request.rpc_id, future)
-                    await self._request_cancel(request.rpc_id)
+                    if sent:
+                        self._retire_call(request.rpc_id, future)
+                        await self._request_cancel(request.rpc_id)
+                    else:
+                        future.cancel()
+                        await self._fail_connection(
+                            ControlError("service_unavailable", retryable=True)
+                        )
                     raise ControlError("request_timeout", retryable=True) from exc
         except asyncio.CancelledError:
-            self._retire_call(request.rpc_id, future)
-            await self._request_cancel(request.rpc_id)
+            if sent:
+                self._retire_call(request.rpc_id, future)
+                await self._request_cancel(request.rpc_id)
+            else:
+                future.cancel()
+                await self._fail_connection(ControlError("service_unavailable", retryable=True))
             raise
         finally:
             self._pending.pop(request.rpc_id, None)

--- a/src/yoetz/service/client.py
+++ b/src/yoetz/service/client.py
@@ -106,6 +106,8 @@ __all__ = [
 ]
 
 _MAX_IN_FLIGHT: Final = 32
+_CANCEL_SEND_TIMEOUT_SECONDS: Final = 0.05
+_STREAM_CLOSE_TIMEOUT_SECONDS: Final = 0.05
 _WORKFLOW_METHODS: Final = frozenset(
     {
         ControlMethod.START,
@@ -120,6 +122,7 @@ _LIFECYCLE_METHODS: Final = frozenset(
     {ControlMethod.SERVICE_STATUS, ControlMethod.SERVICE_LOCK, ControlMethod.SERVICE_STOP}
 )
 _PRIVATE_CONSTRUCTOR_TOKEN: Final = object()
+_CONNECT_HANDSHAKE_TIMEOUT_SECONDS: Final = 5.0
 _SERVICE_START_TIMEOUT_SECONDS: Final = 30.0
 _SERVICE_START_POLL_SECONDS: Final = 0.05
 _SECRET_ENV_MARKERS: Final = (
@@ -575,6 +578,7 @@ class ServiceClient(ControlClientPort):
         "_pending",
         "_pid",
         "_receiver",
+        "_retired_rpc_ids",
         "_session",
         "_stream",
         "_write_lock",
@@ -598,6 +602,7 @@ class ServiceClient(ControlClientPort):
         self._pid = os.getpid()
         self._closed = False
         self._pending: dict[str, asyncio.Future[ControlResult]] = {}
+        self._retired_rpc_ids: set[str] = set()
         self._write_lock = asyncio.Lock()
         self._receiver = asyncio.create_task(self._receive_results())
 
@@ -646,6 +651,13 @@ class ServiceClient(ControlClientPort):
                 ):
                     raise ControlError("service_unavailable", retryable=True)
                 pending = self._pending.get(result.rpc_id)
+                if result.rpc_id in self._retired_rpc_ids:
+                    try:
+                        self._session.correlate(result)
+                    except ControlProtocolError as exc:
+                        raise ControlError("frame_invalid") from exc
+                    self._retired_rpc_ids.remove(result.rpc_id)
+                    continue
                 if pending is None or pending.done():
                     raise ControlError("frame_invalid")
                 try:
@@ -667,10 +679,11 @@ class ServiceClient(ControlClientPort):
         if not self._closed:
             self._closed = True
             self._session.close()
+            self._retired_rpc_ids.clear()
             for pending in tuple(self._pending.values()):
                 if not pending.done():
                     pending.set_exception(error)
-            await self._stream.aclose()
+            await _best_effort_close_stream(self._stream)
         if not from_receiver and self._receiver is not asyncio.current_task():
             self._receiver.cancel()
             await asyncio.gather(self._receiver, return_exceptions=True)
@@ -686,10 +699,25 @@ class ServiceClient(ControlClientPort):
             service_generation=self._session.service_generation,
             target_rpc_id=target_rpc_id,
         )
+        task = asyncio.create_task(self._send(request))
         try:
-            await asyncio.shield(self._send(request))
-        except ControlError, asyncio.CancelledError:
+            done, _pending = await asyncio.wait((task,), timeout=_CANCEL_SEND_TIMEOUT_SECONDS)
+        except asyncio.CancelledError:
+            task.cancel()
+            task.add_done_callback(_consume_background_task)
             return
+        if task in done:
+            _consume_background_task(task)
+            return
+        task.cancel()
+        task.add_done_callback(_consume_background_task)
+
+    def _retire_call(self, rpc_id: str, future: asyncio.Future[ControlResult]) -> None:
+        """Keep bounded correlation state for a terminal result that may still arrive."""
+
+        if not future.done():
+            self._retired_rpc_ids.add(rpc_id)
+            future.cancel()
 
     async def call(self, request: ControlCallRequest) -> ControlResult:
         self._ensure_live()
@@ -699,7 +727,11 @@ class ServiceClient(ControlClientPort):
             or request.service_generation != self._session.service_generation
         ):
             raise ControlError("service_unavailable", retryable=True)
-        if request.rpc_id in self._pending or len(self._pending) >= _MAX_IN_FLIGHT:
+        if (
+            request.rpc_id in self._pending
+            or request.rpc_id in self._retired_rpc_ids
+            or len(self._pending) + len(self._retired_rpc_ids) >= _MAX_IN_FLIGHT
+        ):
             raise ControlError("service_unavailable", retryable=True)
 
         future = asyncio.get_running_loop().create_future()
@@ -709,17 +741,20 @@ class ServiceClient(ControlClientPort):
                 self._session.admit(request)
             except ControlProtocolError as exc:
                 raise ControlError("frame_invalid") from exc
-            await self._send(request)
             if request.deadline_ms is None:
+                await self._send(request)
                 result = await future
             else:
                 try:
                     async with asyncio.timeout(request.deadline_ms / 1_000):
-                        result = await future
+                        await self._send(request)
+                        result = await asyncio.shield(future)
                 except TimeoutError as exc:
+                    self._retire_call(request.rpc_id, future)
                     await self._request_cancel(request.rpc_id)
                     raise ControlError("request_timeout", retryable=True) from exc
         except asyncio.CancelledError:
+            self._retire_call(request.rpc_id, future)
             await self._request_cancel(request.rpc_id)
             raise
         finally:
@@ -1050,6 +1085,101 @@ def _connected_client(
     )
 
 
+class _AcceptedServiceUnresponsive(ControlError):
+    """A fixed endpoint accepted locally but did not complete its bounded handshake."""
+
+    def __init__(self) -> None:
+        super().__init__("service_unavailable", retryable=True)
+
+
+def _consume_background_task[ResultT](task: asyncio.Task[ResultT]) -> None:
+    try:
+        task.result()
+    except BaseException:
+        pass
+
+
+async def _best_effort_close_stream(stream: AuthenticatedUnixStream) -> None:
+    """Bound cleanup even when a faulty peer stream never completes ``aclose``."""
+
+    task = asyncio.create_task(stream.aclose())
+    try:
+        done, _pending = await asyncio.wait((task,), timeout=_STREAM_CLOSE_TIMEOUT_SECONDS)
+    except BaseException:
+        task.cancel()
+        task.add_done_callback(_consume_background_task)
+        raise
+    if task in done:
+        _consume_background_task(task)
+        return
+    task.cancel()
+    task.add_done_callback(_consume_background_task)
+
+
+async def _connect_service_attempt(
+    client_kind: ControlClientKind,
+    *,
+    workspace_locator: WorkspaceLocator | None,
+    projection_render_mode: ProjectionRenderMode,
+    output_is_controlling_tty: bool,
+    timeout_seconds: float,
+) -> ServiceClient:
+    """Connect and handshake within one attempt budget, preserving accepted-socket identity."""
+
+    stream: AuthenticatedUnixStream | None = None
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            stream = await connect_control()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError
+        handshake = asyncio.create_task(
+            client_handshake(
+                stream,
+                client_kind,
+                __version__,
+                workspace_locator=workspace_locator,
+                projection_render_mode=projection_render_mode,
+                output_is_controlling_tty=output_is_controlling_tty,
+            )
+        )
+        try:
+            done, _pending = await asyncio.wait((handshake,), timeout=remaining)
+        except BaseException:
+            handshake.cancel()
+            handshake.add_done_callback(_consume_background_task)
+            raise
+        if handshake not in done:
+            handshake.cancel()
+            handshake.add_done_callback(_consume_background_task)
+            raise TimeoutError
+        session = handshake.result()
+        return _connected_client(stream, session, client_kind)
+    except TimeoutError as exc:
+        accepted = stream is not None
+        if stream is not None:
+            await _best_effort_close_stream(stream)
+        error: ControlError
+        if accepted:
+            error = _AcceptedServiceUnresponsive()
+        else:
+            error = ControlError("service_unavailable", retryable=True)
+        raise error from exc
+    except LocalControlTransportError as exc:
+        if stream is not None:
+            await _best_effort_close_stream(stream)
+        raise _transport_error(exc) from exc
+    except ControlProtocolError as exc:
+        if stream is not None:
+            await _best_effort_close_stream(stream)
+        raise _protocol_error(exc) from exc
+    except BaseException:
+        if stream is not None:
+            await _best_effort_close_stream(stream)
+        raise
+
+
 async def connect_service(
     client_kind: ControlClientKind,
     *,
@@ -1067,30 +1197,13 @@ async def connect_service(
         raise TypeError("projection_render_mode_invalid")
     if type(output_is_controlling_tty) is not bool:
         raise TypeError("projection_tty_fact_invalid")
-    stream: AuthenticatedUnixStream | None = None
-    try:
-        stream = await connect_control()
-        session = await client_handshake(
-            stream,
-            client_kind,
-            __version__,
-            workspace_locator=workspace_locator,
-            projection_render_mode=projection_render_mode,
-            output_is_controlling_tty=output_is_controlling_tty,
-        )
-        return _connected_client(stream, session, client_kind)
-    except LocalControlTransportError as exc:
-        if stream is not None:
-            await stream.aclose()
-        raise _transport_error(exc) from exc
-    except ControlProtocolError as exc:
-        if stream is not None:
-            await stream.aclose()
-        raise _protocol_error(exc) from exc
-    except Exception:
-        if stream is not None:
-            await stream.aclose()
-        raise
+    return await _connect_service_attempt(
+        client_kind,
+        workspace_locator=workspace_locator,
+        projection_render_mode=projection_render_mode,
+        output_is_controlling_tty=output_is_controlling_tty,
+        timeout_seconds=_CONNECT_HANDSHAKE_TIMEOUT_SECONDS,
+    )
 
 
 async def connect_service_on_demand(
@@ -1112,26 +1225,43 @@ async def connect_service_on_demand(
         raise TypeError("workspace_locator_invalid")
     if type(timeout_seconds) is not float or not 0.1 <= timeout_seconds <= 30.0:
         raise ValueError("service_start_timeout_invalid")
+    deadline = time.monotonic() + timeout_seconds
+
+    async def connect_with_remaining_budget() -> ServiceClient:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ControlError("service_unavailable", retryable=True)
+        return await _connect_service_attempt(
+            client_kind,
+            workspace_locator=workspace_locator,
+            projection_render_mode=ProjectionRenderMode.MACHINE_READABLE,
+            output_is_controlling_tty=False,
+            timeout_seconds=min(_CONNECT_HANDSHAKE_TIMEOUT_SECONDS, remaining),
+        )
+
     try:
-        if workspace_locator is None:
-            return await connect_service(client_kind)
-        return await connect_service(client_kind, workspace_locator=workspace_locator)
+        return await connect_with_remaining_budget()
+    except _AcceptedServiceUnresponsive:
+        # A process already owns and accepted the fixed endpoint. Starting a successor cannot
+        # repair that process and only creates a singleton race, so fail this bounded attempt.
+        raise
     except ControlError as exc:
         if exc.reason != "service_unavailable":
             raise
+    if time.monotonic() >= deadline:
+        raise ControlError("service_unavailable", retryable=True)
     try:
         _spawn_service_process()
     except OSError as exc:
         raise ControlError("service_unavailable", retryable=True) from exc
 
-    deadline = time.monotonic() + timeout_seconds
     last_error: ControlError | None = None
     while time.monotonic() < deadline:
-        await asyncio.sleep(_SERVICE_START_POLL_SECONDS)
+        await asyncio.sleep(min(_SERVICE_START_POLL_SECONDS, deadline - time.monotonic()))
         try:
-            if workspace_locator is None:
-                return await connect_service(client_kind)
-            return await connect_service(client_kind, workspace_locator=workspace_locator)
+            return await connect_with_remaining_budget()
+        except _AcceptedServiceUnresponsive:
+            raise
         except ControlError as exc:
             last_error = exc
             if exc.reason != "service_unavailable":

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -1457,6 +1457,11 @@ class ServiceDaemon:
                 resolved = 0 if summary is None else summary.acknowledged + summary.quarantined
                 if resolved == 0:
                     await asyncio.sleep(_OBSERVATION_SWEEP_INTERVAL_SECONDS)
+                else:
+                    # A sweep implementation may complete without suspending.  Even while making
+                    # progress, give control connections and other READY work one scheduler turn
+                    # before the next immediate bulk-drain pass.
+                    await asyncio.sleep(0)
                 try:
                     summary = await asyncio.wait_for(
                         observation_sweep(),

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -1631,13 +1631,10 @@ async def test_ready_maintenance_sweeps_immediately_repeats_and_cancels_before_c
 
     async def sweep() -> ObservationDrainSummary:
         events.append("sweep")
+        if events.count("sweep") == 1:
+            asyncio.get_running_loop().call_soon(events.append, "control_turn")
         if events.count("sweep") >= 2:
             two_sweeps.set()
-        try:
-            await asyncio.sleep(0)
-        except asyncio.CancelledError:
-            events.append("sweep_cancelled")
-            raise
         return ObservationDrainSummary(
             attempted=1,
             acknowledged=1,
@@ -1680,7 +1677,7 @@ async def test_ready_maintenance_sweeps_immediately_repeats_and_cancels_before_c
     await daemon.activate_ready_application(7, 3)
 
     await asyncio.wait_for(two_sweeps.wait(), timeout=1)
-    assert events[:3] == ["sweep", "recommendation_refresh", "sweep"]
+    assert events[:4] == ["sweep", "recommendation_refresh", "control_turn", "sweep"]
     await daemon.lock()
     count_after_lock = events.count("sweep")
     await asyncio.sleep(0.03)

--- a/tests/integration/storage/test_append_and_replay.py
+++ b/tests/integration/storage/test_append_and_replay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import threading
 import uuid
 from collections.abc import Sequence
 from dataclasses import replace
@@ -13,6 +14,7 @@ from pathlib import Path
 import apsw
 import pytest
 
+import yoetz.adapters.sqlite.repository as sqlite_repository
 from builders.ledger_adapters import (
     FixedClock,
     FixedIds,
@@ -425,6 +427,82 @@ async def test_replay_after_append_matches_reference_projection(tmp_path: Path) 
     assert operation.result_locator is not None
     assert operation.result_locator.last_ingestion_sequence == len(records)
     assert stored.frontier == Frontier(expected.frontier, expected.head_digest)
+    reopened_db.close()
+
+
+@pytest.mark.anyio
+async def test_sqlite_recovery_replays_projection_off_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records = replay_records("projection-rebuild")
+    command, objects = command_from_records(records)
+    path = tmp_path / "off-loop-replay.sqlite3"
+    first, first_db = file_sqlite_for(command, objects, path)
+    await first.append_batch(command)
+    first_db.close()
+
+    event_loop_thread = threading.get_ident()
+    replay_threads: list[int] = []
+    original_replay = replay
+
+    def observed_replay(durable: tuple[LedgerRecord, ...]) -> ProjectionState:
+        replay_threads.append(threading.get_ident())
+        return original_replay(durable)
+
+    monkeypatch.setattr(sqlite_repository, "replay", observed_replay)
+    reopened, reopened_db = file_sqlite_for(command, objects, path)
+
+    projection = await reopened.load_projection(
+        command.session_id, ProjectionView.CANDIDATE_FINDINGS
+    )
+
+    assert projection is not None
+    assert replay_threads
+    assert all(thread_id != event_loop_thread for thread_id in replay_threads)
+    reopened_db.close()
+
+
+@pytest.mark.anyio
+async def test_cancelled_recovery_retry_reuses_one_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    records = replay_records("projection-rebuild")
+    command, objects = command_from_records(records)
+    path = tmp_path / "shared-recovery.sqlite3"
+    first, first_db = file_sqlite_for(command, objects, path)
+    await first.append_batch(command)
+    first_db.close()
+
+    started = threading.Event()
+    release = threading.Event()
+    replay_calls = 0
+    original_replay = replay
+
+    def blocked_replay(durable: tuple[LedgerRecord, ...]) -> ProjectionState:
+        nonlocal replay_calls
+        replay_calls += 1
+        started.set()
+        assert release.wait(timeout=2)
+        return original_replay(durable)
+
+    monkeypatch.setattr(sqlite_repository, "replay", blocked_replay)
+    reopened, reopened_db = file_sqlite_for(command, objects, path)
+    first_load = asyncio.create_task(
+        reopened.load_projection(command.session_id, ProjectionView.CANDIDATE_FINDINGS)
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+    first_load.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_load
+
+    retry = asyncio.create_task(
+        reopened.load_projection(command.session_id, ProjectionView.CANDIDATE_FINDINGS)
+    )
+    await asyncio.sleep(0)
+    assert replay_calls == 1
+    release.set()
+    assert await retry is not None
+    assert replay_calls == 1
     reopened_db.close()
 
 

--- a/tests/packaging/test_clean_install.py
+++ b/tests/packaging/test_clean_install.py
@@ -512,6 +512,66 @@ def _stop_service(proc: subprocess.Popen[bytes]) -> None:
             proc.wait(timeout=5)
 
 
+def test_installed_client_bounds_an_accepted_but_silent_service(
+    built_dist: _BuiltDist,
+) -> None:
+    root = _short_home("silent-service")
+    try:
+        home = root / "h"
+        yoetz_exe, env = _tool_install(built_dist.directory, root, home)
+        tool_python = root / "tool" / "yoetz" / "bin" / "python"
+        listener = subprocess.Popen(
+            [
+                str(tool_python),
+                "-c",
+                "import os, socket, time\n"
+                "from platformdirs import PlatformDirs\n"
+                "runtime = PlatformDirs(appname='yoetz', appauthor=False, roaming=False).user_runtime_path\n"
+                "runtime.mkdir(parents=True, exist_ok=True, mode=0o700)\n"
+                "os.chmod(runtime, 0o700)\n"
+                "path = runtime / 'control.sock'\n"
+                "server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)\n"
+                "server.bind(str(path))\n"
+                "os.chmod(path, 0o600)\n"
+                "server.listen(1)\n"
+                "print('ready', flush=True)\n"
+                "connection, _ = server.accept()\n"
+                "time.sleep(15)\n"
+                "connection.close()\n"
+                "server.close()\n",
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            assert listener.stdout is not None
+            assert listener.stdout.readline() == b"ready\n"
+            started = time.monotonic()
+            status = subprocess.run(
+                [str(yoetz_exe), "service", "status", "--json"],
+                capture_output=True,
+                timeout=9,
+                env=env,
+                check=False,
+            )
+            elapsed = time.monotonic() - started
+
+            assert status.returncode in _BOUNDED_EXIT_CODES
+            assert elapsed < 8
+            assert listener.poll() is None
+            assert b"Traceback (most recent call last)" not in status.stderr
+        finally:
+            listener.terminate()
+            try:
+                listener.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                listener.kill()
+                listener.wait(timeout=5)
+    finally:
+        shutil.rmtree(root.parent, ignore_errors=True)
+
+
 def test_fresh_install_no_network_no_provider_secret_service_reports_locked(
     built_dist: _BuiltDist,
 ) -> None:

--- a/tests/subprocess/test_mcp_service_bridge.py
+++ b/tests/subprocess/test_mcp_service_bridge.py
@@ -143,6 +143,7 @@ class _FakeClient:
         self.failure = failure
         self.calls: list[tuple[str, object]] = []
         self.route_profiles: list[tuple[str, str | None]] = []
+        self.deadlines: list[tuple[str, int | None]] = []
         self.closed = False
 
     async def connect(self) -> None:
@@ -157,28 +158,48 @@ class _FakeClient:
             raise failure
         return _failure(result_type, request.request_id)
 
-    async def start(self, request: StartRequest) -> StartResult:
+    async def start(self, request: StartRequest, *, deadline_ms: int | None = None) -> StartResult:
+        self.deadlines.append(("start", deadline_ms))
         return await self._call("start", request, StartResult)
 
-    async def publish_work(self, request: PublishWorkRequest) -> PublishWorkResult:
+    async def publish_work(
+        self, request: PublishWorkRequest, *, deadline_ms: int | None = None
+    ) -> PublishWorkResult:
+        self.deadlines.append(("publish_work", deadline_ms))
         return await self._call("publish_work", request, PublishWorkResult)
 
     async def check(
-        self, request: CheckRequest, *, route_profile: str | None = None
+        self,
+        request: CheckRequest,
+        *,
+        deadline_ms: int | None = None,
+        route_profile: str | None = None,
     ) -> CheckResult:
+        self.deadlines.append(("check", deadline_ms))
         self.route_profiles.append(("check", route_profile))
         return await self._call("check", request, CheckResult)
 
-    async def respond(self, request: RespondRequest) -> RespondResult:
+    async def respond(
+        self, request: RespondRequest, *, deadline_ms: int | None = None
+    ) -> RespondResult:
+        self.deadlines.append(("respond", deadline_ms))
         return await self._call("respond", request, RespondResult)
 
     async def status(
-        self, request: StatusRequest, *, route_profile: str | None = None
+        self,
+        request: StatusRequest,
+        *,
+        deadline_ms: int | None = None,
+        route_profile: str | None = None,
     ) -> StatusResult:
+        self.deadlines.append(("status", deadline_ms))
         self.route_profiles.append(("status", route_profile))
         return await self._call("status", request, StatusResult)
 
-    async def receipt(self, request: ReceiptRequest) -> ReceiptResult:
+    async def receipt(
+        self, request: ReceiptRequest, *, deadline_ms: int | None = None
+    ) -> ReceiptResult:
+        self.deadlines.append(("receipt", deadline_ms))
         return await self._call("receipt", request, ReceiptResult)
 
     async def close(self) -> None:
@@ -232,6 +253,14 @@ async def test_exact_six_dispatchers_use_one_ordinary_client(
         "status",
         "receipt",
     ]
+    assert client.deadlines == [
+        ("start", 30_000),
+        ("publish_work", 30_000),
+        ("check", 300_000),
+        ("respond", 30_000),
+        ("status", 30_000),
+        ("receipt", 30_000),
+    ]
     assert client.closed is False
     await bridge.close_bridge_runtime(runtime)
     assert client.closed is True
@@ -282,6 +311,50 @@ async def test_response_loss_reconnects_once_with_identical_request(
     assert len(stale.calls) == len(replacement.calls) == 1
     assert stale.calls[0][1] is replacement.calls[0][1]
     assert observed_locators == [runtime.workspace_locator, runtime.workspace_locator]
+
+
+@pytest.mark.anyio
+async def test_write_timeout_preserves_unknown_outcome_and_same_request_remedy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient(ControlError("request_timeout", retryable=True))
+    _install_clients(monkeypatch, [client])
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    assert result.isError is True
+    assert result.structuredContent is not None
+    error = cast(dict[str, JsonValue], result.structuredContent["error"])
+    assert error["code"] == "SERVICE_UNAVAILABLE"
+    assert error["retryable"] is True
+    assert error["message"] == (
+        "The local operation timed out and may still have committed. Retry with the same "
+        "request_id to recover the stored outcome; for an existing Yoetz session, status "
+        "view=operation can inspect that request_id."
+    )
+    assert result.structuredContent["request_id"] == request["request_id"]
+    assert client.closed is False
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_status_timeout_names_read_only_fresh_request_remedy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient(ControlError("request_timeout", retryable=True))
+    _install_clients(monkeypatch, [client])
+    runtime = bridge.build_bridge_runtime()
+
+    result = await bridge.dispatch_status(_requests()["status"], runtime)
+
+    assert result.structuredContent is not None
+    error = cast(dict[str, JsonValue], result.structuredContent["error"])
+    assert error["code"] == "SERVICE_UNAVAILABLE"
+    assert "requested no write" in cast(str, error["message"])
+    assert "new request_id" in cast(str, error["message"])
+    await bridge.close_bridge_runtime(runtime)
 
 
 @pytest.mark.anyio
@@ -684,8 +757,11 @@ async def test_cancellation_propagates_without_becoming_a_tool_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _CancellingClient(_FakeClient):
-        async def start(self, request: StartRequest) -> StartResult:
+        async def start(
+            self, request: StartRequest, *, deadline_ms: int | None = None
+        ) -> StartResult:
             del request
+            del deadline_ms
             raise asyncio.CancelledError
 
     _install_clients(monkeypatch, [_CancellingClient()])

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -19,6 +19,7 @@ from yoetz.adapters.sqlite.migrations import initialize_bundle
 from yoetz.adapters.sqlite.observation import SqliteObservationStore
 from yoetz.application.observation_control import build_observation_support_handlers
 from yoetz.application.observation_coordinator import ObservationCoordinator
+from yoetz.application.observation_drain import ObservationOutboxSweeper
 from yoetz.application.observation_materialize import (
     materialize_observation_envelope,
     observation_writer_id,
@@ -37,6 +38,7 @@ from yoetz.domain.observation import (
 )
 from yoetz.domain.values import JsonObject, Timestamp, finding_id
 from yoetz.ports.runtime import TaskRuntime
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import PREFIX_BY_KIND, IdKind
 
 
@@ -364,7 +366,7 @@ def test_local_outbox_v1_compatibility_and_v2_attempt_round_trip(tmp_path: Path)
     assert durable.last_reason == ObservationGapCode.MAPPING_MISSING.value
     assert durable.last_attempt_at == attempted_at
     assert json.loads(state_path.read_text(encoding="utf-8"))["schema"] == (
-        "yoetz.observation-local/4"
+        "yoetz.observation-local/5"
     )
 
 
@@ -794,6 +796,73 @@ async def test_coordinator_rejects_without_mapping(tmp_path: Path) -> None:
     )
     assert result.disposition is ObservationIngestDisposition.REJECTED
     assert result.reason == ObservationGapCode.MAPPING_MISSING.value
+
+
+@pytest.mark.anyio
+async def test_storage_corrupt_blocks_session_for_coordinator_generation(tmp_path: Path) -> None:
+    class _CorruptRuntime:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def route(self, command: object) -> object:
+            del command
+            self.calls += 1
+            raise PublicOperationError(
+                PublicErrorCode.STORAGE_CORRUPT,
+                "The task ledger is unreadable.",
+                False,
+            )
+
+        async def release(self, runtime: object) -> None:
+            raise AssertionError(f"unrouted runtime released: {runtime!r}")
+
+    local = LocalObservationStore(_state=tmp_path)
+    workspace = local.workspace_commitment(str(tmp_path.resolve()))
+    local.grant_consent(workspace)
+    codex_id = "storage-corrupt-session"
+    session = local.bind_codex_session(workspace, codex_id)
+    mapping = LifecycleMapping(
+        mapping_version=1,
+        codex_session_id=codex_id,
+        yoetz_task_id=_task_id(),
+        yoetz_session_id=PREFIX_BY_KIND[IdKind.SESSION] + str(uuid.uuid4()),
+        yoetz_writer_id=PREFIX_BY_KIND[IdKind.WRITER] + str(uuid.uuid4()),
+        last_frontier=None,
+    )
+    runtime = _CorruptRuntime()
+
+    def build_coordinator() -> ObservationCoordinator:
+        return ObservationCoordinator(
+            runtime=runtime,  # type: ignore[arg-type]
+            local=local,
+            clock=object(),  # type: ignore[arg-type]
+            ids=object(),  # type: ignore[arg-type]
+            state_root=tmp_path,
+            mapping_loader=lambda *_args, **_kwargs: mapping,  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+        )
+
+    request = ObservationIngestRequest(
+        codex_session_id=codex_id, envelope=_envelope(session=session)
+    )
+    coordinator = build_coordinator()
+    first = await coordinator.ingest_request(request)
+    second = await coordinator.ingest_request(request)
+
+    assert first.disposition is ObservationIngestDisposition.REJECTED
+    assert first.reason == ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value
+    assert second == first
+    assert runtime.calls == 1
+
+    future = replace(request.envelope, source_identity="hook:future")
+    local.enqueue_outbox(workspace, codex_id, future)
+    sweep = await ObservationOutboxSweeper(local, coordinator).sweep()
+    assert sweep.quarantined == 1
+    assert local.pending_outbox_count(workspace) == 0
+    assert runtime.calls == 1
+
+    restarted = await build_coordinator().ingest_request(request)
+    assert restarted.reason == ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value
+    assert runtime.calls == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/application/test_observation_drain.py
+++ b/tests/unit/application/test_observation_drain.py
@@ -20,6 +20,7 @@ from yoetz.domain.observation import (
     ObservationIngestRequest,
     ObservationIngestResult,
     ObservationSource,
+    ObservationStatusQuery,
 )
 from yoetz.domain.values import JsonObject, Timestamp
 
@@ -77,6 +78,14 @@ def _envelope(session: str, identity: str, ordinal: int) -> ObservationEnvelope:
             ),
             ObservationDrainAction.QUARANTINE,
         ),
+        (
+            ObservationIngestResult(
+                ObservationIngestDisposition.REJECTED,
+                ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value,
+                None,
+            ),
+            ObservationDrainAction.QUARANTINE,
+        ),
     ],
 )
 def test_route_observation_ingest_is_pure(
@@ -96,6 +105,68 @@ def test_route_unknown_rejection_reason_to_safe_retry_fallback() -> None:
 
     assert decision.action is ObservationDrainAction.RETRY
     assert decision.reason == ObservationGapCode.SERVICE_UNAVAILABLE.value
+
+
+def test_bulk_quarantine_records_terminal_reason_and_returns_rows_moved(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    corrupt = store.bind_codex_session(workspace, "corrupt")
+    healthy = store.bind_codex_session(workspace, "healthy")
+    for ordinal in (1, 2):
+        store.enqueue_outbox(
+            workspace,
+            "corrupt",
+            _envelope(corrupt, f"hook:corrupt:{ordinal}", ordinal),
+        )
+    store.enqueue_outbox(workspace, "healthy", _envelope(healthy, "hook:healthy", 1))
+
+    moved = store.quarantine_outbox_session(
+        workspace,
+        "corrupt",
+        ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value,
+    )
+
+    assert moved == 2
+    assert (
+        store.quarantine_outbox_session(
+            workspace,
+            "corrupt",
+            ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value,
+        )
+        == 0
+    )
+    assert [row.codex_session_id for row in store.list_pending_outbox_rows(workspace)] == [
+        "healthy"
+    ]
+    status = store.status(ObservationStatusQuery(workspace))
+    assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status.gaps
+    assert ObservationGapCode.OUTBOX_QUARANTINED.value in status.gaps
+
+
+def test_successful_recovery_probe_heals_only_its_corrupt_session(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    first = store.bind_codex_session(workspace, "corrupt-first")
+    second = store.bind_codex_session(workspace, "corrupt-second")
+    store.enqueue_outbox(workspace, "corrupt-first", _envelope(first, "hook:first:1", 1))
+    store.enqueue_outbox(workspace, "corrupt-second", _envelope(second, "hook:second:1", 1))
+    reason = ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value
+    assert store.quarantine_outbox_session(workspace, "corrupt-first", reason) == 1
+    assert store.quarantine_outbox_session(workspace, "corrupt-second", reason) == 1
+
+    assert store.ingest(_envelope(first, "hook:first:repaired", 2)).disposition is (
+        ObservationIngestDisposition.ACCEPTED
+    )
+    assert reason in store.status(ObservationStatusQuery(workspace)).gaps
+
+    assert store.ingest(_envelope(second, "hook:second:repaired", 2)).disposition is (
+        ObservationIngestDisposition.ACCEPTED
+    )
+    healed = store.status(ObservationStatusQuery(workspace))
+    assert reason not in healed.gaps
+    assert ObservationGapCode.OUTBOX_QUARANTINED.value in healed.gaps
 
 
 class _Coordinator:
@@ -200,6 +271,49 @@ async def test_sweep_round_robins_pending_workspaces_under_limit(tmp_path: Path)
     assert summary.attempted == 2
     assert set(coordinator.calls) == expected_sessions
     assert len(store.pending_workspaces()) == 2
+
+
+@pytest.mark.anyio
+async def test_storage_corrupt_quarantines_session_backlog_and_keeps_healthy_lane(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    corrupt_commitment = store.bind_codex_session(workspace, "corrupt-session")
+    healthy_commitment = store.bind_codex_session(workspace, "healthy-session")
+    outcomes: dict[str, ObservationIngestResult | Exception] = {}
+    for ordinal in (1, 2, 3):
+        envelope = _envelope(corrupt_commitment, f"hook:corrupt:{ordinal}", ordinal)
+        store.enqueue_outbox(workspace, "corrupt-session", envelope)
+        outcomes[envelope.source_identity] = ObservationIngestResult(
+            ObservationIngestDisposition.REJECTED,
+            ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value,
+            None,
+        )
+    healthy = _envelope(healthy_commitment, "hook:healthy", 1)
+    store.enqueue_outbox(workspace, "healthy-session", healthy)
+    outcomes[healthy.source_identity] = ObservationIngestResult(
+        ObservationIngestDisposition.ACCEPTED,
+        None,
+        healthy.cursor,
+    )
+
+    coordinator = _Coordinator(outcomes)
+    summary = await ObservationOutboxSweeper(store, coordinator).sweep()
+
+    assert coordinator.calls.count("corrupt-session") == 1
+    assert coordinator.calls.count("healthy-session") == 1
+    assert summary.attempted == 2
+    assert summary.acknowledged == 1
+    assert summary.quarantined == 3
+    assert summary.reasons == ((ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value, 1),)
+    assert store.pending_outbox_count(workspace) == 0
+    assert store.quarantined_count(workspace) == 3
+    status = store.status(ObservationStatusQuery(workspace))
+    assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status.gaps
+    assert ObservationGapCode.OUTBOX_QUARANTINED.value in status.gaps
+    assert store.reclaim_quarantine(workspace) == 3
 
 
 @pytest.mark.anyio

--- a/tests/unit/service/test_client.py
+++ b/tests/unit/service/test_client.py
@@ -250,7 +250,10 @@ async def test_on_demand_connect_spawns_only_after_absent_service(
     calls = 0
     spawned = 0
 
-    async def scripted_connect(kind: ControlClientKind) -> object:
+    async def scripted_connect(
+        kind: ControlClientKind,
+        **_kwargs: object,
+    ) -> object:
         nonlocal calls
         assert kind is ControlClientKind.MCP_BRIDGE
         calls += 1
@@ -262,7 +265,7 @@ async def test_on_demand_connect_spawns_only_after_absent_service(
         nonlocal spawned
         spawned += 1
 
-    monkeypatch.setattr(client_module, "connect_service", scripted_connect)
+    monkeypatch.setattr(client_module, "_connect_service_attempt", scripted_connect)
     monkeypatch.setattr(client_module, "_spawn_service_process", spawn)
     connected = await connect_service_on_demand(ControlClientKind.MCP_BRIDGE, timeout_seconds=0.2)
     assert connected is expected
@@ -280,7 +283,10 @@ async def test_on_demand_reuses_workspace_locator_for_every_reconnect_attempt(
     observed: list[WorkspaceLocator | None] = []
 
     async def scripted_connect(
-        kind: ControlClientKind, *, workspace_locator: WorkspaceLocator | None = None
+        kind: ControlClientKind,
+        *,
+        workspace_locator: WorkspaceLocator | None = None,
+        **_kwargs: object,
     ) -> object:
         assert kind is ControlClientKind.MCP_BRIDGE
         observed.append(workspace_locator)
@@ -288,7 +294,7 @@ async def test_on_demand_reuses_workspace_locator_for_every_reconnect_attempt(
             raise ControlError("service_unavailable", retryable=True)
         return expected
 
-    monkeypatch.setattr(client_module, "connect_service", scripted_connect)
+    monkeypatch.setattr(client_module, "_connect_service_attempt", scripted_connect)
     monkeypatch.setattr(client_module, "_spawn_service_process", lambda: None)
     connected = await connect_service_on_demand(
         ControlClientKind.MCP_BRIDGE,
@@ -298,6 +304,101 @@ async def test_on_demand_reuses_workspace_locator_for_every_reconnect_attempt(
 
     assert connected is expected
     assert observed == [locator, locator]
+
+
+@pytest.mark.anyio
+async def test_on_demand_does_not_spawn_after_accepted_service_stalls_handshake(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.service.client as client_module
+
+    stream = _FakeStream()
+    spawned = 0
+
+    async def connect() -> AuthenticatedUnixStream:
+        return cast(AuthenticatedUnixStream, stream)
+
+    async def stalled_handshake(*_args: object, **_kwargs: object) -> object:
+        await asyncio.Event().wait()
+
+    def spawn() -> None:
+        nonlocal spawned
+        spawned += 1
+
+    monkeypatch.setattr(client_module, "connect_control", connect)
+    monkeypatch.setattr(client_module, "client_handshake", stalled_handshake)
+    monkeypatch.setattr(client_module, "_CONNECT_HANDSHAKE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(client_module, "_spawn_service_process", spawn)
+
+    with pytest.raises(ControlError, match="service_unavailable"):
+        await connect_service_on_demand(ControlClientKind.MCP_BRIDGE, timeout_seconds=0.2)
+
+    assert stream.closed is True
+    assert spawned == 0
+
+
+@pytest.mark.anyio
+async def test_on_demand_initial_connect_is_inside_the_total_start_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.service.client as client_module
+
+    spawned = 0
+
+    async def stalled_connect() -> AuthenticatedUnixStream:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    def spawn() -> None:
+        nonlocal spawned
+        spawned += 1
+
+    monkeypatch.setattr(client_module, "connect_control", stalled_connect)
+    monkeypatch.setattr(client_module, "_spawn_service_process", spawn)
+    started = asyncio.get_running_loop().time()
+
+    with pytest.raises(ControlError, match="service_unavailable"):
+        await connect_service_on_demand(ControlClientKind.MCP_BRIDGE, timeout_seconds=0.1)
+
+    assert asyncio.get_running_loop().time() - started < 0.5
+    assert spawned == 0
+
+
+@pytest.mark.anyio
+async def test_connect_timeout_does_not_wait_for_never_closing_accepted_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import yoetz.service.client as client_module
+
+    class _NeverClosingStream(_FakeStream):
+        async def aclose(self) -> None:
+            await asyncio.Event().wait()
+
+    stream = _NeverClosingStream()
+    spawned = 0
+
+    async def connect() -> AuthenticatedUnixStream:
+        return cast(AuthenticatedUnixStream, stream)
+
+    async def stalled_handshake(*_args: object, **_kwargs: object) -> object:
+        await asyncio.Event().wait()
+
+    def spawn() -> None:
+        nonlocal spawned
+        spawned += 1
+
+    monkeypatch.setattr(client_module, "connect_control", connect)
+    monkeypatch.setattr(client_module, "client_handshake", stalled_handshake)
+    monkeypatch.setattr(client_module, "_CONNECT_HANDSHAKE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(client_module, "_STREAM_CLOSE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(client_module, "_spawn_service_process", spawn)
+    started = asyncio.get_running_loop().time()
+
+    with pytest.raises(ControlError, match="service_unavailable"):
+        await connect_service_on_demand(ControlClientKind.MCP_BRIDGE, timeout_seconds=0.2)
+
+    assert asyncio.get_running_loop().time() - started < 0.1
+    assert spawned == 0
 
 
 def test_on_demand_service_environment_strips_secret_shaped_names(
@@ -571,6 +672,167 @@ def _receipt_request(seed: int) -> ReceiptRequest:
             "redaction_profile": "default_local_export",
         }
     )
+
+
+class _BlockedSendStream(_FakeStream):
+    def __init__(self, *, allow_count: int) -> None:
+        super().__init__()
+        self.allow_count = allow_count
+        self.send_attempts = 0
+
+    async def send_all(self, data: Buffer) -> None:
+        self.send_attempts += 1
+        if self.send_attempts > self.allow_count:
+            await asyncio.Event().wait()
+        await super().send_all(data)
+
+
+@pytest.mark.anyio
+async def test_rpc_deadline_covers_blocked_send_and_bounded_cancel_attempt() -> None:
+    stream = _BlockedSendStream(allow_count=0)
+    client = _client(stream, ControlClientKind.MCP_BRIDGE)
+    started = asyncio.get_running_loop().time()
+
+    with pytest.raises(ControlError, match="request_timeout"):
+        await client.receipt(_receipt_request(20), deadline_ms=10)
+
+    assert asyncio.get_running_loop().time() - started < 0.2
+    assert stream.send_attempts == 2
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_blocked_cancel_notification_cannot_materially_extend_rpc_deadline() -> None:
+    stream = _BlockedSendStream(allow_count=1)
+    client = _client(stream, ControlClientKind.MCP_BRIDGE)
+    started = asyncio.get_running_loop().time()
+
+    with pytest.raises(ControlError, match="request_timeout"):
+        await client.receipt(_receipt_request(21), deadline_ms=10)
+
+    assert asyncio.get_running_loop().time() - started < 0.2
+    assert len(stream.sent) == 1
+    assert stream.send_attempts == 2
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_late_timed_out_result_is_retired_without_poisoning_concurrent_call() -> None:
+    stream = _FakeStream()
+    client = _client(stream, ControlClientKind.MCP_BRIDGE)
+
+    with pytest.raises(ControlError, match="request_timeout"):
+        await client.receipt(_receipt_request(22), deadline_ms=10)
+    first = next(
+        frame
+        for frame in (decode_control_frame(encoded) for encoded in stream.sent)
+        if frame["kind"] == "call"
+    )
+
+    healthy = asyncio.create_task(client.receipt(_receipt_request(23), deadline_ms=500))
+    await _wait_for_sent(stream, 3)
+    second = decode_control_frame(stream.sent[2])
+    assert second["kind"] == "call"
+
+    for frame in (first, second):
+        await stream.feed(
+            encode_control_frame(
+                ControlResult(
+                    protocol_version="1.0",
+                    rpc_id=cast(str, frame["rpc_id"]),
+                    service_instance_id=_SERVICE_ID,
+                    service_generation="1",
+                    method=ControlMethod.RECEIPT,
+                    outcome="error",
+                    body=ControlError("privacy_projection_unavailable", retryable=True),
+                )
+            )
+        )
+
+    with pytest.raises(ControlError, match="privacy_projection_unavailable"):
+        await healthy
+    assert stream.closed is False
+    assert client._retired_rpc_ids == set()  # pyright: ignore[reportPrivateUsage]
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_late_result_during_bounded_cancel_window_uses_tombstone_first() -> None:
+    class _BlockedCancelOnceStream(_FakeStream):
+        def __init__(self) -> None:
+            super().__init__()
+            self.send_attempts = 0
+
+        async def send_all(self, data: Buffer) -> None:
+            self.send_attempts += 1
+            if self.send_attempts == 2:
+                await asyncio.Event().wait()
+            await super().send_all(data)
+
+    stream = _BlockedCancelOnceStream()
+    client = _client(stream, ControlClientKind.MCP_BRIDGE)
+    timed_out = asyncio.create_task(client.receipt(_receipt_request(24), deadline_ms=10))
+    await _wait_for_sent(stream, 1)
+    first = decode_control_frame(stream.sent[0])
+    for _ in range(100):
+        if stream.send_attempts == 2:
+            break
+        await asyncio.sleep(0.001)
+    assert stream.send_attempts == 2
+
+    await stream.feed(
+        encode_control_frame(
+            ControlResult(
+                protocol_version="1.0",
+                rpc_id=cast(str, first["rpc_id"]),
+                service_instance_id=_SERVICE_ID,
+                service_generation="1",
+                method=ControlMethod.RECEIPT,
+                outcome="error",
+                body=ControlError("privacy_projection_unavailable", retryable=True),
+            )
+        )
+    )
+    with pytest.raises(ControlError, match="request_timeout"):
+        await timed_out
+
+    healthy = asyncio.create_task(client.receipt(_receipt_request(25), deadline_ms=500))
+    await _wait_for_sent(stream, 2)
+    second = decode_control_frame(stream.sent[1])
+    await stream.feed(
+        encode_control_frame(
+            ControlResult(
+                protocol_version="1.0",
+                rpc_id=cast(str, second["rpc_id"]),
+                service_instance_id=_SERVICE_ID,
+                service_generation="1",
+                method=ControlMethod.RECEIPT,
+                outcome="error",
+                body=ControlError("privacy_projection_unavailable", retryable=True),
+            )
+        )
+    )
+    with pytest.raises(ControlError, match="privacy_projection_unavailable"):
+        await healthy
+    assert stream.closed is False
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_unanswered_timeout_tombstones_bound_new_admission() -> None:
+    stream = _FakeStream()
+    client = _client(stream, ControlClientKind.MCP_BRIDGE)
+
+    for seed in range(30, 62):
+        with pytest.raises(ControlError, match="request_timeout"):
+            await client.receipt(_receipt_request(seed), deadline_ms=1)
+
+    assert len(client._retired_rpc_ids) == 32  # pyright: ignore[reportPrivateUsage]
+    sent_before = len(stream.sent)
+    with pytest.raises(ControlError, match="service_unavailable"):
+        await client.receipt(_receipt_request(63), deadline_ms=1)
+    assert len(stream.sent) == sent_before
+    await client.close()
 
 
 @pytest.mark.anyio

--- a/tests/unit/service/test_client.py
+++ b/tests/unit/service/test_client.py
@@ -697,7 +697,8 @@ async def test_rpc_deadline_covers_blocked_send_and_bounded_cancel_attempt() -> 
         await client.receipt(_receipt_request(20), deadline_ms=10)
 
     assert asyncio.get_running_loop().time() - started < 0.2
-    assert stream.send_attempts == 2
+    assert stream.send_attempts == 1
+    assert stream.closed is True
     await client.close()
 
 
@@ -832,6 +833,7 @@ async def test_unanswered_timeout_tombstones_bound_new_admission() -> None:
     with pytest.raises(ControlError, match="service_unavailable"):
         await client.receipt(_receipt_request(63), deadline_ms=1)
     assert len(stream.sent) == sent_before
+    assert stream.closed is True
     await client.close()
 
 


### PR DESCRIPTION
## Summary

- treat observation-task `STORAGE_CORRUPT` as terminal `observation_storage_corrupt`, quarantine the affected session backlog, and suppress repeated probes within one READY generation while healthy lanes continue
- make ledger recovery cooperative and cancellation-safe by sharing recovery work, moving reducer replay off the daemon event loop, yielding during reconstruction, and yielding between immediate maintenance sweeps
- bound local connect/handshake and MCP workflow RPCs end to end, including frame writes and best-effort cancellation/cleanup, while preserving late-result correlation and same-`request_id` unknown-outcome guidance
- document the storage, observation, and ordinary-control contracts in ADR-003, ADR-010, and `docs/INTERFACES.md`

## Root cause

The READY observation sweeper could repeatedly reopen a mapped task whose legacy pending check failed frozen-case recovery as `STORAGE_CORRUPT`. CPU-heavy recovery ran in the daemon event loop and generic `service_unavailable` routing made the condition retryable, starving all local control traffic. Separately, clients had no bounded connect/handshake path and MCP dispatchers omitted RPC deadlines; writes and cancellation cleanup could also outlive a nominal deadline.

## Verification

- focused and adjacent observation/service/storage/MCP suites: **170 passed**
- clean built-wheel accepted-but-silent service regression: **1 passed**
- Ruff format/check: passed
- pinned Pyright: 0 errors, 0 warnings
- `git diff --check`: passed

The complete repository test suite was not run locally; focused critical coverage and the installed-artifact regression passed.

Fixes #232
Fixes #233

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix local service starvation and bound MCP deadlines for RPC calls and connect handshakes
> - Adds per-RPC deadline enforcement in [mcp/server.py](https://github.com/TheGaySupreme123/yoetz/pull/234/files#diff-c616ccad24db0e2cd8e339a92a3879eb0913ea6c8fa89377d28d7f2b5b3a2df8): workflow operations use a 30s deadline, semantic check uses 300s. On `request_timeout`, write operations advise retrying with the same `request_id`; read operations advise a fresh `request_id`.
> - Rewrites `ServiceClient.call` in [service/client.py](https://github.com/TheGaySupreme123/yoetz/pull/234/files#diff-71e8be61c140d78a6e517de0e04d2a286bba38e6ff4b12d9e18d3f001cdeedc1) to retire timed-out in-flight RPCs, track them with `_retired_rpc_ids`, and drop their late results without poisoning concurrent calls or raising `frame_invalid`.
> - Bounds connect+handshake to 5s per attempt and the overall on-demand startup budget to 30s; an accepted-but-silent endpoint raises a distinct `_AcceptedServiceUnresponsive` error and suppresses spawning.
> - Reduces SQLite recovery event-loop starvation by yielding every 32 decoded rows and running the replay reducer in `asyncio.to_thread`.
> - Adds `ObservationOutboxSweeper` quarantine logic for sessions flagged `OBSERVATION_STORAGE_CORRUPT`, and `ObservationCoordinator` now rejects further ingests for those sessions.
> - Risk: `ServiceClient` now fails the connection and returns `service_unavailable` when the retired RPC ID set exceeds capacity, which is a new hard admission-control boundary that was not present before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75aff37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->