### PR TITLE
Stop hook advice falling back to stale workspace snapshots

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2297,6 +2297,13 @@ Shared closed types:
   privacy gateway, over minimized approved packets. Deterministic finding identity is
   candidate-scoped; envelope-linked candidates use only their mapped ledger events as subject refs,
   while standing session conditions use the stable lifecycle event.
+  Hook-channel delivery is relevance-scoped: task-scoped conditions come from the mapped Yoetz
+  session snapshot when one exists, otherwise from the current Codex session's retained envelopes.
+  The workspace-wide snapshot is not a fallback for task-scoped work. Deliberately workspace-
+  standing machine conditions remain deliverable from that workspace snapshot at the documented
+  session-boundary cadence. The agent-visible context carries only the bounded rule, action, and
+  evidence token; deciding whether the advice belongs to the current target never requires
+  inspecting Yoetz storage.
 
 Independent verification support (local control, not MCP):
 

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -135,6 +135,15 @@ registration is global, file-free, and marker-free, so reusing the skill-install
 misuse fields designed for on-disk trusted-project content. The guarantee below is unchanged —
 adding a harness is still one `HarnessId` value plus adapters, with no shared-type edits.
 
+**Amendment (2026-08-14):** Hook advice delivery no longer falls back to the workspace-wide
+`advice_snapshot` for task-scoped conditions. Before a Codex session is mapped, task-scoped
+advice is selected only from that Codex session's retained envelopes. After mapping, delivery
+uses the mapped Yoetz session snapshot when present, otherwise the current Codex session's
+envelopes. Workspace-standing machine conditions (`connect_provider`) remain readable from the
+workspace snapshot at the documented session-boundary cadence. Suppression is keyed by Yoetz
+session when mapped and by Codex session commitment when unmapped, so one task cannot silence
+or re-enable another. No new durable field or observation-authority change.
+
 **Amendment (2026-07-22):** First-party Codex observation is required for v0.1 completion of the
 Codex integration, still on protocol version `0.1`. Observation is a sibling local-control
 capability (`ObservationPort`), not a seventh MCP tool and not an `IntegrationsPort` overload.

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -31,6 +31,7 @@ from yoetz.domain.observation import (
     ObservationGapCode,
     ObservationIngestDisposition,
     ObservationIngestResult,
+    ObservationLifecycle,
     ObservationRevokeCommand,
     ObservationSource,
     ObservationStatus,
@@ -439,6 +440,61 @@ def _load_session_advice(raw: object) -> dict[str, AdviceSnapshot]:
     return result
 
 
+def _advice_delivery_scope_key(
+    *,
+    yoetz_session_id: str | None,
+    session_commitment: str | None,
+) -> str | None:
+    """Prefer the mapped Yoetz session; otherwise the current Codex session."""
+
+    if type(yoetz_session_id) is str:
+        return yoetz_session_id
+    if type(session_commitment) is str:
+        return session_commitment
+    return None
+
+
+def _task_scoped_delivery_snapshot(
+    state: _WorkspaceState,
+    *,
+    yoetz_session_id: str | None,
+    session_commitment: str | None,
+) -> AdviceSnapshot | None:
+    """Task-scoped snapshot for hook delivery: never the workspace fallback.
+
+    A mapped Yoetz session snapshot is authority when present. Otherwise the
+    current Codex session's retained envelopes are rebuilt in memory so a
+    same-session failed command stays deliverable before ``start`` returns.
+    """
+
+    if type(yoetz_session_id) is str and state.session_advice is not None:
+        mapped = state.session_advice.get(yoetz_session_id)
+        if mapped is not None:
+            return mapped
+    if type(session_commitment) is not str or not session_commitment:
+        return None
+    envelopes = tuple(
+        envelope
+        for envelope in (state.envelopes or ())
+        if envelope.session_commitment == session_commitment
+    )
+    if not envelopes:
+        return None
+    from yoetz.application.observation_advice import (
+        ObservationAdviceBuildInput,
+        build_observation_advice_snapshot,
+    )
+
+    return build_observation_advice_snapshot(
+        ObservationAdviceBuildInput(
+            envelopes=envelopes,
+            lifecycle=ObservationLifecycle.ACTIVE,
+            gaps=(),
+            has_real_observation=True,
+        )
+    )
+
+
 def _copy_state(state: _WorkspaceState) -> _WorkspaceState:
     """Independent copy of one workspace state for the parse cache.
 
@@ -828,6 +884,7 @@ class LocalObservationStore:
         *,
         yoetz_session_id: str | None = None,
         allow_standing: bool = True,
+        session_commitment: str | None = None,
     ) -> AdviceDelivery | None:
         """Select advice to deliver once per *condition* identity. Never mutates state.
 
@@ -836,6 +893,12 @@ class LocalObservationStore:
         agent. Persisting the identity here would mean a hook killed between
         the save and the stdout write suppresses that advice permanently, which
         is strictly worse than the storm this cadence exists to stop.
+
+        Task-scoped conditions never fall back to the workspace-wide snapshot
+        (#249). A mapped Yoetz session uses its own snapshot when present;
+        otherwise selection is rebuilt from the current Codex session's
+        retained envelopes. The workspace snapshot may contribute only
+        deliberately standing machine conditions.
 
         ``allow_standing=False`` withholds standing machine conditions
         (STANDING_MACHINE_ACTIONS) and falls through to the highest-ranked
@@ -847,26 +910,40 @@ class LocalObservationStore:
             advice_delivery_identity,
             hook_advice_context,
             select_advice_item,
+            select_standing_item,
         )
 
         with self._lock:
             state = self._load(workspace)
-            snapshot: AdviceSnapshot | None = None
-            if type(yoetz_session_id) is str and state.session_advice is not None:
-                snapshot = state.session_advice.get(yoetz_session_id)
+            snapshot = _task_scoped_delivery_snapshot(
+                state,
+                yoetz_session_id=yoetz_session_id,
+                session_commitment=session_commitment,
+            )
+            item = None
+            if snapshot is not None:
+                if not snapshot.ranked_finding_ids:
+                    snapshot = None
+                else:
+                    item = select_advice_item(snapshot, allow_standing=allow_standing)
+                    if item is None and snapshot.ranked_items:
+                        # Every ranked item on the task-scoped snapshot was
+                        # cadence-gated on this event class.
+                        snapshot = None
+            if snapshot is None and allow_standing and state.advice_snapshot is not None:
+                standing = select_standing_item(state.advice_snapshot)
+                if standing is not None:
+                    snapshot = state.advice_snapshot
+                    item = standing
             if snapshot is None:
-                snapshot = state.advice_snapshot
-            if snapshot is None:
-                return None
-            if not snapshot.ranked_finding_ids:
-                return None
-            item = select_advice_item(snapshot, allow_standing=allow_standing)
-            if item is None and snapshot.ranked_items:
-                # Every ranked item was cadence-gated on this event class.
                 return None
             identity = advice_delivery_identity(snapshot, item=item)
-            if type(yoetz_session_id) is str:
-                delivered = (state.session_advice_suppression or {}).get(yoetz_session_id)
+            scope = _advice_delivery_scope_key(
+                yoetz_session_id=yoetz_session_id,
+                session_commitment=session_commitment,
+            )
+            if type(scope) is str:
+                delivered = (state.session_advice_suppression or {}).get(scope)
             else:
                 delivered = state.last_advice_suppression
             if delivered == identity:
@@ -884,6 +961,7 @@ class LocalObservationStore:
         delivery_identity: str,
         *,
         yoetz_session_id: str | None = None,
+        session_commitment: str | None = None,
     ) -> None:
         """Record advice as delivered — call only after the text reached the agent.
 
@@ -894,6 +972,11 @@ class LocalObservationStore:
         migration, and downgrade is symmetric. They stay single values, never a
         set: A→B→A must redeliver A.
 
+        Mapped deliveries key suppression by Yoetz session; unmapped hook
+        deliveries key it by Codex session commitment so one task cannot
+        silence another (#249). Callers that pass neither still use the
+        workspace-wide slot.
+
         A crash between the emission and this call costs at most one
         redelivery; the reverse order would cost the advice entirely.
         """
