### PR TITLE
Fix retained finding coverage in receipts

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -880,11 +880,16 @@ deciding between the two, shared by the receipt and by compact status coverage.
   `availability` is the current `CaseAvailabilityFacts`, `coverage` is the weakest material fold,
   `gaps` is the exact sorted typed `CaseGap` tuple after check/semantic/availability accounting, and
   `applicable_check` is the exact readable `CheckRecordedPayload` that still applies to this
-  material state or `None`. A check applies when no event appended after the check's own record
-  supersedes it under `kernel/reducers.invalidates_recorded_check`: the check's atomic result
-  events — the `finding_recorded` records it returned and its `check_recorded` — land with it and
-  never revoke it (a deterministic candidate that re-derives a live recorded finding with the same
-  kind, policy, and subject refs keeps that finding's ID and is cited in `returned_finding_ids`
+  material state or `None`. The application folds coverage from the frozen current case, the
+  applicable check, and every retained current finding row. When a historical finding contributes
+  a gap absent from the recovered current case/check, that code remains in top-level coverage and
+  is represented once by the task-global internal marker `retained_finding_coverage:<code>`; the
+  finding's own coverage remains unchanged. A check applies when no event appended after the
+  check's own record supersedes it under `kernel/reducers.invalidates_recorded_check`: the atomic
+  check-result events — the `finding_recorded` records it returned and its `check_recorded` — land
+  with it and never revoke it (a deterministic candidate that re-derives a live recorded finding
+  with the same kind, policy, and subject refs keeps that finding's ID and is cited in
+  `returned_finding_ids`
   without a duplicate `finding_recorded` event); an immaterial advance — `receipt_recorded`, `session_opened`,
   `session_resumed` — never revokes it; and a readable `response_recorded` answering a finding the
   check itself returned never revokes it, though the context then carries the

--- a/src/yoetz/application/receipt.py
+++ b/src/yoetz/application/receipt.py
@@ -74,6 +74,7 @@ from yoetz.protocol.coverage import (
     PublicationChannel,
     coverage_for_channel,
     coverage_to_json,
+    weakest,
 )
 from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
 from yoetz.protocol.ids import IdKind
@@ -309,6 +310,7 @@ def _context(
     assert type(projection) is ProjectionState
     assert type(case) is DeterministicCase
     applicable: CheckRecordedPayload | None = None
+    finding_states = _finding_states(projection)
     gaps = list(case.gaps)
     latest = projection.latest_tested_state
     check_record: LedgerRecord | None = None
@@ -370,6 +372,28 @@ def _context(
         for code in applicable.coverage.known_gaps:
             if not any(gap.code == code for gap in gaps):
                 gaps.append(CaseGap(f"check_coverage:{code}", code, ()))
+    coverage = case_coverage(case)
+    if applicable is not None:
+        coverage = weakest(coverage, applicable.coverage)
+    # Findings are historical material, not merely presentation rows. Observation advice can
+    # retain a finding stamped while delivery was stale after the current projection and latest
+    # check have recovered. Fold every retained row before constructing the context so the
+    # builder's corruption guard remains strict while the application supplies the honest weakest
+    # coverage the receipt document already promises.
+    for state in finding_states:
+        record = projection.findings[state.finding_id]
+        assert record.payload is not None
+        coverage = weakest(coverage, record.payload.coverage)
+
+    # ReceiptBuildContext requires exact equality between Coverage.known_gaps and CaseGap codes.
+    # Check-derived codes were materialized above; a code introduced only by a retained finding
+    # receives one task-global structural marker so many historical findings cannot exhaust the
+    # receipt's bounded 64-gap surface.
+    represented_codes = {gap.code for gap in gaps}
+    for code in coverage.known_gaps:
+        if code not in represented_codes:
+            gaps.append(CaseGap(f"retained_finding_coverage:{code}", code, ()))
+            represented_codes.add(code)
     ordered_gaps = tuple(
         sorted(
             gaps,
@@ -379,45 +403,19 @@ def _context(
             ),
         )
     )
-    coverage = case_coverage(case)
     codes = tuple(sorted({gap.code for gap in ordered_gaps}, key=str.encode))
     if codes != coverage.known_gaps:
         freshness = coverage.ledger_freshness
         if codes and freshness is LedgerFreshness.CURRENT:
             freshness = LedgerFreshness.PARTIAL
         coverage = replace(coverage, ledger_freshness=freshness, known_gaps=codes)
-    if applicable is not None:
-        from yoetz.protocol.coverage import weakest
-
-        coverage = weakest(coverage, applicable.coverage)
-        # ReceiptBuildContext requires exact equality between coverage.known_gaps and CaseGap codes.
-        extra_codes = set(coverage.known_gaps) - {gap.code for gap in ordered_gaps}
-        if extra_codes:
-            extended = list(ordered_gaps)
-            for code in sorted(extra_codes, key=str.encode):
-                extended.append(CaseGap(f"check_coverage:{code}", code, ()))
-            ordered_gaps = tuple(
-                sorted(
-                    extended,
-                    key=lambda gap: (
-                        gap.marker.encode("ascii"),
-                        tuple(ref.encode("ascii") for ref in gap.subject_refs),
-                    ),
-                )
-            )
-        codes = tuple(sorted({gap.code for gap in ordered_gaps}, key=str.encode))
-        if codes != coverage.known_gaps:
-            freshness = coverage.ledger_freshness
-            if codes and freshness is LedgerFreshness.CURRENT:
-                freshness = LedgerFreshness.PARTIAL
-            coverage = replace(coverage, ledger_freshness=freshness, known_gaps=codes)
     return ReceiptBuildContext(
         projection,
         frontier,
         case.availability,
         coverage,
         ordered_gaps,
-        _finding_states(projection),
+        finding_states,
         applicable,
     )
 

--- a/tests/integration/application/test_respond_status_receipt.py
+++ b/tests/integration/application/test_respond_status_receipt.py
@@ -20,10 +20,24 @@ from builders.start_application import (
 )
 from yoetz.application.check import FinalSemanticEvaluation
 from yoetz.application.egress import PrivacyCoordinator
+from yoetz.application.observation_materialize import observation_author
 from yoetz.application.service import Application, VerificationPolicy
 from yoetz.application.start import StartInternalResult
-from yoetz.domain.events import RuntimeProfile
-from yoetz.domain.findings import SemanticDispatchKind, SemanticProvenance
+from yoetz.domain.events import (
+    EventDraft,
+    EventSchema,
+    RuntimeProfile,
+    encode_payload,
+    media_type_for,
+)
+from yoetz.domain.findings import (
+    FINDING_KIND_TRAITS,
+    Finding,
+    FindingKind,
+    FindingOrigin,
+    SemanticDispatchKind,
+    SemanticProvenance,
+)
 from yoetz.domain.privacy import (
     AuthorizationScope,
     AuthorizationScopeKind,
@@ -38,15 +52,31 @@ from yoetz.domain.privacy import (
     ReceiptTransformations,
 )
 from yoetz.domain.receipts import PolicyVersionEntry, ReceiptVersionSlice, SchemaVersionEntry
-from yoetz.domain.values import Frontier, session_id
+from yoetz.domain.values import (
+    Frontier,
+    event_id,
+    finding_id,
+    session_id,
+    timestamp_from_datetime,
+)
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
-from yoetz.ports.ledger import CheckCommitResult
+from yoetz.ports.ledger import AppendCommand, AppendEntry, CheckCommitResult, OperationKind
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectSource
 from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
 from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
 from yoetz.ports.semantic import SamplingParams, SemanticJudgment
 from yoetz.protocol.canonical import JsonValue, canonical_encode
-from yoetz.protocol.coverage import CheckType
+from yoetz.protocol.coverage import (
+    ArtifactObservation,
+    AuthorshipAssurance,
+    CheckType,
+    Coverage,
+    EvidenceImmutability,
+    LedgerFreshness,
+    PublicationChannel,
+    coverage_for_channel,
+)
 from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.models import (
     CheckRequest,
@@ -902,6 +932,139 @@ async def test_receipt_build_context_is_complete() -> None:
     # the human wording rather than the wire enum spelling (spaces, not underscores).
     assert "unresolved findings remain" in text_receipt.human_text
     assert text_receipt.conclusion == receipt.conclusion
+
+
+async def test_receipt_folds_retained_observation_finding_coverage_after_recovery() -> None:
+    """Regression for #259.
+
+    Observation advice records its own finding coverage inside the finding payload while the
+    accepted engine-derived envelope remains current. A later healthy check can therefore have
+    stronger current coverage without erasing the historical ``cursor_stale`` limitation carried
+    by the retained finding. Receipt construction must weaken to that history, not classify the
+    valid state as ``STORAGE_CORRUPT``.
+    """
+
+    app, runtime, _ = _build_app(seed_offset=16)
+    started = await app.start(start_request(2500, title="Recovered observation coverage"))
+    start_frontier = Frontier(int(started.frontier.sequence), started.frontier.head_digest)
+    ledger, objects = next(iter(runtime.resources.values()))
+    records = tuple(
+        [
+            record
+            async for record in ledger.load_events(
+                started.session_id, through=start_frontier.sequence
+            )
+        ]
+    )
+    assert records
+
+    retained_coverage = Coverage(
+        publication_channels=(PublicationChannel.ENGINE_DERIVED,),
+        authorship_assurance=AuthorshipAssurance.HARNESS_OBSERVED,
+        artifact_observation=ArtifactObservation.HOOK_OBSERVED,
+        evidence_immutability=EvidenceImmutability.METADATA_ONLY,
+        ledger_freshness=LedgerFreshness.PARTIAL,
+        check_types=(CheckType.DETERMINISTIC,),
+        known_gaps=("cursor_stale",),
+    )
+    kind = FindingKind.LEDGER_STALE_OR_INCOMPLETE
+    retained = Finding(
+        finding_id(protocol_id("fnd_", 2501)),
+        kind,
+        FindingOrigin.DETERMINISTIC,
+        FINDING_KIND_TRAITS[kind][0],
+        "Observation delivery was stale.",
+        "Observation delivery later recovered; retain this historical limitation.",
+        (records[0].event_id,),
+        "work-integrity",
+        "0.1.0",
+        start_frontier,
+        retained_coverage,
+        None,
+    )
+    payload = canonical_encode(encode_payload(retained))
+    now = app.clock.now_utc()
+    metadata = ObjectMetadata(
+        ObjectKind.EVENT_PAYLOAD,
+        media_type_for("finding_recorded"),
+        started.task_id,
+        now,
+    )
+    staged = await objects.stage(ObjectSource(data=payload, declared_size=len(payload)), metadata)
+    payload_ref = await objects.finalize(staged)
+    appended = await ledger.append_batch(
+        AppendCommand(
+            started.task_id,
+            started.session_id,
+            started.writer_id,
+            protocol_id("req_", 2502),
+            OperationKind.PUBLISH_WORK,
+            _DIGEST,
+            start_frontier.sequence,
+            (
+                AppendEntry(
+                    EventDraft(
+                        event_id(protocol_id("evt_", 2503)),
+                        EventSchema("finding_recorded", "1.0.0"),
+                        timestamp_from_datetime(now),
+                        (),
+                        retained,
+                        (),
+                        (),
+                    ),
+                    observation_author(),
+                    payload_ref,
+                    payload_ref.commitment,
+                    metadata.media_type,
+                    payload_ref.plaintext_size,
+                    PublicationChannel.ENGINE_DERIVED,
+                    coverage_for_channel(PublicationChannel.ENGINE_DERIVED),
+                    "projected",
+                ),
+            ),
+        )
+    )
+
+    checked = await app.check(
+        CheckRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 2504)),
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(appended.result_frontier),
+                "mode": "deterministic_only",
+                "max_findings": "3",
+            }
+        )
+    )
+    assert type(checked) is CheckCommitResult
+    assert checked.findings == ()
+    assert "cursor_stale" not in checked.coverage.known_gaps
+
+    receipt = await app.receipt(
+        ReceiptRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 2505)),
+                "task_id": started.task_id,
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(checked.result_frontier),
+                "format": "json",
+                "include": "standard",
+                "redaction_profile": "full_local",
+            }
+        )
+    )
+
+    assert FINDING_KIND_TRAITS[kind][1] is False
+    assert receipt.conclusion == "insufficient_coverage"
+    assert receipt.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+    assert "cursor_stale" in receipt.coverage.known_gaps
+    document = cast(Mapping[str, JsonValue], receipt.document)
+    findings = cast(tuple[Mapping[str, JsonValue], ...], document["findings"])
+    assert any(item["finding_id"] == retained.finding_id for item in findings)
+    gaps = cast(tuple[Mapping[str, JsonValue], ...], document["gaps"])
+    assert sum(item["code"] == "cursor_stale" for item in gaps) == 1
 
 
 async def test_successful_check_contributes_to_receipt_at_resulting_head() -> None:


### PR DESCRIPTION
Fixes #259

## What changed

- Fold every retained current finding into the receipt build context's weakest material coverage.
- Preserve historical gap codes, such as `cursor_stale`, with one bounded task-global structural gap per distinct code.
- Keep `ReceiptBuildContext`'s strict coverage validation intact so genuinely inconsistent case state still fails closed.
- Document the receipt coverage composition rule in `docs/INTERFACES.md`.
- Add an end-to-end regression for a non-actionable observation finding whose `cursor_stale` gap recovers before a later clean check and receipt.

## Root cause

Receipt context construction folded the frozen current case and applicable check, but omitted the retained finding rows that the receipt must carry. After observation recovery, the current case/check could legitimately be stronger than a historical finding. The builder correctly rejected that stronger top-level coverage, and the application mapped the validation failure to `STORAGE_CORRUPT`.

The application now supplies the honest weakest coverage instead of weakening the builder's corruption guard.

## Impact

A receipt remains constructible after observation delivery recovers. It carries the historical limitation and produces a coverage-bounded conclusion rather than incorrectly reporting an unreadable/corrupt case.

## Intake

- Duplicate search and distinct scope are recorded on #259.
- Maintainer acknowledgement and P1 severity assessment are recorded on #259.
- Public behavior authority updated: `docs/INTERFACES.md`.

