### PR TITLE
Improve observation frontier feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ describes behavior intended for the first release rather than a change from a pr
 ### Added
 
 - Cooperative writers now receive a one-shot, coalesced notice when the observation writer moves the
-  task frontier, including the bounded sequence range and observation-record count. Successful
-  routine reads remain available in the local observation store but are rate-limited out of the
-  task ledger; failures and conservatively unrecognized commands still materialize normally
+  task frontier, including the bounded sequence range and observation-record count. The notice map
+  is capped, drops ended-session entries, and is reconstructed on retry from a completed append's
+  frontier metadata when the local write did not land. Successful routine reads remain available in
+  the local observation store but are rate-limited out of the task ledger; failures, denials,
+  path-qualified executables, and conservatively unrecognized commands still materialize normally
   (issue #244, ADR-022 amendment).
 
 - Consent-based Codex observation activation and durable delivery repair (issues #204 and #205,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ describes behavior intended for the first release rather than a change from a pr
 
 ### Added
 
+- Cooperative writers now receive a one-shot, coalesced notice when the observation writer moves the
+  task frontier, including the bounded sequence range and observation-record count. Successful
+  routine reads remain available in the local observation store but are rate-limited out of the
+  task ledger; failures and conservatively unrecognized commands still materialize normally
+  (issue #244, ADR-022 amendment).
+
 - Consent-based Codex observation activation and durable delivery repair (issues #204 and #205,
   ADR-012 amendment): setup now distinguishes installed hook sources from an active plugin, previews
   the exact selected Codex executable and explicitly selected existing home, repository marketplace,

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2379,16 +2379,20 @@ quarantined-at time behind the trusted-clock epoch fence; an operator can drop i
 
 Routine-read materialization follows ADR-022's rate policy. A service-owned structural
 `action=routine_read` label is derived only for the closed direct-read tool set or a conservatively
-parsed, single read-only shell command; host-supplied action text cannot select it. Both the pre-event
-and a successful or status-unknown post-event remain in the bounded local observation store but do
-not append task-ledger events. A failed post-event materializes normally, and ambiguous shell input
-is never treated as read-only.
+parsed, single read-only shell command; host-supplied action text cannot select it. Path-qualified
+executables, Git `--output` / `--ext-diff`, explicit `success=false` or `denied=true`, and other
+ambiguous shell input stay ordinary observations. Both the pre-event and a successful or
+status-unknown post-event remain in the bounded local observation store but do not append
+task-ledger events. A failed post-event materializes normally.
 
 The local observation state also owns a sparse, one-shot `FrontierMotionNotice` per Codex session:
 `from_sequence`, `to_sequence`, final `head_digest`, and exact accepted observation-record count.
-Only a newly accepted observation append creates it; idempotent replay does not. Contiguous pending
-notices coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after emitting
-its bounded agent context. This context is informational: it neither weakens exact-frontier checks
+A newly accepted observation append creates it. Idempotent replay of a completed append
+reconciles a missing pending notice from that append's committed frontier metadata; a still-pending
+notice is coalesced rather than duplicated. The mapping is capped and drops ended-session entries
+before serialization; a malformed stored value is ignored as empty. Contiguous pending notices
+coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after emitting its
+bounded agent context. This context is informational: it neither weakens exact-frontier checks
 nor expands the ADR-022 predicate that permits a cooperative publish to retain a stale frontier
 across observation-authored records.
 

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2377,6 +2377,21 @@ quarantined-at time behind the trusted-clock epoch fence; an operator can drop i
 (evictions and reclaims counted separately), first/last receipt times, and
 `quarantine_detail_evicted`.
 
+Routine-read materialization follows ADR-022's rate policy. A service-owned structural
+`action=routine_read` label is derived only for the closed direct-read tool set or a conservatively
+parsed, single read-only shell command; host-supplied action text cannot select it. Both the pre-event
+and a successful or status-unknown post-event remain in the bounded local observation store but do
+not append task-ledger events. A failed post-event materializes normally, and ambiguous shell input
+is never treated as read-only.
+
+The local observation state also owns a sparse, one-shot `FrontierMotionNotice` per Codex session:
+`from_sequence`, `to_sequence`, final `head_digest`, and exact accepted observation-record count.
+Only a newly accepted observation append creates it; idempotent replay does not. Contiguous pending
+notices coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after emitting
+its bounded agent context. This context is informational: it neither weakens exact-frontier checks
+nor expands the ADR-022 predicate that permits a cooperative publish to retain a stale frontier
+across observation-authored records.
+
 `hook_observed` (publication channel and artifact-observation class) and `harness_observed`
 authorship require real observation evidence under an active consented observation arm — never a
 trigger-only hook, consent marker, empty status, or degraded/stopped source alone.

--- a/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
@@ -73,19 +73,23 @@ unsupported claims and unbounded duplicate findings.
 
 9. Successful routine reads are rate-limited at the task-ledger boundary. The hook adapter labels
    only a closed set of read tools and conservatively parsed single read-only shell commands as
-   `routine_read`; shell composition, redirection, mutation flags, unknown commands, and other
+   `routine_read`; path-qualified executables, side-effecting Git options, shell composition,
+   redirection, mutation flags, unknown commands, explicit failures or denials, and other
    ambiguity fail closed to ordinary materialization. The complete hook envelope remains in the
    bounded local observation store, but its pre-event and successful post-event do not mint
    individual task-ledger records. A failed post-event still materializes action and result records,
    and edits, checks, tests, lifecycle events, and other non-routine observations are unchanged.
 
 10. Every newly accepted observation-authored append records one bounded pending frontier-motion
-    notice for the originating Codex session. Contiguous undelivered appends coalesce their
-    from/to sequences and record count. A later advice-safe `PostToolUse` hook surfaces that the
-    motion was hook-observed, explains that held cooperative publish frontiers remain admissible
-    only across observation-authored motion, and directs exact-frontier operations to refresh
-    status. The notice is removed only after its bytes reach the hook consumer. It grants no
-    authority, changes no optimistic-concurrency predicate, and adds no MCP operation.
+    notice for the originating Codex session. A retry of a completed append whose local notice
+    write did not land reconstructs that notice from the committed append's frontier metadata.
+    Contiguous undelivered appends coalesce their from/to sequences and record count. The
+    per-workspace notice map is capped and drops ended-session entries before serialization. A
+    later advice-safe `PostToolUse` hook surfaces that the motion was hook-observed, explains that
+    held cooperative publish frontiers remain admissible only across observation-authored motion,
+    and directs exact-frontier operations to refresh status. The notice is removed only after its
+    bytes reach the hook consumer. It grants no authority, changes no optimistic-concurrency
+    predicate, and adds no MCP operation.
 
 ## Security and privacy consequences
 

--- a/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-and-frontier-concurrency.md
@@ -1,10 +1,11 @@
 # ADR-022 — Harness observation writer identity and observation-tolerant optimistic concurrency
 
 **Status:** Accepted (2026-08-13), acknowledged for issues #214–#223.
+**Amended:** 2026-08-14 for moderator-approved issue #244.
 **Implemented by:** `src/yoetz/application/observation_materialize.py`,
 `src/yoetz/application/observation_coordinator.py`, `src/yoetz/adapters/memory/ledger.py`,
 `src/yoetz/application/publish_work.py`, and `src/yoetz/service/ready_composition.py`.
-**Relates to:** ADR-009, ADR-010, ADR-020, and issues #214, #216, #217, and #223.
+**Relates to:** ADR-009, ADR-010, ADR-020, and issues #214, #216, #217, #223, and #244.
 
 **Proposed amendment for issue #231:** `provider_not_ready` remains bounded local advice, but the
 observation coordinator does not materialize it as an agent-facing finding. Provider readiness is a
@@ -70,6 +71,22 @@ unsupported claims and unbounded duplicate findings.
    configuration and availability remain visible through observation advice before a check and
    through the check coverage vector and receipt limitations after one.
 
+9. Successful routine reads are rate-limited at the task-ledger boundary. The hook adapter labels
+   only a closed set of read tools and conservatively parsed single read-only shell commands as
+   `routine_read`; shell composition, redirection, mutation flags, unknown commands, and other
+   ambiguity fail closed to ordinary materialization. The complete hook envelope remains in the
+   bounded local observation store, but its pre-event and successful post-event do not mint
+   individual task-ledger records. A failed post-event still materializes action and result records,
+   and edits, checks, tests, lifecycle events, and other non-routine observations are unchanged.
+
+10. Every newly accepted observation-authored append records one bounded pending frontier-motion
+    notice for the originating Codex session. Contiguous undelivered appends coalesce their
+    from/to sequences and record count. A later advice-safe `PostToolUse` hook surfaces that the
+    motion was hook-observed, explains that held cooperative publish frontiers remain admissible
+    only across observation-authored motion, and directs exact-frontier operations to refresh
+    status. The notice is removed only after its bytes reach the hook consumer. It grants no
+    authority, changes no optimistic-concurrency predicate, and adds no MCP operation.
+
 ## Security and privacy consequences
 
 The observation writer id is derivable from public task/session identifiers, but derivation grants
@@ -87,4 +104,7 @@ own action, not unrelated third-party authorship.
 Cooperative work can retain a frontier across observation-only delivery, while real cooperative
 concurrency still conflicts. Check cases make progress by temporarily applying back-pressure to the
 outbox rather than weakening verdict binding. Observation can contribute evidence and bounded
-advice without impersonating the agent or minting the same standing finding indefinitely.
+advice without impersonating the agent or minting the same standing finding indefinitely. Routine
+reads retain their local observation evidence without producing an unbounded task-ledger trail, and
+cooperative writers learn about meaningful observation-authored frontier motion before their next
+state-sensitive operation.

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -44,7 +44,13 @@ from yoetz.domain.observation import (
     observation_envelope_to_json,
     workspace_commitment_from_path,
 )
-from yoetz.domain.values import JsonObject, JsonValue, Timestamp, timestamp_from_datetime
+from yoetz.domain.values import (
+    JsonObject,
+    JsonValue,
+    Timestamp,
+    timestamp_from_datetime,
+    validate_sha256_digest,
+)
 from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
 from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
 
@@ -56,6 +62,7 @@ except ImportError:  # pragma: no cover - the Yoetz service is hosted on POSIX
 __all__ = [
     "HOOK_MAPPING_VERSION",
     "AdviceDelivery",
+    "FrontierMotionNotice",
     "LocalObservationConsent",
     "LocalObservationStore",
     "ObservationOutboxRow",
@@ -276,6 +283,40 @@ class AdviceDelivery:
 
 
 @dataclass(frozen=True, slots=True)
+class FrontierMotionNotice:
+    """One bounded, one-shot notice that the observation writer moved a task frontier."""
+
+    from_sequence: int
+    to_sequence: int
+    head_digest: str
+    observation_record_count: int
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.from_sequence) is not int
+            or type(self.to_sequence) is not int
+            or type(self.observation_record_count) is not int
+            or not 0 <= self.from_sequence < self.to_sequence <= _MAX_SAFE_INTEGER
+            or not 1 <= self.observation_record_count <= self.to_sequence - self.from_sequence
+        ):
+            raise ProtocolValueError("invalid_event_value_type")
+        validate_sha256_digest(self.head_digest)
+
+    @property
+    def delivery_identity(self) -> str:
+        return canonical_digest(
+            JsonObject(
+                {
+                    "from_sequence": self.from_sequence,
+                    "head_digest": self.head_digest,
+                    "observation_record_count": self.observation_record_count,
+                    "to_sequence": self.to_sequence,
+                }
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class LocalObservationConsent:
     workspace_commitment: str
     granted_at: Timestamp
@@ -350,6 +391,7 @@ class _WorkspaceState:
     last_advice_suppression: str | None = None
     session_advice: dict[str, AdviceSnapshot] | None = None
     session_advice_suppression: dict[str, str] | None = None
+    frontier_motion_notices: dict[str, FrontierMotionNotice] | None = None
     open_pre: dict[str, str] | None = None
     stream_cursors: dict[str, ObservationCursor] | None = None
     stream_partials: dict[str, bytes] | None = None
@@ -418,6 +460,8 @@ class _WorkspaceState:
             self.session_advice = {}
         if self.session_advice_suppression is None:
             self.session_advice_suppression = {}
+        if self.frontier_motion_notices is None:
+            self.frontier_motion_notices = {}
 
 
 def _cursor_key(source: ObservationSource, session_commitment: str) -> str:
@@ -513,6 +557,7 @@ def _copy_state(state: _WorkspaceState) -> _WorkspaceState:
         unsupported_events=set(state.unsupported_events or ()),
         session_advice=dict(state.session_advice or {}),
         session_advice_suppression=dict(state.session_advice_suppression or {}),
+        frontier_motion_notices=dict(state.frontier_motion_notices or {}),
         open_pre=dict(state.open_pre or {}),
         stream_cursors=dict(state.stream_cursors or {}),
         stream_partials=dict(state.stream_partials or {}),
@@ -999,6 +1044,61 @@ class LocalObservationStore:
                 if state.last_advice_suppression == delivery_identity:
                     return
                 state.last_advice_suppression = delivery_identity
+            self._save(workspace, state)
+
+    def note_frontier_motion(
+        self,
+        workspace: str,
+        codex_session_id: str,
+        *,
+        from_sequence: int,
+        to_sequence: int,
+        head_digest: str,
+        observation_record_count: int,
+    ) -> None:
+        """Merge contiguous observation appends into one pending agent notice."""
+
+        candidate = FrontierMotionNotice(
+            from_sequence,
+            to_sequence,
+            head_digest,
+            observation_record_count,
+        )
+        with self._lock:
+            state = self._load(workspace)
+            assert state.frontier_motion_notices is not None
+            prior = state.frontier_motion_notices.get(codex_session_id)
+            if prior is not None and prior.to_sequence == candidate.from_sequence:
+                candidate = FrontierMotionNotice(
+                    prior.from_sequence,
+                    candidate.to_sequence,
+                    candidate.head_digest,
+                    prior.observation_record_count + candidate.observation_record_count,
+                )
+            elif prior is not None and candidate.to_sequence <= prior.to_sequence:
+                return
+            state.frontier_motion_notices[codex_session_id] = candidate
+            self._save(workspace, state)
+
+    def peek_frontier_motion(
+        self, workspace: str, codex_session_id: str
+    ) -> FrontierMotionNotice | None:
+        with self._lock:
+            state = self._load(workspace)
+            return (state.frontier_motion_notices or {}).get(codex_session_id)
+
+    def commit_frontier_motion_delivery(
+        self, workspace: str, codex_session_id: str, delivery_identity: str
+    ) -> None:
+        """Remove exactly the notice whose context bytes reached the hook consumer."""
+
+        with self._lock:
+            state = self._load(workspace)
+            notices = state.frontier_motion_notices or {}
+            current = notices.get(codex_session_id)
+            if current is None or current.delivery_identity != delivery_identity:
+                return
+            del notices[codex_session_id]
             self._save(workspace, state)
 
     def advice_snapshot_for(self, workspace: str) -> AdviceSnapshot | None:
@@ -2264,10 +2364,11 @@ class LocalObservationStore:
                 }
             )
         payload: dict[str, JsonValue] = {
-            # /5 adds terminal corruption-session tracking. /3 added quarantined_at per
+            # /6 adds one-shot task-frontier motion notices. /5 adds terminal
+            # corruption-session tracking. /3 added quarantined_at per
             # quarantine entry and the reclaimed counter. Readers tolerate both directions:
             # unknown keys are ignored and missing keys default safely.
-            "schema": "yoetz.observation-local/5",
+            "schema": "yoetz.observation-local/6",
             "workspace_commitment": workspace,
             "consent": consent_json,
             "session_workspaces": JsonObject(
@@ -2416,6 +2517,23 @@ class LocalObservationStore:
         if state.storage_corrupt_sessions:
             payload["storage_corrupt_sessions"] = tuple(
                 sorted(state.storage_corrupt_sessions, key=str.encode)
+            )
+        if state.frontier_motion_notices:
+            payload["frontier_motion_notices"] = JsonObject(
+                {
+                    key: JsonObject(
+                        {
+                            "from_sequence": notice.from_sequence,
+                            "head_digest": notice.head_digest,
+                            "observation_record_count": notice.observation_record_count,
+                            "to_sequence": notice.to_sequence,
+                        }
+                    )
+                    for key, notice in sorted(
+                        state.frontier_motion_notices.items(),
+                        key=lambda item: item[0].encode(),
+                    )
+                }
             )
         return payload
 
@@ -2657,6 +2775,22 @@ class LocalObservationStore:
         quarantine_reclaimed_count = (
             raw_quarantine_reclaimed_count if type(raw_quarantine_reclaimed_count) is int else 0
         )
+        frontier_motion_notices: dict[str, FrontierMotionNotice] = {}
+        for key, value in cast(
+            Mapping[str, JsonValue], raw.get("frontier_motion_notices") or {}
+        ).items():
+            if type(key) is not str or not isinstance(value, Mapping):
+                continue
+            notice = cast(Mapping[str, JsonValue], value)
+            try:
+                frontier_motion_notices[key] = FrontierMotionNotice(
+                    cast(int, notice.get("from_sequence")),
+                    cast(int, notice.get("to_sequence")),
+                    cast(str, notice.get("head_digest")),
+                    cast(int, notice.get("observation_record_count")),
+                )
+            except ProtocolValueError, TypeError, ValueError:
+                continue
         return _WorkspaceState(
             consent=consent,
             session_workspaces=session_workspaces,
@@ -2680,6 +2814,7 @@ class LocalObservationStore:
                 ).items()
                 if type(key) is str and type(value) is str
             },
+            frontier_motion_notices=frontier_motion_notices,
             open_pre=open_pre,
             stream_cursors=stream_cursors,
             stream_partials=stream_partials,

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -92,6 +92,7 @@ _MAX_QUARANTINE_AGE_DAYS: Final = 14
 # graph per workspace forever.
 _MAX_STATE_CACHE_ENTRIES: Final = 8
 _MAX_HOOK_SEQUENCES: Final = 256
+_MAX_FRONTIER_MOTION_NOTICES: Final = 256
 _MAX_SAFE_INTEGER: Final = 9_007_199_254_740_991
 # Wall/monotonic drift tolerated before persisted monotonic samples are treated
 # as belonging to a different boot epoch (and therefore fenced off).
@@ -478,6 +479,26 @@ def _load_session_advice(raw: object) -> dict[str, AdviceSnapshot]:
         try:
             result[key] = advice_snapshot_from_json(
                 JsonObject(cast(Mapping[str, JsonValue], value))
+            )
+        except ProtocolValueError, TypeError, ValueError:
+            continue
+    return result
+
+
+def _load_frontier_motion_notices(raw: object) -> dict[str, FrontierMotionNotice]:
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, FrontierMotionNotice] = {}
+    for key, value in cast(Mapping[str, JsonValue], raw).items():
+        if type(key) is not str or not isinstance(value, Mapping):
+            continue
+        notice = cast(Mapping[str, JsonValue], value)
+        try:
+            result[key] = FrontierMotionNotice(
+                cast(int, notice.get("from_sequence")),
+                cast(int, notice.get("to_sequence")),
+                cast(str, notice.get("head_digest")),
+                cast(int, notice.get("observation_record_count")),
             )
         except ProtocolValueError, TypeError, ValueError:
             continue
@@ -2085,6 +2106,21 @@ class LocalObservationStore:
         if len(kept) != len(state.quarantine):
             state.quarantine[:] = kept
 
+    def _prune_frontier_motion_notices(self, state: _WorkspaceState) -> None:
+        """Drop ended-session notices and cap the per-workspace mapping."""
+
+        notices = state.frontier_motion_notices
+        if not notices:
+            return
+        ended = state.ended_sessions or set()
+        bindings = state.codex_session_bindings or {}
+        for session_id in tuple(notices):
+            commitment = bindings.get(session_id)
+            if commitment is not None and commitment in ended:
+                del notices[session_id]
+        while len(notices) > _MAX_FRONTIER_MOTION_NOTICES:
+            del notices[next(iter(notices))]
+
     def _save(
         self,
         workspace_commitment: str,
@@ -2105,8 +2141,14 @@ class LocalObservationStore:
         _ensure_dir(directory)
         path = self._workspace_path(workspace_commitment)
         quarantined_before = len(state.quarantine or ())
+        notices_before = len(state.frontier_motion_notices or ())
         self._prune_expired_quarantine(state)
-        if projected is not None and len(state.quarantine or ()) == quarantined_before:
+        self._prune_frontier_motion_notices(state)
+        if (
+            projected is not None
+            and len(state.quarantine or ()) == quarantined_before
+            and len(state.frontier_motion_notices or ()) == notices_before
+        ):
             payload = projected
         else:
             payload = canonical_encode(self._state_to_json(workspace_commitment, state)) + b"\n"
@@ -2775,22 +2817,7 @@ class LocalObservationStore:
         quarantine_reclaimed_count = (
             raw_quarantine_reclaimed_count if type(raw_quarantine_reclaimed_count) is int else 0
         )
-        frontier_motion_notices: dict[str, FrontierMotionNotice] = {}
-        for key, value in cast(
-            Mapping[str, JsonValue], raw.get("frontier_motion_notices") or {}
-        ).items():
-            if type(key) is not str or not isinstance(value, Mapping):
-                continue
-            notice = cast(Mapping[str, JsonValue], value)
-            try:
-                frontier_motion_notices[key] = FrontierMotionNotice(
-                    cast(int, notice.get("from_sequence")),
-                    cast(int, notice.get("to_sequence")),
-                    cast(str, notice.get("head_digest")),
-                    cast(int, notice.get("observation_record_count")),
-                )
-            except ProtocolValueError, TypeError, ValueError:
-                continue
+        frontier_motion_notices = _load_frontier_motion_notices(raw.get("frontier_motion_notices"))
         return _WorkspaceState(
             consent=consent,
             session_workspaces=session_workspaces,

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -113,6 +113,7 @@ from yoetz.ports.ids import IdPort
 from yoetz.ports.ledger import (
     AppendCommand,
     AppendEntry,
+    AppendResult,
     OperationKind,
     ProjectionView,
 )
@@ -488,7 +489,7 @@ class ObservationCoordinator:
                         legacy_writer_id=mapping.yoetz_writer_id,
                     )
                     if claim is not None:
-                        operation_id, materialization_digest = claim
+                        operation_id, materialization_digest, append_result = claim
                         store.record_logical_identity_claim(
                             workspace=workspace,
                             logical_identity=canonical_logical_identity(envelope),
@@ -498,6 +499,18 @@ class ObservationCoordinator:
                             mapping_version=envelope.cursor.mapping_version,
                             materialized_at=timestamp_from_datetime(self.clock.now_utc()),
                         )
+                        if append_result is not None and append_result.outcome == "accepted":
+                            await self._local(
+                                partial(
+                                    self.local.note_frontier_motion,
+                                    workspace,
+                                    codex_session_id,
+                                    from_sequence=append_result.subject_frontier.sequence,
+                                    to_sequence=append_result.result_frontier.sequence,
+                                    head_digest=append_result.result_frontier.head_digest,
+                                    observation_record_count=len(append_result.accepted),
+                                )
+                            )
 
                 stage = "verification"
                 await self._enqueue_verification(
@@ -633,7 +646,7 @@ class ObservationCoordinator:
         batch: MaterializedObservationBatch,
         *,
         legacy_writer_id: str | None = None,
-    ) -> tuple[str, str] | None:
+    ) -> tuple[str, str, AppendResult | None] | None:
         writer_id = runtime.writer_id
         if writer_id is None:
             return None
@@ -650,7 +663,7 @@ class ObservationCoordinator:
         operation_id = self._stable_operation_id(digest)
         existing = await runtime.ledger.lookup_operation(writer_id, operation_id)
         if existing is not None:
-            return operation_id, digest
+            return operation_id, digest, None
         if legacy_writer_id is not None and legacy_writer_id != writer_id:
             legacy_digest = observation_operation_digest(
                 task_id=runtime.task_id,
@@ -664,7 +677,7 @@ class ObservationCoordinator:
                 await runtime.ledger.lookup_operation(legacy_writer_id, legacy_operation_id)
                 is not None
             ):
-                return legacy_operation_id, legacy_digest
+                return legacy_operation_id, legacy_digest, None
 
         author = observation_author()
         refs: list[ObjectRef] = []
@@ -722,8 +735,8 @@ class ObservationCoordinator:
             tuple(refs),
             command,
         )
-        await run_prepared_append(runtime.ledger, mutation)
-        return operation_id, digest
+        append_result = await run_prepared_append(runtime.ledger, mutation)
+        return operation_id, digest, append_result
 
     async def _materialize_approved_check(
         self,

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from functools import partial
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Final, Protocol, cast
+from typing import Any, Final, Literal, Protocol, cast
 
 from yoetz.adapters.approved_checks import ApprovedCheckRunner, ApprovedCheckStatus
 from yoetz.adapters.git_subject_state import (
@@ -100,6 +100,7 @@ from yoetz.domain.values import (
     action_id,
     event_id,
     evidence_id,
+    frontier_from_json,
     object_id,
     result_id,
     timestamp_from_datetime,
@@ -111,10 +112,14 @@ from yoetz.observability.privacy import redact_sensitive_content
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.ids import IdPort
 from yoetz.ports.ledger import (
+    AcceptedEventSummary,
     AppendCommand,
     AppendEntry,
     AppendResult,
+    AppendWarning,
     OperationKind,
+    OperationRecord,
+    OperationState,
     ProjectionView,
 )
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource
@@ -154,6 +159,52 @@ def _materialized_advice_items(items: Sequence[AdviceItem]) -> tuple[AdviceItem,
         for item in items
         if item.origin == "deterministic" and item.rule_code in _ADVICE_FINDING_KIND_BY_RULE
     )
+
+
+def _append_result_from_committed(record: object) -> AppendResult | None:
+    """Rebuild frontier metadata from a completed append so retry can note motion."""
+
+    if type(record) is not OperationRecord:
+        return None
+    if record.state is not OperationState.COMPLETE or record.result_canonical is None:
+        return None
+    try:
+        parsed = strict_json_parse(record.result_canonical)
+    except ProtocolValueError, TypeError, ValueError:
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    result_map = cast(Mapping[str, object], parsed)
+    accepted_raw = result_map.get("accepted")
+    if not isinstance(accepted_raw, list | tuple) or not accepted_raw:
+        return None
+    try:
+        accepted = tuple(
+            AcceptedEventSummary(
+                cast(str, item["event_id"]),
+                int(cast(str, item["ingestion_sequence"])),
+                int(cast(str, item["writer_sequence"])),
+                cast(str, item["entry_digest"]),
+                cast(
+                    Literal["projected", "unknown_unprojected"],
+                    item["projection_status"],
+                ),
+            )
+            for item in cast(tuple[Mapping[str, object], ...], accepted_raw)
+        )
+        warnings_raw = result_map.get("warnings") or ()
+        warnings = tuple(
+            AppendWarning(cast(str, value)) for value in cast(tuple[object, ...], warnings_raw)
+        )
+        return AppendResult(
+            "replayed",
+            accepted,
+            frontier_from_json(result_map["subject_frontier"]),
+            frontier_from_json(result_map["result_frontier"]),
+            warnings,
+        )
+    except KeyError, ProtocolValueError, TypeError, ValueError:
+        return None
 
 
 __all__ = [
@@ -499,7 +550,7 @@ class ObservationCoordinator:
                             mapping_version=envelope.cursor.mapping_version,
                             materialized_at=timestamp_from_datetime(self.clock.now_utc()),
                         )
-                        if append_result is not None and append_result.outcome == "accepted":
+                        if append_result is not None:
                             await self._local(
                                 partial(
                                     self.local.note_frontier_motion,
@@ -663,7 +714,7 @@ class ObservationCoordinator:
         operation_id = self._stable_operation_id(digest)
         existing = await runtime.ledger.lookup_operation(writer_id, operation_id)
         if existing is not None:
-            return operation_id, digest, None
+            return operation_id, digest, _append_result_from_committed(existing)
         if legacy_writer_id is not None and legacy_writer_id != writer_id:
             legacy_digest = observation_operation_digest(
                 task_id=runtime.task_id,
@@ -673,11 +724,15 @@ class ObservationCoordinator:
                 draft_roles=tuple(item.role for item in batch.drafts),
             )
             legacy_operation_id = self._stable_operation_id(legacy_digest)
-            if (
-                await runtime.ledger.lookup_operation(legacy_writer_id, legacy_operation_id)
-                is not None
-            ):
-                return legacy_operation_id, legacy_digest, None
+            legacy_existing = await runtime.ledger.lookup_operation(
+                legacy_writer_id, legacy_operation_id
+            )
+            if legacy_existing is not None:
+                return (
+                    legacy_operation_id,
+                    legacy_digest,
+                    _append_result_from_committed(legacy_existing),
+                )
 
         author = observation_author()
         refs: list[ObjectRef] = []

--- a/src/yoetz/application/observation_materialize.py
+++ b/src/yoetz/application/observation_materialize.py
@@ -284,8 +284,16 @@ def materialize_observation_envelope(
         return MaterializedObservationBatch((), coverage, channel, gaps, "lifecycle_only")
 
     drafts: list[MaterializedObservationDraft] = []
+    routine_read = structural.get("action") == "routine_read"
 
     if kind == "PreToolUse":
+        if routine_read:
+            # The full envelope remains in the observation store. Successful read-only calls are
+            # rate-limited at the task-ledger boundary rather than minting one pending action per
+            # file lookup; a failed PostToolUse still materializes below.
+            return MaterializedObservationBatch(
+                (), coverage, channel, gaps, "routine_read_deferred"
+            )
         if correlation is None:
             return MaterializedObservationBatch(
                 (), coverage, channel, gaps, "missing_tool_identity"
@@ -329,6 +337,10 @@ def materialize_observation_envelope(
         return MaterializedObservationBatch(tuple(drafts), coverage, channel, gaps, None)
 
     if kind == "PostToolUse":
+        if routine_read and _exit_status(structural) in {None, 0}:
+            return MaterializedObservationBatch(
+                (), coverage, channel, gaps, "routine_read_coalesced"
+            )
         if unpaired or correlation is None:
             # Standalone structural observation: evidence only; do not invent the action.
             evidence = stable_observation_id(

--- a/src/yoetz/application/observation_materialize.py
+++ b/src/yoetz/application/observation_materialize.py
@@ -160,6 +160,14 @@ def _exit_status(payload: Mapping[str, JsonValue]) -> int | None:
     return None
 
 
+def _explicit_post_failure(payload: Mapping[str, JsonValue]) -> bool:
+    """True when a post-event is an explicit failure or denial, not status-unknown."""
+
+    if _exit_status(payload) not in {None, 0}:
+        return True
+    return payload.get("success") is False or payload.get("denied") is True
+
+
 def _action_kind(tool: str | None) -> ActionKind:
     if tool is None:
         return ActionKind.OTHER
@@ -337,7 +345,7 @@ def materialize_observation_envelope(
         return MaterializedObservationBatch(tuple(drafts), coverage, channel, gaps, None)
 
     if kind == "PostToolUse":
-        if routine_read and _exit_status(structural) in {None, 0}:
+        if routine_read and not _explicit_post_failure(structural):
             return MaterializedObservationBatch(
                 (), coverage, channel, gaps, "routine_read_coalesced"
             )

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import shlex
 import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping
@@ -23,6 +24,7 @@ from yoetz.adapters.integrations.observation_local import (
     HOOK_MAPPING_VERSION,
     YOETZ_TOOL_NAMES,
     AdviceDelivery,
+    FrontierMotionNotice,
     LocalObservationStore,
     ObservationOutboxRow,
 )
@@ -122,6 +124,21 @@ _HOOK_CONNECT_PREFLIGHT_SECONDS: Final = 1.0
 # Never an abort point: the drain and preflight budgets own enforcement.
 _HOOK_TOTAL_BUDGET_SECONDS: Final = 1.0
 _TIMING_REPORT_EVENTS: Final = frozenset({"SessionStart", "Stop", "SessionEnd"})
+_ROUTINE_READ_TOOLS: Final = frozenset(
+    {
+        "glob",
+        "grep",
+        "list_files",
+        "read",
+        "read_file",
+        "search",
+        "view_file",
+    }
+)
+_SHELL_TOOLS: Final = frozenset(
+    {"bash", "command", "exec", "exec_command", "local_shell", "run_terminal_cmd", "shell"}
+)
+_READ_ONLY_COMMANDS: Final = frozenset({"head", "ls", "pwd", "rg", "tail", "wc"})
 _STRUCTURAL_ALLOW: Final = frozenset(
     {
         "tool_name",
@@ -229,6 +246,50 @@ def _bool_or_none(value: object) -> bool | None:
     return value if type(value) is bool else None
 
 
+def _routine_read_action(payload: Mapping[str, JsonValue]) -> bool:
+    """Recognize a deliberately narrow, side-effect-free tool invocation.
+
+    The returned bit is structural only; command text remains visible-content input and is never
+    copied into the observation envelope. Ambiguous shell syntax fails closed to ordinary
+    materialization. This is a rate policy, not a general shell-effect analyzer.
+    """
+
+    tool = _token_or_none(payload.get("tool_name"))
+    if tool is None:
+        return False
+    lowered = tool.lower()
+    if lowered in _ROUTINE_READ_TOOLS:
+        return True
+    if lowered not in _SHELL_TOOLS:
+        return False
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, Mapping):
+        return False
+    nested = cast(Mapping[str, JsonValue], tool_input)
+    raw = nested.get("cmd") or nested.get("command")
+    if type(raw) is not str or not raw or len(raw) > 16_384:
+        return False
+    # Multiple commands, redirection, substitution, and pipelines require a real shell parser.
+    # They remain ordinary observations rather than being optimistically labelled read-only.
+    if any(marker in raw for marker in ("\n", "\r", ";", "&", "|", ">", "<", "`", "$(")):
+        return False
+    try:
+        argv = shlex.split(raw, posix=True)
+    except ValueError:
+        return False
+    if not argv:
+        return False
+    command = argv[0].rsplit("/", 1)[-1]
+    if command == "rg" and any(arg == "--pre" or arg.startswith("--pre=") for arg in argv[1:]):
+        # ripgrep's preprocessor is an arbitrary executable, not a read primitive.
+        return False
+    if command in _READ_ONLY_COMMANDS:
+        return True
+    if command == "git" and len(argv) >= 2:
+        return argv[1] in {"diff", "log", "rev-parse", "show", "status"}
+    return False
+
+
 def _extract_structural(payload: Mapping[str, JsonValue], event_name: str) -> JsonObject:
     fields: dict[str, JsonValue] = {"hook_name": event_name}
     tool_name = _token_or_none(payload.get("tool_name"))
@@ -264,6 +325,9 @@ def _extract_structural(payload: Mapping[str, JsonValue], event_name: str) -> Js
         digest = _token_or_none(nested.get("changed_paths_digest"))
         if digest is not None and "changed_paths_digest" not in fields:
             fields["changed_paths_digest"] = digest
+    if event_name in {"PreToolUse", "PostToolUse"} and _routine_read_action(payload):
+        # Service-owned classification overrides an untrusted host-supplied action token.
+        fields["action"] = "routine_read"
     for key in ("exit_status", "duration_ms", "event_ordinal", "attempt"):
         number = _int_or_none(payload.get(key))
         if number is not None:
@@ -544,6 +608,16 @@ def _cached_recommendation_context(*, _state: Path | None) -> str:
         f"for approval; if approved run 'yoetz recommend accept {item.id}', "
         f"otherwise 'yoetz recommend decline {item.id}'."
     )[:_MAX_ADVICE_CONTEXT]
+
+
+def _frontier_motion_context(notice: FrontierMotionNotice) -> str:
+    return (
+        "Yoetz: task frontier moved from "
+        f"{notice.from_sequence} to {notice.to_sequence} when the Yoetz observation writer "
+        f"appended {notice.observation_record_count} ledger record(s). "
+        "Held publish frontiers remain valid across observation-only motion; "
+        "run status before an exact-frontier check."
+    )
 
 
 async def _try_service_ingest(
@@ -1227,6 +1301,7 @@ def handle_observe(
         # a blocked host pipe delays advice, never observation ingest or outbox work.
         # Commit remains after emit, so a failed write never suppresses a later delivery.
         pending_delivery: AdviceDelivery | None = None
+        pending_frontier_notice: FrontierMotionNotice | None = None
         delivery_session_id: str | None = None
         delivery_eligible = (
             not additional and resolved_event in ADVICE_SAFE_EVENTS and not skip_advice_loop
@@ -1239,6 +1314,12 @@ def handle_observe(
         with delivery_gate as delivery_acquired:
             if delivery_eligible and delivery_acquired:
                 delivery_session_id = None if mapping is None else mapping.yoetz_session_id
+                if resolved_event == "PostToolUse":
+                    pending_frontier_notice = store.peek_frontier_motion(
+                        workspace_commitment, codex_session_id
+                    )
+                    if pending_frontier_notice is not None:
+                        additional = _frontier_motion_context(pending_frontier_notice)
                 delivery = store.peek_advice_for_delivery(
                     workspace_commitment,
                     yoetz_session_id=delivery_session_id,
@@ -1246,7 +1327,9 @@ def handle_observe(
                     session_commitment=session_commitment,
                 )
                 if delivery is not None:
-                    additional = delivery.text[:_MAX_ADVICE_CONTEXT]
+                    additional = " ".join(part for part in (additional, delivery.text) if part)[
+                        :_MAX_ADVICE_CONTEXT
+                    ]
                     pending_delivery = delivery
 
             # Release recommendations are read from one bounded local cache only.
@@ -1270,6 +1353,13 @@ def handle_observe(
                         pending_delivery.delivery_identity,
                         yoetz_session_id=delivery_session_id,
                         session_commitment=session_commitment,
+                    )
+            if emitted and pending_frontier_notice is not None:
+                with contextlib.suppress(BaseException):
+                    store.commit_frontier_motion_delivery(
+                        workspace_commitment,
+                        codex_session_id,
+                        pending_frontier_notice.delivery_identity,
                     )
         _record_pass_timing(
             resolved_event,

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -279,13 +279,23 @@ def _routine_read_action(payload: Mapping[str, JsonValue]) -> bool:
         return False
     if not argv:
         return False
-    command = argv[0].rsplit("/", 1)[-1]
+    command = argv[0]
+    if "/" in command or "\\" in command:
+        # Path-qualified names are not the closed basename set; a local `./ls`
+        # or `/tmp/head` is an arbitrary executable, not a trusted read tool.
+        return False
     if command == "rg" and any(arg == "--pre" or arg.startswith("--pre=") for arg in argv[1:]):
         # ripgrep's preprocessor is an arbitrary executable, not a read primitive.
         return False
     if command in _READ_ONLY_COMMANDS:
         return True
     if command == "git" and len(argv) >= 2:
+        if any(
+            arg == "--ext-diff" or arg == "--output" or arg.startswith("--output=")
+            for arg in argv[1:]
+        ):
+            # `--output` writes a file; `--ext-diff` runs an external helper.
+            return False
         return argv[1] in {"diff", "log", "rev-parse", "show", "status"}
     return False
 
@@ -325,8 +335,17 @@ def _extract_structural(payload: Mapping[str, JsonValue], event_name: str) -> Js
         digest = _token_or_none(nested.get("changed_paths_digest"))
         if digest is not None and "changed_paths_digest" not in fields:
             fields["changed_paths_digest"] = digest
-    if event_name in {"PreToolUse", "PostToolUse"} and _routine_read_action(payload):
+    success = _bool_or_none(payload.get("success"))
+    denied = _bool_or_none(payload.get("denied"))
+    if (
+        event_name in {"PreToolUse", "PostToolUse"}
+        and _routine_read_action(payload)
+        and success is not False
+        and denied is not True
+    ):
         # Service-owned classification overrides an untrusted host-supplied action token.
+        # Explicit failures and denials stay ordinary observations even when the
+        # tool name would otherwise be a routine read.
         fields["action"] = "routine_read"
     for key in ("exit_status", "duration_ms", "event_ordinal", "attempt"):
         number = _int_or_none(payload.get(key))

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -131,6 +131,43 @@ def test_materialize_pre_post_and_unpaired() -> None:
     assert ObservationGapCode.UNPAIRED_EVENT.value in unpaired.gaps
 
 
+def test_successful_routine_reads_stay_observation_only_but_failures_materialize() -> None:
+    task = _task_id()
+    session = f"hmac-sha256:{'ed' * 32}"
+    pre = _envelope(session=session, kind="PreToolUse", identity="hook:read-pre")
+    pre_structural = JsonObject({**pre.structural_payload, "action": "routine_read"})
+    deferred = materialize_observation_envelope(
+        replace(pre, structural_payload=pre_structural), task_id=task
+    )
+    assert deferred.drafts == ()
+    assert deferred.skip_reason == "routine_read_deferred"
+
+    post = _envelope(
+        session=session,
+        kind="PostToolUse",
+        identity="hook:read-post",
+        exit_status=0,
+    )
+    post_structural = JsonObject({**post.structural_payload, "action": "routine_read"})
+    coalesced = materialize_observation_envelope(
+        replace(post, structural_payload=post_structural), task_id=task
+    )
+    assert coalesced.drafts == ()
+    assert coalesced.skip_reason == "routine_read_coalesced"
+
+    failed = materialize_observation_envelope(
+        replace(
+            post,
+            structural_payload=JsonObject({**post_structural, "exit_status": 1}),
+        ),
+        task_id=task,
+    )
+    assert [item.draft.schema.name for item in failed.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+
+
 def test_completion_signal_is_evidence_unless_claim_kind_is_explicit() -> None:
     task = _task_id()
     session = f"hmac-sha256:{'ac' * 32}"
@@ -227,6 +264,41 @@ def test_local_outbox_enqueue_ack_and_overflow(tmp_path: Path) -> None:
     assert store.pending_outbox_count(workspace) == 1
     assert store.acknowledge_outbox(workspace, "sess-outbox", envelope.source_identity) is True
     assert store.pending_outbox_count(workspace) == 0
+
+
+def test_frontier_motion_notice_merges_contiguous_appends_and_is_one_shot(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.note_frontier_motion(
+        workspace,
+        "motion-session",
+        from_sequence=7,
+        to_sequence=9,
+        head_digest="sha256:" + "1" * 64,
+        observation_record_count=2,
+    )
+    store.note_frontier_motion(
+        workspace,
+        "motion-session",
+        from_sequence=9,
+        to_sequence=10,
+        head_digest="sha256:" + "2" * 64,
+        observation_record_count=1,
+    )
+
+    reloaded = LocalObservationStore(_state=tmp_path)
+    notice = reloaded.peek_frontier_motion(workspace, "motion-session")
+    assert notice is not None
+    assert (notice.from_sequence, notice.to_sequence, notice.observation_record_count) == (7, 10, 3)
+    assert notice.head_digest == "sha256:" + "2" * 64
+
+    reloaded.commit_frontier_motion_delivery(workspace, "motion-session", "sha256:" + "0" * 64)
+    assert reloaded.peek_frontier_motion(workspace, "motion-session") == notice
+    reloaded.commit_frontier_motion_delivery(workspace, "motion-session", notice.delivery_identity)
+    assert reloaded.peek_frontier_motion(workspace, "motion-session") is None
 
 
 def test_outbox_ack_does_not_clear_source_reported_overflow(tmp_path: Path) -> None:
@@ -366,7 +438,7 @@ def test_local_outbox_v1_compatibility_and_v2_attempt_round_trip(tmp_path: Path)
     assert durable.last_reason == ObservationGapCode.MAPPING_MISSING.value
     assert durable.last_attempt_at == attempted_at
     assert json.loads(state_path.read_text(encoding="utf-8"))["schema"] == (
-        "yoetz.observation-local/5"
+        "yoetz.observation-local/6"
     )
 
 

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
 import time
 import uuid
 from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -37,7 +39,9 @@ from yoetz.domain.observation import (
     observation_ingest_request_to_json,
 )
 from yoetz.domain.values import JsonObject, Timestamp, finding_id
+from yoetz.ports.ledger import CheckPhase, OperationKind, OperationRecord, OperationState
 from yoetz.ports.runtime import TaskRuntime
+from yoetz.protocol.canonical import canonical_encode
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import PREFIX_BY_KIND, IdKind
 
@@ -167,6 +171,30 @@ def test_successful_routine_reads_stay_observation_only_but_failures_materialize
         "result_recorded",
     ]
 
+    denied = materialize_observation_envelope(
+        replace(
+            post,
+            structural_payload=JsonObject({**post_structural, "denied": True}),
+        ),
+        task_id=task,
+    )
+    assert [item.draft.schema.name for item in denied.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+
+    marked_failed = materialize_observation_envelope(
+        replace(
+            post,
+            structural_payload=JsonObject({**post_structural, "success": False}),
+        ),
+        task_id=task,
+    )
+    assert [item.draft.schema.name for item in marked_failed.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+
 
 def test_completion_signal_is_evidence_unless_claim_kind_is_explicit() -> None:
     task = _task_id()
@@ -250,6 +278,93 @@ async def test_live_upgrade_finds_materialization_under_legacy_writer(tmp_path: 
     ]
 
 
+@pytest.mark.anyio
+async def test_existing_operation_reconstructs_frontier_motion_metadata(tmp_path: Path) -> None:
+    from types import SimpleNamespace
+
+    task_id = _task_id()
+    session_id = PREFIX_BY_KIND[IdKind.SESSION] + str(uuid.uuid4())
+    writer_id = observation_writer_id(task_id, session_id)
+    envelope = _envelope(session=f"hmac-sha256:{'af' * 32}", identity="hook:replay-motion")
+    batch = materialize_observation_envelope(envelope, task_id=task_id)
+    canonical = canonical_encode(
+        {
+            "accepted": (
+                {
+                    "entry_digest": "sha256:" + "a" * 64,
+                    "event_id": PREFIX_BY_KIND[IdKind.EVENT] + str(uuid.uuid4()),
+                    "ingestion_sequence": "4",
+                    "projection_status": "projected",
+                    "writer_sequence": "1",
+                },
+            ),
+            "result_frontier": {"head_digest": "sha256:" + "c" * 64, "sequence": "5"},
+            "subject_frontier": {"head_digest": "sha256:" + "b" * 64, "sequence": "3"},
+            "warnings": (),
+        }
+    )
+    existing = OperationRecord(
+        writer_id,
+        PREFIX_BY_KIND[IdKind.REQUEST] + str(uuid.uuid4()),
+        OperationKind.PUBLISH_WORK,
+        "sha256:" + "d" * 64,
+        OperationState.COMPLETE,
+        CheckPhase.TERMINAL,
+        None,
+        None,
+        None,
+        None,
+        None,
+        canonical,
+        "sha256:" + hashlib.sha256(canonical).hexdigest(),
+        None,
+        None,
+        datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    class _Ledger:
+        async def lookup_operation(self, looked_up_writer: str, operation_id: str):
+            del looked_up_writer, operation_id
+            return existing
+
+    class _Clock:
+        def now_utc(self) -> Timestamp:
+            return Timestamp("2026-01-01T00:00:00.000Z")
+
+    class _Ids:
+        def new(self, kind: IdKind) -> str:
+            return PREFIX_BY_KIND[kind] + str(uuid.uuid4())
+
+    coordinator = ObservationCoordinator(
+        runtime=object(),  # type: ignore[arg-type]
+        local=LocalObservationStore(_state=tmp_path),
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=_Ids(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+    )
+    runtime = SimpleNamespace(
+        task_id=task_id,
+        session_id=session_id,
+        writer_id=writer_id,
+        ledger=_Ledger(),
+    )
+
+    recovered = await coordinator._append_materialized(  # pyright: ignore[reportPrivateUsage]
+        cast(TaskRuntime, runtime),
+        envelope,
+        batch,
+    )
+
+    assert recovered is not None
+    _operation_id, _digest, append_result = recovered
+    assert append_result is not None
+    assert append_result.outcome == "replayed"
+    assert append_result.subject_frontier.sequence == 3
+    assert append_result.result_frontier.sequence == 5
+    assert append_result.result_frontier.head_digest == "sha256:" + "c" * 64
+    assert len(append_result.accepted) == 1
+
+
 def test_local_outbox_enqueue_ack_and_overflow(tmp_path: Path) -> None:
     store = LocalObservationStore(_state=tmp_path)
     workspace = store.workspace_commitment(str(tmp_path.resolve()))
@@ -299,6 +414,72 @@ def test_frontier_motion_notice_merges_contiguous_appends_and_is_one_shot(
     assert reloaded.peek_frontier_motion(workspace, "motion-session") == notice
     reloaded.commit_frontier_motion_delivery(workspace, "motion-session", notice.delivery_identity)
     assert reloaded.peek_frontier_motion(workspace, "motion-session") is None
+
+
+def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.bind_codex_session(workspace, "live-session")
+    store.note_frontier_motion(
+        workspace,
+        "live-session",
+        from_sequence=1,
+        to_sequence=2,
+        head_digest="sha256:" + "4" * 64,
+        observation_record_count=1,
+    )
+    state_path = store._workspace_path(workspace)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    raw["frontier_motion_notices"] = []
+    state_path.write_text(json.dumps(raw), encoding="utf-8")
+    assert (
+        LocalObservationStore(_state=tmp_path).peek_frontier_motion(workspace, "live-session")
+        is None
+    )
+
+    store = LocalObservationStore(_state=tmp_path)
+    store.grant_consent(workspace)
+    ended = store.bind_codex_session(workspace, "ended-session")
+    store.note_frontier_motion(
+        workspace,
+        "ended-session",
+        from_sequence=2,
+        to_sequence=3,
+        head_digest="sha256:" + "5" * 64,
+        observation_record_count=1,
+    )
+    store.note_session_end(workspace, ended)
+    assert store.peek_frontier_motion(workspace, "ended-session") is None
+
+
+def test_frontier_motion_notices_are_capped(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    digest = "sha256:" + "6" * 64
+    over_cap = 257
+    for index in range(over_cap):
+        store.note_frontier_motion(
+            workspace,
+            f"session-{index}",
+            from_sequence=index + 1,
+            to_sequence=index + 2,
+            head_digest=digest,
+            observation_record_count=1,
+        )
+    reloaded = LocalObservationStore(_state=tmp_path)
+    surviving = [
+        session
+        for index in range(over_cap)
+        if (session := f"session-{index}")
+        and reloaded.peek_frontier_motion(workspace, session) is not None
+    ]
+    assert len(surviving) == over_cap - 1
+    assert "session-0" not in surviving
+    assert "session-256" in surviving
 
 
 def test_outbox_ack_does_not_clear_source_reported_overflow(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -150,6 +150,38 @@ def test_identical_tool_calls_remain_distinct(tmp_path: Path) -> None:
     assert first.source_identity != second.source_identity
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "expected"),
+    [
+        ("Read", {"path": "ignored"}, True),
+        ("exec_command", {"cmd": "rg -n observation src tests"}, True),
+        ("exec_command", {"cmd": "git status --short"}, True),
+        ("exec_command", {"cmd": "sed -n '1,20p' README.md"}, False),
+        ("exec_command", {"cmd": "sed -i s/a/b/ README.md"}, False),
+        ("exec_command", {"cmd": "rg --pre ./prepare term src"}, False),
+        ("exec_command", {"cmd": "rg term src | tee report.txt"}, False),
+        ("exec_command", {"cmd": "pytest -q"}, False),
+    ],
+)
+def test_routine_read_classification_is_conservative_and_structural(
+    tool_name: str, tool_input: dict[str, str], expected: bool
+) -> None:
+    envelope = map_hook_payload_to_envelope(
+        "PostToolUse",
+        {
+            "session_id": "routine-read",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "exit_status": 0,
+        },
+        session_commitment=f"hmac-sha256:{'11' * 32}",
+        event_ordinal=1,
+        key_material=_KEY,
+    )
+    assert (envelope.structural_payload.get("action") == "routine_read") is expected
+    assert "cmd" not in envelope.structural_payload
+
+
 def test_observe_without_consent_exits_zero_no_spool(tmp_path: Path) -> None:
     stdout = io.BytesIO()
     code = handle_observe(
@@ -164,6 +196,55 @@ def test_observe_without_consent_exits_zero_no_spool(tmp_path: Path) -> None:
     )
     assert code == 0
     assert json.loads(stdout.getvalue().decode()) == {}
+
+
+def test_post_tool_hook_delivers_pending_frontier_motion_once(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.bind_codex_session(workspace, "frontier-motion")
+    store.note_frontier_motion(
+        workspace,
+        "frontier-motion",
+        from_sequence=4,
+        to_sequence=6,
+        head_digest="sha256:" + "3" * 64,
+        observation_record_count=2,
+    )
+
+    payload = json.dumps(
+        {"session_id": "frontier-motion", "tool_name": "Read", "exit_status": 0}
+    ).encode()
+    first = io.BytesIO()
+    assert (
+        handle_observe(
+            event_name="PostToolUse",
+            stdin_bytes=payload,
+            stdout=first,
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+    context = json.loads(first.getvalue())["hookSpecificOutput"]["additionalContext"]
+    assert "task frontier moved from 4 to 6" in context
+    assert "observation writer appended 2 ledger record(s)" in context
+    assert "run status before an exact-frontier check" in context
+
+    second = io.BytesIO()
+    assert (
+        handle_observe(
+            event_name="PostToolUse",
+            stdin_bytes=payload,
+            stdout=second,
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+    assert "task frontier moved" not in second.getvalue().decode()
 
 
 def test_stdout_teardown_failure_exits_zero_and_records_diagnostic(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -161,6 +161,10 @@ def test_identical_tool_calls_remain_distinct(tmp_path: Path) -> None:
         ("exec_command", {"cmd": "rg --pre ./prepare term src"}, False),
         ("exec_command", {"cmd": "rg term src | tee report.txt"}, False),
         ("exec_command", {"cmd": "pytest -q"}, False),
+        ("exec_command", {"cmd": "./ls"}, False),
+        ("exec_command", {"cmd": "/tmp/head README.md"}, False),
+        ("exec_command", {"cmd": "git diff --output=result.patch"}, False),
+        ("exec_command", {"cmd": "git diff --ext-diff HEAD"}, False),
     ],
 )
 def test_routine_read_classification_is_conservative_and_structural(
@@ -180,6 +184,34 @@ def test_routine_read_classification_is_conservative_and_structural(
     )
     assert (envelope.structural_payload.get("action") == "routine_read") is expected
     assert "cmd" not in envelope.structural_payload
+
+
+@pytest.mark.parametrize(
+    ("payload_extra", "expected_routine"),
+    [
+        ({"exit_status": 0}, True),
+        ({"success": True}, True),
+        ({"success": False}, False),
+        ({"denied": True}, False),
+        ({"success": False, "exit_status": 0}, False),
+    ],
+)
+def test_routine_read_label_excludes_explicit_failures(
+    payload_extra: dict[str, bool | int], expected_routine: bool
+) -> None:
+    envelope = map_hook_payload_to_envelope(
+        "PostToolUse",
+        {
+            "session_id": "routine-read-outcome",
+            "tool_name": "read",
+            "tool_input": {"path": "ignored"},
+            **payload_extra,
+        },
+        session_commitment=f"hmac-sha256:{'22' * 32}",
+        event_ordinal=1,
+        key_material=_KEY,
+    )
+    assert (envelope.structural_payload.get("action") == "routine_read") is expected_routine
 
 
 def test_observe_without_consent_exits_zero_no_spool(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #244

## What changed

- conservatively classify routine read-only hook calls and keep successful routine reads in the bounded local observation store without minting individual task-ledger records
- retain normal materialization for failures, ambiguous shell commands, edits, checks, tests, and other meaningful observations
- persist and coalesce one-shot observation-writer frontier-motion notices per Codex session
- emit the notice through the existing PostToolUse context channel and consume it only after successful output
- amend ADR-022, the shared interface contract, and the unreleased changelog

## Why

Routine reads were advancing the task-global frontier once per hook record, obscuring meaningful work and making cooperative writers discover observation-driven movement only when a later state-sensitive operation raced. The root cause was unconditional pre/post materialization combined with no bounded writer-facing motion surface.

## Impact

Cooperative writers get clear source-attributed frontier feedback without weakening exact-frontier checks or expanding the MCP surface. Routine read evidence remains locally retained while task-ledger growth tracks more meaningful information.

## Validation

- `uv run pytest tests/unit/application/test_observation_coordinator.py tests/unit/cli/test_observe_hooks.py -q` — 80 passed
- `uv run pytest tests/integration/observation -q -k 'not test_session_start_creates_binding_without_mcp_start'` — 43 passed, 1 deselected
- `npx --no-install pyright` — 0 errors
- Ruff lint and format checks passed

## Known test limitation

`test_session_start_creates_binding_without_mcp_start` independently expects non-empty context for `skip_service=True`, while that existing SessionStart path emits `{}`. This change only reads frontier notices on PostToolUse and does not alter that SessionStart branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add one-shot frontier motion notices and rate-limit routine reads at the observation boundary
> - Introduces `FrontierMotionNotice`, a dataclass in [`observation_local.py`](https://github.com/TheGaySupreme123/yoetz/pull/252/files#diff-dcc1feb8bc7f834d09056738e52fec58f85bdd06640418a241feda997cb5be82) that tracks task frontier movement per Codex session, with validated fields and a deterministic `delivery_identity` for one-shot delivery semantics.
> - Adds `note_frontier_motion`, `peek_frontier_motion`, and `commit_frontier_motion_delivery` to `LocalObservationStore`, coalescing contiguous observation-authored appends into a single pending notice per session and clearing it only after confirmed delivery.
> - Classifies routine read tool calls (file reads, safe shell commands) in [`observe_hooks.py`](https://github.com/TheGaySupreme123/yoetz/pull/252/files#diff-cdfa4cdbe7cfccf96a65db7f69d192cac91fad8eba4ec777e16f9a4d177f49c4) and [`observation_materialize.py`](https://github.com/TheGaySupreme123/yoetz/pull/252/files#diff-1de83d62d0cc1aefdc476012f9a551f77580154e24747fb3875d6824270f5e2b); successful routine reads skip task-ledger draft creation while failed ones still materialize normally.
> - Delivers the pending frontier motion notice as human-readable context in the PostToolUse hook output, then atomically removes it on successful emission.
> - Behavioral Change: on-disk observation state schema bumps from `/5` to `/6`; older readers ignore the new `frontier_motion_notices` field, and the new writer tolerates missing fields from older files.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #252 opened
>
> - Added frontier motion notices capping, pruning, and reconstruction system [135eafd]
> - Tightened routine read classification to exclude path-qualified executables, certain Git flags, and explicit failures or denials [135eafd]
> - Added comprehensive test coverage for frontier motion notices, routine read classification, and append result reconstruction [135eafd]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 213d576. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->