@@ -902,12 +985,16 @@ class LocalObservationStore:
             raise ProtocolValueError("invalid_event_value_type")
         with self._lock:
             state = self._load(workspace)
-            if type(yoetz_session_id) is str:
+            scope = _advice_delivery_scope_key(
+                yoetz_session_id=yoetz_session_id,
+                session_commitment=session_commitment,
+            )
+            if type(scope) is str:
                 if state.session_advice_suppression is None:
                     state.session_advice_suppression = {}
-                if state.session_advice_suppression.get(yoetz_session_id) == delivery_identity:
+                if state.session_advice_suppression.get(scope) == delivery_identity:
                     return
-                state.session_advice_suppression[yoetz_session_id] = delivery_identity
+                state.session_advice_suppression[scope] = delivery_identity
             else:
                 if state.last_advice_suppression == delivery_identity:
                     return

--- a/src/yoetz/application/observation_advice.py
+++ b/src/yoetz/application/observation_advice.py
@@ -55,6 +55,7 @@ __all__ = [
     "hook_advice_context",
     "minimized_semantic_evidence_packet",
     "select_advice_item",
+    "select_standing_item",
     "should_reissue_advice",
     "stable_advice_finding_id",
 ]
@@ -503,6 +504,17 @@ def select_advice_item(snapshot: AdviceSnapshot, *, allow_standing: bool) -> Adv
         return None
     for item in snapshot.ranked_items:
         if allow_standing or item.recommended_next_action not in STANDING_MACHINE_ACTIONS:
