### PR TITLE
Converge packaged resource regeneration

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -118,17 +118,14 @@ jobs:
       - name: Check dependency locks without modifying them
         run: uv sync --locked --all-extras --group dev
 
-      - name: Verify generated schemas are exact (no drift)
-        run: uv run --locked python scripts/generate_schemas.py --check
+      - name: Verify generated schemas and packaged resources reached a fixed point
+        run: uv run --locked python scripts/sync_resource_ripple.py --check
 
       - name: Verify CHECK continuation schemas are exact
         run: uv run --locked python scripts/sync_check_continuation_schemas.py --check
 
       - name: Verify repository-authority control schemas are exact
         run: uv run --locked python scripts/sync_repository_authority_schemas.py --check
-
-      - name: Verify packaged resource manifest and byte parity
-        run: uv run --locked python scripts/verify_resource_manifest.py --check
 
       - name: Validate schema $id/$ref resolution from the local manifest (network denied)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,9 +124,8 @@ jobs:
 
       - name: Verify generated schema/resource parity
         run: |
-          uv run --locked python scripts/generate_schemas.py --check
+          uv run --locked python scripts/sync_resource_ripple.py --check
           uv run --locked python scripts/sync_check_continuation_schemas.py --check
-          uv run --locked python scripts/verify_resource_manifest.py --check
 
       - name: Verify migration/protocol/vector append-only policy against the previous release
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,14 @@ uv run pytest <path-to-touched-tests>
 Use Ruff and the pinned npm Pyright (`npx --no-install pyright`) from repository metadata. Prefer the
 smallest relevant test slice.
 
+For any packaged-resource inventory change, use the owning fixed-point command instead of running
+its dependent generators individually:
+
+```text
+uv run python scripts/sync_resource_ripple.py --write
+uv run python scripts/sync_resource_ripple.py --check
+```
+
 ## Hard rules
 
 - Do not weaken the honesty rules in [`CONTRIBUTING.md`](CONTRIBUTING.md). Coverage-bounded wording,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ prerequisites only, never an end-user runtime requirement.
 
 Resource inventory changes feed the package manifest, version-manifest schema, schema inventory,
 runtime-support digest, and packaged byte mirrors. Do not run those generators in a hand-selected
-order. After adding, removing, or changing a packaged resource inventory entry, run:
+order — a wrong order leaves a stale artifact that is still internally byte-consistent, so no byte
+parity check can see it. After adding, removing, or changing a packaged resource inventory entry
+(or any file one of those entries points at), run:
 
 ```text
 uv run python scripts/sync_resource_ripple.py --write
@@ -64,9 +66,12 @@ uv run python scripts/sync_resource_ripple.py --check
 ```
 
 The write command repeats the complete dependency sequence until the owned bytes reach a fixed
-point, then runs the same read-only checks as CI. When the number of inventory entries changes,
-review and update the single `REVIEWED_RESOURCE_COUNT` tripwire in `src/yoetz/version.py` before
-running it; every per-kind count and generated cardinality is derived from the manifest entries.
+point, then runs the same read-only checks as CI. Those checks include building the installed
+version manifest and validating it against the generated version-manifest schema, which is what
+catches a stale cardinality constant locally instead of in CI. When the number of inventory entries
+changes, review and update the single `REVIEWED_RESOURCE_COUNT` tripwire in `src/yoetz/version.py`
+before running it; every per-kind count and generated cardinality is derived from the manifest
+entries.
 
 ## Making a change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,22 @@ The pinned toolchain is Ruff for lint/format and the official npm-distributed Py
 (`npx --no-install pyright`) in strict mode for type checking; Node/npm are contributor and CI
 prerequisites only, never an end-user runtime requirement.
 
+### Packaged resource ripple
+
+Resource inventory changes feed the package manifest, version-manifest schema, schema inventory,
+runtime-support digest, and packaged byte mirrors. Do not run those generators in a hand-selected
+order. After adding, removing, or changing a packaged resource inventory entry, run:
+
+```text
+uv run python scripts/sync_resource_ripple.py --write
+uv run python scripts/sync_resource_ripple.py --check
+```
+
+The write command repeats the complete dependency sequence until the owned bytes reach a fixed
+point, then runs the same read-only checks as CI. When the number of inventory entries changes,
+review and update the single `REVIEWED_RESOURCE_COUNT` tripwire in `src/yoetz/version.py` before
+running it; every per-kind count and generated cardinality is derived from the manifest entries.
+
 ## Making a change
 
 - Make the smallest change that satisfies the decision and its tests.
@@ -105,7 +121,8 @@ Silence, ignoring a thread, or "will do later" without maintainer agreement is n
 
 - Don't open a PR without a linked issue and duplicate search.
 - Don't hand-edit a generated or frozen artifact (a lock file, a generated schema mirror, a release
-  manifest) — regenerate it through its owning script.
+  manifest) — regenerate it through its owning script. For the resource/schema graph, the owning
+  entrypoint is `scripts/sync_resource_ripple.py`.
 - Don't invent a second formatter, linter, or type-checker configuration; the pinned tools in
   `pyproject.toml` and the development-only `package.json` are the only ones this project uses.
 - Don't add a new distribution surface without design-gate acknowledgement. The end-user install

--- a/scripts/sync_resource_ripple.py
+++ b/scripts/sync_resource_ripple.py
@@ -27,6 +27,20 @@ _OWNED_FILES: Final = (
     "skills/codex/yoetz/manifest.json",
     "support/runtime-support.json",
 )
+_SEMANTIC_CHECK_SOURCE: Final = """\
+import json
+import pathlib
+
+from jsonschema import Draft202012Validator
+
+from yoetz.version import build_version_manifest, version_manifest_json
+
+schema = json.loads(
+    pathlib.Path("schemas/version/version-manifest-1.0.0.schema.json").read_bytes()
+)
+document = json.loads(version_manifest_json(build_version_manifest(), include_resources=True))
+Draft202012Validator(schema).validate(document)
+"""
 
 
 def _iter_owned_files(repo_root: Path) -> Iterator[Path]:
@@ -113,22 +127,60 @@ def _preflight(repo_root: Path) -> bool:
     return False
 
 
