### PR TITLE
Source standing provider advice from live machine facts (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,19 @@ carried them; they are listed because each one describes the behavior that now s
   on (`connect_provider`)
   travel only on session-boundary events, falling through to the next actionable item on
   per-tool-call hooks rather than masking it (issue #241).
+- The Stop hook advised `connect_provider` right after the same mapped session completed a
+  successful external semantic dispatch: READY composition froze `semantic_ready=False` and an
+  empty connected-provider snapshot into the observation advice fact, so the standing
+  `provider_not_ready` condition fired for every semantic-configured installation regardless of
+  live state. The fact is now recomputed on every advice build from current machine facts —
+  endpoint bound, provider factory available, and exact configured-credential presence in the
+  vault — and absence from the lazily filled connected registry no longer triggers the advice on
+  its own, because repository-scoped activation is re-established automatically at dispatch and
+  is not an operator action. A genuinely missing credential still surfaces at the bounded #241
+  cadence, credential revocation puts the condition back into the advice snapshot from current
+  evidence — delivery of the byte-identical text then follows the documented #241 cadence
+  (session boundaries; repeats within one session scope only after different advice intervened) —
+  and repository-scoped dispatch authority remains resolved per check (issue #265).
 - Every workspace exec call paid 3.5–7.5 seconds of synchronous observe-hook overhead — process
   startup importing the full CLI graph (~325 ms per hook) and, dominating on a lived-in store,
   10–18 full serialize-and-fsync cycles of the workspace state file per hook. The hook entry now

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2338,7 +2338,10 @@ Shared closed types:
   session snapshot when one exists, otherwise from the current Codex session's retained envelopes.
   The workspace-wide snapshot is not a fallback for task-scoped work. Deliberately workspace-
   standing machine conditions remain deliverable from that workspace snapshot at the documented
-  session-boundary cadence (`SessionStart` and `Stop`). The agent-visible context carries only
+  session-boundary cadence (`SessionStart` and `Stop`), and they rest on structural machine facts
+  recomputed at advice build time (configured endpoint, provider factory availability, exact
+  configured-credential presence) — never on a READY-time snapshot or on absence from the lazily
+  activated provider registry, and never as a claim of repository-scoped dispatch authority (#265). The agent-visible context carries only
   the bounded rule, action, and evidence token; deciding whether the advice belongs to the
   current target never requires inspecting Yoetz storage. Hook stdout is event-specific:
   `SessionStart` / `PostToolUse` / `UserPromptSubmit` emit `hookSpecificOutput.additionalContext`;

--- a/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
@@ -122,6 +122,7 @@ outbox rather than weakening verdict binding. Observation can contribute evidenc
 advice without impersonating the agent or minting the same standing finding indefinitely. Routine
 reads retain their local observation evidence without producing an unbounded task-ledger trail, and
 cooperative writers learn about meaningful observation-authored frontier motion before their next
-state-sensitive operation. Observation-advice policy `0.1.1` applies the condition-scoped identity
-to new materialization. Historical duplicate findings remain append-only evidence; this change does
+state-sensitive operation. Observation-advice policy `0.1.2` applies the condition-scoped identity
+to new materialization (`0.1.1` first introduced it; `0.1.2` rebased the standing
+`provider_not_ready` condition onto per-build structural machine facts for issue #265). Historical duplicate findings remain append-only evidence; this change does
 not erase or rewrite an existing task ledger.

--- a/src/yoetz/application/observation_advice.py
+++ b/src/yoetz/application/observation_advice.py
@@ -129,6 +129,9 @@ type CallableSemanticReview = Callable[
     [tuple[ObservationAdviceCandidate, ...], str, tuple[str, ...], str | None],
     ObservationAdviceSemanticAddon | None | Awaitable[ObservationAdviceSemanticAddon | None],
 ]
+type CallableComposition = Callable[
+    [], ObservationCompositionFact | None | Awaitable[ObservationCompositionFact | None]
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,10 +159,21 @@ class ObservationAdviceContextBuilder:
 
     check_facts: CallableFacts | None = None
     inspect_fact: CallableInspect | None = None
-    composition: ObservationCompositionFact | None = None
+    # A callable composition is resolved on every build so standing provider
+    # advice reflects current machine facts instead of a READY-time
+    # snapshot (#265); a plain fact value stays supported for fixed contexts.
+    composition: ObservationCompositionFact | CallableComposition | None = None
     plan_path_digests: CallablePlans | None = None
     semantic_addon: CallableSemantic | None = None
     semantic_review: CallableSemanticReview | None = None
+
+    async def _resolve_composition(self) -> ObservationCompositionFact | None:
+        if not callable(self.composition):
+            return self.composition
+        resolved = self.composition()
+        if inspect.isawaitable(resolved):
+            resolved = await resolved
+        return resolved if type(resolved) is ObservationCompositionFact else None
 
     async def build(
         self,
@@ -169,6 +183,7 @@ class ObservationAdviceContextBuilder:
         yoetz_session_id: str | None = None,
     ) -> AdviceSnapshot | None:
         envelopes = store.list_envelopes(workspace)
+        composition = await self._resolve_composition()
         status = await store.status(ObservationStatusQuery(workspace))
         store_check_facts = getattr(store, "load_check_facts", None)
         checks: tuple[ObservationCheckFact, ...] = ()
@@ -190,7 +205,7 @@ class ObservationAdviceContextBuilder:
                 gaps=status.gaps,
                 check_facts=checks,
                 inspect_fact=inspect_fact,
-                composition=self.composition,
+                composition=composition,
                 plan_path_digests=plans,
             )
             candidates = observation_advice_findings(context)
@@ -224,7 +239,7 @@ class ObservationAdviceContextBuilder:
                 gaps=status.gaps,
                 check_facts=checks,
                 inspect_fact=inspect_fact,
-                composition=self.composition,
+                composition=composition,
                 plan_path_digests=plans,
                 prior_snapshot=prior,
                 semantic_addon=semantic,

--- a/src/yoetz/kernel/policies/observation_advice.py
+++ b/src/yoetz/kernel/policies/observation_advice.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 OBSERVATION_ADVICE_POLICY_ID: Final = "observation-advice"
-OBSERVATION_ADVICE_POLICY_VERSION: Final = "0.1.1"
+OBSERVATION_ADVICE_POLICY_VERSION: Final = "0.1.2"
 
 OBSERVATION_ADVICE_FACT_CODES: Final = frozenset(
     {
@@ -142,6 +142,10 @@ class ObservationInspectFact:
 
 @dataclass(frozen=True, slots=True)
 class ObservationCompositionFact:
+    # semantic_ready is the structural usability of the configured semantic
+    # path — endpoint bound, factory available, configured credential present.
+    # It claims nothing about repository-scoped dispatch authority, which is
+    # resolved per check (#265).
     semantic_configured: bool
     semantic_ready: bool
     provider_factory_ids: tuple[str, ...]
@@ -521,22 +525,28 @@ def _observation_gaps(
 def _provider_not_ready(
     composition: ObservationCompositionFact | None,
 ) -> list[ObservationAdviceCandidate]:
+    # connect_provider is a standing machine action, so it must rest on facts
+    # that establish the operator has something to connect: semantic wanted
+    # but the configured path is structurally unusable. Absence from the
+    # connected registry is not such a fact — activation is lazy and
+    # repository-scoped, re-established automatically on dispatch (#265) —
+    # so registry lag only names evidence, it never triggers the advice.
     if composition is None:
+        return []
+    if not composition.semantic_configured or composition.semantic_ready:
         return []
     configured = set(composition.provider_factory_ids)
     connected = set(composition.connected_provider_ids)
     missing = configured - connected
-    if missing or (composition.semantic_configured and not composition.semantic_ready):
-        return [
-            _candidate(
-                FindingKind.MATERIAL_LIMITATION_OMITTED,
-                "provider_not_ready",
-                "connect_provider",
-                tuple(sorted(missing or {"semantic:not_ready"}, key=_ascii)),
-                "provider-not-ready",
-            )
-        ]
-    return []
+    return [
+        _candidate(
+            FindingKind.MATERIAL_LIMITATION_OMITTED,
+            "provider_not_ready",
+            "connect_provider",
+            tuple(sorted(missing or {"semantic:not_ready"}, key=_ascii)),
+            "provider-not-ready",
+        )
+    ]
 
 
 def _semantic_without_attempt(

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -2314,6 +2314,38 @@ async def provide_service_ready_context(
     provider_binding: ProviderBinding | None = None
     provider_credential_connected = await configured_provider_credential_present()
     semantic_ready = False
+
+    async def observation_composition_fact() -> ObservationCompositionFact | None:
+        # Standing provider advice must rest on current machine facts, not this
+        # READY-time snapshot: credential presence changes at runtime and the
+        # connected registry only fills lazily on repository-scoped dispatch, so
+        # the frozen values would advise connect_provider against an installation
+        # that just dispatched successfully (#265). Structural usability claims
+        # no repository authority; an unreadable fact (for example a vault
+        # locking race) yields no fact rather than a false not-ready claim.
+        try:
+            connected_now = cast(
+                tuple[str, ...], tuple(getattr(gateway, "connected_provider_ids", lambda: ())())
+            )
+            # provider_factory_ids is provider-id grain while factories are
+            # keyed by full binding; the id test is exact today because the
+            # factory set is built from this same config.provider through the
+            # same provider_binding_from_config, so an id match implies the
+            # binding match. The credential probe below is full-binding grain.
+            structurally_usable = (
+                candidate_binding is not None
+                and candidate_binding.provider_id in provider_factory_ids
+                and await configured_provider_credential_present()
+            )
+        except Exception:
+            return None
+        return ObservationCompositionFact(
+            semantic_configured=semantic_configured,
+            semantic_ready=structurally_usable,
+            provider_factory_ids=provider_factory_ids,
+            connected_provider_ids=connected_now,
+        )
+
     capabilities = {
         RuntimeCapability.STRUCTURAL_READ,
         RuntimeCapability.PAYLOAD_READ,
@@ -2525,12 +2557,7 @@ async def provide_service_ready_context(
         clock=clock,
         ids=ids,
         advice_context_builder=ObservationAdviceContextBuilder(
-            composition=ObservationCompositionFact(
-                semantic_configured=semantic_configured,
-                semantic_ready=semantic_ready,
-                provider_factory_ids=provider_factory_ids,
-                connected_provider_ids=connected_provider_ids,
-            ),
+            composition=observation_composition_fact,
             semantic_review=_semantic_review if semantic_configured else None,
         ),
         verification_supervisor=verification_supervisor,

--- a/tests/integration/service/test_ready_composition.py
+++ b/tests/integration/service/test_ready_composition.py
@@ -24,8 +24,14 @@ from yoetz.adapters.sqlite.migrations import CATALOG_MIGRATIONS, Migration, init
 from yoetz.application.service import ClientProjectionContext, ControlProjectionBinding
 from yoetz.config.models import YoetzConfig
 from yoetz.config.write import fireworks_provider
+from yoetz.domain.observation import ObservationLifecycle
 from yoetz.domain.privacy import AuthorizationScope, AuthorizationScopeKind
 from yoetz.domain.values import JsonObject
+from yoetz.kernel.policies.observation_advice import (
+    ObservationAdviceContext,
+    ObservationCompositionFact,
+    observation_advice_findings,
+)
 from yoetz.ports.control import (
     ControlCallRequest,
     ControlClientKind,
@@ -1495,6 +1501,131 @@ async def test_ready_composition_reports_exact_configured_credential_presence(
         other_config = YoetzConfig(profile="local-openai", provider=other_provider)
         app = await application_factory(other_config)(1, vault.generation)
         assert app.provider_credential_connected is False
+    finally:
+        if app is not None:
+            await app.close()
+        await vault.close()
+        memory.close()
+        await lifecycle.close()
+
+
+@pytest.mark.anyio
+async def test_observation_provider_fact_tracks_live_credential_within_one_generation(
+    tmp_path: Path,
+) -> None:
+    """The standing-advice provider fact follows the vault, not the READY snapshot (#265).
+
+    The incident session was advised connect_provider at Stop right after a
+    successful semantic dispatch because the advice fact froze
+    ``semantic_ready=False`` at composition. The fact source must observe a
+    credential stored or discarded mid-generation without recomposition, and
+    must not fire the advice from registry lag alone.
+    """
+
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "d" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    await lifecycle.acquire_singleton()
+    await lifecycle.transition(ServiceState.LOCKED)
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "e" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "f" * 64)
+    provider = fireworks_provider(model="accounts/fireworks/models/minimax-m3")
+    config = YoetzConfig(profile="local-openai", provider=provider)
+    factory = build_ready_application_factory(
+        lifecycle=lifecycle,
+        vault=vault,
+        config=config,
+        paths=_Paths(tmp_path),
+        clock=clock,
+        secret_memory=memory,
+        diagnostics=_Diagnostics(),
+    )
+
+    def provider_rules(fact: object) -> set[str]:
+        assert type(fact) is ObservationCompositionFact
+        return {
+            item.rule_code
+            for item in observation_advice_findings(
+                ObservationAdviceContext(
+                    envelopes=(),
+                    lifecycle=ObservationLifecycle.ACTIVE,
+                    gaps=(),
+                    composition=fact,
+                )
+            )
+        }
+
+    app = None
+    try:
+        context = await factory.context_provider(1, vault.generation)
+        assert context.rediscover_pending_verification is not None
+        coordinator: object = getattr(context.rediscover_pending_verification, "__self__")
+        builder_composition: object = getattr(coordinator, "advice_context_builder").composition
+        assert callable(builder_composition), "the advice provider fact must be sourced per build"
+        composition = cast(
+            Callable[[], Awaitable[ObservationCompositionFact | None]], builder_composition
+        )
+        app = await factory.open(context)
+
+        # Genuinely missing credential: the advice stays visible.
+        fact = await composition()
+        assert type(fact) is ObservationCompositionFact
+        assert fact.semantic_configured is True
+        assert fact.semantic_ready is False
+        assert "provider_not_ready" in provider_rules(fact)
+
+        # Credential ceremony lands mid-generation: the next build sees it and
+        # the connect_provider recommendation becomes inapplicable, even though
+        # the lazy connected registry has still never listed the provider.
+        credential_binding = provider_credential_profile_binding(
+            provider.provider_id,
+            provider.model,
+            provider.endpoint_profile_id,
+            provider.endpoint_profile_version,
+        )
+        proof = HumanAuthorizationProof(
+            "provider-proof-mid-generation",
+            "provider_credential_set",
+            credential_binding.target_digest("set"),
+            1,
+            vault.generation,
+            None,
+            1.0,
+            60.0,
+        )
+        credential = memory.capture(
+            SecretPurpose.PROVIDER_CREDENTIAL,
+            bytearray(b"test-provider-token-mid-generation"),
+        )
+        await vault.store_provider_credential("set", credential_binding, credential, proof, 2.0)
+
+        connected = await composition()
+        assert type(connected) is ObservationCompositionFact
+        assert connected.semantic_ready is True
+        assert "fireworks" not in connected.connected_provider_ids
+        assert provider_rules(connected) == set()
+
+        # Revocation resurfaces the advice from current evidence.
+        await vault.discard_provider_credential(credential_binding)
+        revoked = await composition()
+        assert type(revoked) is ObservationCompositionFact
+        assert revoked.semantic_ready is False
+        assert "provider_not_ready" in provider_rules(revoked)
     finally:
         if app is not None:
             await app.close()

--- a/tests/unit/adapters/test_observation_local_advice_delivery.py
+++ b/tests/unit/adapters/test_observation_local_advice_delivery.py
@@ -47,6 +47,15 @@ _READY = ObservationCompositionFact(
     provider_factory_ids=(),
     connected_provider_ids=(),
 )
+# Structurally usable configured provider that has not (yet) appeared in the
+# lazily-filled connected registry — the shape a fresh per-build fact takes
+# right after a successful mapped-session dispatch or before the first one (#265).
+_USABLE = ObservationCompositionFact(
+    semantic_configured=True,
+    semantic_ready=True,
+    provider_factory_ids=("fireworks",),
+    connected_provider_ids=(),
+)
 
 
 def _envelope(
@@ -271,6 +280,77 @@ def test_standing_advice_reaches_the_agent_only_at_session_boundaries(
     assert "resolve_failed_command" in failed
     _run(tmp_path, "PostToolUse", "cadence", tool_name="shell", exit_status=0, correlation_id="c1")
     assert "connect_provider" in _run(tmp_path, "Stop", "cadence")
+
+
+def test_usable_provider_receives_no_connect_provider_at_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A structurally usable provider never triggers connect_provider at Stop (#265).
+
+    The hook itself succeeds on every event — ``_run`` asserts exit code 0 — so
+    an empty text is an advice-content verdict, not a delivery failure. This is
+    the shape of the incident session: semantic dispatch had just succeeded,
+    yet the frozen READY snapshot advised reconnecting the provider.
+    """
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _USABLE)
+
+    started = _run(tmp_path, "SessionStart", "usable", source="startup")
+    _run(tmp_path, "PostToolUse", "usable", tool_name="shell", exit_status=0)
+    stopped = _run(tmp_path, "Stop", "usable")
+
+    assert "connect_provider" not in started
+    assert "connect_provider" not in stopped
+    assert stopped == ""
+
+
+def test_credential_revocation_resurfaces_connect_provider_from_current_facts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Past usability never suppresses advice once current facts say not-ready (#265).
+
+    The advice source is per-build, so a provider that was usable (no advice)
+    and is then revoked must be advised again at the next standing boundary.
+    """
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _USABLE)
+    assert _run(tmp_path, "Stop", "revoked") == ""
+
+    _compose(monkeypatch, _STANDING)
+    assert "connect_provider" in _run(tmp_path, "Stop", "revoked")
+
+
+def test_delivered_then_retired_condition_resurfaces_at_the_documented_cadence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retire-and-return keeps the #241 identity contract, and the honest bound with it (#265).
+
+    A condition that was already delivered, retired on live facts, and then
+    returned renders byte-identical text, so within the same session scope it
+    stays suppressed exactly like any repeat (#241). The current evidence is
+    still in the workspace snapshot, and the next session boundary delivers it.
+    """
+
+    store, workspace = _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+    assert "connect_provider" in _run(tmp_path, "Stop", "flap")
+
+    _compose(monkeypatch, _USABLE)
+    assert _run(tmp_path, "Stop", "flap") == ""
+
+    _compose(monkeypatch, _STANDING)
+    # Same scope, identical text: the #241 dedup holds even across the retire.
+    assert _run(tmp_path, "Stop", "flap") == ""
+    snapshot = store.advice_snapshot_for(workspace)
+    assert snapshot is not None
+    assert any(item.rule_code == "provider_not_ready" for item in snapshot.ranked_items), (
+        "the resurfaced condition must be present as current evidence even while "
+        "its delivery is deduplicated"
+    )
+    # A fresh session scope hears about the still-true condition again.
+    assert "connect_provider" in _run(tmp_path, "SessionStart", "flap-next", source="startup")
 
 
 def test_changed_advice_is_still_delivered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -26,6 +26,7 @@ from yoetz.application.observation_coordinator import (
 )
 from yoetz.cli.observe_hooks import handle_observe
 from yoetz.domain.observation import (
+    AdviceSnapshot,
     ObservationCursor,
     ObservationEnvelope,
     ObservationLifecycle,
@@ -153,6 +154,81 @@ def test_standing_provider_condition_keeps_one_candidate_identity_as_envelopes_g
     # #241: the delivery identity is over what the agent actually receives, so
     # it must NOT move with the envelope stream the basis digest tracks.
     assert advice_delivery_identity(first) == advice_delivery_identity(latest)
+
+
+def test_callable_composition_is_resolved_freshly_on_every_build() -> None:
+    """The provider fact is recomputed per build, tracking live machine state (#265).
+
+    A READY-frozen fact kept advising connect_provider after the same mapped
+    session dispatched successfully. A per-build source lets current structural
+    usability retire the advice and credential revocation resurface it.
+    """
+
+    facts = [
+        ObservationCompositionFact(
+            semantic_configured=True,
+            semantic_ready=False,
+            provider_factory_ids=("fireworks",),
+            connected_provider_ids=(),
+        ),
+        ObservationCompositionFact(
+            semantic_configured=True,
+            semantic_ready=True,
+            provider_factory_ids=("fireworks",),
+            connected_provider_ids=("fireworks",),
+        ),
+        ObservationCompositionFact(
+            semantic_configured=True,
+            semantic_ready=False,
+            provider_factory_ids=("fireworks",),
+            connected_provider_ids=(),
+        ),
+    ]
+    builds: list[ObservationCompositionFact] = []
+
+    async def composition() -> ObservationCompositionFact:
+        fact = facts[len(builds)]
+        builds.append(fact)
+        return fact
+
+    class _Store:
+        def list_envelopes(self, workspace: str) -> tuple[ObservationEnvelope, ...]:
+            del workspace
+            return (_envelope("hook:one", {"tool_name": "shell"}),)
+
+        async def status(self, query: ObservationStatusQuery) -> ObservationStatus:
+            del query
+            return ObservationStatus(
+                ObservationLifecycle.ACTIVE,
+                _COMMITMENT,
+                {},
+                _TIME,
+                0,
+                (),
+                (),
+                None,
+            )
+
+        def load_advice_snapshot(self, workspace: str) -> None:
+            del workspace
+            return None
+
+    builder = ObservationAdviceContextBuilder(composition=composition)
+
+    def rule_codes(snapshot: object) -> tuple[str, ...]:
+        if snapshot is None:
+            return ()
+        assert isinstance(snapshot, AdviceSnapshot)
+        return tuple(item.rule_code for item in snapshot.ranked_items)
+
+    missing = asyncio.run(builder.build(_COMMITMENT, _Store()))  # type: ignore[arg-type]
+    connected = asyncio.run(builder.build(_COMMITMENT, _Store()))  # type: ignore[arg-type]
+    revoked = asyncio.run(builder.build(_COMMITMENT, _Store()))  # type: ignore[arg-type]
+
+    assert len(builds) == 3, "the composition source was not consulted on every build"
+    assert "provider_not_ready" in rule_codes(missing)
+    assert "provider_not_ready" not in rule_codes(connected)
+    assert "provider_not_ready" in rule_codes(revoked)
 
 
 def test_delivery_identity_is_stable_while_the_envelope_stream_grows() -> None:

--- a/tests/unit/kernel/test_observation_advice_policies.py
+++ b/tests/unit/kernel/test_observation_advice_policies.py
@@ -251,6 +251,69 @@ def test_provider_not_ready() -> None:
     assert "provider_not_ready" in rules
 
 
+def test_registry_lag_alone_does_not_emit_provider_not_ready() -> None:
+    """A structurally usable provider absent from the lazy registry is not "not ready" (#265).
+
+    Registry activation is repository-scoped and re-established automatically at
+    dispatch, so a configured provider missing from the connected set proves
+    nothing the operator can act on with connect_provider.
+    """
+
+    rules = _rules(
+        ObservationAdviceContext(
+            envelopes=(),
+            lifecycle=ObservationLifecycle.ACTIVE,
+            gaps=(),
+            composition=ObservationCompositionFact(
+                semantic_configured=True,
+                semantic_ready=True,
+                provider_factory_ids=("fireworks",),
+                connected_provider_ids=(),
+            ),
+        )
+    )
+    assert "provider_not_ready" not in rules
+
+
+def test_provider_not_ready_requires_semantic_to_be_configured() -> None:
+    """With semantic disabled, connect_provider advice has no action to recommend (#265)."""
+
+    rules = _rules(
+        ObservationAdviceContext(
+            envelopes=(),
+            lifecycle=ObservationLifecycle.ACTIVE,
+            gaps=(),
+            composition=ObservationCompositionFact(
+                semantic_configured=False,
+                semantic_ready=False,
+                provider_factory_ids=("fireworks",),
+                connected_provider_ids=(),
+            ),
+        )
+    )
+    assert "provider_not_ready" not in rules
+
+
+def test_provider_not_ready_names_the_unusable_configured_provider() -> None:
+    """The structural condition keeps naming the configured provider as evidence."""
+
+    context = ObservationAdviceContext(
+        envelopes=(),
+        lifecycle=ObservationLifecycle.ACTIVE,
+        gaps=(),
+        composition=ObservationCompositionFact(
+            semantic_configured=True,
+            semantic_ready=False,
+            provider_factory_ids=("fireworks",),
+            connected_provider_ids=(),
+        ),
+    )
+    candidates = observation_advice_findings(context)
+    item = next(item for item in candidates if item.rule_code == "provider_not_ready")
+    assert item.evidence_refs == ("fireworks",)
+    assert item.next_action == "connect_provider"
+
+
 def test_semantic_claim_without_attempt() -> None:
     envelopes = (
         _envelope(


### PR DESCRIPTION
Closes #265

## Problem

In session `01a001a8-66b5-7a23-aaf4-64adf3c07a74`, a `semantic_required` check dispatched to Fireworks and succeeded (`semantic_status: succeeded`, provider request id, receipt) — and 30 seconds later the Stop hook injected *"Configured provider is not ready … Next: connect_provider. Evidence: fireworks."*

Root cause, confirmed by static audit: `provide_service_ready_context()` froze the observation advice fact at READY composition with `semantic_ready=False` unconditionally **and** a connected-provider snapshot that is structurally guaranteed to be empty (the gateway registry is `None` until the first repository-scoped activation). Both trigger predicates of `_provider_not_ready()` were therefore permanently true for every semantic-configured installation — the advice was never based on live evidence at all. Real checks resolve the binding dynamically after repository-scoped admission, so a truthful success never refreshed the frozen fact.

## Fix (narrow, sourcing + predicate only)

- **`ObservationAdviceContextBuilder.composition`** may now be a callable (sync or async) resolved on every build, mirroring the existing `check_facts`/`semantic_review` injection pattern. A plain fact value stays supported (all existing constructors unchanged).
- **`provide_service_ready_context()`** injects an async closure computing the fact per build from current machine-scope facts: endpoint bound, provider factory available, and exact configured-credential presence in the vault (`has_provider_credential` is an in-memory index lookup, ~0.04 ms). An unreadable vault (locking race) yields *no fact* rather than a false not-ready claim.
- **`_provider_not_ready()`** fires only when semantic is configured but the path is structurally unusable. Absence from the connected registry no longer triggers the advice on its own — activation is lazy, repository-scoped, and re-established automatically at each dispatch, so it is not an operator-actionable condition; the configured-minus-connected set still names evidence (`Evidence: fireworks`).
- `OBSERVATION_ADVICE_POLICY_VERSION` 0.1.1 → 0.1.2. Nothing pins the literal; the bump re-keys evidence-basis digests only (at most a one-time snapshot reissue — the #241 delivery identity deliberately excludes it, so no redelivery).

`rule_code`, `detail_token`, next-action, finding-kind, and all wire shapes are unchanged, so per the issue's design gate this stays below the maintainer-pause threshold.

## Honesty boundary

Readiness is **not** upgraded into proof of future dispatch: the fact is structural usability of the configured path (machine-scope, matching `connect_provider`'s `STANDING_MACHINE_ACTIONS` classification), never a repository-authority claim. Repository-scoped admission stays resolved per check, exactly as before. `ServiceReadyContext.semantic_ready` / `provider_credential_connected` and the `external_provider` capability (#171 operator surface) are untouched.

## Acceptance criteria → evidence

- **Successful mapped-session dispatch → no `connect_provider` at next Stop**: dispatch requires the credential, so the fresh fact reports usable and the rule cannot fire — `test_usable_provider_receives_no_connect_provider_at_stop` (hook exit code 0 asserted separately from content, per the delivery-vs-content criterion).
- **Genuinely missing credential stays visible at bounded cadence**: `test_observation_provider_fact_tracks_live_credential_within_one_generation` (real vault, mid-generation), all 23 pre-existing #241 cadence tests unchanged and passing.
- **Revocation resurfaces from current evidence**: same integration test discards the credential and the condition returns; `test_delivered_then_retired_condition_resurfaces_at_the_documented_cadence` pins the delivery bound honestly — the resurfaced byte-identical text follows the documented #241 cadence (redelivered at the next session boundary; within one scope only after different advice intervened).
- **Registry lag alone never fires**: `test_registry_lag_alone_does_not_emit_provider_not_ready`.
- **Fresh per-build sourcing**: `test_callable_composition_is_resolved_freshly_on_every_build` (missing → connected → revoked across three builds of one builder).
- **#241/#249/#171/#231 intact**: full existing suites pass unchanged (no identity fields moved, no delivery/gating/scoping code touched, receipts untouched).

An adversarial review pass over the diff (closure lifetimes after gateway/vault close, event-loop safety of the vault mutex, 0.1.1-era persisted snapshot compatibility, `semantic_configured=False` warning loss, other composition consumers) found no correctness defects; its cadence-wording finding is addressed by the dedicated test and CHANGELOG phrasing above.

## Validation

- `pytest tests/unit tests/property tests/conformance -m "not fault and not soak and not live"` — **2593 passed**
- `tests/integration/{service,observation,application,privacy,storage,objects}` — **448 passed**, 1 pre-existing failure (`test_session_start_creates_binding_without_mcp_start`) that reproduces identically on clean `main` at 7bc6b81 and is unrelated (flagged separately)
- `tests/unit/protocol tests/unit/kernel` under `PYTHONHASHSEED=0` and `=1` — passed
- `ruff check` / `ruff format --check` / `pyright` — clean

Standalone per the issue handoff: no dependency on #264/#266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Source standing provider advice from live machine facts per build
> - `ObservationAdviceContextBuilder` now accepts a callable for its `composition` field in [observation_advice.py](https://github.com/TheGaySupreme123/yoetz/pull/268/files#diff-4ad7c14d0922000b3aa7d3043abaf37e4199da6b80da3a953d14312a10485400), resolving it on every `build()` call instead of freezing a READY-time snapshot.
> - [ready_composition.py](https://github.com/TheGaySupreme123/yoetz/pull/268/files#diff-aa060b3002474d342468ec0065563958ded4194ac7027914db3c0ebf18a940c6) replaces the static `ObservationCompositionFact` with an async callable that checks live connectivity and configured-credential presence at advice-build time.
> - The `_provider_not_ready` policy helper in [observation_advice.py](https://github.com/TheGaySupreme123/yoetz/pull/268/files#diff-6eb3f417aa4a3346a826ad7cd8daa872fb288971c26c610278e4edc3832420b9) now only emits advice when semantic is configured and structurally not ready; absence from the lazily activated connected-provider registry alone no longer triggers it.
> - Policy version bumped to 0.1.2. Behavioral Change: mid-session credential changes are now reflected in standing provider advice, and a provider that completed external semantic dispatch will no longer incorrectly receive `connect_provider` advice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 246fc25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->