+            return item
+    return None
+
+
+def select_standing_item(snapshot: AdviceSnapshot) -> AdviceItem | None:
+    """Highest-ranked workspace-standing machine condition, if the snapshot has one."""
+
+    if not snapshot.ranked_items:
+        return None
+    for item in snapshot.ranked_items:
+        if item.recommended_next_action in STANDING_MACHINE_ACTIONS:
             return item
     return None
 

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -1243,6 +1243,7 @@ def handle_observe(
                     workspace_commitment,
                     yoetz_session_id=delivery_session_id,
                     allow_standing=resolved_event in STANDING_ADVICE_CADENCE_EVENTS,
+                    session_commitment=session_commitment,
                 )
                 if delivery is not None:
                     additional = delivery.text[:_MAX_ADVICE_CONTEXT]
@@ -1268,6 +1269,7 @@ def handle_observe(
                         workspace_commitment,
                         pending_delivery.delivery_identity,
                         yoetz_session_id=delivery_session_id,
+                        session_commitment=session_commitment,
                     )
         _record_pass_timing(
             resolved_event,

--- a/tests/unit/adapters/test_observation_local_advice_delivery.py
+++ b/tests/unit/adapters/test_observation_local_advice_delivery.py
@@ -180,6 +180,7 @@ def test_hook_serializes_advice_selection_through_commit_without_workspace_batch
         *,
         yoetz_session_id: str | None = None,
         allow_standing: bool = True,
+        session_commitment: str | None = None,
     ) -> AdviceDelivery | None:
         phases.append(
             ("peek", workspace in self._batch)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
@@ -189,6 +190,7 @@ def test_hook_serializes_advice_selection_through_commit_without_workspace_batch
             workspace,
             yoetz_session_id=yoetz_session_id,
             allow_standing=allow_standing,
+            session_commitment=session_commitment,
         )
 
     def commit(
@@ -197,6 +199,7 @@ def test_hook_serializes_advice_selection_through_commit_without_workspace_batch
         delivery_identity: str,
         *,
         yoetz_session_id: str | None = None,
+        session_commitment: str | None = None,
     ) -> None:
         phases.append(
             ("commit", workspace in self._batch)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
@@ -206,6 +209,7 @@ def test_hook_serializes_advice_selection_through_commit_without_workspace_batch
             workspace,
             delivery_identity,
             yoetz_session_id=yoetz_session_id,
+            session_commitment=session_commitment,
         )
 
     monkeypatch.setattr(LocalObservationStore, "peek_advice_for_delivery", peek)
