### PR TITLE
Stop receipt crashing on observation finding event citations

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -819,8 +819,18 @@ deciding between the two, shared by the receipt and by compact status coverage.
   artifact/freshness caps but caps immutability at `content_digest`, adding respectively
   `redacted_object` or `captured_object_unavailable`. An unresolved typed ref preserves all other
   dimensions, caps freshness at `partial`, and adds `missing_ref`; an opaque event does the same and
-  adds `unknown_event`. Every cap is a registered component-wise minimum, existing gaps are unioned
-  and sorted, and overflow of the 64-token bound fails case freezing rather than truncating.
+  adds `unknown_event`. Finding and contradiction citations may name an `evt_` id that is absent
+  from the accepted prefix (observation advice historically computed those ids from envelopes that
+  were never appended). Replay does not mint one `missing_ref` marker per such citation — that
+  would overflow the 64-gap projection and receipt bounds on a large observation finding set.
+  Case construction instead keeps those citations out of `allowed_ids` and, when no `missing_ref`
+  is already present, adds one task-global `missing_ref:cited_event_absent` gap. Projection
+  `source_event_id` values, selected frozen-history members, and
+  `latest_tested_state.source_check_event_id` remain required: a missing one is still an invalid
+  case and surfaces as a bounded `STORAGE_CORRUPT` receipt/status/check error, never
+  `INTERNAL_ERROR`. Every cap is a registered component-wise
+  minimum, existing gaps are unioned and sorted, and overflow of the 64-token bound fails case
+  freezing rather than truncating.
   Relevant digest evidence additionally contributes `evidence_digest_subject_legacy_unknown`,
   `evidence_content_digest_only`, or `evidence_content_withheld`. Relevance follows the current
   claim/obligation/response support graph (including referenced results); unrelated historical

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -1726,7 +1726,12 @@ class MemoryLedgerAdapter:
                 return FrozenCase(case, renewed)
         assert projection is not None and frontier is not None and records is not None
         availability = await self.load_case_availability(session_id, frontier, projection)
-        case = build_deterministic_case(projection, records, availability)
+        try:
+            case = build_deterministic_case(projection, records, availability)
+        except ValueError as exc:
+            if str(exc) == "deterministic_case_invalid":
+                raise _error(PublicErrorCode.STORAGE_CORRUPT) from exc
+            raise
         dependency = _case_dependency_digest(case)
         case_json = deterministic_case_to_json(case)
         case_bytes = canonical_encode(

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -1660,11 +1660,15 @@ class ObservationCoordinator:
             refs_by_source.setdefault(envelope.source_identity, set()).update(
                 self._materialized_event_refs(runtime.task_id, envelope)
             )
+        known_event_ids: set[str] = set()
         lifecycle_ref: str | None = None
         async for record in runtime.ledger.load_events(runtime.session_id):
-            if record.schema.name in {"session_opened", "session_resumed"}:
+            known_event_ids.add(str(record.event_id))
+            if lifecycle_ref is None and record.schema.name in {
+                "session_opened",
+                "session_resumed",
+            }:
                 lifecycle_ref = str(record.event_id)
-                break
         projection = await runtime.ledger.load_projection(
             runtime.session_id, ProjectionView.COMPACT
         )
@@ -1686,19 +1690,22 @@ class ObservationCoordinator:
                 ref
                 for source_ref in item.evidence_refs
                 for ref in refs_by_source.get(source_ref, ())
+                if ref in known_event_ids
             }
             if not matched_refs:
                 # A candidate that names no envelope is a standing condition about the session,
                 # so anchor it on the session lifecycle event: one stable ref for the life of the
                 # condition, which is what lets check and receipt collapse repeats. Where no