## Verification

- 306 relevant receipt, coverage, check, status, response, observation, and #253 regression tests passed.
- `uv run ruff check .`
- `uv run ruff format --check .` — 573 files formatted
- `npx --no-install pyright` — 0 errors
- `git diff --check`
- `uv run python scripts/scan_public_boundary.py --source-tree .` — 932 files scanned

The full repository test suite was intentionally not run; verification used all affected and adjacent suites.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix retained finding coverage in receipts to include gaps from historical findings
> - `ReceiptBuildContext` in [receipt.py](https://github.com/TheGaySupreme123/yoetz/pull/260/files#diff-3440c59540bf832be672ceb269bd86832a48647ef853b0c678432008d55bde40) now folds coverage from retained finding rows into the cumulative coverage alongside the frozen case and applicable check coverage.
> - When a gap code is present only due to retained findings (absent from the recovered case/check), a single `retained_finding_coverage:<code>` marker `CaseGap` is emitted to represent it.
> - `coverage.known_gaps` and freshness are now synchronized with the final gap set regardless of whether an applicable check exists, removing the previous check-only path.
> - Behavioral Change: receipts that previously reported sufficient coverage may now report `insufficient_coverage` (with `LedgerFreshness.PARTIAL`) when retained findings introduce gap codes not covered by the current case or check.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2833fdf. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->