### PR TITLE
Fix observation finding identity churn

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2319,9 +2319,13 @@ Shared closed types:
   it is never a seventh MCP tool. Deterministic observation-advice policies derive the snapshot
   from retained envelopes (and optional inspect/approved-check/composition facts) even with zero
   cooperative Yoetz MCP publications. Optional semantic advice is additive only, through the
-  privacy gateway, over minimized approved packets. Deterministic finding identity is
-  candidate-scoped; envelope-linked candidates use only their mapped ledger events as subject refs,
-  while standing session conditions use the stable lifecycle event.
+  privacy gateway, over minimized approved packets. Deterministic finding identity is condition-
+  scoped over policy, kind, rule code, and rule-specific cause; rolling or accumulating evidence
+  refs never participate in identity. Envelope-linked candidates use only their mapped ledger
+  events as the first durable subject anchors, while standing session conditions use the stable
+  lifecycle event. Once a readable condition finding exists, later evidence-window or frontier
+  changes update the observation snapshot and coverage/gap state without appending another
+  `finding_recorded` event.
   Hook-channel delivery is relevance-scoped: task-scoped conditions come from the mapped Yoetz
   session snapshot when one exists, otherwise from the current Codex session's retained envelopes.
   The workspace-wide snapshot is not a fallback for task-scoped work. Deliberately workspace-

--- a/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
@@ -1,10 +1,11 @@
 # ADR-022 — Harness observation writer identity and observation-tolerant optimistic concurrency
 
 **Status:** Accepted (2026-08-13), recorded for issues #214–#223 and acknowledged in issue #225.
-**Amended:** 2026-08-14 for moderator-approved issue #244.
+**Amended:** 2026-08-14 for moderator-approved issue #244 and the reopened issue #216 recurrence.
 **Implemented by:** `src/yoetz/application/observation_materialize.py`,
 `src/yoetz/application/observation_coordinator.py`, `src/yoetz/adapters/memory/ledger.py`,
-`src/yoetz/application/publish_work.py`, and `src/yoetz/service/ready_composition.py`.
+`src/yoetz/application/publish_work.py`, `src/yoetz/kernel/policies/observation_advice.py`, and
+`src/yoetz/service/ready_composition.py`.
 **Relates to:** ADR-009, ADR-010, ADR-020, and
 issues #214, #216, #217, #223, #224, #225, #226, #227, and #244.
 
@@ -63,10 +64,13 @@ unsupported claims and unbounded duplicate findings.
    structural payload explicitly carries an admitted `claim_kind`. Mapping version
    `obs-ledger/1.2.0` separates these identities from historical observation-derived claims.
 
-6. Deterministic advice finding ids are candidate-scoped over policy, kind, rule code, evidence
-   refs, and detail token. Candidate subject refs map only their source envelopes to ledger event ids;
-   a standing condition with no envelope anchors to the session lifecycle event. Already-recorded
-   candidates with the same subject refs are not appended again.
+6. Deterministic advice finding IDs are condition-scoped over policy, kind, rule code, and detail
+   token. Evidence refs prove the condition but never identify it: several rules intentionally cite
+   a rolling or accumulating envelope window. Candidate subject refs map only their source envelopes
+   to ledger event ids; a standing condition with no envelope anchors to the session lifecycle
+   event. Once a readable finding for that condition exists, later evidence-window or frontier
+   changes do not append another `finding_recorded` event. The current observation snapshot and
+   coverage/gap state retain the changing evidence context without growing the durable finding set.
 
 7. A provenance-dispute response disposition is deferred to issue #224. This change removes the
    false observation-authored claim premise but does not add a fourth `ResponseDisposition`, change
@@ -118,4 +122,6 @@ outbox rather than weakening verdict binding. Observation can contribute evidenc
 advice without impersonating the agent or minting the same standing finding indefinitely. Routine
 reads retain their local observation evidence without producing an unbounded task-ledger trail, and
 cooperative writers learn about meaningful observation-authored frontier motion before their next
-state-sensitive operation.
+state-sensitive operation. Observation-advice policy `0.1.1` applies the condition-scoped identity
+to new materialization. Historical duplicate findings remain append-only evidence; this change does
+not erase or rewrite an existing task ledger.

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -1723,6 +1723,31 @@ class ObservationCoordinator:
 
         if type(snapshot) is not AdviceSnapshot or runtime.writer_id is None:
             return
