### PR TITLE
Fix advertised evidence schema versions

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2787,7 +2787,9 @@ facade and are never MCP tools.
   `tools/list` returns), `TOOL_DESCRIPTOR_DIGESTS`, `TOOL_DESCRIPTOR_SET_DIGEST`,
   `server_instructions()`, `ORDINARY_MCP_PUBLISH_EVENT_FAMILIES`, and
   `PRESENTATION_INPUT_SCHEMA_BUDGETS`. `ToolDescriptor.input_schema` is the tools/list presentation
-  projection (inlined common shapes, ordinary publish event families, minimal examples);
+  projection (inlined common shapes, ordinary publish event families, minimal examples), preserving
+  every catalogued schema-version branch for each advertised ordinary event family. Every shipped
+  worked example validates against that presentation schema as well as catalog admission;
   `catalog_input_schema` / full catalog request schemas remain admission authority via
   `*.model_validate`. `status` carries `readOnlyHint=true`; `receipt` carries
   `readOnlyHint=false` because it stages an object and appends a `receipt_recorded` event. Every

--- a/src/yoetz/mcp/descriptors.py
+++ b/src/yoetz/mcp/descriptors.py
@@ -13,7 +13,12 @@ from typing import Final, Literal, cast
 
 from yoetz.mcp.resources import read_resource
 from yoetz.protocol.canonical import JsonValue
