### PR TITLE
Fix sweep diagnosability (#278), text-fallback summaries (#279), and the skip_service advisory (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ describes behavior intended for the first release rather than a change from a pr
 
 ### Added
 
+- MCP success summaries now preserve the canonical frontier head digest and, for generic
+  operations such as `start`, returned task/session/writer identifiers after strict shape
+  validation. The bounded text fallback can therefore seed the next request even when a host drops
+  `structuredContent` (issue #279).
+
+- Local-only SessionStart observation now emits the static attach advisory without opening a
+  service connection, and pending standing advice shares that bootstrap context instead of being
+  starved (issue #280).
+
+- Observation sweeps that raise now retain the exception's bounded reason and origin in owner-only
+  diagnostics; only the actual sweep deadline emits `sweep_deadline_exceeded` (issue #278).
+
 - `publish_work` rejections for a payload field placed on the wrong event family now name the
   field's one legal owning family (issue #266). When an `extra_forbidden` key byte-equals a frozen
   catalogued payload property with exactly one owner among the ordinary publish families — the

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -126,6 +126,14 @@ admitted-key answer. The same fact is repeated as one bounded sentence in the au
 as a `Repair:` clause on the compatible text summary channel, because MCP hosts are not required
 to surface `structuredContent`.
 
+Every MCP result also carries a bounded ASCII text projection (at most 512 bytes) for hosts that
+drop `structuredContent`. A successful projection includes the first valid returned frontier's
+`sequence` and canonical `head_digest` when both are present. Generic successful operations also
+include any returned, kind-valid `task_id`, `session_id`, and `writer_id`; in particular, the
+`start` text alone carries the identifiers and frontier needed to author the next request.
+Caller-controlled prose, malformed identifiers, and malformed digests are never admitted to this
+text channel.
+
 Protocol reason
 `expected_frontier_required` marks a state-sensitive `publish_work` batch that omitted
 `expected_frontier`. It names that field and is retryable because validation wrote no durable
@@ -1458,7 +1466,9 @@ or paths. The daemon's control-plane watchdog samples event-loop lag from a plai
 appends `control_plane_saturation_entered`/`_persists`/`_cleared` records (component
 `service.daemon`) with those counts at a bounded cadence, so a starved control plane is diagnosed
 while it is happening rather than never (#238); sweep failures append
-`observation_sweep_failed`. The same `correlation_id` is attached to the raised
+`observation_sweep_failed`. A sweep-raised exception uses the unexpected-exception recorder so
+its bounded reason and origin survive; only an actual sweep deadline records
+`sweep_deadline_exceeded`. The same `correlation_id` is attached to the raised
 `ControlError` (and to the reduced publish acceptance envelope when that path is taken) so the
 agent-facing public error and the durable sink share one identity. The MCP bridge reuses a
 service-supplied id rather than minting a second one; only bridge-local failures without a

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -985,7 +985,9 @@ def handle_observe(
 
     ``skip_service`` keeps the hook fully local: capture, binding, and outbox
     enqueue still run, but no service connection is ever opened (auto-attach,
-    mapped-session status, and outbox drains are all skipped).
+    mapped-session status, and outbox drains are all skipped). Advisory output
+    that needs no service still runs — an unattached SessionStart binding emits
+    the static "call start to attach a task" context either way (issue #280).
 
     ``_entry_monotonic`` is the console shim's pre-import sample; without it the
     recorded import stage reads zero rather than guessing.
@@ -1209,6 +1211,7 @@ def handle_observe(
         # skip_service so local-only callers (e.g. the setup readiness probe)
         # never create or attach real ledger tasks.
         additional = ""
+        attach_advisory_only = False
         mapping: LifecycleMapping | None = load_mapping(codex_session_id, _state=_state)
         drain_started = _monotonic()
         if resolved_event == "SessionStart":
@@ -1224,18 +1227,22 @@ def handle_observe(
                 with acquire_session_lock(codex_session_id, _state=_state) as owned:
                     if owned:
                         mapping = load_mapping(codex_session_id, _state=_state)
-                        if mapping is None and not skip_advice_loop and not skip_service:
+                        if mapping is None and not skip_advice_loop:
+                            if not skip_service:
 
-                            async def _attach() -> LifecycleMapping | None:
-                                return await _try_auto_start(codex_session_id, _state=_state)
+                                async def _attach() -> LifecycleMapping | None:
+                                    return await _try_auto_start(codex_session_id, _state=_state)
 
-                            mapping = cast(LifecycleMapping | None, _resolve_runner()(_attach))
+                                mapping = cast(LifecycleMapping | None, _resolve_runner()(_attach))
                             if mapping is None:
+                                # Static advisory for the unattached binding: it needs no
+                                # service, so local-only mode still emits it (issue #280).
                                 additional = (
                                     "Yoetz observation is consented for this workspace; "
                                     "no ledger task is mapped yet (observation-derived binding "
                                     "only). Call start to attach a task."
                                 )
+                                attach_advisory_only = True
                             else:
                                 additional = _active_context(mapping, mapping.last_frontier)
                         elif mapping is not None and not skip_service:
@@ -1330,8 +1337,12 @@ def handle_observe(
         # continued this turn. Blocking again would loop; leave advice for a
         # later turn or SessionStart instead of consuming it here.
         stop_already_active = payload.get("stop_hook_active") is True
+        # Task/receipt context always wins this shared channel outright, with one exception:
+        # the static attach advisory carries no advice of its own, so pending advice joins it
+        # (the delivery text is appended below) instead of being silently starved at the very
+        # SessionStart that bootstraps an unmapped session (issues #241, #280).
         delivery_eligible = (
-            not additional
+            (not additional or attach_advisory_only)
             and resolved_event in ADVICE_SAFE_EVENTS
             and not skip_advice_loop
             and not stop_already_active

--- a/src/yoetz/mcp/summaries.py
+++ b/src/yoetz/mcp/summaries.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from yoetz.protocol.canonical import JsonValue, ensure_canonical_value
 from yoetz.protocol.errors import PublicErrorCode
+from yoetz.protocol.ids import IdKind, is_valid_id
 
 __all__ = [
     "render_safe_compact_summary",
@@ -29,6 +30,8 @@ _CORRELATION_ID: Final = re.compile(
     r"^err_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
     re.ASCII,
 )
+# Closed shape for the frontier head: either the genesis sentinel or a canonical digest.
+_HEAD_DIGEST: Final = re.compile(r"^(?:genesis|sha256:[0-9a-f]{64})$", re.ASCII)
 
 
 def _mapping(value: object) -> Mapping[str, JsonValue]:
@@ -59,15 +62,47 @@ def _safe_count(value: object) -> str:
     return "unavailable"
 
 
-def _sequence(envelope: Mapping[str, JsonValue]) -> str:
+def _frontier_clause(envelope: Mapping[str, JsonValue]) -> str:
+    """Render sequence plus head digest so the text channel alone can seed the next frontier.
+
+    The text summary is the documented authoring fallback when a host drops structured
+    content, and ``publish_work`` needs ``expected_frontier.head_digest``, not only the
+    sequence, so a summary that carried the sequence alone could not construct the next
+    request (issue #279).
+    """
+
     for key in ("result_frontier", "subject_frontier", "head_frontier", "frontier"):
         frontier = envelope.get(key)
         if isinstance(frontier, Mapping):
             typed_frontier = cast(Mapping[str, JsonValue], frontier)
             sequence = _safe_count(typed_frontier.get("sequence"))
             if sequence != "unavailable":
-                return sequence
-    return "unavailable"
+                head = typed_frontier.get("head_digest")
+                if type(head) is str and _HEAD_DIGEST.fullmatch(head) is not None:
+                    return f"frontier: {sequence}; head_digest: {head}"
+                return f"frontier: {sequence}"
+    return "frontier: unavailable"
+
+
+def _identity_clause(envelope: Mapping[str, JsonValue]) -> str:
+    """Render the returned identifiers the next request must echo, when present (issue #279).
+
+    Each value is re-gated against the strict public-id validator, so this projector admits
+    the operation's own minted identifiers and nothing else.
+    """
+
+    parts: list[str] = []
+    for label, key, kind in (
+        ("task", "task_id", IdKind.TASK),
+        ("session", "session_id", IdKind.SESSION),
+        ("writer", "writer_id", IdKind.WRITER),
+    ):
+        value = envelope.get(key)
+        if is_valid_id(kind, value):
+            parts.append(f"{label}: {cast(str, value)}")
+    if not parts:
+        return ""
+    return "; ".join(parts) + "; "
 
 
 def _item_count(value: object) -> str:
@@ -151,11 +186,11 @@ def summary_for_check(envelope: object) -> str:
         return _bounded(
             f"Semantic review not requested; deterministic-only check verdict: {verdict}; "
             f"findings returned: {findings}; suppressed: {suppressed}; "
-            f"semantic status/reason: {status}/{reason}; frontier: {_sequence(source)}."
+            f"semantic status/reason: {status}/{reason}; {_frontier_clause(source)}."
         )
     return _bounded(
         f"Check verdict: {verdict}; findings returned: {findings}; suppressed: {suppressed}; "
-        f"semantic status/reason: {status}/{reason}; frontier: {_sequence(source)}."
+        f"semantic status/reason: {status}/{reason}; {_frontier_clause(source)}."
     )
 
 
@@ -184,7 +219,7 @@ def summary_for_status(envelope: object) -> str:
     freshness, obligations, findings = _compact_status_fields(source)
     gaps = _item_count(source.get("gaps"))
     return _bounded(
-        f"Status view: {view}; frontier: {_sequence(source)}; freshness: {freshness}; "
+        f"Status view: {view}; {_frontier_clause(source)}; freshness: {freshness}; "
         f"open obligations: {obligations}; unresolved findings: {findings}; reported gaps: {gaps}."
     )
 
@@ -199,20 +234,21 @@ def summary_for_receipt(envelope: object) -> str:
         limitations = _item_count(typed_coverage.get("known_gaps"))
     suppressed = _safe_count(source.get("suppressed_finding_count"))
     return _bounded(
-        f"Receipt conclusion: {conclusion}; frontier: {_sequence(source)}; "
+        f"Receipt conclusion: {conclusion}; {_frontier_clause(source)}; "
         f"coverage limitations: {limitations}; suppressed findings: {suppressed}."
     )
 
 
 def _summary_for_other_success(source: Mapping[str, JsonValue]) -> str:
     outcome = _safe_token(source.get("outcome"), fallback="recorded")
+    identity = _identity_clause(source)
     accepted = source.get("accepted_events")
     if accepted is not None:
         return _bounded(
             f"Operation outcome: {outcome}; accepted events: {_item_count(accepted)}; "
-            f"frontier: {_sequence(source)}."
+            f"{identity}{_frontier_clause(source)}."
         )
-    return _bounded(f"Operation outcome: {outcome}; frontier: {_sequence(source)}.")
+    return _bounded(f"Operation outcome: {outcome}; {identity}{_frontier_clause(source)}.")
 
 
 def render_safe_compact_summary(envelope: object) -> str:

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -1532,21 +1532,30 @@ class ServiceDaemon:
 
         try:
             return await asyncio.wait_for(guarded(), timeout=_OBSERVATION_SWEEP_DEADLINE_SECONDS)
-        except TimeoutError:
+        except TimeoutError as exc:
             # ``asyncio.TimeoutError`` is the builtin ``TimeoutError``, so any socket or OS
             # timeout raised inside the sweep lands here too and must not be reported as the
             # deadline. The flag above is the discriminator.
-            reason = "sweep_failed" if raised_inside else "sweep_deadline_exceeded"
-            record_bounded_event_without_raising(
+            if raised_inside:
+                record_unexpected_exception_without_raising(
+                    exc,
+                    component="service.daemon",
+                    operation="observation_sweep_failed",
+                )
+            else:
+                record_bounded_event_without_raising(
+                    component="service.daemon",
+                    operation="observation_sweep_failed",
+                    reason="sweep_deadline_exceeded",
+                )
+        except Exception as exc:
+            # The sweep raised on its own: keep the exception's bounded identity (reason and
+            # origin) rather than collapsing every distinct fault into one ``sweep_failed``
+            # token (issue #278).
+            record_unexpected_exception_without_raising(
+                exc,
                 component="service.daemon",
                 operation="observation_sweep_failed",
-                reason=reason,
-            )
-        except Exception:
-            record_bounded_event_without_raising(
-                component="service.daemon",
-                operation="observation_sweep_failed",
-                reason="sweep_failed",
             )
         return None
 

--- a/tests/conformance/surfaces/test_cli_mcp_parity.py
+++ b/tests/conformance/surfaces/test_cli_mcp_parity.py
@@ -19,7 +19,8 @@ def test_human_summary_is_weaker_than_structured_output() -> None:
     summary = render_safe_compact_summary(check)
     assert summary == (
         "Check verdict: incomplete_check; findings returned: 1; suppressed: 3; semantic "
-        "status/reason: not_configured/provider_not_configured; frontier: 7."
+        "status/reason: not_configured/provider_not_configured; frontier: 7; "
+        "head_digest: sha256:" + "0" * 64 + "."
     )
     assert secret not in summary
     assert len(summary.encode("ascii")) <= 512

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -1687,24 +1687,31 @@ async def test_ready_maintenance_sweeps_immediately_repeats_and_cancels_before_c
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    ("stall", "expected"),
-    [(False, "sweep_failed"), (True, "sweep_deadline_exceeded")],
-)
+@pytest.mark.parametrize("stall", [False, True])
 async def test_only_the_deadline_reports_sweep_deadline_exceeded(
-    monkeypatch: pytest.MonkeyPatch, stall: bool, expected: str
+    monkeypatch: pytest.MonkeyPatch, stall: bool
 ) -> None:
     """asyncio.TimeoutError is TimeoutError: a socket timeout inside a sweep is not the deadline."""
 
-    reasons: list[str] = []
+    bounded_reasons: list[str] = []
+    recorded_exceptions: list[BaseException] = []
 
-    def record(*, component: str, operation: str, reason: str) -> str:
+    def record_bounded(*, component: str, operation: str, reason: str) -> str:
         assert component == "service.daemon"
         assert operation == "observation_sweep_failed"
-        reasons.append(reason)
+        bounded_reasons.append(reason)
         return "err_00000000-0000-4000-8000-000000000000"
 
-    monkeypatch.setattr(daemon_module, "record_bounded_event_without_raising", record)
+    def record_exception(exc: BaseException, *, component: str, operation: str) -> str:
+        assert component == "service.daemon"
+        assert operation == "observation_sweep_failed"
+        recorded_exceptions.append(exc)
+        return "err_00000000-0000-4000-8000-000000000001"
+
+    monkeypatch.setattr(daemon_module, "record_bounded_event_without_raising", record_bounded)
+    monkeypatch.setattr(
+        daemon_module, "record_unexpected_exception_without_raising", record_exception
+    )
     monkeypatch.setattr(daemon_module, "_OBSERVATION_SWEEP_DEADLINE_SECONDS", 0.05)
 
     async def sweep() -> ObservationDrainSummary:
@@ -1718,7 +1725,44 @@ async def test_only_the_deadline_reports_sweep_deadline_exceeded(
     summary = await daemon._bounded_observation_sweep(sweep)  # pyright: ignore[reportPrivateUsage]
 
     assert summary is None
-    assert reasons == [expected]
+    if stall:
+        # Only the real deadline is a non-exception operating state.
+        assert bounded_reasons == ["sweep_deadline_exceeded"]
+        assert recorded_exceptions == []
+    else:
+        # The sweep's own exception keeps its identity instead of a generic token (issue #278).
+        assert bounded_reasons == []
+        assert len(recorded_exceptions) == 1
+        assert isinstance(recorded_exceptions[0], TimeoutError)
+    await daemon.close()
+
+
+@pytest.mark.anyio
+async def test_ordinary_sweep_exception_keeps_its_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raised sweep records the exception itself, not a generic token (issue #278)."""
+
+    recorded: list[tuple[BaseException, str, str]] = []
+
+    def record_exception(exc: BaseException, *, component: str, operation: str) -> str:
+        recorded.append((exc, component, operation))
+        return "err_00000000-0000-4000-8000-000000000002"
+
+    monkeypatch.setattr(
+        daemon_module, "record_unexpected_exception_without_raising", record_exception
+    )
+
+    async def sweep() -> ObservationDrainSummary:
+        raise RuntimeError("sweep exploded")
+
+    daemon, _application, _vault, _listener = _daemon()
+    summary = await daemon._bounded_observation_sweep(sweep)  # pyright: ignore[reportPrivateUsage]
+    assert summary is None
+    assert len(recorded) == 1
+    exc, component, operation = recorded[0]
+    assert isinstance(exc, RuntimeError)
+    assert (component, operation) == ("service.daemon", "observation_sweep_failed")
     await daemon.close()
 
 

--- a/tests/unit/adapters/test_observation_local_advice_delivery.py
+++ b/tests/unit/adapters/test_observation_local_advice_delivery.py
@@ -713,6 +713,25 @@ def test_unmapped_session_start_still_delivers_workspace_standing_advice(
     assert "resolve_failed_command" not in started
 
 
+def test_unmapped_session_start_joins_attach_advisory_with_standing_advice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The attach advisory and pending advice share the channel, neither starves the other.
+
+    The advisory is a static bootstrap instruction with no advice content of its own
+    (issue #280); standing advice must still reach the agent at the same SessionStart
+    (issue #241), so the delivery text is appended after the advisory.
+    """
+
+    _consented(tmp_path)
+    _compose(monkeypatch, _STANDING)
+
+    started = _run(tmp_path, "SessionStart", "joined", source="startup")
+    assert "Call start to attach a task." in started
+    assert "connect_provider" in started
+    assert started.index("Call start to attach a task.") < started.index("connect_provider")
+
+
 def test_delivery_in_task_a_does_not_suppress_same_condition_in_task_b(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/test_summaries_text_fallback.py
+++ b/tests/unit/mcp/test_summaries_text_fallback.py
@@ -1,0 +1,69 @@
+"""The text summary is an authoring fallback: it must seed the next request (issue #279)."""
+
+from __future__ import annotations
+
+from yoetz.mcp.summaries import render_safe_compact_summary
+
+_HEAD = "sha256:" + "1" * 64
+_TASK = "tsk_00000000-0000-4000-8000-000000000001"
+_SESSION = "ses_00000000-0000-4000-8000-000000000002"
+_WRITER = "wri_00000000-0000-4000-8000-000000000003"
+
+
+def test_start_summary_carries_the_identifiers_publish_work_requires() -> None:
+    summary = render_safe_compact_summary(
+        {
+            "ok": True,
+            "outcome": "created",
+            "task_id": _TASK,
+            "session_id": _SESSION,
+            "writer_id": _WRITER,
+            "frontier": {"sequence": "1", "head_digest": _HEAD},
+        }
+    )
+    assert summary == (
+        f"Operation outcome: created; task: {_TASK}; session: {_SESSION}; "
+        f"writer: {_WRITER}; frontier: 1; head_digest: {_HEAD}."
+    )
+    assert len(summary.encode("ascii")) <= 512
+
+
+def test_publish_work_summary_carries_the_new_head_digest() -> None:
+    summary = render_safe_compact_summary(
+        {
+            "ok": True,
+            "outcome": "recorded",
+            "accepted_events": [{"event_id": "evt_x"}],
+            "result_frontier": {"sequence": "4", "head_digest": _HEAD},
+        }
+    )
+    assert summary == (
+        f"Operation outcome: recorded; accepted events: 1; frontier: 4; head_digest: {_HEAD}."
+    )
+
+
+def test_malformed_identifiers_and_digests_are_never_admitted() -> None:
+    hostile = "ses_../../etc/passwd or a very long injected user string"
+    summary = render_safe_compact_summary(
+        {
+            "ok": True,
+            "outcome": "created",
+            "task_id": "not-an-id",
+            "session_id": hostile,
+            "writer_id": 7,
+            "frontier": {"sequence": "1", "head_digest": "sha256:not-hex"},
+        }
+    )
+    assert summary == "Operation outcome: created; frontier: 1."
+    assert hostile not in summary
+
+
+def test_genesis_head_digest_is_admitted() -> None:
+    summary = render_safe_compact_summary(
+        {
+            "ok": True,
+            "outcome": "created",
+            "frontier": {"sequence": "0", "head_digest": "genesis"},
+        }
+    )
+    assert summary == "Operation outcome: created; frontier: 0; head_digest: genesis."


### PR DESCRIPTION
Fixes three defects filed from the 2026-08-15 dogfood run (session 01a006a4).

## #278 — observation sweep failures discard the exception identity

`_bounded_observation_sweep` reported every raised exception through `record_bounded_event_without_raising(reason="sweep_failed")` — a recorder documented for non-exception events, so the exception's bounded reason and origin were dropped and 12 consecutive live failures were byte-identical and undiagnosable.

- A sweep that raises (either an ordinary exception, or its own `TimeoutError` discriminated from the deadline by the existing `raised_inside` flag) now goes through `record_unexpected_exception_without_raising`, which derives the bounded reason and origin and writes the durable owner-only diagnostic line.
- Only the genuine deadline remains a bounded `sweep_deadline_exceeded` event, so the two cases stay distinguishable.
- Not addressed here: escalation after N consecutive failures (the issue's "ideally" item). With identity now on every record, each line is actionable; escalation is a separate design decision.

## #279 — the `start` text summary could not seed the next request

`_summary_for_other_success` rendered only `outcome` and the frontier sequence, so on a host that drops structured content (the real configuration behind #203/#173) the documented text authoring fallback dead-ended at the very first operation.

- Every summary now renders the frontier `head_digest` (or `genesis`) alongside the sequence, since `publish_work` needs `expected_frontier.head_digest`, not just the sequence.
- Generic success summaries (which render `start`) additionally carry `task_id`, `session_id`, and `writer_id` when present.
- Privacy posture is unchanged: each identifier is re-gated through the strict public-id validator (`yoetz.protocol.ids`) and the digest through a closed `genesis|sha256:[0-9a-f]{64}` shape, so the projector still admits only the operation's own minted values. Worst realistic `start` summary is ~285 bytes, well inside the 512-byte bound.

Example `start` summary now:
```
Operation outcome: created; task: tsk_…; session: ses_…; writer: wri_…; frontier: 1; head_digest: sha256:…
```

## #280 — main was red: attach advisory suppressed under `skip_service`

The static "call start to attach a task" advisory sat behind `not skip_service`, contradicting the documented local-only contract and leaving `test_session_start_creates_binding_without_mcp_start` red on `main`.

- The advisory (a static literal needing no service) now emits in local-only mode too; only the auto-attach RPC stays behind the `skip_service` gate. The `handle_observe` docstring states the contract explicitly.
- Making the advisory occupy the shared context channel would have starved standing advice at the bootstrap SessionStart (the #241 cadence tests caught this), so pending advice now joins the advisory via the existing append mechanism instead of being suppressed by it. A new test pins advisory + advice coexisting in order.

## Testing

- New/updated tests: sweep exception identity (2 daemon tests), text-fallback summaries (4 new tests incl. hostile-input rejection), advisory+advice join, updated pinned parity strings.
- Full suite: 3727 passed, 6 failed — all 6 are the known local worktree-environment failures in `tests/packaging` (they shell out to `yoetz state capture`, which rejects git worktrees); verified byte-identical failures with this change stashed.
- `ruff check`, `ruff format --check`, and `pyright` (strict) clean on all touched files.

Closes #278. Closes #279. Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sweep diagnosability, text-fallback summaries, and the skip_service attach advisory
> - MCP text summaries now include the canonical `head_digest` alongside the frontier sequence; generic successes (e.g. start, publish_work) also include validated `task_id`/`session_id`/`writer_id`. Malformed identifiers and digests are silently excluded.
> - Observation sweep exception handling in `_bounded_observation_sweep` now distinguishes between exceptions raised inside the sweep (recorded via `record_unexpected_exception_without_raising`) and true deadline expiry (the only case that records `sweep_deadline_exceeded`).
> - `SessionStart` in local-only mode now emits a static attach advisory without opening a service connection, and pending standing advice is delivered alongside that advisory rather than being deferred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0b0dcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->