+        candidate_items = _materialized_advice_items(snapshot.ranked_items)
+        if not candidate_items:
+            return
+        finding_projection = await runtime.ledger.load_projection(
+            runtime.session_id, ProjectionView.CANDIDATE_FINDINGS
+        )
+        projected_findings: Mapping[FindingId, ProjectionRecord[Finding]] = (
+            finding_projection.state.findings
+            if finding_projection is not None and type(finding_projection.state) is ProjectionState
+            else {}
+        )
+        candidate_items = tuple(
+            item
+            for item in candidate_items
+            if (
+                (existing := projected_findings.get(item.finding_id)) is None
+                or existing.payload is None
+            )
+        )
+        if not candidate_items:
+            # A readable condition finding already anchors the durable record.
+            # Rolling evidence remains current in the observation snapshot and
+            # coverage/gap state; appending a revision here would invalidate
+            # checks and grow the ledger once per routine envelope.
+            return
         refs_by_source: dict[str, set[str]] = {}
         for envelope in envelopes:
             refs_by_source.setdefault(envelope.source_identity, set()).update(
@@ -1741,17 +1766,6 @@ class ObservationCoordinator:
             runtime.session_id, ProjectionView.COMPACT
         )
         frontier = Frontier.genesis() if projection is None else projection.frontier
