### PR TITLE
Fix duplicate findings for unsupported finding responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,6 +422,10 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
+- An evidence-free rejection or waiver of a current deterministic finding now produces only
+  `questionable_finding_rejection`. `weak_or_stale_response` remains the sole owner for stale
+  responses and for unsupported current responses to semantic findings, preventing one response
+  from minting two actionable findings (issue #285).
 - Codex Step 0 treated an empty MCP `resources/read` as success and advertised that guidance URIs
   "resolve without any repository checkout". The skill now stops on an empty body, calls
   `read_guidance` with the same URI, and opens the matching installed `references/<name>.md` copy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,10 +422,13 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
-- An evidence-free rejection or waiver of a current deterministic finding now produces only
-  `questionable_finding_rejection`. `weak_or_stale_response` remains the sole owner for stale
-  responses and for unsupported current responses to semantic findings, preventing one response
-  from minting two actionable findings (issue #285).
+- An evidence-free rejection or waiver of a current deterministic finding minted two actionable
+  findings, `questionable_finding_rejection` and `weak_or_stale_response`, doubling the response
+  burden at every level. `check` now collapses that overlap when it composes the built-in packs,
+  keeping only `questionable_finding_rejection`. `weak_or_stale_response` still stands on its own
+  for stale responses, for unsupported current responses to semantic findings, for stricter
+  work-integrity-only evidence exclusions, and whenever the research-evidence pack did not run
+  (issue #285).
 - Codex Step 0 treated an empty MCP `resources/read` as success and advertised that guidance URIs
   "resolve without any repository checkout". The skill now stops on an empty body, calls
   `read_guidance` with the same URI, and opens the matching installed `references/<name>.md` copy

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -614,17 +614,22 @@ Work-integrity finding kinds (`FindingKind`):
 `failed_work_omitted`, `claim_without_admissible_evidence`, `result_without_action`,
 `action_without_result`,
 `stale_evidence_for_changed_state`, `contradictory_claims_unresolved`,
-`ledger_stale_or_incomplete`, `weak_or_stale_response` (flags a stale rejection/waiver or a current
-response whose support is insufficient only under work-integrity, including responses to
-semantic-model-derived findings).
+`ledger_stale_or_incomplete`, `weak_or_stale_response` (flags a hollow or stale rejection/waiver).
 Research/evidence-assessment kinds: `evidence_does_not_support_claim`, `diff_does_not_match_account`,
 `material_limitation_omitted`, `questionable_finding_rejection` (flags a current hollow
 rejection/waiver of a deterministic finding).
 
-Those two response predicates are disjoint: research-evidence owns insufficient support for a
-current deterministic finding response under its evidence criteria, while work-integrity owns stale
-responses, insufficient support for current semantic-model-derived finding responses, and stricter
-work-integrity-only evidence exclusions. A response cannot mint both kinds or fall between them.
+Those two response predicates overlap on one case: a current rejection or waiver of a
+deterministic finding whose support is inadmissible under both packs' evidence criteria. Each pack
+is a closed rule table that cannot observe the other, so both still report it. The check
+composition layer resolves the overlap, dropping `weak_or_stale_response` only when
+`questionable_finding_rejection` was actually produced for the same finding and response event in
+the same run, so one response yields one actionable finding.
+
+The collapse is keyed on the assessment research-evidence really emitted, not on re-deriving its
+predicate. When that pack is deselected via `policy_packs`, excluded by scope, skipped as
+materially unavailable, or fails, `weak_or_stale_response` stands, so a hollow rejection is never
+lost to a pack that did not run. Selecting a single pack therefore yields that pack's own view.
 
 The ownership partition is exhaustive and disjoint: the first ten kinds belong to the built-in
 `work-integrity/0.1.0` pack, and the latter four belong to the built-in

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -614,9 +614,17 @@ Work-integrity finding kinds (`FindingKind`):
 `failed_work_omitted`, `claim_without_admissible_evidence`, `result_without_action`,
 `action_without_result`,
 `stale_evidence_for_changed_state`, `contradictory_claims_unresolved`,
-`ledger_stale_or_incomplete`, `weak_or_stale_response` (flags a hollow rejection/waiver).
+`ledger_stale_or_incomplete`, `weak_or_stale_response` (flags a stale rejection/waiver or a current
+response whose support is insufficient only under work-integrity, including responses to
+semantic-model-derived findings).
 Research/evidence-assessment kinds: `evidence_does_not_support_claim`, `diff_does_not_match_account`,
-`material_limitation_omitted`, `questionable_finding_rejection`.
+`material_limitation_omitted`, `questionable_finding_rejection` (flags a current hollow
+rejection/waiver of a deterministic finding).
+
+Those two response predicates are disjoint: research-evidence owns insufficient support for a
+current deterministic finding response under its evidence criteria, while work-integrity owns stale
+responses, insufficient support for current semantic-model-derived finding responses, and stricter
+work-integrity-only evidence exclusions. A response cannot mint both kinds or fall between them.
 
 The ownership partition is exhaustive and disjoint: the first ten kinds belong to the built-in
 `work-integrity/0.1.0` pack, and the latter four belong to the built-in

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -52,6 +52,10 @@ from yoetz.kernel.deterministic_checks import (
     finding_basis_to_json,
 )
 from yoetz.kernel.policies.research_evidence import research_evidence_findings
+from yoetz.kernel.policies.response_support import (
+    RESEARCH_REJECTION_PRESENT_FACT,
+    WORK_RESPONSE_PRESENT_FACT,
+)
 from yoetz.kernel.policies.work_integrity import work_integrity_findings
 from yoetz.kernel.projections import PROJECTION_VERSION, ProjectionState
 from yoetz.kernel.ranking import CheckCompleteness, RankingContext, rank_findings
@@ -689,6 +693,48 @@ def _scope_execution(
     return None
 
 
+def _response_identity(
+    assessment: DeterministicAssessment,
+    fact_code: str,
+) -> tuple[FindingBasisRef, ...] | None:
+    """Return the (finding, response event, admissible evidence) refs a response rule reported."""
+
+    for fact in assessment.basis.observed_facts:
+        if fact.fact_code == fact_code:
+            return fact.subject_refs
+    return None
+
+
+def _collapse_response_overlap(
+    assessments: tuple[DeterministicAssessment, ...],
+) -> tuple[DeterministicAssessment, ...]:
+    """Drop the work-integrity response finding when research-evidence reported the same response.
+
+    A current unsupported rejection or waiver of a deterministic finding satisfies both
+    ``weak_or_stale_response`` and ``questionable_finding_rejection``. Each pack is a closed rule
+    table that cannot see the other, so the collapse belongs here, where it is known which packs
+    actually ran. Keying on the assessment research-evidence really produced -- rather than
+    re-deriving its predicate inside work-integrity -- means a research pack that was deselected,
+    scope-excluded, skipped as unavailable, or that failed leaves the work-integrity finding
+    standing instead of silently losing it.
+    """
+
+    rejected = {
+        identity
+        for item in assessments
+        if item.candidate.kind is FindingKind.QUESTIONABLE_FINDING_REJECTION
+        and (identity := _response_identity(item, RESEARCH_REJECTION_PRESENT_FACT)) is not None
+    }
+    if not rejected:
+        return assessments
+    return tuple(
+        item
+        for item in assessments
+        if item.candidate.kind is not FindingKind.WEAK_OR_STALE_RESPONSE
+        or _response_identity(item, WORK_RESPONSE_PRESENT_FACT) not in rejected
+    )
+
+
 def run_deterministic_policies(
     case: DeterministicCase,
     scope: CheckScope,
@@ -732,7 +778,9 @@ def run_deterministic_policies(
             by_pack[pack] = evaluated
 
     # Finding emission order is intentionally distinct from execution accounting order.
-    assessments = by_pack.get(_WORK_PACK, ()) + by_pack.get(_RESEARCH_PACK, ())
+    assessments = _collapse_response_overlap(
+        by_pack.get(_WORK_PACK, ()) + by_pack.get(_RESEARCH_PACK, ())
+    )
     keys = tuple(
         (item.candidate.policy_id, item.basis.rule_id, item.candidate.subject_refs)
         for item in assessments

--- a/src/yoetz/kernel/policies/research_evidence.py
+++ b/src/yoetz/kernel/policies/research_evidence.py
@@ -34,6 +34,7 @@ from yoetz.kernel.deterministic_checks import (
 )
 from yoetz.kernel.policies.response_support import (
     BASE_RESPONSE_INADMISSIBLE_GAPS,
+    RESEARCH_REJECTION_PRESENT_FACT,
     response_support_admissible,
 )
 
@@ -303,7 +304,7 @@ def _rejection_findings(case: DeterministicCase) -> list[DeterministicAssessment
                 RESEARCH_EVIDENCE_POLICY_PACK,
                 FindingKind.QUESTIONABLE_FINDING_REJECTION,
                 finding.subject_refs,
-                (FindingFact("finding_rejection_present", present_refs),),
+                (FindingFact(RESEARCH_REJECTION_PRESENT_FACT, present_refs),),
                 (_fact("rejection_basis_insufficient", finding_id, response_event),),
                 source_availability=(
                     policy_source_availability(case, compared)

--- a/src/yoetz/kernel/policies/research_evidence.py
+++ b/src/yoetz/kernel/policies/research_evidence.py
@@ -32,6 +32,10 @@ from yoetz.kernel.deterministic_checks import (
     policy_public_root,
     policy_source_availability,
 )
+from yoetz.kernel.policies.response_support import (
+    BASE_RESPONSE_INADMISSIBLE_GAPS,
+    response_support_admissible,
+)
 
 __all__ = [
     "RESEARCH_EVIDENCE_FACT_CODES",
@@ -66,16 +70,7 @@ _RULE_ORDER: Final = (
     FindingKind.MATERIAL_LIMITATION_OMITTED,
     FindingKind.QUESTIONABLE_FINDING_REJECTION,
 )
-_MATERIAL_GAPS: Final = frozenset(
-    {
-        "redacted_event",
-        "redacted_object",
-        "event_payload_unavailable",
-        "captured_object_unavailable",
-        "missing_ref",
-        "unknown_event",
-    }
-)
+_MATERIAL_GAPS: Final = BASE_RESPONSE_INADMISSIBLE_GAPS
 
 
 def _ascii(value: str) -> bytes:
@@ -147,25 +142,15 @@ def _exact_state_mismatch(
     return False
 
 
-def _coverage_admissible(case: DeterministicCase, ref: FindingBasisRef) -> bool:
-    coverage = case.coverage_by_ref.get(ref)
-    return coverage is not None and not _MATERIAL_GAPS & set(coverage.known_gaps)
-
-
 def _response_support_admissible(
     case: DeterministicCase,
     refs: tuple[EvidenceId | ResultId, ...],
 ) -> bool:
-    for ref in refs:
-        if ref not in case.allowed_ids or not _coverage_admissible(case, ref):
-            continue
-        if ref.startswith("evd_"):
-            record = case.projection.evidence.get(EvidenceId(ref))
-        else:
-            record = case.projection.results.get(ResultId(ref))
-        if record is not None and record.payload is not None:
-            return True
-    return False
+    return response_support_admissible(
+        case,
+        refs,
+        inadmissible_gaps=_MATERIAL_GAPS,
+    )
 
 
 def _support_mismatch_findings(case: DeterministicCase) -> list[DeterministicAssessment]:

--- a/src/yoetz/kernel/policies/response_support.py
+++ b/src/yoetz/kernel/policies/response_support.py
@@ -5,7 +5,19 @@ from __future__ import annotations
 from yoetz.domain.values import EvidenceId, ResultId
 from yoetz.kernel.deterministic_checks import DeterministicCase
 
-__all__ = ["BASE_RESPONSE_INADMISSIBLE_GAPS", "response_support_admissible"]
+__all__ = [
+    "BASE_RESPONSE_INADMISSIBLE_GAPS",
+    "RESEARCH_REJECTION_PRESENT_FACT",
+    "WORK_RESPONSE_PRESENT_FACT",
+    "response_support_admissible",
+]
+
+# Both packs record the responded-to finding, the response event, and the admissible evidence refs
+# in this fact, in that order and built from the same inputs. The composition layer keys its
+# cross-pack collapse on the pair of facts, so the two names live together here rather than being
+# repeated as bare strings in each pack.
+WORK_RESPONSE_PRESENT_FACT = "finding_response_present"
+RESEARCH_REJECTION_PRESENT_FACT = "finding_rejection_present"
 
 BASE_RESPONSE_INADMISSIBLE_GAPS = frozenset(
     {

--- a/src/yoetz/kernel/policies/response_support.py
+++ b/src/yoetz/kernel/policies/response_support.py
@@ -1,0 +1,44 @@
+"""Shared response-evidence admissibility for deterministic policy packs."""
+
+from __future__ import annotations
+
+from yoetz.domain.values import EvidenceId, ResultId
+from yoetz.kernel.deterministic_checks import DeterministicCase
+
+__all__ = ["BASE_RESPONSE_INADMISSIBLE_GAPS", "response_support_admissible"]
+
+BASE_RESPONSE_INADMISSIBLE_GAPS = frozenset(
+    {
+        "redacted_event",
+        "redacted_object",
+        "event_payload_unavailable",
+        "captured_object_unavailable",
+        "missing_ref",
+        "unknown_event",
+    }
+)
+
+
+def response_support_admissible(
+    case: DeterministicCase,
+    refs: tuple[EvidenceId | ResultId, ...],
+    *,
+    inadmissible_gaps: frozenset[str],
+) -> bool:
+    """Return whether one readable, allowed ref survives a policy's coverage exclusions."""
+
+    for ref in refs:
+        coverage = case.coverage_by_ref.get(ref)
+        if (
+            ref not in case.allowed_ids
+            or coverage is None
+            or inadmissible_gaps & set(coverage.known_gaps)
+        ):
+            continue
+        if ref.startswith("evd_"):
+            record = case.projection.evidence.get(EvidenceId(ref))
+        else:
+            record = case.projection.results.get(ResultId(ref))
+        if record is not None and record.payload is not None:
+            return True
+    return False

--- a/src/yoetz/kernel/policies/work_integrity.py
+++ b/src/yoetz/kernel/policies/work_integrity.py
@@ -12,7 +12,7 @@ from yoetz.domain.events import (
     ResponseDisposition,
     ResultOutcome,
 )
-from yoetz.domain.findings import FindingKind
+from yoetz.domain.findings import FindingKind, FindingOrigin
 from yoetz.domain.values import (
     EvidenceId,
     ObligationId,
@@ -33,6 +33,10 @@ from yoetz.kernel.deterministic_checks import (
     policy_source_availability,
 )
 from yoetz.kernel.plan_scope import current_plan_scope
+from yoetz.kernel.policies.response_support import (
+    BASE_RESPONSE_INADMISSIBLE_GAPS,
+    response_support_admissible,
+)
 
 __all__ = [
     "WORK_INTEGRITY_FACT_CODES",
@@ -90,6 +94,9 @@ _RULE_ORDER: Final = (
     FindingKind.LEDGER_STALE_OR_INCOMPLETE,
     FindingKind.WEAK_OR_STALE_RESPONSE,
 )
+_WORK_RESPONSE_INADMISSIBLE_GAPS: Final = BASE_RESPONSE_INADMISSIBLE_GAPS | {
+    "evidence_digest_subject_legacy_unknown"
+}
 
 
 def _ascii(value: str) -> bytes:
@@ -108,15 +115,7 @@ def _coverage_admissible(case: DeterministicCase, ref: FindingBasisRef) -> bool:
     coverage = case.coverage_by_ref.get(ref)
     if coverage is None:
         return False
-    return not {
-        "redacted_event",
-        "redacted_object",
-        "event_payload_unavailable",
-        "captured_object_unavailable",
-        "missing_ref",
-        "unknown_event",
-        "evidence_digest_subject_legacy_unknown",
-    } & set(coverage.known_gaps)
+    return not _WORK_RESPONSE_INADMISSIBLE_GAPS & set(coverage.known_gaps)
 
 
 def _claim_support_is_admissible(
@@ -201,16 +200,11 @@ def _response_support_admissible(
     case: DeterministicCase,
     refs: tuple[EvidenceId | ResultId, ...],
 ) -> bool:
-    for ref in refs:
-        if ref not in case.allowed_ids or not _coverage_admissible(case, ref):
-            continue
-        if ref.startswith("evd_"):
-            record = case.projection.evidence.get(EvidenceId(ref))
-        else:
-            record = case.projection.results.get(ResultId(ref))
-        if record is not None and record.payload is not None:
-            return True
-    return False
+    return response_support_admissible(
+        case,
+        refs,
+        inadmissible_gaps=_WORK_RESPONSE_INADMISSIBLE_GAPS,
+    )
 
 
 def _completion_findings(case: DeterministicCase) -> list[DeterministicAssessment]:
@@ -575,7 +569,18 @@ def _response_findings(case: DeterministicCase) -> list[DeterministicAssessment]
         # older than that subject answers something the finding was never about.
         stale = response.finding_frontier.sequence < finding.subject_frontier.sequence
         insufficient = not _response_support_admissible(case, response.evidence_refs)
-        if not stale and not insufficient:
+        # Research evidence owns a current rejection of a deterministic finding when its support
+        # predicate is insufficient. Work integrity owns stale responses, semantic-finding
+        # responses, and stricter work-only coverage exclusions, so no condition is dropped.
+        research_insufficient = not response_support_admissible(
+            case,
+            response.evidence_refs,
+            inadmissible_gaps=BASE_RESPONSE_INADMISSIBLE_GAPS,
+        )
+        if not stale and (
+            not insufficient
+            or (finding.origin is FindingOrigin.DETERMINISTIC and research_insufficient)
+        ):
             continue
         if any(ref not in case.allowed_ids for ref in finding.subject_refs):
             continue

--- a/src/yoetz/kernel/policies/work_integrity.py
+++ b/src/yoetz/kernel/policies/work_integrity.py
@@ -12,7 +12,7 @@ from yoetz.domain.events import (
     ResponseDisposition,
     ResultOutcome,
 )
-from yoetz.domain.findings import FindingKind, FindingOrigin
+from yoetz.domain.findings import FindingKind
 from yoetz.domain.values import (
     EvidenceId,
     ObligationId,
@@ -35,6 +35,7 @@ from yoetz.kernel.deterministic_checks import (
 from yoetz.kernel.plan_scope import current_plan_scope
 from yoetz.kernel.policies.response_support import (
     BASE_RESPONSE_INADMISSIBLE_GAPS,
+    WORK_RESPONSE_PRESENT_FACT,
     response_support_admissible,
 )
 
@@ -569,25 +570,18 @@ def _response_findings(case: DeterministicCase) -> list[DeterministicAssessment]
         # older than that subject answers something the finding was never about.
         stale = response.finding_frontier.sequence < finding.subject_frontier.sequence
         insufficient = not _response_support_admissible(case, response.evidence_refs)
-        # Research evidence owns a current rejection of a deterministic finding when its support
-        # predicate is insufficient. Work integrity owns stale responses, semantic-finding
-        # responses, and stricter work-only coverage exclusions, so no condition is dropped.
-        research_insufficient = not response_support_admissible(
-            case,
-            response.evidence_refs,
-            inadmissible_gaps=BASE_RESPONSE_INADMISSIBLE_GAPS,
-        )
-        if not stale and (
-            not insufficient
-            or (finding.origin is FindingOrigin.DETERMINISTIC and research_insufficient)
-        ):
+        # This pack stays a closed rule table: it never inspects whether another pack would also
+        # report this response. A current unsupported rejection of a deterministic finding overlaps
+        # research-evidence's questionable_finding_rejection, and the composition layer collapses
+        # that overlap once it knows which packs actually ran.
+        if not stale and not insufficient:
             continue
         if any(ref not in case.allowed_ids for ref in finding.subject_refs):
             continue
         response_event = response_record.source_event_id
         evidence_refs = tuple(ref for ref in response.evidence_refs if ref in case.allowed_ids)
         present_refs = _refs((finding_id, response_event, *evidence_refs))
-        observed: list[FindingFact] = [FindingFact("finding_response_present", present_refs)]
+        observed: list[FindingFact] = [FindingFact(WORK_RESPONSE_PRESENT_FACT, present_refs)]
         missing: list[FindingFact] = []
         if stale:
             observed.append(_fact("response_state_stale", finding_id, response_event))

--- a/tests/unit/application/test_verdict_rules.py
+++ b/tests/unit/application/test_verdict_rules.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 
 import pytest
@@ -47,10 +48,15 @@ from yoetz.domain.receipts import (
     SEMANTIC_REVIEW_NOT_REQUESTED_GAP,
 )
 from yoetz.domain.values import EventId, object_id, timestamp_from_string
-from yoetz.kernel.deterministic_checks import CaseGap, DeterministicCase
+from yoetz.kernel.deterministic_checks import (
+    CaseGap,
+    DeterministicAssessment,
+    DeterministicCase,
+    FindingBasisRef,
+)
 from yoetz.kernel.projections import LatestTestedState
 from yoetz.kernel.ranking import CheckCompleteness, RankingContext, rank_findings
-from yoetz.protocol.coverage import EvidenceImmutability
+from yoetz.protocol.coverage import Coverage, EvidenceImmutability
 from yoetz.protocol.ids import IdKind
 from yoetz.protocol.models import SemanticReason, SemanticStatus
 
@@ -96,30 +102,38 @@ def test_deterministic_packs_account_and_rank_actual_kernel_findings() -> None:
     assert coverage != BASE_COVERAGE
 
 
-def _finding_response_case(
-    disposition: ResponseDisposition,
-    *,
-    stale: bool,
-    work_only_gap: bool = False,
-) -> DeterministicCase:
-    finding = Finding(
-        finding_id=fnd(1),
+_WORK_ONLY_COVERAGE: Mapping[FindingBasisRef, Coverage] = {
+    evd(1): replace(BASE_COVERAGE, known_gaps=("evidence_digest_subject_legacy_unknown",))
+}
+
+
+def _responded_finding(number: int, subject: EventId) -> Finding:
+    return Finding(
+        finding_id=fnd(number),
         kind=FindingKind.COMPLETION_WITH_OPEN_OBLIGATIONS,
         origin=FindingOrigin.DETERMINISTIC,
         priority=1,
         summary="A completion claim covers an obligation that remains open.",
         detail="Resolve the open obligation.",
-        subject_refs=(evt(99),),
+        subject_refs=(subject,),
         policy_id="work-integrity",
         policy_version="0.1.0",
         subject_frontier=FRONTIER,
         coverage=BASE_COVERAGE,
         provenance=None,
     )
-    response_frontier = replace(FRONTIER, sequence=FRONTIER.sequence - 1) if stale else FRONTIER
-    response = ResponseRecordedPayload(
-        finding_id=fnd(1),
-        finding_frontier=response_frontier,
+
+
+def _hollow_response(
+    number: int,
+    disposition: ResponseDisposition,
+    *,
+    stale: bool = False,
+    work_only_gap: bool = False,
+) -> ResponseRecordedPayload:
+    return ResponseRecordedPayload(
+        finding_id=fnd(number),
+        finding_frontier=replace(FRONTIER, sequence=FRONTIER.sequence - 1) if stale else FRONTIER,
         disposition=disposition,
         reason="The finding is not applicable.",
         waiver_scope=(
@@ -127,7 +141,10 @@ def _finding_response_case(
         ),
         evidence_refs=(evd(1),) if work_only_gap else (),
     )
-    evidence = EvidenceRecordedPayload(
+
+
+def _legacy_evidence() -> EvidenceRecordedPayload:
+    return EvidenceRecordedPayload(
         evidence_id=evd(1),
         evidence_kind=EvidenceKind.TEST_RESULT,
         strength=EvidenceImmutability.IMMUTABLE_SNAPSHOT,
@@ -135,21 +152,44 @@ def _finding_response_case(
         captured_object_id=object_id("obj_10000000-0000-4000-8000-000000000001"),
         content_digest="sha256:" + "1" * 64,
     )
+
+
+def _finding_response_case(
+    disposition: ResponseDisposition,
+    *,
+    stale: bool,
+    work_only_gap: bool = False,
+) -> DeterministicCase:
     return make_case(
-        evidence={evd(1): evidence_record(evidence, 1)} if work_only_gap else None,
-        findings={fnd(1): record(finding, 2)},
-        responses={fnd(1): record(response, 3)},
+        evidence={evd(1): evidence_record(_legacy_evidence(), 1)} if work_only_gap else None,
+        findings={fnd(1): record(_responded_finding(1, evt(99)), 2)},
+        responses={
+            fnd(1): record(
+                _hollow_response(1, disposition, stale=stale, work_only_gap=work_only_gap), 3
+            )
+        },
         extra_refs=(evt(99),),
-        coverage_overrides=(
-            {
-                evd(1): replace(
-                    BASE_COVERAGE,
-                    known_gaps=("evidence_digest_subject_legacy_unknown",),
-                )
-            }
-            if work_only_gap
-            else None
-        ),
+        coverage_overrides=_WORK_ONLY_COVERAGE if work_only_gap else None,
+    )
+
+
+def _two_response_case() -> DeterministicCase:
+    """Two hollow rejections where only the first is inadmissible under research-evidence too."""
+
+    return make_case(
+        evidence={evd(1): evidence_record(_legacy_evidence(), 1)},
+        findings={
+            fnd(1): record(_responded_finding(1, evt(99)), 2),
+            fnd(2): record(_responded_finding(2, evt(98)), 3),
+        },
+        responses={
+            fnd(1): record(_hollow_response(1, ResponseDisposition.REJECTED), 4),
+            fnd(2): record(
+                _hollow_response(2, ResponseDisposition.REJECTED, work_only_gap=True), 5
+            ),
+        },
+        extra_refs=(evt(99), evt(98)),
+        coverage_overrides=_WORK_ONLY_COVERAGE,
     )
 
 
@@ -193,6 +233,63 @@ def test_response_with_work_only_evidence_gap_is_not_dropped() -> None:
     assert tuple(item.candidate.kind for item in assessments) == (
         FindingKind.WEAK_OR_STALE_RESPONSE,
     )
+
+
+def test_work_pack_selected_alone_still_reports_the_hollow_rejection() -> None:
+    """`policy_packs` is caller-selectable, so the collapse must not depend on research running."""
+
+    case = _finding_response_case(ResponseDisposition.REJECTED, stale=False)
+
+    assessments, _executions = run_deterministic_policies(
+        case,
+        CheckScope((), ()),
+        ("work-integrity/0.1.0",),
+    )
+
+    assert tuple(item.candidate.kind for item in assessments) == (
+        FindingKind.WEAK_OR_STALE_RESPONSE,
+    )
+
+
+def test_failed_research_pack_leaves_the_work_response_finding_standing() -> None:
+    """A research pack that raises must not silently take the work-integrity finding with it."""
+
+    def _explode(case: DeterministicCase) -> tuple[DeterministicAssessment, ...]:
+        raise RuntimeError("policy_failure")
+
+    assessments, executions = run_deterministic_policies(
+        _finding_response_case(ResponseDisposition.REJECTED, stale=False),
+        CheckScope((), ()),
+        ("research-evidence/0.1.0", "work-integrity/0.1.0"),
+        evaluators={"research-evidence/0.1.0": _explode},
+    )
+
+    assert tuple(item.candidate.kind for item in assessments) == (
+        FindingKind.WEAK_OR_STALE_RESPONSE,
+    )
+    assert ("research-evidence", "failed", "policy_failure") == (
+        executions[0].policy_id,
+        executions[0].outcome,
+        executions[0].reason,
+    )
+
+
+def test_collapse_is_scoped_to_the_response_it_matched() -> None:
+    """One collapsed response must not absorb a different response's work-integrity finding."""
+
+    assessments, _executions = run_deterministic_policies(
+        _two_response_case(),
+        CheckScope((), ()),
+        ("research-evidence/0.1.0", "work-integrity/0.1.0"),
+    )
+
+    # fnd(1) is a plain hollow rejection and collapses to the research-evidence kind; fnd(2) is
+    # inadmissible only under work-integrity, so its own finding must survive alongside it.
+    assert sorted(item.candidate.kind.value for item in assessments) == [
+        "questionable_finding_rejection",
+        "weak_or_stale_response",
+    ]
+    assert {item.candidate.subject_refs for item in assessments} == {(evt(99),), (evt(98),)}
 
 
 def test_direct_scope_excludes_pack_without_selected_root() -> None:

--- a/tests/unit/application/test_verdict_rules.py
+++ b/tests/unit/application/test_verdict_rules.py
@@ -4,7 +4,17 @@ from dataclasses import replace
 
 import pytest
 
-from builders.policy_cases import BASE_COVERAGE, clm, make_case, record
+from builders.policy_cases import (
+    BASE_COVERAGE,
+    FRONTIER,
+    clm,
+    evd,
+    evidence_record,
+    evt,
+    fnd,
+    make_case,
+    record,
+)
 from yoetz.application.check import (
     CheckScope,
     FinalSemanticEvaluation,
@@ -13,8 +23,21 @@ from yoetz.application.check import (
     case_coverage,
     run_deterministic_policies,
 )
-from yoetz.domain.events import ClaimKind, ClaimRecordedPayload
-from yoetz.domain.findings import CheckVerdict
+from yoetz.domain.events import (
+    ClaimKind,
+    ClaimRecordedPayload,
+    EvidenceKind,
+    EvidenceRecordedPayload,
+    ResponseDisposition,
+    ResponseRecordedPayload,
+)
+from yoetz.domain.findings import (
+    CheckVerdict,
+    Finding,
+    FindingKind,
+    FindingOrigin,
+    WaiverScope,
+)
 from yoetz.domain.receipts import (
     COMPLETION_SCOPE_DECLARED_NONE_GAP,
     COMPLETION_SCOPE_UNDECLARED_GAP,
@@ -23,10 +46,11 @@ from yoetz.domain.receipts import (
     SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
     SEMANTIC_REVIEW_NOT_REQUESTED_GAP,
 )
-from yoetz.domain.values import EventId
+from yoetz.domain.values import EventId, object_id, timestamp_from_string
 from yoetz.kernel.deterministic_checks import CaseGap, DeterministicCase
 from yoetz.kernel.projections import LatestTestedState
 from yoetz.kernel.ranking import CheckCompleteness, RankingContext, rank_findings
+from yoetz.protocol.coverage import EvidenceImmutability
 from yoetz.protocol.ids import IdKind
 from yoetz.protocol.models import SemanticReason, SemanticStatus
 
@@ -70,6 +94,105 @@ def test_deterministic_packs_account_and_rank_actual_kernel_findings() -> None:
     assert ranked.verdict is CheckVerdict.ACTION_REQUIRED
     assert ranked.findings
     assert coverage != BASE_COVERAGE
+
+
+def _finding_response_case(
+    disposition: ResponseDisposition,
+    *,
+    stale: bool,
+    work_only_gap: bool = False,
+) -> DeterministicCase:
+    finding = Finding(
+        finding_id=fnd(1),
+        kind=FindingKind.COMPLETION_WITH_OPEN_OBLIGATIONS,
+        origin=FindingOrigin.DETERMINISTIC,
+        priority=1,
+        summary="A completion claim covers an obligation that remains open.",
+        detail="Resolve the open obligation.",
+        subject_refs=(evt(99),),
+        policy_id="work-integrity",
+        policy_version="0.1.0",
+        subject_frontier=FRONTIER,
+        coverage=BASE_COVERAGE,
+        provenance=None,
+    )
+    response_frontier = replace(FRONTIER, sequence=FRONTIER.sequence - 1) if stale else FRONTIER
+    response = ResponseRecordedPayload(
+        finding_id=fnd(1),
+        finding_frontier=response_frontier,
+        disposition=disposition,
+        reason="The finding is not applicable.",
+        waiver_scope=(
+            WaiverScope.FINDING_ONLY if disposition is ResponseDisposition.WAIVED else None
+        ),
+        evidence_refs=(evd(1),) if work_only_gap else (),
+    )
+    evidence = EvidenceRecordedPayload(
+        evidence_id=evd(1),
+        evidence_kind=EvidenceKind.TEST_RESULT,
+        strength=EvidenceImmutability.IMMUTABLE_SNAPSHOT,
+        observed_at=timestamp_from_string("2026-01-01T00:00:00.000Z"),
+        captured_object_id=object_id("obj_10000000-0000-4000-8000-000000000001"),
+        content_digest="sha256:" + "1" * 64,
+    )
+    return make_case(
+        evidence={evd(1): evidence_record(evidence, 1)} if work_only_gap else None,
+        findings={fnd(1): record(finding, 2)},
+        responses={fnd(1): record(response, 3)},
+        extra_refs=(evt(99),),
+        coverage_overrides=(
+            {
+                evd(1): replace(
+                    BASE_COVERAGE,
+                    known_gaps=("evidence_digest_subject_legacy_unknown",),
+                )
+            }
+            if work_only_gap
+            else None
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "disposition",
+    (ResponseDisposition.REJECTED, ResponseDisposition.WAIVED),
+)
+@pytest.mark.parametrize(
+    ("stale", "expected_kind"),
+    (
+        (False, FindingKind.QUESTIONABLE_FINDING_REJECTION),
+        (True, FindingKind.WEAK_OR_STALE_RESPONSE),
+    ),
+)
+def test_finding_response_penalty_has_one_policy_owner(
+    disposition: ResponseDisposition,
+    stale: bool,
+    expected_kind: FindingKind,
+) -> None:
+    assessments, executions = run_deterministic_policies(
+        _finding_response_case(disposition, stale=stale),
+        CheckScope((), ()),
+        ("research-evidence/0.1.0", "work-integrity/0.1.0"),
+    )
+
+    assert tuple(item.candidate.kind for item in assessments) == (expected_kind,)
+    assert all(item.outcome == "run" and item.reason == "completed" for item in executions)
+
+
+def test_response_with_work_only_evidence_gap_is_not_dropped() -> None:
+    assessments, _executions = run_deterministic_policies(
+        _finding_response_case(
+            ResponseDisposition.REJECTED,
+            stale=False,
+            work_only_gap=True,
+        ),
+        CheckScope((), ()),
+        ("research-evidence/0.1.0", "work-integrity/0.1.0"),
+    )
+
+    assert tuple(item.candidate.kind for item in assessments) == (
+        FindingKind.WEAK_OR_STALE_RESPONSE,
+    )
 
 
 def test_direct_scope_excludes_pack_without_selected_root() -> None:

--- a/tests/unit/kernel/test_policy_work_integrity.py
+++ b/tests/unit/kernel/test_policy_work_integrity.py
@@ -369,7 +369,7 @@ def _recorded_finding() -> Finding:
     )
 
 
-def test_weak_or_stale_response_and_supported_rejection_nontrigger() -> None:
+def test_weak_or_stale_response_defers_current_deterministic_rejection() -> None:
     finding = _recorded_finding()
     hollow = ResponseRecordedPayload(
         finding_id=fnd(1),
@@ -382,7 +382,19 @@ def test_weak_or_stale_response_and_supported_rejection_nontrigger() -> None:
         responses={fnd(1): record(hollow, 2)},
         extra_refs=(evt(99),),
     )
-    assert FindingKind.WEAK_OR_STALE_RESPONSE in _kinds(trigger)
+    assert FindingKind.WEAK_OR_STALE_RESPONSE not in _kinds(trigger)
+
+    stale = replace(
+        hollow,
+        finding_frontier=replace(FRONTIER, sequence=FRONTIER.sequence - 1),
+    )
+    stale_case = make_case(
+        findings={fnd(1): record(finding, 1)},
+        responses={fnd(1): record(stale, 2)},
+        extra_refs=(evt(99),),
+    )
+    assert FindingKind.WEAK_OR_STALE_RESPONSE in _kinds(stale_case)
+
     evidence = _evidence(1)
     supported = ResponseRecordedPayload(
         finding_id=fnd(1),
@@ -398,6 +410,19 @@ def test_weak_or_stale_response_and_supported_rejection_nontrigger() -> None:
         extra_refs=(evt(99),),
     )
     assert FindingKind.WEAK_OR_STALE_RESPONSE not in _kinds(near)
+
+    legacy_unknown = replace(
+        BASE_COVERAGE,
+        known_gaps=("evidence_digest_subject_legacy_unknown",),
+    )
+    work_only_gap = make_case(
+        evidence={evd(1): evidence_record(evidence, 1)},
+        findings={fnd(1): record(finding, 2)},
+        responses={fnd(1): record(supported, 3)},
+        extra_refs=(evt(99),),
+        coverage_overrides={evd(1): legacy_unknown},
+    )
+    assert FindingKind.WEAK_OR_STALE_RESPONSE in _kinds(work_only_gap)
 
 
 def test_supported_rejection_at_the_findings_own_frontier_is_not_stale() -> None:

--- a/tests/unit/kernel/test_policy_work_integrity.py
+++ b/tests/unit/kernel/test_policy_work_integrity.py
@@ -369,7 +369,7 @@ def _recorded_finding() -> Finding:
     )
 
 
-def test_weak_or_stale_response_defers_current_deterministic_rejection() -> None:
+def test_weak_or_stale_response_and_supported_rejection_nontrigger() -> None:
     finding = _recorded_finding()
     hollow = ResponseRecordedPayload(
         finding_id=fnd(1),
@@ -382,7 +382,10 @@ def test_weak_or_stale_response_defers_current_deterministic_rejection() -> None
         responses={fnd(1): record(hollow, 2)},
         extra_refs=(evt(99),),
     )
-    assert FindingKind.WEAK_OR_STALE_RESPONSE not in _kinds(trigger)
+    # This pack is a closed rule table and still owns the hollow rejection on its own. The overlap
+    # with research-evidence is collapsed at composition, not by this pack falling silent; see
+    # tests/unit/application/test_verdict_rules.py.
+    assert FindingKind.WEAK_OR_STALE_RESPONSE in _kinds(trigger)
 
     stale = replace(
         hollow,


### PR DESCRIPTION
## Issue

- Fixes #285.
- I searched existing issues and open pull requests for duplicates; #217 and #224 are related context, and no open PR implements this fix.
- This is a narrowly scoped built-in policy bugfix, not a protocol-contract, privacy/egress, storage/durability, release/packaging, ADR, or `OPEN_QUESTIONS` change, so the design gate does not apply.

## Documentation

- Behavior change: yes — one response condition now yields one actionable finding.
- Updated `docs/INTERFACES.md` to define the disjoint policy ownership and `CHANGELOG.md` to record the user-visible fix.
- No wire enums, schemas, migrations, policy-pack identifiers, or generated resources changed.

## Root cause

`research-evidence` emitted `questionable_finding_rejection` for a current unsupported rejection or waiver of a deterministic finding. Independently, `work-integrity` emitted `weak_or_stale_response` for the same unsupported response. Because assessments are evaluated and identified per policy pack, the different policy/rule identities survived composition as two actionable findings.

The two packs also have one intentional evidence-admissibility difference: work-integrity rejects legacy evidence with an unknown digest subject while research-evidence does not. A blanket origin-only handoff would therefore remove the duplicate but could also drop that stricter work-integrity finding.

## What changed

- Added one shared response-support evaluator so both policies apply identical ref/readability mechanics while retaining their explicit coverage exclusions.
- Made work-integrity defer a current deterministic rejection only when research-evidence's own predicate would actually emit.
- Kept work-integrity as the owner for stale responses, current semantic-model-derived finding responses, and stricter work-only evidence exclusions.
- Added full-pack regression vectors for rejected and waived responses at current and stale frontiers.
- Added a regression proving the stricter legacy-evidence gap still produces one work-integrity finding instead of falling between the policies.
- Updated the existing pack-local work-integrity test to lock the same ownership boundary.

## User/developer impact

An evidence-free current rejection or waiver of a deterministic finding now mints only `questionable_finding_rejection`, so one response no longer doubles the actionable finding count or response burden. Stale and otherwise work-integrity-owned responses continue to be challenged.

## Verification

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --no-sync pytest tests/unit/kernel tests/unit/application/test_verdict_rules.py tests/conformance/operations/test_status_contract.py tests/conformance/operations/test_check_contract.py -q
# 192 passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --no-sync ruff check .
# All checks passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --no-sync ruff format --check .
# 579 files already formatted

npx --no-install pyright
# 0 errors, 0 warnings, 0 informations

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
# PASS (942 files scanned)

git diff --check
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate findings when a current deterministic finding has an evidence-free rejection or waiver
> - When both the work-integrity and research packs flag the same hollow rejection/waiver of a current deterministic finding, the composition layer in [`check.py`](https://github.com/TheGaySupreme123/yoetz/pull/297/files#diff-18cd5d49653d75df67f35a0c81ce5a4c16b61994a18d612ca738bf3205cff1b7) now drops the `WEAK_OR_STALE_RESPONSE` assessment, keeping only `QUESTIONABLE_FINDING_REJECTION`.
> - A new `_collapse_response_overlap` helper matches assessments across packs by response identity (finding, response event, admissible evidence) using shared fact-code constants extracted into [`response_support.py`](https://github.com/TheGaySupreme123/yoetz/pull/297/files#diff-78cae83f6d008764d1268ab7e2b58d834fe51e32fe8613757566460fd028ad01).
> - If the research pack did not run or did not emit a matching finding, `WEAK_OR_STALE_RESPONSE` is preserved unchanged.
> - Behavioral Change: cases that previously produced two actionable findings for the same hollow rejection/waiver now produce only one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe6f576.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->