### PR TITLE
Fix Stop hook Failed on valid advice output (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,13 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
+- A Stop hook that selected advice completed in ~1.4s with exit 0, then Codex marked it Failed
+  with `hook returned invalid stop hook JSON output`. Stop has no `hookSpecificOutput`; the
+  event-agnostic emitter was writing `additionalContext` onto a wire type that only admits
+  universal fields plus `decision`/`reason`. Stop advice now uses `decision: block` plus
+  `reason`, with `stop_hook_active` as the host loop guard. SessionEnd no longer peeks or
+  commits advice: the host discards that stdout, so a delivery there would consume text the
+  agent never sees (issue #222).
 - The very first MCP call after a cold start could return `SERVICE_UNAVAILABLE` from a healthy
   install: the daemon published its control endpoint and accepted connections up to ~19 seconds
   before it could answer a handshake, and the on-demand connector treated the silent socket of

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2303,9 +2303,13 @@ Shared closed types:
   session snapshot when one exists, otherwise from the current Codex session's retained envelopes.
   The workspace-wide snapshot is not a fallback for task-scoped work. Deliberately workspace-
   standing machine conditions remain deliverable from that workspace snapshot at the documented
-  session-boundary cadence. The agent-visible context carries only the bounded rule, action, and
-  evidence token; deciding whether the advice belongs to the current target never requires
-  inspecting Yoetz storage.
+  session-boundary cadence (`SessionStart` and `Stop`). The agent-visible context carries only
+  the bounded rule, action, and evidence token; deciding whether the advice belongs to the
+  current target never requires inspecting Yoetz storage. Hook stdout is event-specific:
+  `SessionStart` / `PostToolUse` / `UserPromptSubmit` emit `hookSpecificOutput.additionalContext`;
+  `Stop` emits `decision: block` plus `reason` (Codex has no Stop `hookSpecificOutput`, and
+  `stop_hook_active` plus delivery identity are the loop guard); `SessionEnd` always emits `{}`
+  because the host discards its stdout and a peek/commit there would consume undelivered advice.
 
 Independent verification support (local control, not MCP):
 
@@ -2337,8 +2341,9 @@ Independent verification support (local control, not MCP):
   discovers pending work at startup, drains one serialized check per workspace through the
   enforcing sandbox, reclaims expired leases, and stops before vault/runtime closure. Hook ingest
   never executes approved checks inside the hook RPC budget. Pure-ingress hook handlers declare
-  `"async": true` and never block a host tool call; handlers that return advice context stay
-  synchronous with a declared 10-second budget, and `SessionEnd` keeps the host-clamped 3 seconds.
+  `"async": true` and never block a host tool call; handlers that return `additionalContext` or a
+  Stop `decision: block` stay synchronous with a declared 10-second budget, and `SessionEnd`
+  keeps the host-clamped 3 seconds (ingest/drain only; it is not an advice channel).
 
 Observation consent is one project-level confirmation recorded as a private workspace commitment.
 The normalized locator is authenticated encrypted content; plaintext keeps only commitment and

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -135,6 +135,14 @@ registration is global, file-free, and marker-free, so reusing the skill-install
 misuse fields designed for on-disk trusted-project content. The guarantee below is unchanged —
 adding a harness is still one `HarnessId` value plus adapters, with no shared-type edits.
 
+**Amendment (2026-08-14, issue #222):** Codex hook stdout is event-specific. `SessionStart`,
+`PostToolUse`, and `UserPromptSubmit` keep `hookSpecificOutput.additionalContext`. `Stop` and
+`SubagentStop` have no such field: JSON that includes `hookSpecificOutput` is marked Failed with
+`hook returned invalid stop hook JSON output`. When Stop has advice, Yoetz emits
+`decision: block` plus `reason` so the text reaches the model as a continuation, and it does not
+block again when the host sets `stop_hook_active`. `SessionEnd` has no output schema and the host
+discards stdout, so it is not advice-safe and never consumes a pending delivery.
+
 **Amendment (2026-08-14):** Hook advice delivery no longer falls back to the workspace-wide
 `advice_snapshot` for task-scoped conditions. Before a Codex session is mapped, task-scoped
 advice is selected only from that Codex session's retained envelopes. After mapping, delivery

--- a/src/yoetz/adapters/integrations/codex_plugin.py
+++ b/src/yoetz/adapters/integrations/codex_plugin.py
@@ -117,13 +117,13 @@ def _hooks_json() -> bytes:
     #
     # Execution-mode split (#209): handlers that only ingest and always emit {}
     # run "async": true so they never sit in a tool call's critical path — an
-    # async Codex hook cannot block or return a decision, which these never do.
+    # async Codex hook cannot apply control effects, which these never need.
     # Handlers that return additionalContext (SessionStart advice/attach,
-    # PostToolUse/Stop advice) stay synchronous with a timeout the handler can
-    # actually meet; Codex's own default would be 600s, so 10s here is still a
-    # deliberate bound, not a relaxation. SessionEnd is host-clamped to 3s max
-    # and is downgraded to sync (with a per-session warning) if declared async,
-    # so it keeps its own explicit 3.
+    # PostToolUse advice) or a Stop ``decision: block`` stay synchronous with a
+    # timeout the handler can actually meet; Codex's own default would be 600s,
+    # so 10s here is still a deliberate bound, not a relaxation. SessionEnd is
+    # host-clamped to 3s max, discards stdout, and is downgraded to sync (with
+    # a per-session warning) if declared async, so it keeps its own explicit 3.
     observe = "yoetz hooks observe --workspace . --event"
     observe_timeout = 10
     session_end_timeout = 3

--- a/src/yoetz/cli/hook_io.py
+++ b/src/yoetz/cli/hook_io.py
@@ -15,11 +15,31 @@ from typing import BinaryIO, Final, cast
 from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 from yoetz.protocol.errors import ProtocolValueError
 
-__all__ = ["context_output", "read_hook_payload", "stderr_line", "stdout_json"]
+__all__ = [
+    "ADDITIONAL_CONTEXT_EVENTS",
+    "STOP_CONTROL_EVENTS",
+    "context_output",
+    "read_hook_payload",
+    "stderr_line",
+    "stdout_json",
+]
 
 _MAX_STDIN_BYTES: Final = 262_144
 _MAX_CONTEXT_CHARS: Final = 2_000
 _MAX_STDERR_CHARS: Final = 200
+# Codex events whose output schema admits hookSpecificOutput.additionalContext.
+ADDITIONAL_CONTEXT_EVENTS: Final = frozenset(
+    {
+        "PostToolUse",
+        "PreToolUse",
+        "SessionStart",
+        "SubagentStart",
+        "UserPromptSubmit",
+    }
+)
+# Codex Stop / SubagentStop admit only universal fields plus decision/reason.
+# hookSpecificOutput is invalid and the host marks the hook Failed (#222).
+STOP_CONTROL_EVENTS: Final = frozenset({"Stop", "SubagentStop"})
 
 
 def stderr_line(message: str) -> None:
@@ -42,15 +62,29 @@ def stdout_json(value: JsonValue, stream: BinaryIO | None = None) -> bool:
 
 
 def context_output(event_name: str, additional_context: str) -> dict[str, JsonValue]:
+    """Return the Codex-valid stdout object for one event's advice text.
+
+    SessionStart / PostToolUse / UserPromptSubmit inject model-visible
+    ``additionalContext``. Stop / SubagentStop have no such field: the only
+    way to reach the model is ``decision: block`` plus ``reason``. Every other
+    event, including SessionEnd (stdout discarded), emits ``{}``.
+    """
+
     text = additional_context.strip()
+    if not text:
+        return {}
     if len(text) > _MAX_CONTEXT_CHARS:
         text = text[:_MAX_CONTEXT_CHARS]
-    return {
-        "hookSpecificOutput": {
-            "hookEventName": event_name,
-            "additionalContext": text,
+    if event_name in STOP_CONTROL_EVENTS:
+        return {"decision": "block", "reason": text}
+    if event_name in ADDITIONAL_CONTEXT_EVENTS:
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "additionalContext": text,
+            }
         }
-    }
+    return {}
 
 
 def read_hook_payload(raw: bytes | None = None) -> Mapping[str, JsonValue]:

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -89,13 +89,17 @@ SUPPORTED_HOOK_EVENTS: Final = frozenset(
         "SubagentStop",
     }
 )
-ADVICE_SAFE_EVENTS: Final = frozenset({"PostToolUse", "SessionStart", "Stop", "SessionEnd"})
+# Events that can deliver advice on a Codex-valid output contract. SessionEnd
+# is excluded: the host discards its stdout, so a peek/commit there would
+# consume advice the agent never sees (#222).
+ADVICE_SAFE_EVENTS: Final = frozenset({"PostToolUse", "SessionStart", "Stop"})
 # Standing machine conditions (connect_provider and kin) reach the agent at
 # session boundaries only. PostToolUse is deliberately excluded: it is the
 # per-tool-call channel that produced 29 byte-identical injections in one
 # session (#241). Codex fires Stop per assistant turn, so the achievable bound
-# is once per turn and only when a different advice text intervened.
-STANDING_ADVICE_CADENCE_EVENTS: Final = frozenset({"SessionStart", "Stop", "SessionEnd"})
+# is once per turn and only when a different advice text intervened. SessionEnd
+# is teardown-only and cannot continue the agent.
+STANDING_ADVICE_CADENCE_EVENTS: Final = frozenset({"SessionStart", "Stop"})
 _MAX_ADVICE_CONTEXT: Final = 1_200
 _MAX_CONTENT_CHUNK: Final = 256 * 1024
 # Ingest rejections that are recoverable: keep the outbox entry pending for a
@@ -1228,8 +1232,15 @@ def handle_observe(
         # Commit remains after emit, so a failed write never suppresses a later delivery.
         pending_delivery: AdviceDelivery | None = None
         delivery_session_id: str | None = None
+        # stop_hook_active is the host loop guard: a prior Stop already
+        # continued this turn. Blocking again would loop; leave advice for a
+        # later turn or SessionStart instead of consuming it here.
+        stop_already_active = payload.get("stop_hook_active") is True
         delivery_eligible = (
-            not additional and resolved_event in ADVICE_SAFE_EVENTS and not skip_advice_loop
+            not additional
+            and resolved_event in ADVICE_SAFE_EVENTS
+            and not skip_advice_loop
+            and not stop_already_active
         )
         delivery_gate = (
             store.advice_delivery_lease(workspace_commitment)

--- a/tests/unit/adapters/test_codex_plugin.py
+++ b/tests/unit/adapters/test_codex_plugin.py
@@ -199,8 +199,10 @@ def test_observe_hook_execution_modes_never_block_tool_calls() -> None:
     call and had both hooks SIGKILLed at the deadline. The contract is now:
     handlers that always emit ``{}`` declare ``"async": true`` (Codex ignores
     the field on hosts that predate it), handlers that return
-    ``additionalContext`` stay synchronous at 10s, and SessionEnd stays inside
-    the host's hard 3s clamp so it never draws a per-session warning.
+    ``additionalContext`` or a Stop ``decision: block`` stay synchronous at 10s,
+    and SessionEnd stays inside the host's hard 3s clamp so it never draws a
+    per-session warning. SessionEnd is not advice-safe (#222): the host
+    discards its stdout.
     """
 
     from yoetz.cli.observe_hooks import ADVICE_SAFE_EVENTS, SUPPORTED_HOOK_EVENTS
@@ -217,22 +219,25 @@ def test_observe_hook_execution_modes_never_block_tool_calls() -> None:
         "SubagentStop",
     )
     # The async split's real invariant: async iff the handler never returns
-    # additionalContext, i.e. iff the event is outside ADVICE_SAFE_EVENTS and
-    # outside the cue-only UserPromptSubmit. If someone adds an event to
-    # ADVICE_SAFE_EVENTS while it is still declared async here, Codex would
-    # silently defer its advice to the next turn boundary.
-    assert set(pure_ingress) == SUPPORTED_HOOK_EVENTS - ADVICE_SAFE_EVENTS - {"UserPromptSubmit"}
+    # host-consumed advice or a Stop decision. SessionEnd is sync only because
+    # Codex downgrades async SessionEnd; it is not advice-safe. If someone adds
+    # an event to ADVICE_SAFE_EVENTS while it is still declared async here,
+    # Codex would silently drop its advice or decision.
+    assert set(pure_ingress) == (
+        SUPPORTED_HOOK_EVENTS - ADVICE_SAFE_EVENTS - {"UserPromptSubmit", "SessionEnd"}
+    )
     for event in pure_ingress:
         handler = _observe_handler(parsed, event)
         assert handler.get("async") is True, f"{event} observe must not block the session"
         assert handler["timeout"] == 10, f"{event} needs an explicit modest timeout"
     for event in ("SessionStart", "PostToolUse", "Stop"):
         handler = _observe_handler(parsed, event)
-        assert "async" not in handler, f"{event} returns additionalContext; async drops it"
+        assert "async" not in handler, f"{event} returns advice or a Stop decision; async drops it"
         assert handler["timeout"] == 10, f"{event} declared timeout must be meetable"
     session_end = _observe_handler(parsed, "SessionEnd")
     assert "async" not in session_end, "Codex downgrades async SessionEnd with a warning"
     assert session_end["timeout"] == 3, "Codex hard-clamps SessionEnd timeouts above 3s"
+    assert "SessionEnd" not in ADVICE_SAFE_EVENTS
 
 
 def test_install_refuses_when_tested_set_empty(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_observation_local_advice_delivery.py
+++ b/tests/unit/adapters/test_observation_local_advice_delivery.py
@@ -130,9 +130,11 @@ def _run(tmp_path: Path, event: str, session: str, **payload: object) -> str:
     assert code == 0
     emitted = cast(Mapping[str, object], json.loads(out.getvalue().decode() or "{}"))
     specific = emitted.get("hookSpecificOutput")
-    if not isinstance(specific, Mapping):
-        return ""
-    return str(cast(Mapping[str, object], specific).get("additionalContext") or "")
+    if isinstance(specific, Mapping):
+        return str(cast(Mapping[str, object], specific).get("additionalContext") or "")
+    if emitted.get("decision") == "block":
+        return str(emitted.get("reason") or "")
+    return ""
 
 
 def _consented(tmp_path: Path) -> tuple[LocalObservationStore, str]:
@@ -368,6 +370,110 @@ def test_successful_emit_records_the_delivery_identity(
     recorded = (state.session_advice_suppression or {}).get(store.session_commitment("recorded"))
     assert type(recorded) is str and recorded.startswith("deliver-")
     assert "connect_provider" not in _run(tmp_path, "Stop", "recorded")
+
+
+def test_stop_advice_uses_block_decision_not_hook_specific_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#222: Codex Stop rejects hookSpecificOutput as invalid JSON."""
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+    _run(tmp_path, "SessionStart", "stop-shape", source="startup")
+    failed = _run(
+        tmp_path,
+        "PostToolUse",
+        "stop-shape",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="c1",
+    )
+    assert "resolve_failed_command" in failed
+    _run(
+        tmp_path,
+        "PostToolUse",
+        "stop-shape",
+        tool_name="shell",
+        exit_status=0,
+        correlation_id="c1",
+    )
+
+    out = io.BytesIO()
+    code = handle_observe(
+        event_name="Stop",
+        stdin_bytes=json.dumps({"session_id": "stop-shape", "hook_event_name": "Stop"}).encode(),
+        stdout=out,
+        workspace=str(tmp_path),
+        _state=tmp_path,
+        skip_service=True,
+    )
+    assert code == 0
+    emitted = json.loads(out.getvalue().decode())
+    assert "hookSpecificOutput" not in emitted
+    assert emitted["decision"] == "block"
+    assert "connect_provider" in str(emitted["reason"])
+
+
+def test_stop_hook_active_does_not_block_or_consume_advice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Host loop guard: a prior Stop already continued this turn (#222)."""
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+    _run(tmp_path, "SessionStart", "loop-guard", source="startup")
+    failed = _run(
+        tmp_path,
+        "PostToolUse",
+        "loop-guard",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="c1",
+    )
+    assert "resolve_failed_command" in failed
+    _run(
+        tmp_path,
+        "PostToolUse",
+        "loop-guard",
+        tool_name="shell",
+        exit_status=0,
+        correlation_id="c1",
+    )
+
+    guarded = _run(tmp_path, "Stop", "loop-guard", stop_hook_active=True)
+    assert guarded == ""
+    assert "connect_provider" in _run(tmp_path, "Stop", "loop-guard")
+
+
+def test_session_end_does_not_consume_undeliverable_advice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SessionEnd stdout is discarded; peek/commit there would lose the advice."""
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+    _run(tmp_path, "SessionStart", "teardown", source="startup")
+    failed = _run(
+        tmp_path,
+        "PostToolUse",
+        "teardown",
+        tool_name="shell",
+        exit_status=1,
+        correlation_id="c1",
+    )
+    assert "resolve_failed_command" in failed
+    _run(
+        tmp_path,
+        "PostToolUse",
+        "teardown",
+        tool_name="shell",
+        exit_status=0,
+        correlation_id="c1",
+    )
+
+    teardown = _run(tmp_path, "SessionEnd", "teardown")
+    assert teardown == ""
+    assert "connect_provider" in _run(tmp_path, "Stop", "teardown")
 
 
 def test_a_then_b_then_a_redelivers_a(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_hook_io.py
+++ b/tests/unit/cli/test_hook_io.py
@@ -1,0 +1,32 @@
+"""Event-specific Codex hook stdout contracts (#222)."""
+
+from __future__ import annotations
+
+from yoetz.cli.hook_io import context_output
+
+
+def test_session_start_and_post_tool_use_emit_additional_context() -> None:
+    for event in ("SessionStart", "PostToolUse", "UserPromptSubmit"):
+        assert context_output(event, "  bounded advice  ") == {
+            "hookSpecificOutput": {
+                "hookEventName": event,
+                "additionalContext": "bounded advice",
+            }
+        }
+
+
+def test_stop_and_subagent_stop_emit_block_decision_not_hook_specific_output() -> None:
+    for event in ("Stop", "SubagentStop"):
+        emitted = context_output(event, "refresh status before an exact-frontier check")
+        assert emitted == {
+            "decision": "block",
+            "reason": "refresh status before an exact-frontier check",
+        }
+        assert "hookSpecificOutput" not in emitted
+
+
+def test_session_end_and_unknown_events_emit_empty_object() -> None:
+    assert context_output("SessionEnd", "would be discarded by the host") == {}
+    assert context_output("PreCompact", "never an advice channel") == {}
+    assert context_output("Stop", "   ") == {}
+    assert context_output("SessionStart", "") == {}


### PR DESCRIPTION
## Issue

- Linked issue: `Fixes #222`
- I searched existing issues and PRs for duplicates before opening this PR. The prior close was PR #228, which addressed the exit-zero/stdout-teardown suspicion. This PR is the remaining event-specific output-shape fix from the 2026-08-14 reopen diagnosis.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging, ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

The issue was already acknowledged and closed by #228. The owner reopened it with a host-side diagnosis: Codex Stop has no `hookSpecificOutput`, so the still-event-agnostic emitter is invalid JSON whenever Stop selects advice. This PR implements that stated fix boundary rather than opening a second issue.

## Documentation

- Behavior change? `yes`
- Docs updated: ADR-010 amendment, `docs/INTERFACES.md` hook-output contract, `CHANGELOG.md`.

## Verification

Commands run:

```text
uv run pytest tests/unit/cli/test_hook_io.py tests/unit/cli/test_observe_hooks.py tests/unit/cli/test_hooks.py tests/unit/adapters/test_codex_plugin.py tests/unit/adapters/test_observation_local_advice_delivery.py tests/unit/application/test_observation_advice.py tests/integration/observation/test_e2e_successor_acceptance.py tests/subprocess/test_hooks_cli.py -q
# 105 passed

uv run pytest tests/unit/cli/test_hook_io.py tests/unit/adapters/test_observation_local_advice_delivery.py tests/unit/adapters/test_codex_plugin.py tests/unit/cli/test_observe_hooks.py tests/unit/cli/test_hooks.py tests/unit/application/test_observation_advice.py -q
# 93 passed

uv run ruff check src/yoetz/cli/hook_io.py src/yoetz/cli/observe_hooks.py src/yoetz/adapters/integrations/codex_plugin.py tests/unit/cli/test_hook_io.py tests/unit/adapters/test_codex_plugin.py tests/unit/adapters/test_observation_local_advice_delivery.py
# All checks passed

npx --no-install pyright src/yoetz/cli/hook_io.py src/yoetz/cli/observe_hooks.py src/yoetz/adapters/integrations/codex_plugin.py tests/unit/cli/test_hook_io.py tests/unit/adapters/test_codex_plugin.py tests/unit/adapters/test_observation_local_advice_delivery.py
# 0 errors, 0 warnings
```

`tests/integration/observation/test_acceptance_scenarios.py::test_session_start_creates_binding_without_mcp_start` fails on current `main` with the same `{}` assertion; it is not caused by this change.

Isolated `codex-testing` Stop teardown remains the post-land host proof.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

#228 kept `handle_observe` exit-zero. The reopen reproduced the host-visible `Stop Failed` after a 1.428s exit-0 pass: when Stop has advice, Yoetz emitted

```json
{"hookSpecificOutput":{"hookEventName":"Stop","additionalContext":"..."}}
```

Codex `StopCommandOutputWire` admits only universal fields plus optional `decision`/`reason`. JSON-looking stdout that fails that schema is `hook returned invalid stop hook JSON output`.

This change makes hook stdout event-specific:

- `SessionStart` / `PostToolUse` / `UserPromptSubmit` keep `hookSpecificOutput.additionalContext`
- `Stop` / `SubagentStop` emit `decision: block` plus `reason` so the text reaches the model, and skip delivery when `stop_hook_active` is true
- `SessionEnd` always emits `{}` and is no longer advice-safe, because the host discards that stdout and a peek/commit there would consume undelivered advice

`{}` remains the no-advice Stop contract.
