### PR TITLE
Fix state-capture bounds, CLI failure reporting, and provider finding materialization (#229, #230, #231)

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2125,6 +2125,13 @@ port returns no repository content, path, filename, branch, remote, Git output, 
 digest. It is client-local support used before ordinary publication, not a seventh MCP/workflow
 operation, not service-owned ambient inspection, and not an `ArtifactInspectionPort`.
 
+The closed limitation values are `not_git`, `unsafe_root`, `submodule_present`,
+`symlink_unsupported`, `object_format_unsupported`, `git_config_limit_exceeded`,
+`read_limit_exceeded`, `file_limit_exceeded`, `git_failed`, and `input_changed`. The Git config
+prefix scan has its own 1 MiB bound; it never reuses the subprocess-stderr cap. The state-capture
+CLI surfaces only one of these closed tokens, with bounded remediation where one is registered;
+unrecognized exception text remains `invalid_request` and is never echoed.
+
 Publishing a captured digest preserves the actual publication channel and authorship assurance. A
 complete capture may support `content_digest` evidence immutability, but never earns
 `harness_observed`, `hook_observed`, `artifact_verified`, or `independently_reproduced` by itself.

--- a/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
@@ -6,6 +6,13 @@
 `src/yoetz/application/publish_work.py`, and `src/yoetz/service/ready_composition.py`.
 **Relates to:** ADR-009, ADR-010, ADR-020, and issues #214, #216, #217, and #223.
 
+**Proposed amendment for issue #231:** `provider_not_ready` remains bounded local advice, but the
+observation coordinator does not materialize it as an agent-facing finding. Provider readiness is a
+machine condition rather than a repair to the recorded work. A requested check still records the
+exact semantic status and coverage limitation, and receipts retain that limitation; the amendment
+does not make the affected receipt clean. This is the narrow option that preserves proof-based
+finding resolution and does not change `ResponseDisposition` or finding-kind traits.
+
 ## Context
 
 Live observation and cooperative MCP publication share one task-global ledger frontier. Observation
@@ -57,6 +64,11 @@ unsupported claims and unbounded duplicate findings.
    false observation-authored claim premise but does not add a fourth `ResponseDisposition`, change
    response schemas, migrate SQL constraints, or weaken the rule that a recorded finding remains
    historically visible.
+
+8. Standing provider-readiness advice is not converted into a `material_limitation_omitted`
+   finding. That finding kind remains actionable for an omission in the work account. Provider
+   configuration and availability remain visible through observation advice before a check and
+   through the check coverage vector and receipt limitations after one.
 
 ## Security and privacy consequences
 

--- a/src/yoetz/adapters/git_subject_state.py
+++ b/src/yoetz/adapters/git_subject_state.py
@@ -42,6 +42,7 @@ GIT_SUBJECT_STATE_FORMAT: Final = "yoetz.git-subject-state/1"
 _FORMAT_TOKEN: Final = SubjectStateFormat.GIT_STRUCTURAL_V1.value
 _GIT_TIMEOUT_SECONDS: Final = 10.0
 _STDERR_LIMIT: Final = 16_384
+_GIT_CONFIG_LIMIT: Final = 1_048_576
 _COMMAND_OUTPUT_LIMIT: Final = MAX_SUBJECT_STATE_HASH_BYTES + 1
 _PATH_OUTPUT_LIMIT: Final = 8_388_608
 _READ_CHUNK: Final = 65_536
@@ -708,9 +709,16 @@ def _verify_git_metadata(root: Path) -> None:
         raise _CaptureFailure(SubjectStateLimitation.UNSAFE_ROOT)
     config = git_root / "config"
     try:
-        encoded = _read_small_mutable(config, _STDERR_LIMIT)
+        encoded = _read_small_mutable(config, _GIT_CONFIG_LIMIT)
     except OSError as exc:
         raise _CaptureFailure(SubjectStateLimitation.UNSAFE_ROOT) from exc
+    except _CaptureFailure as exc:
+        if exc.limitation is SubjectStateLimitation.READ_LIMIT_EXCEEDED:
+            raise _CaptureFailure(
+                SubjectStateLimitation.GIT_CONFIG_LIMIT_EXCEEDED,
+                exc.status,
+            ) from exc
+        raise
     try:
         for line in encoded.splitlines():
             section = line.lstrip().lower()

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Protocol, cast
+from types import MappingProxyType
+from typing import Any, Final, Protocol, cast
 
 from yoetz.adapters.approved_checks import ApprovedCheckRunner, ApprovedCheckStatus
 from yoetz.adapters.git_subject_state import (
@@ -127,6 +128,29 @@ from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_
 from yoetz.protocol.coverage import EvidenceImmutability, PublicationChannel, coverage_for_channel
 from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
+
+_ADVICE_FINDING_KIND_BY_RULE: Final = MappingProxyType(
+    {
+        "failed_command_unresolved": FindingKind.FAILED_WORK_OMITTED,
+        "edit_after_successful_check": FindingKind.STALE_EVIDENCE_FOR_CHANGED_STATE,
+        "completion_without_verification": FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+        "static_test_for_live_claim": FindingKind.EVIDENCE_DOES_NOT_SUPPORT_CLAIM,
+        "subagent_finding_unaddressed": FindingKind.MATERIAL_LIMITATION_OMITTED,
+        "change_outside_plan": FindingKind.DIFF_DOES_NOT_MATCH_ACCOUNT,
+        "observation_gap_or_stale": FindingKind.LEDGER_STALE_OR_INCOMPLETE,
+        "semantic_claim_without_attempt": FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
+    }
+)
+
+
+def _materialized_advice_items(items: Sequence[AdviceItem]) -> tuple[AdviceItem, ...]:
+    """Keep advice that describes repairable work; machine conditions remain advice only."""
+
+    return tuple(
+        item
+        for item in items
+        if item.origin == "deterministic" and item.rule_code in _ADVICE_FINDING_KIND_BY_RULE
+    )
 
 __all__ = [
     "ObservationAdviceHook",
@@ -1588,22 +1612,7 @@ class ObservationCoordinator:
             if finding_projection is not None and type(finding_projection.state) is ProjectionState
             else {}
         )
-        kind_by_rule = {
-            "failed_command_unresolved": FindingKind.FAILED_WORK_OMITTED,
-            "edit_after_successful_check": FindingKind.STALE_EVIDENCE_FOR_CHANGED_STATE,
-            "completion_without_verification": FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
-            "static_test_for_live_claim": FindingKind.EVIDENCE_DOES_NOT_SUPPORT_CLAIM,
-            "subagent_finding_unaddressed": FindingKind.MATERIAL_LIMITATION_OMITTED,
-            "change_outside_plan": FindingKind.DIFF_DOES_NOT_MATCH_ACCOUNT,
-            "observation_gap_or_stale": FindingKind.LEDGER_STALE_OR_INCOMPLETE,
-            "provider_not_ready": FindingKind.MATERIAL_LIMITATION_OMITTED,
-            "semantic_claim_without_attempt": FindingKind.CLAIM_WITHOUT_ADMISSIBLE_EVIDENCE,
-        }
-        candidate_items = tuple(
-            item
-            for item in snapshot.ranked_items
-            if item.origin == "deterministic" and item.rule_code in kind_by_rule
-        )
+        candidate_items = _materialized_advice_items(snapshot.ranked_items)
         if not candidate_items:
             return
         items: list[tuple[AdviceItem, tuple[str, ...]]] = []
@@ -1665,7 +1674,7 @@ class ObservationCoordinator:
         envelope_coverage = coverage_for_channel(PublicationChannel.ENGINE_DERIVED)
         for item, subject_ref_values in items:
             subject_refs = tuple(event_id(ref) for ref in subject_ref_values)
-            kind = kind_by_rule[item.rule_code]
+            kind = _ADVICE_FINDING_KIND_BY_RULE[item.rule_code]
             policy_id = (
                 "work-integrity"
                 if kind

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -152,6 +152,7 @@ def _materialized_advice_items(items: Sequence[AdviceItem]) -> tuple[AdviceItem,
         if item.origin == "deterministic" and item.rule_code in _ADVICE_FINDING_KIND_BY_RULE
     )
 
+
 __all__ = [
     "ObservationAdviceHook",
     "ObservationCoordinator",

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -983,7 +983,10 @@ def state_capture(
 
     try:
         from yoetz.adapters.git_subject_state import GitSubjectStateAdapter, open_local_workspace
-        from yoetz.ports.subject_state import SubjectStateCaptureCommand, SubjectStateFormat
+        from yoetz.ports.subject_state import (
+            SubjectStateCaptureCommand,
+            SubjectStateFormat,
+        )
 
         handle = open_local_workspace(workspace)
         result = GitSubjectStateAdapter().capture(
@@ -1000,7 +1003,15 @@ def state_capture(
             "diff_digest": state.diff_digest if state is not None else None,
         }
         _human_or_json(output, json_output=json_output)
-    except OSError, ValueError:
+    except ValueError as error:
+        from yoetz.ports.subject_state import SubjectStateLimitation
+
+        reason = str(error)
+        if reason in {item.value for item in SubjectStateLimitation}:
+            _stderr(_bounded_failure_line(reason))
+            _finish(exit_code_for(PublicErrorCode.INVALID_REQUEST))
+        _finish(_usage_failure())
+    except OSError:
         _finish(_usage_failure())
 
 

--- a/src/yoetz/cli/exits.py
+++ b/src/yoetz/cli/exits.py
@@ -172,6 +172,14 @@ REMEDIATION_MESSAGES: Final = MappingProxyType(
         "provider_not_configured": (
             "no provider and model are configured for this installation; run 'yoetz --set' first"
         ),
+        "unsafe_root": (
+            "the workspace or Git metadata has a symlinked, foreign-owned, writable, or otherwise "
+            "unsafe ancestor; pass the fully resolved path to a repository owned by the current user"
+        ),
+        "git_config_limit_exceeded": (
+            "the repository's .git/config exceeds the bounded 1 MiB safety scan; remove stale local "
+            "branch configuration or use a fresh clone"
+        ),
         "pending_expired": (
             "that pending decision expired before it was authorized; run "
             "'yoetz consent prepare <operation>' again"

--- a/src/yoetz/ports/subject_state.py
+++ b/src/yoetz/ports/subject_state.py
@@ -42,6 +42,7 @@ class SubjectStateLimitation(str, Enum):  # noqa: UP042 - exact wire-valued Enum
     SUBMODULE_PRESENT = "submodule_present"
     SYMLINK_UNSUPPORTED = "symlink_unsupported"
     OBJECT_FORMAT_UNSUPPORTED = "object_format_unsupported"
+    GIT_CONFIG_LIMIT_EXCEEDED = "git_config_limit_exceeded"
     READ_LIMIT_EXCEEDED = "read_limit_exceeded"
     FILE_LIMIT_EXCEEDED = "file_limit_exceeded"
     GIT_FAILED = "git_failed"

--- a/tests/unit/adapters/test_git_subject_state.py
+++ b/tests/unit/adapters/test_git_subject_state.py
@@ -314,3 +314,18 @@ def test_path_safety_malicious_config_and_capture_are_read_only(tmp_path: Path) 
     assert filtered.subject_state is None
     assert filtered.limitations == (SubjectStateLimitation.UNSAFE_ROOT,)
     assert not filter_canary.exists()
+
+
+def test_git_config_scan_has_its_own_practical_bound(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    config = repository / ".git" / "config"
+    config.write_bytes(config.read_bytes() + b"# branch history\n" * 1_100)
+    assert config.stat().st_size > 16_384
+
+    captured = GitSubjectStateAdapter().capture(_command(repository))
+    assert captured.status is SubjectStateStatus.CAPTURED
+    assert captured.limitations == ()
+
+    config.write_bytes(config.read_bytes() + b"# bounded padding\n" * 70_000)
+    with pytest.raises(ValueError, match="^git_config_limit_exceeded$"):
+        open_local_workspace(repository)

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -17,6 +17,9 @@ from yoetz.application.observation_advice import (
     minimized_semantic_evidence_packet,
     should_reissue_advice,
 )
+from yoetz.application.observation_coordinator import (
+    _materialized_advice_items,  # pyright: ignore[reportPrivateUsage]  # noqa: PLC2701
+)
 from yoetz.cli.observe_hooks import handle_observe
 from yoetz.domain.observation import (
     ObservationCursor,
@@ -142,6 +145,7 @@ def test_standing_provider_condition_keeps_one_candidate_identity_as_envelopes_g
     )
     assert latest_provider.finding_id == first_provider.finding_id
     assert latest.evidence_basis_digest != first.evidence_basis_digest
+    assert latest_provider not in _materialized_advice_items(latest.ranked_items)
 
 
 def test_semantic_packet_minimization() -> None:

--- a/tests/unit/cli/test_state_capture.py
+++ b/tests/unit/cli/test_state_capture.py
@@ -1,0 +1,52 @@
+"""State-capture CLI structural failure reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from yoetz.adapters import git_subject_state
+from yoetz.cli.app import app
+
+_RUNNER = CliRunner()
+
+
+@pytest.mark.parametrize(
+    ("reason", "remediation_fragment"),
+    [
+        ("unsafe_root", "fully resolved path"),
+        ("git_config_limit_exceeded", "bounded 1 MiB safety scan"),
+    ],
+)
+def test_structural_limitation_is_not_reported_as_invalid_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+    remediation_fragment: str,
+) -> None:
+    def _fail(_workspace: Path) -> object:
+        raise ValueError(reason)
+
+    monkeypatch.setattr(git_subject_state, "open_local_workspace", _fail)
+    result = _RUNNER.invoke(app, ["state", "capture", "--workspace", str(tmp_path), "--json"])
+
+    assert result.exit_code == 2
+    assert result.output.startswith(f"{reason}:")
+    assert remediation_fragment in result.output
+    assert "invalid_request" not in result.output
+
+
+def test_unknown_value_error_remains_a_usage_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fail(_workspace: Path) -> object:
+        raise ValueError("untrusted detail")
+
+    monkeypatch.setattr(git_subject_state, "open_local_workspace", _fail)
+    result = _RUNNER.invoke(app, ["state", "capture", "--workspace", str(tmp_path), "--json"])
+
+    assert result.exit_code == 2
+    assert result.output == "invalid_request: the command input is invalid\n"
+    assert "untrusted detail" not in result.output


### PR DESCRIPTION
Fixes #229, fixes #230, fixes #231.

## What changed

**#229 — purpose-specific Git-config bound.** The `.git/config` prefix scan reused the 16 KiB `_STDERR_LIMIT`, so any repository with a large-but-legitimate config failed capture. `git_subject_state.py` now uses a dedicated `_GIT_CONFIG_LIMIT` (1 MiB) and translates an exceeded read into the new closed limitation token `git_config_limit_exceeded` (`SubjectStateLimitation.GIT_CONFIG_LIMIT_EXCEEDED`).

**#230 — state-capture CLI stops collapsing structural failures to `invalid_request`.** `state_capture` in `cli/app.py` now catches `ValueError` separately: when the message is a closed `SubjectStateLimitation` token, it emits the bounded failure line plus registered remediation (`unsafe_root` and `git_config_limit_exceeded` added to `REMEDIATION_MESSAGES`) with the `INVALID_REQUEST` exit code; unknown exception text is never echoed and still degrades to the generic usage failure.

**#231 — `provider_not_ready` no longer materializes as an actionable finding (design-gated).** The advice→finding map is hoisted to module-level `_ADVICE_FINDING_KIND_BY_RULE` with the `provider_not_ready` entry removed, and `_materialized_advice_items()` documents the rule: advice that describes repairable work materializes; machine conditions remain advice and check/receipt coverage limitations only. `ResponseDisposition`, finding-kind traits, and proof-based finding resolution are unchanged. Recorded as a proposed amendment in ADR-022 (new point 8) with the closed limitation-value list documented in `docs/INTERFACES.md`.

## Design gate disposition

#231 touches receipt semantics, a design-gated area. The maintainer directed this PR during the 2026-08-13 dogfood review; the ADR-022 amendment in this diff is the recorded design. (An attempt to post the acknowledgement on the issue itself was withheld so the maintainer can post it first-hand.)

## Verification

- Focused + broad slices: 230 tests passed in the authoring session; independently re-run post-session: 66 focused tests (adapters, CLI state-capture, observation advice/coordinator, packaging boundary) pass.
- Repo-wide Ruff: clean. Pinned Pyright on touched files: 0 errors / 0 warnings.
- `git diff --check` clean.
- Live check: real `yoetz state capture` against this checkout now gets past its oversized `.git/config` (previously the #229 failure) and reports the separate pre-existing `file_limit_exceeded` limitation as designed.

## Provenance

Implemented by codex session `019ffb69-22d9-74e1-bb2e-a7c33cbca8a0` during a yoetz dogfood run (task `tsk_6c924b55-115c-47d9-b824-8dfd4cba45ec`). The session's sandbox could not write Git refs, so the branch/commit/PR were created on its behalf. Honesty note: the session's yoetz ledger holds the plan and three obligations but no completion publication, check verdict, or receipt — the local service died mid-session before the completion sequence could run (being filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix state-capture bounds, CLI failure reporting, and provider finding materialization
> - Adds a dedicated 1 MiB bound for `.git/config` scanning in [`git_subject_state.py`](https://github.com/TheGaySupreme123/yoetz/pull/236/files#diff-f2837dfb0f1f290ca400e631032d0b0c53a3c24073ac32606171e87aab1d6b09), separate from stderr limits, and raises a new `git_config_limit_exceeded` limitation token when exceeded.
> - Updates the CLI in [`app.py`](https://github.com/TheGaySupreme123/yoetz/pull/236/files#diff-2b91f9c098cb7464c84b1998a29cf3f3a2ccf20abdfe09bbf4ac3a759a000659) to surface known structural limitation tokens (e.g. `unsafe_root`, `git_config_limit_exceeded`) with bounded remediation messages, while treating unknown `ValueError`s as usage failures without echoing untrusted detail.
> - Excludes `provider_not_ready` advice from agent-facing finding materialization in [`observation_coordinator.py`](https://github.com/TheGaySupreme123/yoetz/pull/236/files#diff-9c1e421ea56d92f6009fe6952e18d4ca0b9f9778a4f181a458b54cd3a9ec80de); only deterministic advice with specific rule codes is materialized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1df0f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer CLI remediation guidance for unsafe repository roots and oversized Git configuration files.
  - Added specific reporting for Git configuration size-limit failures.
- **Bug Fixes**
  - Improved `state capture --json` error handling, preserving known limitation reasons while sanitizing unexpected errors.
  - Provider-readiness advice is no longer presented as an agent-facing finding.
- **Documentation**
  - Documented capture limitations, configuration scan bounds, CLI behavior, and exception handling.
  - Clarified how provider availability appears in observations, checks, and receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->