-                # lifecycle event exists yet, fall back to every observed ref rather than
-                # dropping the finding — a finding that silently fails to land is the one
-                # outcome this must never produce.
+                # lifecycle event exists yet, fall back to every observed ref that was actually
+                # appended rather than dropping the finding — a finding that silently fails to
+                # land is the one outcome this must never produce. Computed draft IDs that
+                # never entered the ledger stay out of subject_refs: receipt case construction
+                # must not see citations that cannot be closed against the accepted prefix.
                 if lifecycle_ref is not None:
                     matched_refs.add(lifecycle_ref)
                 else:
                     for observed in refs_by_source.values():
-                        matched_refs.update(observed)
+                        matched_refs.update(ref for ref in observed if ref in known_event_ids)
             subject_refs = tuple(sorted(matched_refs, key=str.encode)[:64])
             if not subject_refs:
                 continue

--- a/src/yoetz/application/receipt.py
+++ b/src/yoetz/application/receipt.py
@@ -557,19 +557,36 @@ async def execute_receipt(app: Application, request: ReceiptRequest) -> ReceiptI
         availability = await runtime.ledger.load_case_availability(
             runtime.session_id, frontier, projection
         )
-        case = build_deterministic_case(projection, records, availability)
-        context = _context(projection, frontier, case, records)
-        now = app.clock.now_utc()
-        document = build_receipt(
-            context,
-            receipt_id(app.ids.new(IdKind.RECEIPT)),
-            task_id(runtime.task_id),
-            session_id(runtime.session_id),
-            timestamp_from_datetime(now),
-            versions,
-            request.redaction_profile,
-            request.include,
-        )
+        try:
+            case = build_deterministic_case(projection, records, availability)
+            context = _context(projection, frontier, case, records)
+            now = app.clock.now_utc()
+            document = build_receipt(
+                context,
+                receipt_id(app.ids.new(IdKind.RECEIPT)),
+                task_id(runtime.task_id),
+                session_id(runtime.session_id),
+                timestamp_from_datetime(now),
+                versions,
+                request.redaction_profile,
+                request.include,
+            )
+        except ValueError as exc:
+            # Remaining case/receipt construction failures are a storage or projection
+            # inconsistency. Finding citations that name events outside the accepted prefix
+            # are represented as missing_ref gaps inside build_deterministic_case and must
+            # not reach this path. Do not collapse a classified ledger condition to
+            # INTERNAL_ERROR.
+            if str(exc) in {
+                "deterministic_case_invalid",
+                "receipt_build_context_invalid",
+                "projection_corrupt",
+            }:
+                raise _error(
+                    PublicErrorCode.STORAGE_CORRUPT,
+                    "The receipt case is unreadable.",
+                ) from exc
+            raise
         document_json = cast(JsonValue, receipt_document_to_json(document))
         document_bytes = canonical_encode(document_json)
         digest = canonical_digest(document_json)

