### PR TITLE
Read the observation runtime gate lock-free; never silently discard a hook event at the gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,6 +550,16 @@ carried them; they are listed because each one describes the behavior that now s
   session where every check returned `blocked_by_policy` / `route_semantic_ceiling` with nothing
   connecting the two. `yoetz privacy setup` now names the mismatch and the command that fixes it,
   and the terminal interface reports the agent-route verdict as its own readiness line.
+- Ordinary store-lock contention discarded hook events as `runtime_gate_unsafe`: the runtime-gate
+  read serialized on the interprocess store lock, whose two-second acquisition timeout is routinely
+  exceeded by a concurrent hook's batched local pass, and the guard treated the resulting
+  `TimeoutError` as an unsafe gate — dropping the event before capture with no stderr line and no
+  workspace gap, on a workspace every health surface reported as covered. The gate is now read
+  lock-free through a single descriptor (it is an owner-only marker replaced only atomically), a
+  contended read is reported as `runtime_gate_contended` and falls back to the missing-marker
+  default instead of discarding the event, and a genuinely unsafe gate still fails closed but says
+  so on stderr and records an `observation_storage_corrupt` coverage gap for the bound workspace so
+  `observe status` can see the drop (issue #273).
 
 ### Security
 

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -715,7 +715,7 @@ class LocalObservationStore:
         """
 
         path = self._root / _RUNTIME_GATE_NAME
-        flags = os.O_RDONLY | os.O_CLOEXEC
+        flags = os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NONBLOCK", 0)
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         try:
@@ -749,6 +749,12 @@ class LocalObservationStore:
                 chunks.append(chunk)
                 remaining -= len(chunk)
             raw = b"".join(chunks)
+            if len(raw) > _MAX_RUNTIME_GATE_BYTES:
+                raise _error(
+                    PublicErrorCode.STORAGE_UNSAFE,
+                    "Observation runtime gate is unsafe.",
+                    retryable=False,
+                )
         except OSError as exc:
             raise _error(
                 PublicErrorCode.STORAGE_UNSAFE,

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -13,6 +13,7 @@ import dataclasses
 import errno
 import os
 import re
+import stat
 import threading
 import time
 from collections.abc import Callable, Generator, Mapping
@@ -703,23 +704,35 @@ class LocalObservationStore:
             _atomic_write(self._root / _RUNTIME_GATE_NAME, payload)
 
     def runtime_enabled(self) -> bool:
-        """Return the current service-synchronized capture gate, failing closed."""
+        """Return the current service-synchronized capture gate, failing closed.
+
+        Deliberately lock-free: the marker is a tiny owner-only file that
+        :meth:`set_runtime_enabled` only ever replaces atomically, and every
+        hook event begins with this read. Serializing it on the interprocess
+        store lock converted ordinary batch contention into gate failures
+        that discarded events (#273). Reading through one descriptor keeps
+        the safety checks and the payload bound to a single inode instead.
+        """
 
         path = self._root / _RUNTIME_GATE_NAME
-        with self._lock:
-            try:
-                facts = path.lstat()
-            except FileNotFoundError:
-                return True
-            except OSError as exc:
-                raise _error(
-                    PublicErrorCode.STORAGE_UNSAFE,
-                    "Observation runtime gate is unavailable.",
-                    retryable=False,
-                ) from exc
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(path, flags)
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            message = (
+                "Observation runtime gate is unsafe."
+                if exc.errno == errno.ELOOP
+                else "Observation runtime gate is unavailable."
+            )
+            raise _error(PublicErrorCode.STORAGE_UNSAFE, message, retryable=False) from exc
+        try:
+            facts = os.fstat(descriptor)
             if (
-                path.is_symlink()
-                or not path.is_file()
+                not stat.S_ISREG(facts.st_mode)
                 or facts.st_uid != os.geteuid()
                 or facts.st_mode & 0o077
                 or facts.st_size <= 0
@@ -730,27 +743,40 @@ class LocalObservationStore:
                     "Observation runtime gate is unsafe.",
                     retryable=False,
                 )
-            try:
-                raw = path.read_bytes()
-                parsed = strict_json_parse(raw)
-            except (OSError, ProtocolValueError) as exc:
-                raise _error(
-                    PublicErrorCode.STORAGE_UNSAFE,
-                    "Observation runtime gate is invalid.",
-                    retryable=False,
-                ) from exc
-            if (
-                not isinstance(parsed, Mapping)
-                or set(parsed) != {"schema", "enabled"}
-                or parsed.get("schema") != _RUNTIME_GATE_SCHEMA
-                or type(parsed.get("enabled")) is not bool
-            ):
-                raise _error(
-                    PublicErrorCode.STORAGE_UNSAFE,
-                    "Observation runtime gate is invalid.",
-                    retryable=False,
-                )
-            return cast(bool, parsed["enabled"])
+            chunks: list[bytes] = []
+            remaining = _MAX_RUNTIME_GATE_BYTES + 1
+            while remaining > 0 and (chunk := os.read(descriptor, remaining)):
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+        except OSError as exc:
+            raise _error(
+                PublicErrorCode.STORAGE_UNSAFE,
+                "Observation runtime gate is invalid.",
+                retryable=False,
+            ) from exc
+        finally:
+            os.close(descriptor)
+        try:
+            parsed = strict_json_parse(raw)
+        except ProtocolValueError as exc:
+            raise _error(
+                PublicErrorCode.STORAGE_UNSAFE,
+                "Observation runtime gate is invalid.",
+                retryable=False,
+            ) from exc
+        if (
+            not isinstance(parsed, Mapping)
+            or set(parsed) != {"schema", "enabled"}
+            or parsed.get("schema") != _RUNTIME_GATE_SCHEMA
+            or type(parsed.get("enabled")) is not bool
+        ):
+            raise _error(
+                PublicErrorCode.STORAGE_UNSAFE,
+                "Observation runtime gate is invalid.",
+                retryable=False,
+            )
+        return cast(bool, parsed["enabled"])
 
     def workspace_commitment(self, path: str) -> str:
         return workspace_commitment_from_path(self.key_material(), path)

--- a/src/yoetz/cli/hook_diagnostics.py
+++ b/src/yoetz/cli/hook_diagnostics.py
@@ -56,6 +56,7 @@ _REASONS: Final = frozenset(
         "drain_budget_exhausted",
         "drain_lease_contended",
         "drain_preflight_failed",
+        "runtime_gate_contended",
         "runtime_gate_unsafe",
         "stdout_write_failed",
         # Observability only: the end-to-end hook budget is a contract, not an

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -968,6 +968,33 @@ async def _try_auto_start(
                 await client.close()
 
 
+def _note_dropped_event_gap(
+    store: LocalObservationStore,
+    payload: Mapping[str, JsonValue],
+    workspace: str | None,
+) -> None:
+    """Record a coverage gap for an event dropped before the local pass ran.
+
+    Mirrors the binding order of the main pass: the explicit workspace
+    argument first, then the Codex-session→workspace map. A silently missing
+    event is the one outcome this subsystem must not produce, so any drop
+    must be visible to ``observe status`` and coverage wording.
+    """
+
+    if workspace is not None:
+        locator = str(Path(workspace).expanduser().resolve(strict=False))
+        commitment: str | None = store.workspace_commitment(locator)
+    else:
+        codex_session_id = validate_codex_session_id(payload.get("session_id"))
+        commitment = store.find_workspace_for_codex_session(codex_session_id)
+    if commitment is None:
+        return
+    consent = store.consent_for(commitment)
+    if consent is None or not consent.active:
+        return
+    store.note_coverage_gap(commitment, ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
+
+
 def handle_observe(
     *,
     event_name: str,
@@ -1028,8 +1055,18 @@ def handle_observe(
         resolved_event = raw_event
         try:
             capture_enabled = store.runtime_enabled()
+        except TimeoutError:
+            # Store-lock contention says nothing about the gate itself.
+            # Fall back to the missing-marker default (enabled) instead of
+            # discarding the event; consent still gates every ingest below.
+            _stderr_line("hook_observe_degraded: runtime_gate_contended")
+            record_hook_diagnostic("runtime_gate_contended", resolved_event, _state=_state)
+            capture_enabled = True
         except Exception:
+            _stderr_line("hook_observe_degraded: runtime_gate_unsafe")
             record_hook_diagnostic("runtime_gate_unsafe", resolved_event, _state=_state)
+            with contextlib.suppress(Exception):
+                _note_dropped_event_gap(store, payload, workspace)
             _stdout_json({}, stdout)
             return 0
         if not capture_enabled:

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -981,10 +981,17 @@ def _note_dropped_event_gap(
     must be visible to ``observe status`` and coverage wording.
     """
 
+    commitment: str | None = None
     if workspace is not None:
-        locator = str(Path(workspace).expanduser().resolve(strict=False))
-        commitment: str | None = store.workspace_commitment(locator)
-    else:
+        try:
+            locator = str(Path(workspace).expanduser().resolve(strict=False))
+            candidate = store.workspace_commitment(locator)
+            consent = store.consent_for(candidate)
+            if consent is not None and consent.active:
+                commitment = candidate
+        except Exception:
+            commitment = None
+    if commitment is None:
         codex_session_id = validate_codex_session_id(payload.get("session_id"))
         commitment = store.find_workspace_for_codex_session(codex_session_id)
     if commitment is None:
@@ -1131,9 +1138,12 @@ def handle_observe(
             )
             gap_codes: list[str] = []
 
-            # Pair pre/post via correlation_id when present.
-            correlation = _token_or_none(payload.get("correlation_id")) or _token_or_none(
-                payload.get("tool_call_id")
+            # Prefer the host's canonical tool-use identity, while retaining
+            # compatibility with earlier tool-call and correlation aliases.
+            correlation = (
+                _token_or_none(payload.get("tool_use_id"))
+                or _token_or_none(payload.get("tool_call_id"))
+                or _token_or_none(payload.get("correlation_id"))
             )
             if correlation is not None and _is_pre_event(resolved_event):
                 store.note_open_pre(workspace_commitment, correlation, resolved_event)

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -6,6 +6,8 @@ import asyncio
 import io
 import json
 import os
+import threading
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
@@ -328,7 +330,9 @@ def test_runtime_disabled_skips_capture_but_session_start_surfaces_cached_recomm
     assert not workspace_state.exists() or not list(workspace_state.glob("*.json"))
 
 
-def test_unsafe_runtime_gate_fails_closed_with_distinct_diagnostic(tmp_path: Path) -> None:
+def test_unsafe_runtime_gate_fails_closed_with_distinct_diagnostic(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     store = LocalObservationStore(_state=tmp_path)
     store.set_runtime_enabled(True)
     gate = tmp_path / "observation/runtime-gate.json"
@@ -342,9 +346,85 @@ def test_unsafe_runtime_gate_fails_closed_with_distinct_diagnostic(tmp_path: Pat
         _state=tmp_path,
     )
     assert json.loads(stdout.getvalue()) == {}
+    assert "hook_observe_degraded: runtime_gate_unsafe" in capsys.readouterr().err
     diagnostics = (tmp_path / "observation/hook-diagnostics.jsonl").read_text()
     assert '"reason":"runtime_gate_unsafe"' in diagnostics
     assert store.pending_workspaces() == ()
+
+
+def test_unsafe_runtime_gate_records_workspace_gap_when_consented(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    gate = tmp_path / "observation/runtime-gate.json"
+    gate.write_text("not-json", encoding="utf-8")
+    stdout = io.BytesIO()
+    handle_observe(
+        event_name="PostToolUse",
+        stdin_bytes=json.dumps({"session_id": "unsafe-gate-gap", "tool_name": "shell"}).encode(),
+        stdout=stdout,
+        workspace=str(tmp_path),
+        _state=tmp_path,
+    )
+    assert json.loads(stdout.getvalue()) == {}
+    status = store.status(ObservationStatusQuery(workspace))
+    assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status.gaps
+
+
+def test_runtime_gate_read_is_lock_free_under_store_contention(tmp_path: Path) -> None:
+    """Holding the interprocess store lock must not block or fail the gate read (#273)."""
+
+    store = LocalObservationStore(_state=tmp_path)
+    store.set_runtime_enabled(True)
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def _hold() -> None:
+        with store._lock:  # pyright: ignore[reportPrivateUsage]
+            acquired.set()
+            release.wait(timeout=10.0)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    try:
+        assert acquired.wait(timeout=5.0)
+        started = time.monotonic()
+        assert store.runtime_enabled() is True
+        assert time.monotonic() - started < 1.0
+    finally:
+        release.set()
+        holder.join()
+
+
+def test_store_lock_contention_at_gate_does_not_discard_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+
+    def _contended(self: LocalObservationStore) -> bool:
+        raise TimeoutError("observation_store_lock_timeout")
+
+    monkeypatch.setattr(LocalObservationStore, "runtime_enabled", _contended)
+    code = handle_observe(
+        event_name="PostToolUse",
+        stdin_bytes=json.dumps(
+            {"session_id": "contended-gate", "tool_name": "shell", "event_ordinal": 1}
+        ).encode(),
+        stdout=io.BytesIO(),
+        workspace=str(tmp_path),
+        _state=tmp_path,
+        skip_service=True,
+    )
+    assert code == 0
+    assert "hook_observe_degraded: runtime_gate_contended" in capsys.readouterr().err
+    diagnostics = (tmp_path / "observation/hook-diagnostics.jsonl").read_text()
+    assert '"reason":"runtime_gate_contended"' in diagnostics
+    assert '"reason":"runtime_gate_unsafe"' not in diagnostics
+    assert store.pending_workspaces() == (workspace,)
 
 
 def test_service_unavailable_never_spools_visible_plaintext(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -30,6 +30,7 @@ from yoetz.domain.observation import (
     ObservationStatusQuery,
     observation_ingest_result_to_json,
 )
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 
 _KEY = b"k" * 32
 
@@ -371,6 +372,44 @@ def test_unsafe_runtime_gate_records_workspace_gap_when_consented(tmp_path: Path
     assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status.gaps
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO gate regression is POSIX-only")
+def test_runtime_gate_fifo_fails_closed_without_blocking(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    store.set_runtime_enabled(True)
+    gate = tmp_path / "observation/runtime-gate.json"
+    gate.unlink()
+    os.mkfifo(gate, mode=0o600)
+
+    started = time.monotonic()
+    with pytest.raises(PublicOperationError) as caught:
+        store.runtime_enabled()
+
+    assert caught.value.code is PublicErrorCode.STORAGE_UNSAFE
+    assert time.monotonic() - started < 1.0
+
+
+def test_unsafe_runtime_gate_falls_back_to_session_mapped_workspace(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    mapped_locator = tmp_path / "mapped-project"
+    stale_locator = tmp_path / "stale-project"
+    mapped = store.workspace_commitment(str(mapped_locator.resolve()))
+    store.grant_consent(mapped)
+    store.bind_codex_session(mapped, "unsafe-gate-mapped")
+    gate = tmp_path / "observation/runtime-gate.json"
+    gate.write_text("not-json", encoding="utf-8")
+
+    handle_observe(
+        event_name="PostToolUse",
+        stdin_bytes=json.dumps({"session_id": "unsafe-gate-mapped", "tool_name": "shell"}).encode(),
+        stdout=io.BytesIO(),
+        workspace=str(stale_locator),
+        _state=tmp_path,
+    )
+
+    status = store.status(ObservationStatusQuery(mapped))
+    assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status.gaps
+
+
 def test_runtime_gate_read_is_lock_free_under_store_contention(tmp_path: Path) -> None:
     """Holding the interprocess store lock must not block or fail the gate read (#273)."""
 
@@ -494,6 +533,51 @@ def test_observe_ingests_when_consented_and_pairs_pre_post(tmp_path: Path) -> No
         ).ObservationStatusQuery(workspace)
     )
     assert status.source_coverage[ObservationSource.CODEX_HOOK] is True
+    assert ObservationGapCode.UNPAIRED_EVENT.value not in status.gaps
+
+
+def test_tool_call_id_pairs_when_legacy_correlation_ids_differ(tmp_path: Path) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+
+    assert (
+        handle_observe(
+            event_name="PreToolUse",
+            stdin_bytes=json.dumps(
+                {
+                    "session_id": "pair-alias",
+                    "tool_name": "shell",
+                    "correlation_id": "pre",
+                    "tool_call_id": "shared",
+                }
+            ).encode(),
+            stdout=io.BytesIO(),
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+    assert (
+        handle_observe(
+            event_name="PostToolUse",
+            stdin_bytes=json.dumps(
+                {
+                    "session_id": "pair-alias",
+                    "tool_name": "shell",
+                    "tool_call_id": "shared",
+                }
+            ).encode(),
+            stdout=io.BytesIO(),
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+
+    status = store.status(ObservationStatusQuery(workspace))
     assert ObservationGapCode.UNPAIRED_EVENT.value not in status.gaps
 
 


### PR DESCRIPTION
Fixes #273.

## Root cause

`runtime_enabled` read the 61-byte gate marker inside the interprocess store lock. The lock's 2-second acquisition timeout is routinely exceeded by a concurrent hook's `store.batched(...)` local pass (Codex runs up to 8 hooks concurrently; #271 measured `max_ms: 3388`), and the guard in `handle_observe` caught the resulting `TimeoutError` under `except Exception`, labeled it `runtime_gate_unsafe`, and returned before session binding, ingest, and outbox enqueue — silently discarding the event with no stderr line and no workspace gap.

## Changes

- **`observation_local.runtime_enabled`** no longer takes the store lock. The marker is an owner-only file that `set_runtime_enabled` only ever replaces atomically, so the lock bought nothing but contention. The read now goes through a single descriptor (`O_NOFOLLOW` open + `fstat` + bounded read), which also closes the old lstat-then-read TOCTOU: the safety checks and the payload are bound to one inode. Validation semantics are unchanged — missing marker defaults to enabled; symlink, foreign owner, loose mode, bad size, or bad shape still raise `STORAGE_UNSAFE` and fail closed.
- **`handle_observe`** distinguishes the two failures the issue conflated:
  - `TimeoutError` (store-lock contention, now defense-in-depth) records `runtime_gate_contended` plus a `hook_observe_degraded:` stderr line and falls back to the missing-marker default (enabled) instead of discarding the event. Consent still gates every ingest downstream.
  - Any other failure still fails closed as `runtime_gate_unsafe`, but now emits the `hook_observe_degraded:` stderr line like every other degraded branch and best-effort records an `observation_storage_corrupt` coverage gap for the bound workspace (explicit workspace argument first, then the Codex-session map, consent-checked), so `observe status` and coverage wording can see the drop. No new wire gap code was introduced.
- **`hook_diagnostics`** admits the new `runtime_gate_contended` reason.

## Verification

- New regression test holds the store lock from another thread and asserts `runtime_enabled()` returns immediately; the issue's cross-process repro (child process holding the flock for 5s) now answers in <1ms where it previously raised `TimeoutError` after exactly 2.00s.
- New tests: contention at the gate still ingests the event (outbox pending, `runtime_gate_contended` recorded, no `runtime_gate_unsafe`); an unsafe gate on a consented workspace records the `observation_storage_corrupt` gap; the existing fail-closed test now also asserts the stderr line.
- `tests/unit/cli` (337), `tests/unit/adapters` + `tests/integration/service/test_ready_composition.py` (269), and `tests/integration/observation` all pass; the one failure there (`test_session_start_creates_binding_without_mcp_start`) fails identically on a clean `main` checkout on this machine and is unrelated. Ruff and pinned Pyright are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read the runtime gate lock-free and never silently discard hook events on gate contention
> - [`LocalObservationStore.runtime_enabled`](https://github.com/TheGaySupreme123/yoetz/pull/281/files#diff-dcc1feb8bc7f834d09056738e52fec58f85bdd06640418a241feda997cb5be82) is rewritten to open the gate file with `O_RDONLY | O_CLOEXEC | O_NOFOLLOW` (non-blocking), validate ownership/permissions via `fstat`, and read with a hard size cap — all without acquiring the interprocess store lock.
> - On store-lock contention (`TimeoutError`), `handle_observe` in [`observe_hooks.py`](https://github.com/TheGaySupreme123/yoetz/pull/281/files#diff-cdfa4cdbe7cfccf96a65db7f69d192cac91fad8eba4ec777e16f9a4d177f49c4) now logs `runtime_gate_contended`, records a diagnostic, and proceeds as if capture is enabled instead of dropping the event.
> - Unsafe gate conditions (symlinks via `ELOOP`, oversized content, bad ownership) emit a stderr line, record a `runtime_gate_unsafe` diagnostic, and call the new `_note_dropped_event_gap` helper to record an `OBSERVATION_STORAGE_CORRUPT` coverage gap for the bound workspace.
> - Event correlation in `handle_observe` now prefers `tool_use_id`, then `tool_call_id`, then `correlation_id` for pre/post event pairing.
> - Behavioral Change: gate evaluation no longer blocks on the interprocess lock; FIFO or symlink gate paths now fail closed rather than blocking or following the link.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ce4504.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->