+def _installed_manifest_agrees_with_schema(repo_root: Path) -> bool:
+    """Prove the installed manifest still satisfies the generated version-manifest schema.
+
+    Both sub-checks below are byte comparisons against artifacts that a mis-ordered regeneration
+    leaves internally self-consistent, so neither notices a stale cardinality constant or a stale
+    runtime-support digest. Building the manifest exercises the support/resource-set binding and
+    validating it against the on-disk schema exercises the generated cardinalities, which is the
+    drift that previously escaped local verification and failed only in CI.
+    """
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _SEMANTIC_CHECK_SOURCE],
+        cwd=repo_root,
+        env=_child_environment(repo_root),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if completed.returncode == 0:
+        return True
+    print("sync_resource_ripple: FAIL (installed_manifest_disagrees_with_schema)", file=sys.stderr)
+    if completed.stderr:
+        print(completed.stderr.rstrip(), file=sys.stderr)
+    return False
+
+
 def _check(repo_root: Path) -> bool:
-    return _run(repo_root, "generate_schemas.py", "--check") and _run(
-        repo_root, "verify_resource_manifest.py", "--check"
+    return (
+        _run(repo_root, "generate_schemas.py", "--check")
+        and _run(repo_root, "verify_resource_manifest.py", "--check")
+        and _installed_manifest_agrees_with_schema(repo_root)
     )
 
 
 def _write_pass(repo_root: Path) -> bool:
     steps = (
+        # Mirror the reviewed sources into the package tree and recompute the resource-set digest.
         ("verify_resource_manifest.py", "--sync"),
+        # Rebind the runtime-support digests to that resource-set digest. This must precede the
+        # version-manifest regeneration below: build_version_manifest() fails closed with
+        # support_resource_set_mismatch while runtime-support still carries the previous digest.
+        ("sync_service_status_schema.py",),
+        # Mirror the refreshed runtime-support bytes. The resource-set digest is unchanged here
+        # because runtime_support content is deliberately excluded from that digest.
+        ("verify_resource_manifest.py", "--sync"),
+        # Regenerate the version-manifest cardinalities from the now-consistent installed manifest.
         (
             "generate_schemas.py",
             "--write",
             "--only",
             _VERSION_MANIFEST_SCHEMA,
         ),
-        ("sync_service_status_schema.py",),
+        # Mirror the regenerated schema bytes and schema inventory. The resource-set digest moves
+        # when they change, which the next pass rebinds into runtime-support.
         ("verify_resource_manifest.py", "--sync"),
     )
     for script_name, *arguments in steps:

--- a/scripts/sync_resource_ripple.py
+++ b/scripts/sync_resource_ripple.py
@@ -1,0 +1,198 @@
+"""Converge and verify every generated artifact in the packaged-resource ripple.
+
+Resource inventory changes cross four generated layers: the package resource manifest, the
+version-manifest schema, the schema inventory/runtime-support digests, and the packaged copies of
+those files. This command owns that order and repeats it to a byte-identical fixed point instead
+of requiring maintainers to remember a multi-pass sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Final
+
+_SCRIPT_ROOT = Path(__file__).resolve().parent
+_DEFAULT_REPO_ROOT = _SCRIPT_ROOT.parent
+
+_MAX_PASSES: Final = 5
+_VERSION_MANIFEST_SCHEMA: Final = "version/version-manifest-1.0.0.schema.json"
+_OWNED_ROOTS: Final = ("schemas", "src/yoetz/resources")
+_OWNED_FILES: Final = (
+    "skills/codex/yoetz/manifest.json",
+    "support/runtime-support.json",
+)
+
+
+def _iter_owned_files(repo_root: Path) -> Iterator[Path]:
+    """Yield every byte-owned artifact in deterministic path order."""
+
+    paths: list[Path] = []
+    for relative_root in _OWNED_ROOTS:
+        root = repo_root / relative_root
+        if root.is_dir():
+            paths.extend(path for path in root.rglob("*") if path.is_file())
+    paths.extend(repo_root / relative_path for relative_path in _OWNED_FILES)
+    yield from sorted(set(paths), key=lambda path: path.relative_to(repo_root).as_posix().encode())
+
+
+def _owned_digest(repo_root: Path) -> str:
+    """Bind the complete owned byte set, including relative names, for convergence checks."""
+
+    digest = hashlib.sha256()
+    for path in _iter_owned_files(repo_root):
+        relative = path.relative_to(repo_root).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(4, "big"))
+        digest.update(relative)
+        data = path.read_bytes()
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+    return digest.hexdigest()
+
+
+def _child_environment(repo_root: Path) -> dict[str, str]:
+    environment = dict(os.environ)
+    source_root = str(repo_root / "src")
+    existing = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = (
+        source_root if not existing else os.pathsep.join((source_root, existing))
+    )
+    return environment
+
+
+def _run(repo_root: Path, script_name: str, *arguments: str) -> bool:
+    script = repo_root / "scripts" / script_name
+    completed = subprocess.run(
+        [sys.executable, str(script), *arguments],
+        cwd=repo_root,
+        env=_child_environment(repo_root),
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+def _preflight(repo_root: Path) -> bool:
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from verify_resource_manifest import load_inventory_config; "
+            "from yoetz.version import REVIEWED_RESOURCE_COUNT; "
+            "print(len(load_inventory_config().entries), REVIEWED_RESOURCE_COUNT)",
+        ],
+        cwd=repo_root / "scripts",
+        env=_child_environment(repo_root),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if probe.returncode != 0:
+        print("sync_resource_ripple: FAIL (preflight_failed)", file=sys.stderr)
+        if probe.stderr:
+            print(probe.stderr.rstrip(), file=sys.stderr)
+        return False
+    try:
+        actual_count, reviewed_count = (int(value) for value in probe.stdout.split())
+    except ValueError:
+        print("sync_resource_ripple: FAIL (preflight_output_invalid)", file=sys.stderr)
+        return False
+    if actual_count == reviewed_count:
+        return True
+    print(
+        "sync_resource_ripple: FAIL (reviewed_resource_count_mismatch)\n"
+        f"  inventory entries: {actual_count}\n"
+        f"  REVIEWED_RESOURCE_COUNT: {reviewed_count}\n"
+        "  review and update the single cardinality tripwire in src/yoetz/version.py first",
+        file=sys.stderr,
+    )
+    return False
+
+
+def _check(repo_root: Path) -> bool:
+    return _run(repo_root, "generate_schemas.py", "--check") and _run(
+        repo_root, "verify_resource_manifest.py", "--check"
+    )
+
+
+def _write_pass(repo_root: Path) -> bool:
+    steps = (
+        ("verify_resource_manifest.py", "--sync"),
+        (
+            "generate_schemas.py",
+            "--write",
+            "--only",
+            _VERSION_MANIFEST_SCHEMA,
+        ),
+        ("sync_service_status_schema.py",),
+        ("verify_resource_manifest.py", "--sync"),
+    )
+    for script_name, *arguments in steps:
+        if not _run(repo_root, script_name, *arguments):
+            print(f"sync_resource_ripple: FAIL (step_failed) {script_name}", file=sys.stderr)
+            return False
+    return True
+
+
+def _write_to_fixed_point(repo_root: Path) -> bool:
+    previous = _owned_digest(repo_root)
+    for pass_number in range(1, _MAX_PASSES + 1):
+        if not _write_pass(repo_root):
+            return False
+        current = _owned_digest(repo_root)
+        if current == previous:
+            if not _check(repo_root):
+                print("sync_resource_ripple: FAIL (post_convergence_check)", file=sys.stderr)
+                return False
+            print(f"sync_resource_ripple: PASS (fixed point after {pass_number} pass(es))")
+            return True
+        previous = current
+    print(
+        f"sync_resource_ripple: FAIL (did_not_converge after {_MAX_PASSES} passes)",
+        file=sys.stderr,
+    )
+    return False
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sync_resource_ripple.py",
+        description="Converge or verify generated schemas and packaged resource artifacts.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="Read-only fixed-point verification.")
+    mode.add_argument(
+        "--write", action="store_true", help="Regenerate to a byte-stable fixed point."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Test-only: operate on another complete checkout.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve() if args.repo_root is not None else _DEFAULT_REPO_ROOT
+    if not repo_root.is_dir():
+        print(f"sync_resource_ripple: FAIL (repo_root_missing) {repo_root}", file=sys.stderr)
+        return 2
+    if not _preflight(repo_root):
+        return 1
+    if args.check:
+        if not _check(repo_root):
+            print("sync_resource_ripple: FAIL (drift_detected)", file=sys.stderr)
+            return 1
+        print("sync_resource_ripple: PASS (generated artifacts are at a fixed point)")
+        return 0
+    return 0 if _write_to_fixed_point(repo_root) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/yoetz/cli/exits.py
+++ b/src/yoetz/cli/exits.py
@@ -134,13 +134,13 @@ def ceremony_refusal_message(reason: str) -> str | None:
 REMEDIATION_MESSAGES: Final = MappingProxyType(
     {
         "support_resource_set_mismatch": (
-            "the runtime support document describes a different resource set; regenerate "
-            "resources with 'python scripts/verify_resource_manifest.py --sync', refresh "
-            "support/runtime-support.json, then sync again"
+            "the runtime support document describes a different resource set; in a source "
+            "checkout run 'python scripts/sync_resource_ripple.py --write', which owns that "
+            "regeneration order"
         ),
         "support_digest_mismatch": (
-            "support/runtime-support.json is not self-consistent; regenerate its manifest_digest "
-            "and then run 'python scripts/verify_resource_manifest.py --sync'"
+            "support/runtime-support.json is not self-consistent; in a source checkout run "
+            "'python scripts/sync_resource_ripple.py --write' to rebuild its digests"
         ),
         "resource_digest_mismatch": (
             "an installed resource does not match the reviewed manifest; reinstall Yoetz from a "
@@ -148,15 +148,16 @@ REMEDIATION_MESSAGES: Final = MappingProxyType(
         ),
         "manifest_digest_mismatch": (
             "the installed resource manifest is not self-consistent; reinstall Yoetz from a "
-            "verified artifact, or regenerate it with 'python scripts/verify_resource_manifest.py --sync'"
+            "verified artifact, or in a source checkout run "
+            "'python scripts/sync_resource_ripple.py --write'"
         ),
         "resource_missing": (
             "a reviewed installed resource is absent; reinstall Yoetz from a verified artifact"
         ),
         "resource_counts_invalid": (
-            "the compiled resource counts do not match the reviewed manifest; regenerate the "
-            "resource tree through 'python scripts/verify_resource_manifest.py --sync' after "
-            "an intentional inventory change"
+            "the compiled resource counts do not match the reviewed manifest; after an "
+            "intentional inventory change, update REVIEWED_RESOURCE_COUNT and run "
+            "'python scripts/sync_resource_ripple.py --write' in a source checkout"
         ),
         "trusted_console_required": (
             "this ceremony needs a foreground terminal Yoetz owns (stdin and stderr on the same "

--- a/src/yoetz/version.py
+++ b/src/yoetz/version.py
@@ -39,6 +39,7 @@ __all__ = [
     "PRIVACY_POLICY_SCHEMA_VERSION",
     "PROJECTION_VERSION",
     "PROTOCOL_VERSION",
+    "REVIEWED_RESOURCE_COUNT",
     "RESEARCH_EVIDENCE_POLICY_VERSION",
     "ResourceIdentity",
     "ResourceIntegrityError",
@@ -70,7 +71,10 @@ _SUPPORT_SCHEMA: Final = "yoetz.runtime-support/1"
 _RESOURCE_ROOT: Final = "yoetz.resources"
 _MANIFEST_LIMIT: Final = 1_048_576
 _RESOURCE_LIMIT: Final = 4_194_304
-_EXPECTED_RESOURCE_COUNT: Final = 98
+# One independently reviewed cardinality tripwire guards the generated resource manifest. All
+# per-kind counts are derived from the manifest entries so adding a resource has exactly one
+# hand-authored count to review and the owning resource-ripple command can regenerate the rest.
+REVIEWED_RESOURCE_COUNT: Final = 98
 _RESOURCE_KINDS: Final = frozenset(
     {
         "canonical_vector",
@@ -408,7 +412,7 @@ def _load_resource_manifest() -> _ResourceManifest:
     entries = tuple(_entry_from_json(item) for item in raw_entries)
     names = tuple(entry.logical_name for entry in entries)
     if (
-        len(entries) != _EXPECTED_RESOURCE_COUNT
+        len(entries) != REVIEWED_RESOURCE_COUNT
         or names != tuple(sorted(set(names), key=str.encode))
         or len({entry.package_path for entry in entries}) != len(entries)
         or sum(entry.kind == "runtime_support" for entry in entries) != 1
@@ -577,16 +581,8 @@ def _resource_counts(entries: tuple[_ResourceEntry, ...]) -> VersionPairs:
         ),
         "total": len(entries),
     }
-    expected = {
-        "canonical_vectors": 9,
-        "guidance_resources": 5,
-        "migrations": 9,
-        "runtime_support_resources": 1,
-        "schema_resources": 72,
-        "skill_resources": 2,
-        "total": 98,
-    }
-    if counts != expected:
+    categorized_total = sum(count for name, count in counts.items() if name != "total")
+    if counts["total"] != REVIEWED_RESOURCE_COUNT or categorized_total != counts["total"]:
         raise ResourceIntegrityError("resource_counts_invalid")
     return tuple((name, str(counts[name])) for name in sorted(counts, key=str.encode))
 

--- a/tests/conformance/compatibility/test_resource_manifest.py
+++ b/tests/conformance/compatibility/test_resource_manifest.py
@@ -14,7 +14,8 @@ file this suite writes into the installed package tree.
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+from collections import Counter
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -24,6 +25,7 @@ import yoetz.version as version_module
 from yoetz.ports.diagnostics import StartupCheckOutcome
 from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 from yoetz.version import (
+    REVIEWED_RESOURCE_COUNT,
     ResourceIntegrityError,
     build_version_manifest,
     read_verified_resource,
@@ -31,16 +33,6 @@ from yoetz.version import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-
-_EXPECTED_RESOURCE_COUNTS = {
-    "canonical_vectors": "9",
-    "guidance_resources": "5",
-    "migrations": "9",
-    "runtime_support_resources": "1",
-    "schema_resources": "72",
-    "skill_resources": "2",
-    "total": "98",
-}
 
 
 def _package_bytes_fn() -> Callable[[str], bytes]:
@@ -51,12 +43,27 @@ def _load_resource_manifest_fn() -> Callable[[], Any]:
     return cast(Callable[[], Any], getattr(version_module, "_load_resource_manifest"))
 
 
+def _derived_resource_counts(entries: Sequence[Any]) -> dict[str, str]:
+    kinds = Counter(cast(str, entry.kind) for entry in entries)
+    return {
+        "canonical_vectors": str(kinds["canonical_vector"]),
+        "guidance_resources": str(kinds["guidance"]),
+        "migrations": str(kinds["migration"]),
+        "runtime_support_resources": str(kinds["runtime_support"]),
+        "schema_resources": str(kinds["json_schema"]),
+        "skill_resources": str(kinds["compatibility_manifest"] + kinds["skill"]),
+        "total": str(len(entries)),
+    }
+
+
 def test_root_resource_bytes_match_manifest() -> None:
     """Every installed resource is byte-identical to both its checked-in root source and manifest."""
 
     manifest = build_version_manifest()
-    assert dict(manifest.resource_counts) == _EXPECTED_RESOURCE_COUNTS
-    assert len(manifest.resources) == 98
+    source_manifest = _load_resource_manifest_fn()()
+    source_entries = cast(tuple[Any, ...], source_manifest.entries)
+    assert dict(manifest.resource_counts) == _derived_resource_counts(source_entries)
+    assert len(manifest.resources) == REVIEWED_RESOURCE_COUNT
 
     for resource in manifest.resources:
         installed = read_verified_resource(resource.name)
@@ -113,7 +120,7 @@ def test_missing_extra_duplicate_and_traversal_cases_fail(
 
     load_resource_manifest = _load_resource_manifest_fn()
     entries, doc = _baseline_entries()
-    assert len(entries) == 98
+    assert len(entries) == REVIEWED_RESOURCE_COUNT
 
     # missing -- dropping the last entry breaks the exact inventory count.
     _install_synthetic_manifest(monkeypatch, doc, entries[:-1])
@@ -158,27 +165,28 @@ def test_public_resource_list_matches_release_artifact() -> None:
     entries = cast(tuple[Any, ...], manifest.entries)
 
     kinds = [cast(str, entry.kind) for entry in entries]
-    assert kinds.count("json_schema") == 72
-    assert kinds.count("canonical_vector") == 9
-    assert kinds.count("migration") == 9
-    assert kinds.count("guidance") == 5
-    assert kinds.count("runtime_support") == 1
-    assert kinds.count("skill") == 1
-    assert kinds.count("compatibility_manifest") == 1
+    assert set(kinds) == {
+        "canonical_vector",
+        "compatibility_manifest",
+        "guidance",
+        "json_schema",
+        "migration",
+        "runtime_support",
+        "skill",
+    }
 
     schema_paths = {
         cast(str, entry.logical_name) for entry in entries if entry.kind == "json_schema"
     }
     assert "schemas/manifest.json" in schema_paths
-    # 71 JSON Schema documents plus the one schema inventory manifest.
-    assert len(schema_paths) - 1 == 71
 
     names = [cast(str, entry.logical_name) for entry in entries]
-    assert len(names) == 98
+    assert len(names) == REVIEWED_RESOURCE_COUNT
     assert names == sorted(set(names), key=lambda item: item.encode("ascii"))
 
     version_manifest = build_version_manifest()
     assert [resource.name for resource in version_manifest.resources] == names
+    assert dict(version_manifest.resource_counts) == _derived_resource_counts(entries)
 
     resource_set_digest = cast(str, manifest.resource_set_digest)
     assert resource_set_digest == version_manifest.resource_manifest_digest

--- a/tests/packaging/test_resource_byte_parity.py
+++ b/tests/packaging/test_resource_byte_parity.py
@@ -2,7 +2,7 @@
 
 Proves each manifest-declared runtime resource is the exact reviewed byte set in the
 root canonical source tree, the ``src/yoetz/resources`` package tree, the built wheel, and a clean
-offline install; that the nine canonical fixtures are the only ``fixtures/`` corpus shipped; and
+offline install; that the canonical fixtures are the only ``fixtures/`` corpus shipped; and
 that corruption/missing/extra resource drift is detected before decode/use, both at the source
 level (``scripts/verify_resource_manifest.py --check``) and at the installed-package level
 (``yoetz.version.read_verified_resource``).
@@ -24,88 +24,11 @@ from typing import Any, Final
 
 import pytest
 
+from yoetz.version import REVIEWED_RESOURCE_COUNT
+
 _REPO_ROOT: Final = Path(__file__).resolve().parents[2]
 _VERIFY_SCRIPT: Final = _REPO_ROOT / "scripts" / "verify_resource_manifest.py"
 _BUILD_TIMEOUT: Final = 120
-_EXPECTED_TOTAL: Final = 98
-_EXPECTED_KIND_COUNTS: Final = {
-    "canonical_vector": 9,
-    "guidance": 5,
-    "migration": 9,
-    "json_schema": 72,
-    "skill": 1,
-    "compatibility_manifest": 1,
-    "runtime_support": 1,
-}
-_WORKTREE_RESOURCE_OVERLAYS: Final = (
-    "guidance/agent-instructions.md",
-    "guidance/coverage-and-receipts.md",
-    "guidance/publication-policy.md",
-    "guidance/request-templates.md",
-    "guidance/workflow.md",
-    "migrations/catalog/0003.sql",
-    "migrations/bundle/0006.sql",
-    "schemas/config/yoetz-config-1.0.0.schema.json",
-    "schemas/events/event-draft-1.0.0.schema.json",
-    "schemas/events/evidence-recorded-1.1.0.schema.json",
-    "schemas/events/opaque-unknown-event-draft-1.0.0.schema.json",
-    "schemas/manifest.json",
-    "schemas/consent/catalog-2.0.0.schema.json",
-    "schemas/consent/catalog-3.0.0.schema.json",
-    "schemas/consent/chat-user-attestation-1.0.0.schema.json",
-    "schemas/consent/pending-agent-2.0.0.schema.json",
-    "schemas/consent/pending-agent-3.0.0.schema.json",
-    "schemas/consent/prepare-result-2.0.0.schema.json",
-    "schemas/consent/prepare-result-3.0.0.schema.json",
-    "schemas/consent/review-result-2.0.0.schema.json",
-    "schemas/consent/review-result-3.0.0.schema.json",
-    "schemas/consent/status-2.0.0.schema.json",
-    "schemas/consent/status-3.0.0.schema.json",
-    "schemas/operations/check-result-1.0.0.schema.json",
-    "schemas/operations/status-result-1.0.0.schema.json",
-    "schemas/service/control-hello-2.0.0.schema.json",
-    "schemas/service/control-hello-result-2.0.0.schema.json",
-    "schemas/service/control-request-2.0.0.schema.json",
-    "schemas/service/control-result-2.0.0.schema.json",
-    "schemas/version/version-manifest-1.0.0.schema.json",
-    "skills/codex/yoetz/SKILL.md",
-    "skills/codex/yoetz/manifest.json",
-    "src/yoetz/resources/manifest.json",
-    "src/yoetz/resources/guidance/agent-instructions.md",
-    "src/yoetz/resources/guidance/coverage-and-receipts.md",
-    "src/yoetz/resources/guidance/publication-policy.md",
-    "src/yoetz/resources/guidance/request-templates.md",
-    "src/yoetz/resources/guidance/workflow.md",
-    "src/yoetz/resources/migrations/catalog/0003.sql",
-    "src/yoetz/resources/migrations/bundle/0006.sql",
-    "src/yoetz/resources/schemas/config/yoetz-config-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/events/event-draft-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/events/evidence-recorded-1.1.0.schema.json",
-    "src/yoetz/resources/schemas/events/opaque-unknown-event-draft-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/manifest.json",
-    "src/yoetz/resources/schemas/consent/catalog-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/catalog-3.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/chat-user-attestation-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/pending-agent-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/pending-agent-3.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/prepare-result-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/prepare-result-3.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/review-result-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/review-result-3.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/status-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/consent/status-3.0.0.schema.json",
-    "src/yoetz/resources/schemas/operations/check-result-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/operations/status-result-1.0.0.schema.json",
-    "src/yoetz/resources/schemas/service/control-hello-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/service/control-hello-result-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/service/control-request-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/service/control-result-2.0.0.schema.json",
-    "src/yoetz/resources/schemas/version/version-manifest-1.0.0.schema.json",
-    "src/yoetz/resources/skills/codex/yoetz/SKILL.md",
-    "src/yoetz/resources/skills/codex/yoetz/manifest.json",
-    "src/yoetz/resources/support/runtime-support.json",
-    "support/runtime-support.json",
-)
 
 
 def _load_manifest() -> Any:  # raw JSON document, deliberately untyped
@@ -133,26 +56,38 @@ def _export_clean_source(dest: Path) -> None:
     finally:
         tar_path.unlink(missing_ok=True)
 
-    # This mutation matrix deliberately starts from ``git archive HEAD`` so unrelated untracked
-    # files cannot enter its baseline. During a release change, however, newly reviewed resources
-    # do not exist in HEAD until the final commit. Overlay only the explicit candidate resource
-    # delta so the tests exercise the complete reviewed inventory before that commit is made.
-    for relative in _WORKTREE_RESOURCE_OVERLAYS:
+    # Start from ``git archive HEAD`` so unrelated untracked files cannot enter the baseline, then
+    # overlay the current generated manifest's complete reviewed source/package set. Deriving this
+    # list from the manifest avoids creating another inventory that must be updated by hand.
+    manifest = _load_manifest()
+    overlays = {"src/yoetz/resources/manifest.json"}
+    for entry in manifest["entries"]:
+        overlays.add(entry["source_path"])
+        overlays.add(f"src/yoetz/resources/{entry['package_path']}")
+    for relative in sorted(overlays, key=str.encode):
         source = _REPO_ROOT / relative
         target = dest / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
 
 
-def test_manifest_has_exactly_96_entries_with_the_reviewed_kind_counts() -> None:
+def test_manifest_matches_the_single_reviewed_count_and_closed_kind_set() -> None:
     manifest = _load_manifest()
     entries = manifest["entries"]
-    assert len(entries) == _EXPECTED_TOTAL
+    assert len(entries) == REVIEWED_RESOURCE_COUNT
 
     counts: dict[str, int] = {}
     for entry in entries:
         counts[entry["kind"]] = counts.get(entry["kind"], 0) + 1
-    assert counts == _EXPECTED_KIND_COUNTS
+    assert set(counts) == {
+        "canonical_vector",
+        "compatibility_manifest",
+        "guidance",
+        "json_schema",
+        "migration",
+        "runtime_support",
+        "skill",
+    }
 
 
 def test_source_tree_and_package_tree_are_byte_identical_in_the_real_checkout() -> None:
@@ -199,17 +134,15 @@ def test_every_manifest_entry_source_path_matches_its_recorded_digest_and_size()
         assert _sha256(data) == entry["sha256"], entry["logical_name"]
 
 
-def test_only_the_nine_canonical_fixtures_are_referenced_by_the_manifest() -> None:
+def test_all_canonical_fixtures_are_referenced_by_the_manifest() -> None:
     manifest = _load_manifest()
     canonical_entries = [
         entry for entry in manifest["entries"] if entry["kind"] == "canonical_vector"
     ]
-    assert len(canonical_entries) == 9
     for entry in canonical_entries:
         assert entry["logical_name"].startswith("fixtures/canonical/")
 
     on_disk = sorted((_REPO_ROOT / "fixtures" / "canonical").glob("*.case.json"))
-    assert len(on_disk) == 9
     referenced = {entry["logical_name"] for entry in canonical_entries}
     assert referenced == {f"fixtures/canonical/{path.name}" for path in on_disk}
 

--- a/tests/packaging/test_resource_ripple.py
+++ b/tests/packaging/test_resource_ripple.py
@@ -1,0 +1,90 @@
+"""The packaged-resource owning command converges, checks, and fails before partial writes."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RIPPLE_SCRIPT = _REPO_ROOT / "scripts" / "sync_resource_ripple.py"
+
+
+def _write(root: Path, relative_path: str, content: str) -> None:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _synthetic_checkout(root: Path, *, inventory_count: int, reviewed_count: int) -> None:
+    _write(root, "src/yoetz/__init__.py", "")
+    _write(
+        root,
+        "src/yoetz/version.py",
+        f"REVIEWED_RESOURCE_COUNT = {reviewed_count}\n",
+    )
+    _write(
+        root,
+        "scripts/verify_resource_manifest.py",
+        "class _Inventory:\n"
+        f"    entries = tuple(range({inventory_count}))\n"
+        "\n"
+        "def load_inventory_config():\n"
+        "    return _Inventory()\n",
+    )
+    _write(
+        root,
+        "scripts/generate_schemas.py",
+        "from pathlib import Path\n"
+        "import sys\n"
+        "root = Path(__file__).resolve().parent.parent\n"
+        "state = root / 'schemas/state.txt'\n"
+        "if '--write' in sys.argv:\n"
+        "    state.write_text('stable\\n', encoding='utf-8')\n"
+        "elif state.read_text(encoding='utf-8') != 'stable\\n':\n"
+        "    raise SystemExit(1)\n",
+    )
+    _write(root, "scripts/sync_service_status_schema.py", "")
+    _write(root, "schemas/state.txt", "stale\n")
+    _write(root, "src/yoetz/resources/manifest.json", "{}\n")
+    _write(root, "skills/codex/yoetz/manifest.json", "{}\n")
+    _write(root, "support/runtime-support.json", "{}\n")
+
+
+def _run(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_RIPPLE_SCRIPT), *arguments],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_real_checkout_passes_the_single_ci_entrypoint() -> None:
+    completed = _run("--check")
+
+    assert completed.returncode == 0, completed.stderr
+    assert "generated artifacts are at a fixed point" in completed.stdout
+
+
+def test_write_repeats_until_the_owned_bytes_are_stable(tmp_path: Path) -> None:
+    _synthetic_checkout(tmp_path, inventory_count=1, reviewed_count=1)
+
+    completed = _run("--write", "--repo-root", str(tmp_path))
+
+    assert completed.returncode == 0, completed.stderr
+    assert "fixed point after 2 pass(es)" in completed.stdout
+    assert (tmp_path / "schemas/state.txt").read_text(encoding="utf-8") == "stable\n"
+
+
+def test_reviewed_count_mismatch_fails_before_any_generator_runs(tmp_path: Path) -> None:
+    _synthetic_checkout(tmp_path, inventory_count=2, reviewed_count=1)
+    sentinel = tmp_path / "schemas/state.txt"
+
+    completed = _run("--write", "--repo-root", str(tmp_path))
+
+    assert completed.returncode == 1
+    assert "reviewed_resource_count_mismatch" in completed.stderr
+    assert sentinel.read_text(encoding="utf-8") == "stale\n"