@@ -340,7 +344,11 @@ def test_failed_stdout_write_redelivers_the_advice_on_the_next_hook(
     store = LocalObservationStore(_state=tmp_path)
     workspace = store.workspace_commitment(str(tmp_path.resolve()))
     state = store._load(workspace)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    scope = store.session_commitment("broken")
     assert state.last_advice_suppression is None, (
+        "a delivery that never reached stdout was recorded as delivered"
+    )
+    assert (state.session_advice_suppression or {}).get(scope) is None, (
         "a delivery that never reached stdout was recorded as delivered"
     )
     assert "connect_provider" in _run(tmp_path, "Stop", "broken")
@@ -357,7 +365,7 @@ def test_successful_emit_records_the_delivery_identity(
     store = LocalObservationStore(_state=tmp_path)
     workspace = store.workspace_commitment(str(tmp_path.resolve()))
     state = store._load(workspace)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-    recorded = state.last_advice_suppression
+    recorded = (state.session_advice_suppression or {}).get(store.session_commitment("recorded"))
     assert type(recorded) is str and recorded.startswith("deliver-")
     assert "connect_provider" not in _run(tmp_path, "Stop", "recorded")
 
@@ -366,6 +374,7 @@ def test_a_then_b_then_a_redelivers_a(tmp_path: Path) -> None:
     """Last-delivered is a single value, never a set: a reappearing condition speaks again."""
 
     store, workspace = _consented(tmp_path)
+    session = "ses_00000000-0000-4000-8000-0000000000aa"
     advice_a = _snapshot(workspace, envelopes=1, composition=_STANDING)
     advice_b = _snapshot(
         workspace,
@@ -377,14 +386,166 @@ def test_a_then_b_then_a_redelivers_a(tmp_path: Path) -> None:
     texts: list[str] = []
     persisted: list[str | None] = []
     for snapshot in (advice_a, advice_b, advice_a):
-        store.set_advice_snapshot(workspace, snapshot)
-        delivery = store.peek_advice_for_delivery(workspace)
+        store.set_session_advice_snapshot(workspace, yoetz_session_id=session, snapshot=snapshot)
+        delivery = store.peek_advice_for_delivery(workspace, yoetz_session_id=session)
         assert delivery is not None
-        store.commit_advice_delivery(workspace, delivery.delivery_identity)
+        store.commit_advice_delivery(
+            workspace, delivery.delivery_identity, yoetz_session_id=session
+        )
         texts.append(delivery.text)
         state = store._load(workspace)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-        persisted.append(state.last_advice_suppression)
+        persisted.append((state.session_advice_suppression or {}).get(session))
 
     assert texts[0] == texts[2] != texts[1]
     assert persisted[0] != persisted[1] and persisted[1] != persisted[2]
     assert persisted[0] == persisted[2]
+
+
+def _map_session(tmp_path: Path, codex_session: str) -> str:
+    from yoetz.adapters.integrations.codex_lifecycle import (
+        mapping_from_start_ids,
+        store_mapping,
+    )
+    from yoetz.protocol.ids import IdKind, new_id
+
+    yoetz_session = new_id(IdKind.SESSION)
+    store_mapping(
+        mapping_from_start_ids(
+            codex_session_id=codex_session,
+            yoetz_task_id=new_id(IdKind.TASK),
+            yoetz_session_id=yoetz_session,
+            yoetz_writer_id=new_id(IdKind.WRITER),
+            last_frontier=None,
+        ),
+        _state=tmp_path,
+    )
+    return yoetz_session
+
+
+def test_workspace_snapshot_is_not_a_task_scoped_fallback(tmp_path: Path) -> None:
+    """A workspace-wide failed_command snapshot is not current-task advice (#249)."""
+
+    store, workspace = _consented(tmp_path)
+    store.set_advice_snapshot(
+        workspace,
+        _snapshot(
+            workspace,
+            envelopes=1,
+            payload={"tool_name": "shell", "exit_status": 1, "correlation_id": "old"},
+        ),
+    )
+    assert store.peek_advice_for_delivery(workspace) is None
+    assert store.peek_advice_for_delivery(workspace, allow_standing=False) is None
+
+
+def test_unmapped_task_does_not_receive_prior_task_failed_command(
+    tmp_path: Path,
+) -> None:
+    """#249: task B must not inherit task A's resolve_failed_command as current work."""
+
+    _consented(tmp_path)
+    first = _run(
+        tmp_path,
+        "PostToolUse",
+        "task-a",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="a1",
+    )
+    assert "resolve_failed_command" in first
+
+    later = _run(tmp_path, "PostToolUse", "task-b", tool_name="shell", exit_status=0)
+    assert "resolve_failed_command" not in later
+    assert later == ""
+
+
+def test_same_session_failed_command_stays_deliverable(tmp_path: Path) -> None:
+    _consented(tmp_path)
+    delivered = _run(
+        tmp_path,
+        "PostToolUse",
+        "same-session",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="s1",
+    )
+    assert "resolve_failed_command" in delivered
+
+
+def test_mapped_session_without_own_snapshot_does_not_use_workspace_task_advice(
+    tmp_path: Path,
+) -> None:
+    _consented(tmp_path)
+    prior = _run(
+        tmp_path,
+        "PostToolUse",
+        "task-a",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="old",
+    )
+    assert "resolve_failed_command" in prior
+    _map_session(tmp_path, "mapped-b")
+
+    delivered = _run(tmp_path, "PostToolUse", "mapped-b", tool_name="shell", exit_status=0)
+    assert "resolve_failed_command" not in delivered
+
+
+def test_mapped_session_snapshot_still_delivers_its_own_failed_command(
+    tmp_path: Path,
+) -> None:
+    store, workspace = _consented(tmp_path)
+    yoetz_session = _map_session(tmp_path, "mapped-own")
+    own = _snapshot(
+        workspace,
+        envelopes=1,
+        payload={"tool_name": "shell", "exit_status": 1, "correlation_id": "own"},
+    )
+    store.set_session_advice_snapshot(workspace, yoetz_session_id=yoetz_session, snapshot=own)
+
+    delivered = _run(tmp_path, "PostToolUse", "mapped-own", tool_name="shell", exit_status=0)
+    assert "resolve_failed_command" in delivered
+
+
+def test_unmapped_session_start_still_delivers_workspace_standing_advice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+    prior = _run(
+        tmp_path,
+        "PostToolUse",
+        "task-a",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="old",
+    )
+    assert "resolve_failed_command" in prior
+
+    started = _run(tmp_path, "SessionStart", "fresh-b", source="startup")
+    assert "connect_provider" in started
+    assert "resolve_failed_command" not in started
+
+
+def test_delivery_in_task_a_does_not_suppress_same_condition_in_task_b(
+    tmp_path: Path,
+) -> None:
+    _consented(tmp_path)
+    first = _run(
+        tmp_path,
+        "PostToolUse",
+        "suppress-a",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="a1",
+    )
+    assert "resolve_failed_command" in first
+    second = _run(
+        tmp_path,
+        "PostToolUse",
+        "suppress-b",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="b1",
+    )
+    assert "resolve_failed_command" in second

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -18,6 +18,7 @@ from yoetz.application.observation_advice import (
     hook_advice_context,
     minimized_semantic_evidence_packet,
     select_advice_item,
+    select_standing_item,
     should_reissue_advice,
 )
 from yoetz.application.observation_coordinator import (
@@ -344,8 +345,10 @@ def test_standing_items_fall_through_to_the_first_actionable_item() -> None:
     ]
     permitted = select_advice_item(snapshot, allow_standing=True)
     withheld = select_advice_item(snapshot, allow_standing=False)
+    standing = select_standing_item(snapshot)
     assert permitted is not None and permitted.rule_code == "provider_not_ready"
     assert withheld is not None and withheld.rule_code == "semantic_claim_without_attempt"
+    assert standing is not None and standing.rule_code == "provider_not_ready"
 
 
 def test_suppression_identity_still_tracks_evidence_for_materialization() -> None:
@@ -578,7 +581,12 @@ def test_observe_hook_refresh_advice_without_mcp_tools(tmp_path: Path) -> None:
     serialized = json.dumps(payload)
     assert "resolve_failed_command" in serialized or status.advice_frontier != "none"
     # Second peek is suppressed (same evidence frontier).
-    assert store.peek_advice_for_delivery(workspace) is None
+    assert (
+        store.peek_advice_for_delivery(
+            workspace, session_commitment=store.session_commitment("advice-1")
+        )
+        is None
+    )
     _ = context
     text = serialized
     assert "AKIA" not in text


### PR DESCRIPTION
## Issue

- Linked issue: `Fixes #249`
- I searched existing issues and PRs for duplicates before opening this PR. #241/#245 bound byte-identical advice storms; they do not fix cross-task selection. #219, #217, and #244 cover adjacent observation issues, not this relevance boundary. No open PR already targets #249.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging, ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.
  - Not design-gated: selection/scope only. Existing advice categories, wire shapes, privacy rules, and durable fields are unchanged. The issue itself marked this as likely not design-gated unless new provenance fields or observation authority were added; they were not.

## Documentation

- Behavior change? `yes`
- Docs updated (ADR, `docs/` page, `docs/INTERFACES.md` entry), or `n/a — no behavior change`:
  - `docs/INTERFACES.md` — hook delivery is relevance-scoped
  - `docs/adr/ADR-010-harness-integration-port.md` — 2026-08-14 amendment for the selection boundary

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/adapters/test_observation_local_advice_delivery.py tests/unit/application/test_observation_advice.py tests/unit/cli/test_observe_hooks.py tests/unit/application/test_observation_coordinator.py tests/unit/adapters/test_codex_plugin.py tests/unit/cli/test_hooks.py
# 121 passed

uv run ruff check src/yoetz/adapters/integrations/observation_local.py src/yoetz/application/observation_advice.py src/yoetz/cli/observe_hooks.py tests/unit/adapters/test_observation_local_advice_delivery.py tests/unit/application/test_observation_advice.py
npx --no-install pyright src/yoetz/adapters/integrations/observation_local.py src/yoetz/application/observation_advice.py src/yoetz/cli/observe_hooks.py tests/unit/adapters/test_observation_local_advice_delivery.py tests/unit/application/test_observation_advice.py
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Before a Codex session is mapped, `peek_advice_for_delivery(..., yoetz_session_id=None)` read the workspace-wide `advice_snapshot`. A prior task's `failed_command_unresolved` condition was therefore injected once into an unrelated new task as current `resolve_failed_command` work. Mapped sessions with no session snapshot had the same silent fallback, and unmapped suppression used a workspace-wide slot.

This change keeps #241's content-identity cadence and commit-after-emit serialization, and tightens selection:

- Task-scoped advice comes from the mapped Yoetz session snapshot when present, otherwise from the current Codex session's retained envelopes.
- The workspace snapshot is no longer a task-scoped fallback.
- Workspace-standing machine conditions (`connect_provider`) remain deliverable at the documented session-boundary cadence.
- Suppression is keyed by Yoetz session when mapped and by Codex session commitment when unmapped.

Regression coverage includes the filed unmapped A→B case, same-session failed commands, mapped-without-snapshot, standing cadence, and cross-task suppression isolation.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop hook advice from falling back to stale workspace snapshots for task-scoped delivery
> - `peek_advice_for_delivery` and `commit_advice_delivery` in [`observation_local.py`](https://github.com/TheGaySupreme123/yoetz/pull/250/files#diff-dcc1feb8bc7f834d09056738e52fec58f85bdd06640418a241feda997cb5be82) now accept `session_commitment` and use it to scope advice selection and suppression to the current Yoetz session or Codex session commitment.
> - A new `_task_scoped_delivery_snapshot` helper selects advice from the mapped Yoetz session snapshot or builds it from current Codex session envelopes, with no implicit fallback to the workspace-wide snapshot for task-scoped conditions.
> - A new `_advice_delivery_scope_key` helper keys suppression state per Yoetz session id or Codex session commitment, so committing advice in one task no longer suppresses the same condition in another task.
> - `select_standing_item` is added to [`observation_advice.py`](https://github.com/TheGaySupreme123/yoetz/pull/250/files#diff-4ad7c14d0922000b3aa7d3043abaf37e4199da6b80da3a953d14312a10485400) to allow explicit selection of workspace-standing machine conditions independent of task-scoped advice.
> - Behavioral Change: workspace-wide task advice is no longer considered for task-scoped delivery; only standing machine conditions fall back to the workspace snapshot when `allow_standing=True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c096f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Advice delivery is now scoped to the relevant task session, improving relevance across mapped and unmapped sessions.
  - Workspace-wide fallback advice is limited to standing machine conditions.
  - Advice shown to agents contains only bounded rule, action, and evidence details.

- **Bug Fixes**
  - Prevented advice suppression from incorrectly carrying across independent sessions.
  - Improved fallback behavior when session mappings are unavailable.

- **Documentation**
  - Documented session-scoped advice delivery and suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->