-        finding_projection = await runtime.ledger.load_projection(
-            runtime.session_id, ProjectionView.CANDIDATE_FINDINGS
-        )
-        projected_findings: Mapping[FindingId, ProjectionRecord[Finding]] = (
-            finding_projection.state.findings
-            if finding_projection is not None and type(finding_projection.state) is ProjectionState
-            else {}
-        )
-        candidate_items = _materialized_advice_items(snapshot.ranked_items)
-        if not candidate_items:
-            return
         items: list[tuple[AdviceItem, tuple[str, ...]]] = []
         for item in candidate_items:
             matched_refs = {
@@ -1776,13 +1790,6 @@ class ObservationCoordinator:
                         matched_refs.update(ref for ref in observed if ref in known_event_ids)
             subject_refs = tuple(sorted(matched_refs, key=str.encode)[:64])
             if not subject_refs:
-                continue
-            existing_finding = projected_findings.get(item.finding_id)
-            if (
-                existing_finding is not None
-                and existing_finding.payload is not None
-                and tuple(str(ref) for ref in existing_finding.payload.subject_refs) == subject_refs
-            ):
                 continue
             items.append((item, subject_refs))
         if not items:

--- a/src/yoetz/kernel/policies/observation_advice.py
+++ b/src/yoetz/kernel/policies/observation_advice.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 OBSERVATION_ADVICE_POLICY_ID: Final = "observation-advice"
-OBSERVATION_ADVICE_POLICY_VERSION: Final = "0.1.0"
+OBSERVATION_ADVICE_POLICY_VERSION: Final = "0.1.1"
 
 OBSERVATION_ADVICE_FACT_CODES: Final = frozenset(
     {
@@ -631,7 +631,14 @@ def evidence_basis_digest(
 
 
 def advice_candidate_digest(candidate: ObservationAdviceCandidate) -> str:
-    """Return the stable identity of one standing advice condition."""
+    """Return the stable identity of one advice condition.
+
+    Evidence references prove the condition but do not identify it. Several
+    rules intentionally retain rolling or accumulating reference windows, so
+    including them here would mint a new finding for every routine envelope.
+    ``detail_token`` carries the rule-specific cause when multiple independent
+    instances of one rule must remain distinct.
+    """
 
     if type(candidate) is not ObservationAdviceCandidate:
         raise ValueError("observation_advice_invalid")
@@ -640,7 +647,6 @@ def advice_candidate_digest(candidate: ObservationAdviceCandidate) -> str:
             "policy": f"{OBSERVATION_ADVICE_POLICY_ID}/{OBSERVATION_ADVICE_POLICY_VERSION}",
             "kind": candidate.kind.value,
             "rule_code": candidate.rule_code,
-            "evidence_refs": candidate.evidence_refs,
             "detail_token": candidate.detail_token,
         }
     )

--- a/src/yoetz/kernel/policies/observation_advice.py
+++ b/src/yoetz/kernel/policies/observation_advice.py
@@ -287,13 +287,19 @@ def _failed_commands(envelopes: Sequence[ObservationEnvelope]) -> list[Observati
         elif exit_status == 0 or success is True:
             unresolved.pop(key, None)
     for key, envelope in unresolved.items():
+        cause_digest = canonical_digest(
+            {
+                "correlation_key": key,
+                "source_identity": envelope.source_identity,
+            }
+        )
         results.append(
             _candidate(
                 FindingKind.FAILED_WORK_OMITTED,
                 "failed_command_unresolved",
                 "resolve_failed_command",
                 (_envelope_ref(envelope),),
-                f"failed:{key[:48]}",
+                f"failed:{cause_digest.removeprefix('sha256:')}",
             )
         )
     return results

--- a/tests/integration/observation/test_e2e_successor_acceptance.py
+++ b/tests/integration/observation/test_e2e_successor_acceptance.py
@@ -421,6 +421,7 @@ async def test_advice_finding_materialization_passes_real_ledger_validation(tmp_
         ownership_fence,
     )
     from yoetz.application.observation_coordinator import ObservationCoordinator
+    from yoetz.application.observation_materialize import materialize_observation_envelope
     from yoetz.domain.events import AcceptedEvent
     from yoetz.domain.findings import Finding
     from yoetz.domain.observation import (
@@ -526,6 +527,41 @@ async def test_advice_finding_materialization_passes_real_ledger_validation(tmp_
     assert accepted.publication_channel is PublicationChannel.ENGINE_DERIVED
     assert accepted.coverage == coverage_for_channel(PublicationChannel.ENGINE_DERIVED)
     assert accepted.payload.coverage == mixed_coverage
+
+    revision_envelope = replace(
+        envelope,
+        source_identity="hook:advice-ledger-revision",
+        cursor=replace(envelope.cursor, event_position=2),
+        structural_payload=JsonObject(
+            {
+                "tool_name": "shell",
+                "tool_call_id": "advice-ledger-revision",
+                "correlation_id": "advice-ledger-revision",
+                "exit_status": 2,
+            }
+        ),
+    )
+    await coordinator._append_materialized(  # pyright: ignore[reportPrivateUsage]
+        runtime,
+        revision_envelope,
+        materialize_observation_envelope(revision_envelope, task_id=seed.task_id),
+    )
+    before_repeat = [row async for row in ledger.load_events(seed.session_id)]
+    revised_item = replace(item, evidence_refs=(revision_envelope.source_identity,))
+    await coordinator._materialize_advice_findings(  # pyright: ignore[reportPrivateUsage]
+        runtime,
+        (envelope, revision_envelope),
+        replace(
+            snapshot,
+            ranked_items=(revised_item,),
+            evidence_basis_digest="sha256:" + "d" * 64,
+            suppression_identity="advice-ledger-validation-2",
+        ),
+    )
+    after_repeat = [row async for row in ledger.load_events(seed.session_id)]
+
+    assert len(after_repeat) == len(before_repeat)
+    assert sum(row.schema.name == "finding_recorded" for row in after_repeat) == 1
 
 
 def test_untrusted_workspace_dot_does_not_bind_without_consent(

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -240,12 +240,17 @@ def test_finding_identity_ignores_evidence_refs_that_are_a_rolling_window() -> N
 
 
 def test_delivery_identity_distinguishes_successive_failed_commands() -> None:
+    shared_prefix = "same-correlation-prefix-" + "x" * 40
     first = build_observation_advice_snapshot(
         ObservationAdviceBuildInput(
             envelopes=(
                 _envelope(
                     "hook:fail-a",
-                    {"tool_name": "shell", "exit_status": 2, "correlation_id": "command-a"},
+                    {
+                        "tool_name": "shell",
+                        "exit_status": 2,
+                        "correlation_id": shared_prefix + "-a",
+                    },
                 ),
             ),
             lifecycle=ObservationLifecycle.ACTIVE,
@@ -258,17 +263,29 @@ def test_delivery_identity_distinguishes_successive_failed_commands() -> None:
             envelopes=(
                 _envelope(
                     "hook:fail-a",
-                    {"tool_name": "shell", "exit_status": 2, "correlation_id": "command-a"},
+                    {
+                        "tool_name": "shell",
+                        "exit_status": 2,
+                        "correlation_id": shared_prefix + "-a",
+                    },
                     pos=1,
                 ),
                 _envelope(
                     "hook:resolve-a",
-                    {"tool_name": "shell", "exit_status": 0, "correlation_id": "command-a"},
+                    {
+                        "tool_name": "shell",
+                        "exit_status": 0,
+                        "correlation_id": shared_prefix + "-a",
+                    },
                     pos=2,
                 ),
                 _envelope(
                     "hook:fail-b",
-                    {"tool_name": "shell", "exit_status": 3, "correlation_id": "command-b"},
+                    {
+                        "tool_name": "shell",
+                        "exit_status": 3,
+                        "correlation_id": shared_prefix + "-b",
+                    },
                     pos=3,
                 ),
             ),

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -228,6 +228,17 @@ def test_delivery_identity_ignores_evidence_refs_that_are_a_rolling_window() -> 
     )
 
 
+def test_finding_identity_ignores_evidence_refs_that_are_a_rolling_window() -> None:
+    """A standing condition remains one durable finding as its citations move (#216)."""
+
+    first = _gap_snapshot(3)
+    later = _gap_snapshot(9)
+
+    assert first.ranked_items[0].evidence_refs != later.ranked_items[0].evidence_refs
+    assert first.evidence_basis_digest != later.evidence_basis_digest
+    assert first.ranked_items[0].finding_id == later.ranked_items[0].finding_id
+
+
 def test_delivery_identity_distinguishes_successive_failed_commands() -> None:
     first = build_observation_advice_snapshot(
         ObservationAdviceBuildInput(
@@ -268,6 +279,7 @@ def test_delivery_identity_distinguishes_successive_failed_commands() -> None:
     )
     assert first is not None and later is not None
     assert first.ranked_items[0].summary == later.ranked_items[0].summary
+    assert first.ranked_items[0].finding_id != later.ranked_items[0].finding_id
     assert advice_delivery_identity(first) != advice_delivery_identity(later)
 
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #216
- I searched existing issues and PRs for duplicates before opening this PR. PR #228 is the incomplete earlier fix; #241/#245 address hook-channel advice delivery rather than durable finding materialization. No open PR targets the reopened #216 recurrence.
- This amends ADR-022's storage/durability behavior. The repository owner reopened #216 with current-runtime evidence and explicitly requested this repair, satisfying the maintainer acknowledgement gate.

## Documentation

- Behavior change? yes
- Docs updated:
  - `docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md`
  - `docs/INTERFACES.md`

## Verification

Commands run:

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest   tests/unit/application/test_observation_advice.py   tests/unit/application/test_observation_coordinator.py   tests/unit/kernel/test_observation_advice_policies.py   tests/unit/adapters/test_observation_local_advice_delivery.py   tests/integration/observation   tests/integration/application/test_respond_status_receipt.py   tests/unit/kernel/test_receipt_builder.py   tests/conformance/operations/test_receipt_contract.py   tests/property/test_reducer_equivalence.py   --deselect tests/integration/observation/test_acceptance_scenarios.py::test_session_start_creates_binding_without_mcp_start -q
# 201 passed, 1 deselected

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check <touched Python files>
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check <touched Python files>
npx --no-install pyright <touched Python files>
git diff --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
# all passed; scan_public_boundary: PASS (932 files)
```

The deselected SessionStart-output assertion fails identically on untouched `origin/main` at `aa93c6a`; it is unrelated to this diff.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

PR #228 moved observation findings from snapshot identity to an advice-candidate digest, but that digest still included `evidence_refs`. The `observation_gap_or_stale` rule intentionally cites the latest three envelopes, so routine hooks rolled those refs and deterministically minted a new `FindingId` on every frontier advance.

This repair:

- scopes deterministic finding identity to policy, kind, rule code, and rule-specific cause;
- keeps rolling evidence in the evidence-basis digest, observation snapshot, and coverage/gap state;
- stops materialization before rescanning envelopes or appending when a readable condition finding already exists;
- bumps the observation-advice policy identity to `0.1.1`;
- proves through unit and real-ledger regressions that moving evidence retains one finding while distinct failed commands remain distinct.

Historical duplicates remain append-only evidence and are not erased or rewritten. The fix prevents new duplicate materialization and keeps future closure ceremony bounded to the one real condition.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix observation finding identity churn by scoping advice candidate digest to condition rather than evidence
> - Removes `evidence_refs` from the `advice_candidate_digest` computation in [observation_advice.py](https://github.com/TheGaySupreme123/yoetz/pull/257/files#diff-6eb3f417aa4a3346a826ad7cd8daa872fb288971c26c610278e4edc3832420b9) so that finding identity is now scoped to policy/version, kind, rule code, and detail token only.
> - Fixes duplicate `finding_recorded` events that were previously appended when evidence windows or frontier changed on an already-readable condition finding.
> - Changes the `detail_token` for `FAILED_WORK_OMITTED` findings to use a canonical digest of correlation key and source identity instead of a truncated correlation key, so successive failed commands with shared prefixes produce distinct identities.
> - Bumps policy version to `0.1.1` and adds integration/unit tests verifying no duplicate findings are recorded across evidence revisions.
> - Behavioral Change: existing advice candidate digests computed under `0.1.0` will differ from those computed under `0.1.1` due to both the evidence-refs exclusion and the new `detail_token` derivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 120d94f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->