--- a/src/yoetz/application/status.py
+++ b/src/yoetz/application/status.py
@@ -666,7 +666,15 @@ async def _candidate_page(
     availability = await runtime.ledger.load_case_availability(
         runtime.session_id, frontier, projection
     )
-    case = build_deterministic_case(projection, records, availability)
+    try:
+        case = build_deterministic_case(projection, records, availability)
+    except ValueError as exc:
+        if str(exc) == "deterministic_case_invalid":
+            raise _error(
+                PublicErrorCode.STORAGE_CORRUPT,
+                "The status case is unreadable.",
+            ) from exc
+        raise
     assessments, _ = run_deterministic_policies(case, CheckScope((), ()), _PACKS)
     indexed = tuple(enumerate(assessments))
     ordered = tuple(

--- a/src/yoetz/kernel/deterministic_checks.py
+++ b/src/yoetz/kernel/deterministic_checks.py
@@ -1457,11 +1457,28 @@ def build_deterministic_case(
     history = tuple(reversed(newest_first))
 
     source_by_ref = _logical_sources(projection)
+    cited_event_absent = False
 
     def add_event_ref(ref: EventId) -> None:
         if ref not in records_by_event:
             raise _invalid_case()
         source_by_ref[ref] = ref
+
+    def add_optional_event_ref(ref: EventId) -> None:
+        """Bind a cited event when it is in the prefix; otherwise note a bounded gap.
+
+        Projection source events and the selected history window remain required. Finding
+        and contradiction citations can name an event that was never appended — observation
+        advice historically computed those IDs from envelopes. Receipts admit at most 64
+        gaps, so many dangling citations collapse to one task-global missing_ref rather
+        than one marker per finding.
+        """
+
+        nonlocal cited_event_absent
+        if ref in records_by_event:
+            source_by_ref[ref] = ref
+            return
+        cited_event_absent = True
 
     for record in _projection_records(projection):
         add_event_ref(record.source_event_id)
@@ -1471,16 +1488,21 @@ def build_deterministic_case(
         add_event_ref(projection.latest_tested_state.source_check_event_id)
     for contradiction in projection.contradictions.values():
         if contradiction.disputed_ref.startswith("evt_"):
-            add_event_ref(event_id(contradiction.disputed_ref))
+            add_optional_event_ref(event_id(contradiction.disputed_ref))
     for record in projection.findings.values():
         if record.payload is not None:
             for ref in record.payload.subject_refs:
                 if ref.startswith("evt_"):
-                    add_event_ref(event_id(ref))
+                    add_optional_event_ref(event_id(ref))
     for gap in gaps.values():
         for ref in gap.subject_refs:
-            if ref.startswith("evt_"):
-                add_event_ref(event_id(ref))
+            if not ref.startswith("evt_"):
+                continue
+            cited = event_id(ref)
+            if cited in records_by_event:
+                source_by_ref[cited] = cited
+    if cited_event_absent and not any(gap.code == "missing_ref" for gap in gaps.values()):
+        _add_gap(gaps, "missing_ref:cited_event_absent", "missing_ref", ())
 
     redacted_object_by_evidence: dict[EvidenceId, set[ObjectId]] = {}
     for target in redacted_objects:

--- a/src/yoetz/kernel/projections.py
+++ b/src/yoetz/kernel/projections.py
@@ -140,6 +140,7 @@ def _validate_missing_target(value: object) -> str:
         "act_": action_id,
         "clm_": claim_id,
         "evd_": evidence_id,
+        "evt_": event_id,
         "fnd_": finding_id,
         "obl_": obligation_id,
         "res_": result_id,

--- a/tests/integration/observation/test_e2e_successor_acceptance.py
+++ b/tests/integration/observation/test_e2e_successor_acceptance.py
@@ -440,6 +440,7 @@ async def test_advice_finding_materialization_passes_real_ledger_validation(tmp_
 
     seed = append_command()
     ledger = memory_adapter(seed)
+    await ledger.append_batch(seed)
     objects = cast(MemoryObjects, ledger._objects)  # pyright: ignore[reportPrivateUsage]
     runtime = TaskRuntime(
         seed.task_id,
@@ -516,13 +517,14 @@ async def test_advice_finding_materialization_passes_real_ledger_validation(tmp_
     )
 
     records = [row async for row in ledger.load_events(seed.session_id)]
-    assert len(records) == 1
-    accepted = records[0]
+    assert len(records) == 2
+    accepted = records[1]
     assert type(accepted) is AcceptedEvent
     assert accepted.schema.name == "finding_recorded"
+    assert type(accepted.payload) is Finding
+    assert tuple(str(ref) for ref in accepted.payload.subject_refs) == (str(records[0].event_id),)
     assert accepted.publication_channel is PublicationChannel.ENGINE_DERIVED
     assert accepted.coverage == coverage_for_channel(PublicationChannel.ENGINE_DERIVED)
-    assert type(accepted.payload) is Finding
     assert accepted.payload.coverage == mixed_coverage
 
 

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -24,6 +24,7 @@ from yoetz.application.observation_materialize import (
     materialize_observation_envelope,
     observation_writer_id,
 )
+from yoetz.domain.findings import Finding
 from yoetz.domain.observation import (
     ObservationCursor,
     ObservationEnvelope,
@@ -1102,6 +1103,15 @@ async def test_advice_finding_materialization_uses_canonical_schema_and_envelope
         ranked_items=(item,),
     )
 
+    ledger_events: list[SimpleNamespace] = []
+
+    def _remember_envelope_events(source: ObservationEnvelope) -> None:
+        batch = materialize_observation_envelope(source, task_id=task_id)
+        for draft in batch.drafts:
+            ledger_events.append(
+                SimpleNamespace(event_id=draft.draft.event_id, schema=draft.draft.schema)
+            )
+
     class _Ledger:
         async def load_projection(self, loaded_session_id: str, view: ProjectionView):
             assert loaded_session_id == session_id
@@ -1109,8 +1119,8 @@ async def test_advice_finding_materialization_uses_canonical_schema_and_envelope
             return None
 
         async def _events(self):
-            if False:
-                yield None
+            for record in ledger_events:
+                yield record
 
         def load_events(self, loaded_session_id: str):
             assert loaded_session_id == session_id
@@ -1191,6 +1201,7 @@ async def test_advice_finding_materialization_uses_canonical_schema_and_envelope
         identity="hook:advice-materialization",
         exit_status=2,
     )
+    _remember_envelope_events(envelope)
 
     await coordinator._materialize_advice_findings(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         cast(TaskRuntime, runtime),
@@ -1213,18 +1224,17 @@ async def test_advice_finding_materialization_uses_canonical_schema_and_envelope
         evidence_basis_digest="sha256:" + "d" * 64,
         suppression_identity="advice-materialization-2",
     )
+    revision_envelope = _envelope(
+        session=f"hmac-sha256:{'d' * 64}",
+        kind="PostToolUse",
+        identity="hook:advice-revision",
+        ordinal=2,
+        exit_status=2,
+    )
+    _remember_envelope_events(revision_envelope)
     await coordinator._materialize_advice_findings(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
         cast(TaskRuntime, runtime),
-        (
-            envelope,
-            _envelope(
-                session=f"hmac-sha256:{'d' * 64}",
-                kind="PostToolUse",
-                identity="hook:advice-revision",
-                ordinal=2,
-                exit_status=2,
-            ),
-        ),
+        (envelope, revision_envelope),
         revised_snapshot,  # type: ignore[arg-type]
     )
     assert len(captured) == 2
@@ -1232,6 +1242,153 @@ async def test_advice_finding_materialization_uses_canonical_schema_and_envelope
         captured[1].command.entries[0].draft.event_id
     )
     assert materialize_calls == ["hook:advice-materialization", "hook:advice-revision"]
+    first_payload = captured[0].command.entries[0].draft.payload
+    assert type(first_payload) is Finding
+    assert first_payload.subject_refs
+    assert {str(ref) for ref in first_payload.subject_refs} <= {
+        str(record.event_id) for record in ledger_events
+    }
+
+
+@pytest.mark.anyio
+async def test_advice_finding_subject_refs_never_cite_unappended_drafts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Computed materialization IDs that never entered the ledger must not become citations."""
+
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from yoetz.application import observation_coordinator as coordinator_module
+    from yoetz.application.unit_of_work import PreparedMutation
+    from yoetz.domain.observation import AdviceItem, AdviceSnapshot
+    from yoetz.ports.ledger import ProjectionView
+    from yoetz.ports.objects import ObjectRef
+    from yoetz.protocol.coverage import PublicationChannel, coverage_for_channel
+
+    task_id = PREFIX_BY_KIND[IdKind.TASK] + str(uuid.uuid4())
+    session_id = PREFIX_BY_KIND[IdKind.SESSION] + str(uuid.uuid4())
+    writer_id = PREFIX_BY_KIND[IdKind.WRITER] + str(uuid.uuid4())
+    lifecycle = PREFIX_BY_KIND[IdKind.EVENT] + "00000000-0000-4000-8000-000000000001"
+    item_coverage = coverage_for_channel(PublicationChannel.HOOK_OBSERVED)
+    item = AdviceItem(
+        finding_id=finding_id(PREFIX_BY_KIND[IdKind.FINDING] + str(uuid.uuid4())),
+        rule_code="failed_command_unresolved",
+        priority=10,
+        summary="A failed command remains unresolved.",
+        detail="Resolve the failed command and rerun the check.",
+        recommended_next_action="rerun_check",
+        evidence_refs=("hook:unappended-draft",),
+        coverage=item_coverage,
+        freshness_frontier="frontier-1",
+    )
+    snapshot = AdviceSnapshot(
+        ranked_finding_ids=(item.finding_id,),
+        evidence_basis_digest="sha256:" + "a" * 64,
+        confidence_coverage=item_coverage,
+        recommended_next_action="rerun_check",
+        freshness_frontier="frontier-1",
+        suppression_identity="advice-unappended-1",
+        ranked_items=(item,),
+    )
+
+    class _Ledger:
+        async def load_projection(self, loaded_session_id: str, view: ProjectionView):
+            del loaded_session_id, view
+            return None
+
+        async def _events(self):
+            yield SimpleNamespace(
+                event_id=lifecycle,
+                schema=SimpleNamespace(name="session_opened"),
+            )
+
+        def load_events(self, loaded_session_id: str):
+            del loaded_session_id
+            return self._events()
+
+        async def lookup_operation(self, loaded_writer_id: str, operation_id: str):
+            del loaded_writer_id, operation_id
+            return None
+
+    class _Objects:
+        async def stage(self, source: object, metadata: object):
+            return source, metadata
+
+        async def finalize(self, staged: tuple[object, object]) -> ObjectRef:
+            source, metadata = staged
+            data = source.data  # type: ignore[attr-defined]
+            assert isinstance(data, bytes)
+            return ObjectRef(
+                PREFIX_BY_KIND[IdKind.OBJECT] + str(uuid.uuid4()),
+                len(data),
+                "hmac-sha256:" + "b" * 64,
+                "sha256:" + "c" * 64,
+                "yoetz-object/1",
+                "test-key-1",
+                metadata,  # type: ignore[arg-type]
+            )
+
+    captured: list[PreparedMutation] = []
+
+    async def _capture_append(ledger: object, prepared: PreparedMutation):
+        del ledger
+        captured.append(prepared)
+        return None
+
+    monkeypatch.setattr(coordinator_module, "run_prepared_append", _capture_append)
+
+    class _Clock:
+        def now_utc(self) -> datetime:
+            return datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _Ids:
+        def new(self, kind: IdKind) -> str:
+            return PREFIX_BY_KIND[kind] + str(uuid.uuid4())
+
+    class _UnusedRuntimePort:
+        async def route(self, command: object) -> object:
+            raise AssertionError("route must not be called")
+
+        async def release(self, runtime: object) -> None:
+            return None
+
+    runtime = SimpleNamespace(
+        task_id=task_id,
+        session_id=session_id,
+        writer_id=writer_id,
+        ledger=_Ledger(),
+        objects=_Objects(),
+    )
+    coordinator = ObservationCoordinator(
+        runtime=_UnusedRuntimePort(),  # type: ignore[arg-type]
+        local=LocalObservationStore(_state=tmp_path),
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=_Ids(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+    )
+    envelope = _envelope(
+        session=f"hmac-sha256:{'d' * 64}",
+        kind="PostToolUse",
+        identity="hook:unappended-draft",
+        exit_status=2,
+    )
+    computed = {
+        str(draft.draft.event_id)
+        for draft in materialize_observation_envelope(envelope, task_id=task_id).drafts
+    }
+    assert computed
+    await coordinator._materialize_advice_findings(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        cast(TaskRuntime, runtime),
+        (envelope,),
+        snapshot,  # type: ignore[arg-type]
+    )
+
+    assert len(captured) == 1
+    payload = captured[0].command.entries[0].draft.payload
+    assert type(payload) is Finding
+    assert tuple(str(ref) for ref in payload.subject_refs) == (lifecycle,)
+    assert computed.isdisjoint(str(ref) for ref in payload.subject_refs)
 
 
 @pytest.mark.anyio

--- a/tests/unit/kernel/test_deterministic_checks.py
+++ b/tests/unit/kernel/test_deterministic_checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import replace
 from types import MappingProxyType
@@ -17,13 +18,22 @@ from yoetz.domain.events import (
     ClaimRecordedPayload,
     NoObligationsReason,
     PlanPublishedPayload,
+    accepted_record_digest_preimage,
+    encode_payload,
 )
-from yoetz.domain.findings import FindingKind, FindingOrigin
+from yoetz.domain.findings import FINDING_KIND_TRAITS, Finding, FindingKind, FindingOrigin
 from yoetz.domain.receipts import (
     COMPLETION_SCOPE_DECLARED_NONE_GAP,
     COMPLETION_SCOPE_UNDECLARED_GAP,
 )
-from yoetz.domain.values import claim_id, object_id, obligation_id
+from yoetz.domain.values import (
+    Frontier,
+    claim_id,
+    event_id,
+    finding_id,
+    object_id,
+    obligation_id,
+)
 from yoetz.kernel import deterministic_checks
 from yoetz.kernel.deterministic_checks import (
     DETERMINISTIC_FINDING_TEMPLATES,
@@ -43,7 +53,21 @@ from yoetz.kernel.policies.research_evidence import RESEARCH_EVIDENCE_POLICY_PAC
 from yoetz.kernel.policies.work_integrity import WORK_INTEGRITY_POLICY_PACK
 from yoetz.kernel.projections import empty_projection_state
 from yoetz.kernel.reducers import replay
-from yoetz.protocol.canonical import canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import (
+    canonical_digest,
+    canonical_encode,
+    entry_digest,
+    strict_json_parse,
+)
+from yoetz.protocol.coverage import (
+    ArtifactObservation,
+    AuthorshipAssurance,
+    CheckType,
+    Coverage,
+    EvidenceImmutability,
+    LedgerFreshness,
+    PublicationChannel,
+)
 
 
 def test_genesis_case_is_exact_and_immutable() -> None:
@@ -358,3 +382,141 @@ def test_unknown_or_tampered_pack_is_rejected() -> None:
     )
     with pytest.raises(ValueError, match="policy_wiring_invalid"):
         run_deterministic_policies(case, PolicyPack("work-integrity", "0.1.1"))
+
+
+def _observation_finding_coverage() -> Coverage:
+    return Coverage(
+        publication_channels=(PublicationChannel.ENGINE_DERIVED,),
+        authorship_assurance=AuthorshipAssurance.HARNESS_OBSERVED,
+        artifact_observation=ArtifactObservation.HOOK_OBSERVED,
+        evidence_immutability=EvidenceImmutability.METADATA_ONLY,
+        ledger_freshness=LedgerFreshness.CURRENT,
+        check_types=(CheckType.DETERMINISTIC,),
+        known_gaps=(),
+    )
+
+
+def _observation_finding(*, number: int, subject_refs: tuple[str, ...]) -> Finding:
+    kind = FindingKind.FAILED_WORK_OMITTED
+    return Finding(
+        finding_id(f"fnd_30000000-0000-4000-8000-{number:012x}"),
+        kind,
+        FindingOrigin.DETERMINISTIC,
+        FINDING_KIND_TRAITS[kind][0],
+        "A failed command remains unresolved.",
+        "Resolve the failed command and rerun the check.",
+        tuple(
+            event_id(ref) if ref.startswith("evt_") else obligation_id(ref)
+            for ref in sorted(subject_refs)
+        ),
+        "work-integrity",
+        "0.1.0",
+        Frontier(1, "sha256:" + "b" * 64),
+        _observation_finding_coverage(),
+        None,
+    )
+
+
+def _append_finding_record(
+    prefix: tuple[Any, ...],
+    finding: Finding,
+    *,
+    number: int,
+) -> tuple[Any, ...]:
+    template = next(
+        record
+        for record in prefix
+        if type(record) is AcceptedEvent and record.schema.name == "finding_recorded"
+    )
+    last = prefix[-1]
+    assert type(last) is AcceptedEvent
+    payload_digest = canonical_digest(encode_payload(finding))
+    next_event = event_id(f"evt_30000000-0000-4000-8000-{number:012x}")
+    next_object = object_id(f"obj_30000000-0000-4000-8000-{number:012x}")
+    next_ledger = replace(
+        last.ledger,
+        ingestion_sequence=last.ledger.ingestion_sequence + 1,
+        previous_entry_digest=last.entry_digest,
+    )
+    next_ref = replace(template.payload_ref, object_id=next_object)
+    preimage: dict[str, Any] = dict(accepted_record_digest_preimage(template))
+    raw_payload_ref = cast(Mapping[str, Any], preimage["payload_ref"])
+    preimage["event_id"] = next_event
+    preimage["payload_ref"] = {**raw_payload_ref, "object_id": next_object}
+    preimage["ledger"] = {
+        "ingestion_sequence": str(next_ledger.ingestion_sequence),
+        "previous_entry_digest": next_ledger.previous_entry_digest,
+        "accepted_at": next_ledger.accepted_at.wire,
+    }
+    record = replace(
+        template,
+        event_id=next_event,
+        payload=finding,
+        payload_ref=next_ref,
+        ledger=next_ledger,
+        entry_digest=entry_digest(cast(Any, preimage)),
+        projection_locator=replace(
+            template.projection_locator,
+            logical_key=str(finding.finding_id),
+            canonical_payload_digest=payload_digest,
+        ),
+    )
+    return (*prefix, record)
+
+
+def test_case_keeps_observation_finding_citations_outside_history_or_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Receipt/case construction must not crash on observation finding event citations.
+
+    Two shapes appear together in the #253 dogfood ledger: citations of real early
+    events that fall outside the frozen history window, and citations of computed
+    observation draft IDs that were never appended.
+    """
+
+    base = replay_records("all-event-families")
+    early = next(
+        record
+        for record in base
+        if type(record) is AcceptedEvent
+        and record.schema.name
+        in {
+            "action_recorded",
+            "check_recorded",
+            "claim_recorded",
+            "decision_recorded",
+            "evidence_recorded",
+            "finding_recorded",
+            "obligation_published",
+            "plan_published",
+            "plan_revised",
+            "response_recorded",
+            "result_recorded",
+        }
+    )
+    phantom = event_id("evt_40000000-0000-4000-8000-0000000000aa")
+    records = base
+    for index in range(1, 81):
+        cited = (str(early.event_id), str(event_id(f"evt_40000000-0000-4000-8000-{index:012x}")))
+        records = _append_finding_record(
+            records,
+            _observation_finding(number=index, subject_refs=cited),
+            number=index,
+        )
+    records = _append_finding_record(
+        records,
+        _observation_finding(number=81, subject_refs=(str(phantom),)),
+        number=81,
+    )
+
+    monkeypatch.setattr(deterministic_checks, "MAX_FROZEN_HISTORY_EVENTS", 2)
+    projection = replay(records)
+    case = build_deterministic_case(projection, records, CaseAvailabilityFacts())
+
+    assert early.event_id in case.allowed_ids
+    assert early.event_id not in {item.event_id for item in case.history}
+    assert phantom not in case.allowed_ids
+    assert any(gap.code == "missing_ref" for gap in case.gaps)
+    assert any(gap.marker == "missing_ref:cited_event_absent" for gap in case.gaps)
+    assert len(case.projection.findings) >= 80
+    assert case.history_omitted_before_count > 0

--- a/tests/unit/kernel/test_reducers_each_family.py
+++ b/tests/unit/kernel/test_reducers_each_family.py
@@ -234,6 +234,31 @@ def test_evidence_claim_response_redaction_paths() -> None:
     assert "redacted_object:obj_20000002-0000-4000-8000-000000000900" in state.coverage_gaps
 
 
+def test_finding_event_subject_ref_outside_prefix_does_not_overflow_projection_gaps() -> None:
+    records = list(_records("all-event-families"))
+    finding = next(
+        record
+        for record in records
+        if type(record) is AcceptedEvent and record.schema.name == "finding_recorded"
+    )
+    assert finding.payload is not None
+    from yoetz.domain.events import encode_payload
+    from yoetz.protocol.canonical import canonical_digest
+
+    phantom = event_id("evt_40000000-0000-4000-8000-0000000000aa")
+    payload = replace(finding.payload, subject_refs=(phantom,))
+    records[records.index(finding)] = replace(
+        finding,
+        payload=payload,
+        projection_locator=replace(
+            finding.projection_locator,
+            canonical_payload_digest=canonical_digest(encode_payload(payload)),
+        ),
+    )
+    state = replay(tuple(records))
+    assert not any(marker.startswith("missing_ref:") for marker in state.coverage_gaps)
+
+
 def test_finding_check_receipt_records() -> None:
     records = _records("all-event-families")
     before_redaction = replay(records[:13])


### PR DESCRIPTION
## Issue

- Linked issue: `Fixes #253`
- I searched existing issues and PRs for duplicates before opening this PR. #200 is a different receipt `internal_error` (replay contiguity). #216/#231 do not cover case construction crashing on finding event-ref closure.
- This is a narrowly scoped bugfix for receipt/case construction over observation-authored findings. The issue is the maintainer-authored expected contract for that crash.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (missing finding/contradiction `evt_` citations become one bounded `missing_ref` gap; remaining case-construction failure is `STORAGE_CORRUPT`, not `INTERNAL_ERROR`)

## Verification

Commands run:

```text
uv run pytest tests/unit/kernel/test_deterministic_checks.py tests/unit/kernel/test_reducers_each_family.py tests/unit/kernel/test_receipt_builder.py tests/unit/application/test_observation_coordinator.py tests/integration/observation/test_e2e_successor_acceptance.py tests/conformance/operations/test_receipt_contract.py tests/property/test_reducer_equivalence.py
# 139 passed

uv run ruff check <touched files>
npx --no-install pyright <touched files>
uv run python scripts/scan_public_boundary.py --source-tree .
# scan_public_boundary: PASS
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Receipt crashed at `build_deterministic_case` when observation-authored findings cited `evt_` ids that were not in the accepted prefix (computed materialization drafts, or events outside the selected case history). That `ValueError` was classified as `INTERNAL_ERROR`.

This change:

- closes those citations against the accepted prefix when the event exists, including events older than the 64-event frozen history window;
- otherwise keeps them out of `allowed_ids` and records one task-global `missing_ref:cited_event_absent` gap (not one marker per finding, which would overflow the 64-gap receipt bound);
- maps any remaining case-construction `ValueError` on receipt/status/check freeze to `STORAGE_CORRUPT`;
- stops new observation advice findings from citing unappended draft ids.

A ledger with 80+ unresolved observation findings, early-history subject refs, and phantom event refs now builds an honest receipt instead of crashing.