-from yoetz.protocol.schemas import SCHEMA_NAMESPACE, load_schema_catalog, schema_document_for
+from yoetz.protocol.schemas import (
+    SCHEMA_NAMESPACE,
+    SCHEMA_VERSION_PATTERN,
+    load_schema_catalog,
+    schema_document_for,
+)
 
 __all__ = [
     "ORDINARY_MCP_PUBLISH_EVENT_FAMILIES",
@@ -94,7 +99,7 @@ PRESENTATION_INPUT_SCHEMA_BUDGETS: Final[Mapping[str, Mapping[str, int]]] = Mapp
                 "max_conditional_nodes": 0,
                 "max_defs_count": 20,
                 "max_defs_nest_depth": 1,
-                "max_encoded_bytes": 28_000,
+                "max_encoded_bytes": 32_000,
             }
         ),
         "check-request": MappingProxyType(
@@ -539,10 +544,16 @@ def _event_family_from_draft_branch(branch: Mapping[str, JsonValue]) -> str | No
         return None
     uri = ref.partition("#")[0]
     marker = "/events/"
-    if marker not in uri or not uri.endswith("-1.0.0.schema.json"):
+    suffix = ".schema.json"
+    if marker not in uri or not uri.endswith(suffix):
         return None
-    slug = uri.rsplit(marker, 1)[1].removesuffix("-1.0.0.schema.json")
-    return slug.replace("-", "_")
+    stem = uri.rsplit(marker, 1)[1].removesuffix(suffix)
+    for delimiter in (index for index, char in enumerate(stem) if char == "-"):
+        slug = stem[:delimiter]
+        version = stem[delimiter + 1 :]
+        if slug and SCHEMA_VERSION_PATTERN.fullmatch(version) is not None:
+            return slug.replace("-", "_")
+    return None
 
 
 def _project_event_draft_for_ordinary_mcp(
@@ -553,6 +564,7 @@ def _project_event_draft_for_ordinary_mcp(
     if not isinstance(one_of, list):
         raise RuntimeError("mcp_event_draft_projection_invalid")
     kept: list[JsonValue] = []
+    kept_families: set[str] = set()
     for branch in cast(list[JsonValue], one_of):
         if not isinstance(branch, Mapping):
             continue
@@ -563,7 +575,8 @@ def _project_event_draft_for_ordinary_mcp(
         family = _event_family_from_draft_branch(branch_map)
         if family in ORDINARY_MCP_PUBLISH_EVENT_FAMILIES:
             kept.append(_mutable_json(branch_map))
-    if len(kept) != len(ORDINARY_MCP_PUBLISH_EVENT_FAMILIES):
+            kept_families.add(family)
+    if kept_families != set(ORDINARY_MCP_PUBLISH_EVENT_FAMILIES):
         raise RuntimeError("mcp_event_draft_projection_incomplete")
     projected["oneOf"] = kept
     return projected

--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -43,6 +43,8 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "actor",
         "actor_id",
         "actor_type",
+        "approval_commitment",
+        "approved_check_result_digest",
         # Frozen payload field names. Without them a nested enum failure (action_kind) projects
         # only to /event_drafts/N and the hint cannot name admitted members.
         "action_id",
@@ -56,6 +58,7 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "at_frontier",
         "attempted_items",
         "authority",
+        "byte_count",
         "captured_object_id",
         "causal_parents",
         "change",
@@ -64,13 +67,15 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "claim_kind",
         "client",
         "command",
+        "content_availability",
         "content_digest",
         "cursor",
         "described_state",
         "description",
         "diff_digest",
-        "disposition",
+        "digest_binding",
         "display_name",
+        "disposition",
         "disputes_refs",
         "dry_run",
         "event_drafts",
@@ -117,6 +122,7 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "priority",
         "protocol_version",
         "publication_channel",
+        "provenance",
         "rationale",
         "reason",
         "redaction_profile",
@@ -139,6 +145,7 @@ _SAFE_LOCATION_SEGMENTS: Final = frozenset(
         "statement",
         "status",
         "strength",
+        "subject",
         "subject_state",
         "summary",
         "supersedes_event_id",
@@ -593,10 +600,10 @@ def _payload_property_names(
     """Return the admitted payload keys of one family version, or "" when they cannot be named.
 
     Both consts must match. A family may carry several admitted versions — ``evidence_recorded``
-    has 1.0.0 and 1.1.0 — while this presentation schema pins one branch per family. Selecting on
-    the name alone would answer a 1.1.0 failure with the 1.0.0 key list and so tell the caller to
-    delete ``digest_binding``, a key 1.1.0 requires (issue #239). When no branch matches both, the
-    caller gets the family-free wording, which still states the count and names ``schema.name``.
+    has 1.0.0 and 1.1.0 — and the presentation schema preserves each versioned branch. Selecting
+    on the name alone would answer a 1.1.0 failure with the 1.0.0 key list and so tell the caller
+    to delete ``digest_binding``, a key 1.1.0 requires (issue #239). When no branch matches both,
+    the caller gets the family-free wording, which still states the count and names ``schema.name``.
 
     Both the name and the version come from frozen schema content on either side: the presentation
     branch's own consts, and the version the validator read from the catalogue. Neither is ever
@@ -1023,8 +1030,41 @@ def _select_union_branch(
     with_family = [item for item in matches if item[1] is not None]
     if len(with_family) == 1:
         return with_family[0]
+    families = {family for _, family in with_family}
+    admitted = {
+        _branch_leaf_admitted_values(document, branch, remaining) for branch, _ in with_family
+    }
+    if len(families) == 1 and len(admitted) == 1 and "" not in admitted:
+        return with_family[0]
     # Ambiguous: stay on the union node so callers can name admitted schema names.
     return None
+
+
+def _branch_leaf_admitted_values(
+    document: Mapping[str, JsonValue], branch: JsonValue, remaining: Sequence[str | int]
+) -> str:
+    """Return a branch leaf's values when a path crosses no nested union."""
+
+    node = branch
+    for segment in remaining:
+        node = _resolve_local(document, node)
+        if type(segment) is int:
+            if not isinstance(node, Mapping):
+                return ""
+            node = cast(Mapping[str, JsonValue], node).get("items")
+            if node is None:
+                return ""
+            continue
+        if not isinstance(node, Mapping):
+            return ""
+        properties = cast(Mapping[str, JsonValue], node).get("properties")
+        if not isinstance(properties, Mapping):
+            return ""
+        fields = cast(Mapping[str, JsonValue], properties)
+        if type(segment) is not str or segment not in fields:
+            return ""
+        node = fields[segment]
+    return _admitted_values(_resolve_local(document, node))
 
 
 def _branch_covers_path(

--- a/tests/conformance/surfaces/test_mcp_contract_matrix.py
+++ b/tests/conformance/surfaces/test_mcp_contract_matrix.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import re
-from typing import cast
+from typing import Any, cast
 
 import pytest
+from jsonschema import Draft202012Validator
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from yoetz.mcp import resources as resource_module
@@ -33,6 +34,7 @@ from yoetz.mcp.resources import (
     read_resource,
 )
 from yoetz.mcp.summaries import render_safe_compact_summary
+from yoetz.protocol.canonical import JsonValue
 from yoetz.protocol.errors import SAFE_DETAIL_KEYS, PublicErrorCode
 from yoetz.protocol.models import (
     FRONTIER_LEAVES,
@@ -381,11 +383,22 @@ def test_advertised_input_schemas_honor_presentation_keyword_budgets() -> None:
 
 
 def test_publish_work_presentation_matches_ordinary_admission_families() -> None:
-    advertised = ordinary_publish_families_in_presentation(
-        descriptor_for("publish_work").input_schema
-    )
+    schema = descriptor_for("publish_work").input_schema
+    advertised = ordinary_publish_families_in_presentation(schema)
     assert advertised == ORDINARY_MCP_PUBLISH_EVENT_FAMILIES
-    encoded = repr(dict(descriptor_for("publish_work").input_schema))
+    event_drafts = cast(dict[str, Any], cast(dict[str, Any], schema["properties"])["event_drafts"])
+    items = cast(dict[str, Any], event_drafts["items"])
+    branches = cast(list[dict[str, Any]], items["oneOf"])
+    evidence_versions: set[str] = set()
+    for branch in branches:
+        branch_properties = cast(dict[str, Any], branch["properties"])
+        schema_node = cast(dict[str, Any], branch_properties["schema"])
+        schema_properties = cast(dict[str, Any], schema_node["properties"])
+        if cast(dict[str, Any], schema_properties["name"])["const"] == "evidence_recorded":
+            version_node = cast(dict[str, Any], schema_properties["version"])
+            evidence_versions.add(cast(str, version_node["const"]))
+    assert evidence_versions == {"1.0.0", "1.1.0"}
+    encoded = repr(dict(schema))
     assert "opaque-unknown-event-draft" not in encoded
     assert "opaque_unknown" not in encoded
 
@@ -432,6 +445,18 @@ def test_presentation_examples_admit_under_catalog_models() -> None:
             assert isinstance(draft_schema, dict)
             exercised.add(cast(str, draft_schema["name"]))
     assert exercised == ORDINARY_MCP_PUBLISH_EVENT_FAMILIES
+
+
+def test_publish_work_examples_validate_against_advertised_input_schema() -> None:
+    """Worked examples must validate against the contract MCP clients actually receive."""
+
+    schema = descriptor_for("publish_work").input_schema
+    examples = cast(list[JsonValue], schema["examples"])
+    validator = cast(Any, Draft202012Validator(cast(Any, schema)))
+
+    for index, example in enumerate(examples):
+        errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+        assert not errors, (index, tuple(error.json_path for error in errors))
 
 
 def test_presentation_input_schema_is_projection_of_catalog_shape() -> None:

--- a/tests/unit/mcp/test_unknown_payload_key_authoring.py
+++ b/tests/unit/mcp/test_unknown_payload_key_authoring.py
@@ -35,8 +35,8 @@ _ADMITTED_PAYLOAD_KEYS = (
     "source_refs",
     "status",
 )
-# The one family the catalogue admits at two versions, and the payload key only the later one
-# admits. The presentation schema carries a single branch for the family, pinned to 1.0.0.
+# The one family the catalogue and presentation schema admit at two versions, and the payload key
+# only the later one admits.
 _MULTI_VERSION_FAMILY = "evidence_recorded"
 _LATER_ONLY_PAYLOAD_KEY = "digest_binding"
 # The public message bound the protocol validator enforces.
@@ -108,19 +108,12 @@ def test_a_single_version_family_is_answered_with_its_own_version_and_full_key_l
         assert key in message, key
 
 
-def test_a_later_family_version_is_never_answered_with_the_earlier_key_list() -> None:
-    """A 1.1.0 evidence payload must not be handed the 1.0.0 contract (issue #239).
-
-    The presentation schema pins one branch per family, and that branch is evidence_recorded
-    1.0.0, whose admitted keys omit `digest_binding`. Selecting it on the family name alone told a
-    caller who had correctly sent `digest_binding` that the schema does not admit it. The version
-    the validator read from the catalogue now has to match the branch's frozen version const, so
-    an unanswerable case degrades to the family-free wording instead of answering it wrongly.
-    """
+def test_a_later_family_version_is_answered_with_its_own_key_list() -> None:
+    """A 1.1.0 evidence payload receives the matching advertised contract (issues #239, #246)."""
 
     request = _single_draft_request(_MULTI_VERSION_FAMILY)
     example_version = cast(str, request["event_drafts"][0]["schema"]["version"])
-    assert example_version != "1.0.0", "the presentation branch pins 1.0.0; pick a later example"
+    assert example_version != "1.0.0", "pick a later-version worked example"
     assert _LATER_ONLY_PAYLOAD_KEY in request["event_drafts"][0]["payload"]
     request["event_drafts"][0]["payload"]["zzz_unknown"] = "x"
 
@@ -129,13 +122,9 @@ def test_a_later_family_version_is_never_answered_with_the_earlier_key_list() ->
 
     assert locations[0]["family"] == _MULTI_VERSION_FAMILY
     assert locations[0]["family_version"] == example_version
-    # No key list at all rather than the wrong one: naming 1.0.0's keys would tell the caller to
-    # delete the evidence-integrity key 1.1.0 requires.
-    assert "admitted keys are" not in message
-    assert f"the {_MULTI_VERSION_FAMILY} schema does not admit" not in message
-    # The degraded wording still states the count and still names where the family goes.
-    assert "the payload carries 1 property the event schema does not admit" in message
-    assert "schema.name admits" in message
+    assert f"the {_MULTI_VERSION_FAMILY} schema does not admit" in message
+    assert "admitted keys are" in message
+    assert _LATER_ONLY_PAYLOAD_KEY in message
     assert len(message.encode("utf-8")) <= _MAX_MESSAGE_BYTES
 
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #246
- I searched existing issues and PRs for duplicates before opening this PR; no duplicate was found.
- This touches the advertised protocol contract. The repository maintainer opened #246 with the exact expected behavior and requested this implementation before the PR was opened.

## Documentation

- Behavior change? yes — the advertised `publish_work` input schema now preserves every catalogued version branch for ordinary event families.
- Docs updated: `docs/INTERFACES.md`.

## Verification

Commands run:

```text
uv run pytest tests/unit/mcp tests/conformance/surfaces/test_mcp_contract_matrix.py tests/conformance/surfaces/test_agent_surface_authorability.py tests/subprocess/test_mcp_initialize_and_tools.py -q
uv run ruff check src/yoetz/mcp/descriptors.py src/yoetz/mcp/errors.py tests/conformance/surfaces/test_mcp_contract_matrix.py tests/unit/mcp/test_unknown_payload_key_authoring.py
uv run ruff format --check src/yoetz/mcp/descriptors.py src/yoetz/mcp/errors.py tests/conformance/surfaces/test_mcp_contract_matrix.py tests/unit/mcp/test_unknown_payload_key_authoring.py
npx --no-install pyright
git diff --check
uv run --locked python scripts/scan_public_boundary.py --source-tree .
```

Results: 158 tests passed; Ruff lint and format checks passed; Pyright reported 0 errors; the public-boundary scan passed for 931 files.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

The MCP presentation projection inferred event families only from payload schema references ending in `-1.0.0.schema.json`. That dropped the catalogued `evidence_recorded` 1.1.0 branch, while projection completeness incorrectly assumed one branch per family. As a result, two shipped worked examples failed validation against the schema clients actually receive.

Parse the canonical schema semver instead of pinning 1.0.0, retain all version branches while checking completeness by represented family, and expand the reviewed presentation-size budget for the additional branch. The newly visible 1.1.0 fields are included in safe authoring locations, and same-family multi-version hints select shared enums or the exact versioned payload key list without exposing caller-controlled keys.

Regression coverage now asserts both evidence versions are advertised and validates every worked example against the advertised Draft 2020-12 schema as well as catalog admission.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix advertised evidence schema versions to include all versioned branches per family
> - Generalizes `_event_family_from_draft_branch` in [descriptors.py](https://github.com/TheGaySupreme123/yoetz/pull/247/files#diff-efbd7f9e90764f21f42b3f2253052cc073a710d65347c453904990feb94ca2bc) to recognize any `.schema.json` suffix instead of being pinned to `1.0.0`, so multiple versioned branches per event family are detected and preserved.
> - Updates `_project_event_draft_for_ordinary_mcp` to validate that all admitted event families are present by name, raising `mcp_event_draft_projection_incomplete` if any are missing.
> - Improves `_select_union_branch` in [errors.py](https://github.com/TheGaySupreme123/yoetz/pull/247/files#diff-37701a62d9b9d312bd9bc0ac5518f534fa379f0a1758aa6820c455bd91375564) to resolve ambiguity when multiple versioned branches share the same family and identical admitted values at the target path, enabling precise admitted-key hints.
> - Increases the `publish-work-request` presentation schema budget from 28,000 to 32,000 encoded bytes to accommodate the additional branches.
> - Adds tests asserting that `evidence_recorded` has both `1.0.0` and `1.1.0` branches in the presentation schema and that all worked examples validate against the advertised input schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0a3ff6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->