--- a/tests/packaging/test_resource_ripple.py
+++ b/tests/packaging/test_resource_ripple.py
@@ -2,12 +2,32 @@
 
 from __future__ import annotations
 
+import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Final, cast
+
+import pytest
+
+from yoetz.protocol.canonical import JsonValue, canonical_encode
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _RIPPLE_SCRIPT = _REPO_ROOT / "scripts" / "sync_resource_ripple.py"
+
+# Every tree the inventory reads from or writes into, so a copied checkout can run the real ripple.
+_CHECKOUT_TREES: Final = (
+    "fixtures/canonical",
+    "guidance",
+    "migrations",
+    "schemas",
+    "scripts",
+    "skills",
+    "src/yoetz",
+    "support",
+)
 
 
 def _write(root: Path, relative_path: str, content: str) -> None:
@@ -16,13 +36,28 @@ def _write(root: Path, relative_path: str, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _copy_checkout(destination: Path) -> None:
+    """Copy the working-tree source and generated trees the ripple reads and writes."""
+
+    ignore = shutil.ignore_patterns("__pycache__", "*.pyc")
+    for relative in _CHECKOUT_TREES:
+        shutil.copytree(_REPO_ROOT / relative, destination / relative, ignore=ignore)
+
+
 def _synthetic_checkout(root: Path, *, inventory_count: int, reviewed_count: int) -> None:
     _write(root, "src/yoetz/__init__.py", "")
     _write(
         root,
         "src/yoetz/version.py",
-        f"REVIEWED_RESOURCE_COUNT = {reviewed_count}\n",
+        f"REVIEWED_RESOURCE_COUNT = {reviewed_count}\n"
+        "\n"
+        "def build_version_manifest():\n"
+        "    return {}\n"
+        "\n"
+        "def version_manifest_json(manifest, *, include_resources=False):\n"
+        "    return b'{}'\n",
     )
+    _write(root, "schemas/version/version-manifest-1.0.0.schema.json", '{"type":"object"}')
     _write(
         root,
         "scripts/verify_resource_manifest.py",
@@ -58,7 +93,7 @@ def _run(*arguments: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         check=False,
         text=True,
-        timeout=120,
+        timeout=600,
     )
 
 
@@ -77,6 +112,60 @@ def test_write_repeats_until_the_owned_bytes_are_stable(tmp_path: Path) -> None:
     assert completed.returncode == 0, completed.stderr
     assert "fixed point after 2 pass(es)" in completed.stdout
     assert (tmp_path / "schemas/state.txt").read_text(encoding="utf-8") == "stable\n"
+
+
+@pytest.mark.slow
+def test_write_converges_a_reviewed_source_byte_change_in_a_real_checkout(tmp_path: Path) -> None:
+    """A guidance byte change ripples through every dependent digest in one command."""
+
+    checkout = tmp_path / "checkout"
+    _copy_checkout(checkout)
+    guidance = checkout / "guidance/workflow.md"
+    guidance.write_bytes(guidance.read_bytes() + b"\n<!-- ripple probe -->\n")
+
+    written = _run("--write", "--repo-root", str(checkout))
+    assert written.returncode == 0, written.stderr + written.stdout
+
+    assert (checkout / "src/yoetz/resources/guidance/workflow.md").read_bytes() == (
+        guidance.read_bytes()
+    )
+    support = json.loads((checkout / "support/runtime-support.json").read_bytes())
+    package_manifest = json.loads((checkout / "src/yoetz/resources/manifest.json").read_bytes())
+    assert support["resource_set_digest"] == package_manifest["resource_set_digest"]
+
+    checked = _run("--check", "--repo-root", str(checkout))
+    assert checked.returncode == 0, checked.stderr + checked.stdout
+
+
+@pytest.mark.slow
+def test_check_rejects_a_self_consistent_but_stale_cardinality_constant(tmp_path: Path) -> None:
+    """Byte-parity alone cannot see a wrong generated cardinality; the owning check must."""
+
+    checkout = tmp_path / "checkout"
+    _copy_checkout(checkout)
+    schema_path = checkout / "schemas/version/version-manifest-1.0.0.schema.json"
+    document = cast(dict[str, Any], json.loads(schema_path.read_bytes()))
+    counts = document["$defs"]["resource_counts"]["properties"]
+    counts["migrations"]["const"] = str(int(counts["migrations"]["const"]) - 1)
+    counts["schema_resources"]["const"] = str(int(counts["schema_resources"]["const"]) + 1)
+    schema_path.write_bytes(canonical_encode(cast(JsonValue, document)))
+
+    # Re-mirror so every byte-parity comparison in the ripple is satisfied by the stale artifact.
+    mirrored = subprocess.run(
+        [sys.executable, str(checkout / "scripts/verify_resource_manifest.py"), "--sync"],
+        cwd=checkout,
+        capture_output=True,
+        check=False,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(checkout / "src")},
+        timeout=120,
+    )
+    assert mirrored.returncode == 0, mirrored.stderr
+
+    checked = _run("--check", "--repo-root", str(checkout))
+
+    assert checked.returncode == 1
+    assert "installed_manifest_disagrees_with_schema" in checked.stderr
 
 
 def test_reviewed_count_mismatch_fails_before_any_generator_runs(tmp_path: Path) -> None:

--- a/tests/packaging/test_version_manifest.py
+++ b/tests/packaging/test_version_manifest.py
@@ -160,7 +160,6 @@ def test_json_version_resource_digest_matches_the_source_manifest(
 
     assert manifest["resource_manifest_digest"] == source_manifest["resource_set_digest"]
     assert manifest["resource_counts"]["total"] == str(len(source_manifest["entries"]))
-    assert len(source_manifest["entries"]) == 98
 
 
 def test_default_json_reports_resource_summary_without_enumerating_entries(
@@ -169,7 +168,7 @@ def test_default_json_reports_resource_summary_without_enumerating_entries(
     completed = _run(installed_candidate, ["version", "--json"])
     manifest = json.loads(completed.stdout)
     assert manifest["resources"] == []
-    assert manifest["resource_counts"]["total"] == "98"
+    assert manifest["resource_counts"]["total"] == str(len(_source_resource_manifest()["entries"]))
 
 
 def test_explicit_resources_flag_enumerates_all_reviewed_identities(
@@ -190,7 +189,7 @@ def test_explicit_resources_flag_enumerates_all_reviewed_identities(
     )
     manifest = json.loads(completed.stdout)
     source_manifest = _source_resource_manifest()
-    assert len(manifest["resources"]) == 98
+    assert len(manifest["resources"]) == len(source_manifest["entries"])
     reported_names = {entry["name"] for entry in manifest["resources"]}
     expected_names = {entry["logical_name"] for entry in source_manifest["entries"]}
     assert reported_names == expected_names

--- a/tests/unit/cli/test_ceremony_refusal_reporting.py
+++ b/tests/unit/cli/test_ceremony_refusal_reporting.py
@@ -147,8 +147,24 @@ def test_resource_count_remediation_names_the_owning_sync_script() -> None:
     message = remediation_message("resource_counts_invalid")
 
     assert message is not None
-    assert "scripts/verify_resource_manifest.py --sync" in message
+    assert "scripts/sync_resource_ripple.py --write" in message
+    assert "REVIEWED_RESOURCE_COUNT" in message
     assert "update the compiled count" not in message
+
+
+def test_resource_remediation_never_names_a_single_step_of_the_ripple() -> None:
+    """A dependent generator alone reproduces the mis-ordered regeneration these tokens report."""
+
+    for reason in (
+        "manifest_digest_mismatch",
+        "resource_counts_invalid",
+        "support_digest_mismatch",
+        "support_resource_set_mismatch",
+    ):
+        message = remediation_message(reason)
+        assert message is not None, reason
+        assert "verify_resource_manifest.py" not in message, reason
+        assert "generate_schemas.py" not in message, reason
 
 
 def test_secret_rejected_names_the_credential_and_the_retry() -> None:

--- a/tests/unit/version/test_manifest.py
+++ b/tests/unit/version/test_manifest.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator
 
 from yoetz.ports.diagnostics import StartupCheckOutcome
 from yoetz.version import (
+    REVIEWED_RESOURCE_COUNT,
     ResourceIntegrityError,
     build_version_manifest,
     read_verified_resource,
@@ -29,16 +30,20 @@ def test_development_manifest_is_truthful_and_complete() -> None:
     )
     assert len(manifest.request_result_schema_versions) == 40
     assert len(manifest.event_schema_versions) == 16
-    assert len(manifest.resources) == 98
-    assert dict(manifest.resource_counts) == {
-        "canonical_vectors": "9",
-        "guidance_resources": "5",
-        "migrations": "9",
-        "runtime_support_resources": "1",
-        "schema_resources": "72",
-        "skill_resources": "2",
-        "total": "98",
+    counts = dict(manifest.resource_counts)
+    assert len(manifest.resources) == REVIEWED_RESOURCE_COUNT == int(counts["total"])
+    assert set(counts) == {
+        "canonical_vectors",
+        "guidance_resources",
+        "migrations",
+        "runtime_support_resources",
+        "schema_resources",
+        "skill_resources",
+        "total",
     }
+    assert sum(int(count) for name, count in counts.items() if name != "total") == int(
+        counts["total"]
+    )
 
 
 def test_version_json_allows_installed_sdk_with_empty_tested_protocol_set() -> None:
@@ -57,7 +62,7 @@ def test_resource_manifest_verifies_every_installed_member() -> None:
 
     assert len(result) == 1
     assert result[0].outcome is StartupCheckOutcome.OK
-    assert result[0].safe_details["resource_count"] == 98
+    assert result[0].safe_details["resource_count"] == REVIEWED_RESOURCE_COUNT
 
 
 def test_guidance_and_skill_source_package_bytes_are_identical() -> None:


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #293
- I searched existing issues and PRs for duplicates before opening this PR.
- This release/packaging change was acknowledged by the maintainer through the issue follow-up and explicit implementation request.

## Documentation

- Behavior change? yes — contributor/release-integrity workflow only; no runtime protocol or wire behavior changes.
- Docs updated: `AGENTS.md` and `CONTRIBUTING.md`; no ADR or `docs/INTERFACES.md` change is required.

## Verification

Commands run:

```text
uv sync --locked --all-extras --group dev
uv run python scripts/sync_resource_ripple.py --write
uv run python scripts/sync_resource_ripple.py --check
uv run pytest tests/packaging/test_resource_ripple.py tests/unit/version/test_manifest.py tests/conformance/compatibility/test_resource_manifest.py -m "not fault and not soak and not live" -q --timeout=120
uv run pytest tests/packaging/test_resource_byte_parity.py -m "not fault and not soak and not live" -q --timeout=120
uv run pytest tests/packaging/test_version_manifest.py -k "json_version_resource_digest_matches_the_source_manifest or default_json_reports_resource_summary_without_enumerating_entries" -q --timeout=120
uv run ruff check scripts/sync_resource_ripple.py src/yoetz/version.py tests/packaging/test_resource_ripple.py tests/packaging/test_resource_byte_parity.py tests/packaging/test_version_manifest.py tests/unit/version/test_manifest.py tests/conformance/compatibility/test_resource_manifest.py
npx --no-install pyright
uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Adds one owning `sync_resource_ripple.py` command that preflights the reviewed inventory count, runs resource sync, version-manifest schema regeneration, runtime-support refresh, and package sync to a byte-stable fixed point, then executes read-only parity checks.

The runtime now keeps one reviewed total cardinality tripwire while deriving per-kind counts from manifest entries. Tests no longer duplicate resource totals/kind cardinalities or maintain a second explicit overlay inventory. CI and contributor guidance use the same fixed-point entrypoint, so the order-dependent multi-pass sequence is no longer tribal knowledge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Converge packaged resource regeneration with a fixed-point ripple script
> - Adds [`scripts/sync_resource_ripple.py`](https://github.com/TheGaySupreme123/yoetz/pull/296/files#diff-a331bab2efeb3602546ee47b252ac5227a6b2470c21e2c7f19ae18a68e31da4c), a new CLI that runs regeneration passes until the owned artifact byte set stabilizes (fixed-point convergence), then validates the result. Replaces two separate generator/verifier invocations in CI and release workflows.
> - Introduces `REVIEWED_RESOURCE_COUNT` as the single exported tripwire constant in [`src/yoetz/version.py`](https://github.com/TheGaySupreme123/yoetz/pull/296/files#diff-365e77d120a12af44c7b53e79e5e1320806d2160512c27ac0bdf46f9df61fe58); the ripple script fails before any generation if this count mismatches the inventory.
> - Removes fixed per-kind resource count constants from `_resource_counts`, replacing them with an internal-consistency check against `REVIEWED_RESOURCE_COUNT`.
> - Updates remediation messages in [`src/yoetz/cli/exits.py`](https://github.com/TheGaySupreme123/yoetz/pull/296/files#diff-d454fcac43591626102ed7bfa80affd10116e239f9debbb7db6166adafc38e67) to point to `sync_resource_ripple.py --write` instead of individual scripts.
> - Behavioral Change: `--check` now also fails when the installed version manifest does not validate against the version-manifest schema, and per-kind cardinality mismatches no longer raise an error on their own.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff1ee5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->