### PR TITLE
Fix stale Codex hook mapping classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,15 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
+- A Codex hook with a stale lifecycle mapping treated the daemon's `SESSION_CONFLICT` or
+  `SESSION_NOT_FOUND` response as proof that the service was unavailable, then repeated that false
+  advisory forever because it retained the old session and writer ids. Status errors now pass
+  through an exhaustive classification: stale mappings tell the agent to call `start` again while
+  explicitly preserving service health, transient reads request a later status read, privacy and
+  vault conditions name their actual recovery paths, and only genuine degradation says the service
+  is unavailable. The stale advisory remains advice-safe and the agent's successful `start` result
+  is still the only source of a replacement mapping (issue #308).
+
 - The end-to-end hook budget was smaller than the budgets enforced inside a single pass, so
   `hook_budget_exceeded` fired on healthy hooks — 253 of 833 diagnostics on one workspace — and
   carried no signal about the regressions it was added for. The total is now derived from the

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2473,7 +2473,14 @@ across workspace sessions under a nonblocking per-workspace lease; within one pa
 and an ended unmapped session is terminally quarantined because no future mapping can deliver it,
 but only after atomically acquiring its lifecycle lock so an attach already in flight wins.
 Turn-boundary hooks retry auto-attach under a bounded budget and record a payload-free diagnostic
-when no mapping results. Workspace-global rejections (`vault_locked`, disabled, paused) end the pass.
+when no mapping results. A status read against a mapping whose Yoetz session or writer was replaced
+classifies `SESSION_CONFLICT` and `SESSION_NOT_FOUND` as `mapping_stale`, not service unavailability:
+the hook preserves the mapping, tells the agent to call `start` again, and accepts only that
+successful `start` result as authority for replacement ids. `OPERATION_PENDING`, `BUNDLE_BUSY`, and
+`FRONTIER_CONFLICT` are transient status reads; vault and repository-privacy failures retain their
+distinct recovery advisories. The closed public-error table is exhaustive so a new code cannot
+silently inherit an unrelated advisory (issue #308). Workspace-global rejections (`vault_locked`,
+disabled, paused) end the pass.
 A `service_unavailable` rejection retires that session's lane for the pass while other sessions
 remain eligible; no later row may step over a failed lane head. Local observation-store acquisition is capped at two
 seconds for both the process-local reentrant lock and the cross-process flock. Coordinator and

--- a/src/yoetz/cli/hook_diagnostics.py
+++ b/src/yoetz/cli/hook_diagnostics.py
@@ -50,6 +50,7 @@ _REASONS: Final = frozenset(
         "service_unavailable",
         "vault_locked",
         "mapping_missing",
+        "mapping_stale",
         "observation_disabled",
         "paused",
         "timeout",

--- a/src/yoetz/cli/hooks.py
+++ b/src/yoetz/cli/hooks.py
@@ -501,6 +501,8 @@ def handle_session_start(
             if kind == "stale":
                 from yoetz.cli.hook_diagnostics import record_hook_diagnostic
 
+                # The delegated observation path cannot reacquire the session lock
+                # held here, so this branch owns the resume event's diagnostic.
                 with contextlib.suppress(Exception):
                     record_hook_diagnostic("mapping_stale", "SessionStart", _state=_state)
                 _stdout_json(_context_output("SessionStart", _STALE_MAPPING_CONTEXT), stdout)

--- a/src/yoetz/cli/hooks.py
+++ b/src/yoetz/cli/hooks.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from collections.abc import Awaitable, Callable, Mapping
 from importlib import resources
 from pathlib import Path
+from types import MappingProxyType
 from typing import BinaryIO, Final, Protocol, cast
 
 from yoetz import __version__
@@ -33,7 +35,7 @@ from yoetz.cli.hook_io import (
 )
 from yoetz.ports.control import ControlClientKind, ControlError
 from yoetz.protocol.canonical import JsonValue
-from yoetz.protocol.errors import ProtocolValueError
+from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode
 from yoetz.protocol.ids import IdKind, new_id
 from yoetz.protocol.models import OperationFailureModel, StatusRequest
 from yoetz.service.client import connect_service
@@ -73,6 +75,77 @@ _UNAVAILABLE_CONTEXT: Final = (
 )
 _LOCKED_CONTEXT: Final = (
     "Yoetz vault is locked for this mapped session; no live receipt can be promised."
+)
+_STALE_MAPPING_CONTEXT: Final = (
+    "Yoetz task mapping for this session is stale: the task was re-started under new "
+    "session and writer ids. The service itself is healthy. Call start again to re-map "
+    "before further material work."
+)
+_RETRY_CONTEXT: Final = (
+    "Yoetz is busy and could not read status on this attempt; the service is reachable. "
+    "Call status before promising a receipt."
+)
+_PRIVACY_CONTEXT: Final = (
+    "Yoetz cannot read this mapped session until repository privacy authority is "
+    "granted; run 'yoetz --privacy'. No live receipt can be promised until then."
+)
+
+# Hook-side classification of every public error a status read can surface. The
+# daemon answering with SESSION_* means the stored mapping no longer names a live
+# route/writer — the service is healthy, so reporting it "unavailable" was false
+# and absorbing (issue #308). "retry" codes are transient reads that can succeed
+# on the next attempt; only genuinely degraded states remain "unavailable".
+_STATUS_ERROR_CLASSES: Final[Mapping[PublicErrorCode, str]] = MappingProxyType(
+    {
+        PublicErrorCode.SESSION_NOT_FOUND: "stale",
+        PublicErrorCode.SESSION_CONFLICT: "stale",
+        PublicErrorCode.VAULT_LOCKED: "locked",
+        PublicErrorCode.OPERATION_PENDING: "retry",
+        PublicErrorCode.BUNDLE_BUSY: "retry",
+        PublicErrorCode.FRONTIER_CONFLICT: "retry",
+        PublicErrorCode.PRIVACY_AUTHORITY_REQUIRED: "privacy",
+        PublicErrorCode.INVALID_REQUEST: "unavailable",
+        PublicErrorCode.PROTOCOL_VERSION_UNSUPPORTED: "unavailable",
+        PublicErrorCode.IDEMPOTENCY_CONFLICT: "unavailable",
+        PublicErrorCode.REQUEST_IDENTITY_CONFLICT: "unavailable",
+        PublicErrorCode.EVENT_INVALID: "unavailable",
+        PublicErrorCode.LIMIT_EXCEEDED: "unavailable",
+        PublicErrorCode.STORAGE_UNSAFE: "unavailable",
+        PublicErrorCode.STORAGE_CORRUPT: "unavailable",
+        PublicErrorCode.MIGRATION_REQUIRED: "unavailable",
+        PublicErrorCode.SERVICE_UNAVAILABLE: "unavailable",
+        PublicErrorCode.PROVIDER_UNAVAILABLE: "unavailable",
+        PublicErrorCode.PROVIDER_REFUSED: "unavailable",
+        PublicErrorCode.PROVIDER_TIMEOUT: "unavailable",
+        PublicErrorCode.SEMANTIC_RESULT_INVALID: "unavailable",
+        PublicErrorCode.CANCELLED: "unavailable",
+        PublicErrorCode.INTERNAL_ERROR: "unavailable",
+    }
+)
+if set(_STATUS_ERROR_CLASSES) != set(PublicErrorCode):
+    raise RuntimeError("status_error_classes_not_exhaustive")
+
+# Transport-level failures, classified over the closed ControlError reason set.
+# Reasons absent here (a future addition) fall back to "unavailable".
+_CONTROL_ERROR_CLASSES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "vault_locked": "locked",
+        "request_timeout": "retry",
+        "service_draining": "retry",
+        "service_generation_changed": "retry",
+        "read_projection_failed": "retry",
+        "response_projection_failed": "retry",
+        "privacy_projection_unavailable": "retry",
+        "privacy_projection_blocked": "privacy",
+        "service_unavailable": "unavailable",
+        "peer_untrusted": "unavailable",
+        "protocol_mismatch": "unavailable",
+        "frame_invalid": "unavailable",
+        "frame_too_large": "unavailable",
+        "request_cancelled": "unavailable",
+        "method_forbidden": "unavailable",
+        "internal_error": "unavailable",
+    }
 )
 
 
@@ -257,7 +330,10 @@ async def _read_status(
     *,
     connect: ServiceConnector = connect_service,
 ) -> StatusOutcome:
-    """Return (context_kind, updated_mapping_or_none). kind is active|unavailable|locked."""
+    """Return (context_kind, updated_mapping_or_none).
+
+    kind is active|stale|locked|retry|privacy|unavailable.
+    """
 
     client: _StatusClient | None = None
     try:
@@ -266,10 +342,7 @@ async def _read_status(
         result = await connected.status(_status_request(mapping), deadline_ms=_STATUS_DEADLINE_MS)
         branch = getattr(result, "root", result)
         if isinstance(branch, OperationFailureModel):
-            code = branch.error.code.value
-            if code == "VAULT_LOCKED":
-                return "locked", None
-            return "unavailable", None
+            return _STATUS_ERROR_CLASSES.get(branch.error.code, "unavailable"), None
         head = getattr(branch, "head_frontier", None)
         task_id = getattr(branch, "task_id", None)
         session_id = getattr(branch, "session_id", None)
@@ -293,9 +366,7 @@ async def _read_status(
         )
         return "active", updated
     except ControlError as error:
-        if error.reason == "vault_locked":
-            return "locked", None
-        return "unavailable", None
+        return _CONTROL_ERROR_CLASSES.get(error.reason, "unavailable"), None
     except Exception:
         return "unavailable", None
     finally:
@@ -427,8 +498,21 @@ def handle_session_start(
                     stdout,
                 )
                 return 0
+            if kind == "stale":
+                from yoetz.cli.hook_diagnostics import record_hook_diagnostic
+
+                with contextlib.suppress(Exception):
+                    record_hook_diagnostic("mapping_stale", "SessionStart", _state=_state)
+                _stdout_json(_context_output("SessionStart", _STALE_MAPPING_CONTEXT), stdout)
+                return 0
             if kind == "locked":
                 _stdout_json(_context_output("SessionStart", _LOCKED_CONTEXT), stdout)
+                return 0
+            if kind == "retry":
+                _stdout_json(_context_output("SessionStart", _RETRY_CONTEXT), stdout)
+                return 0
+            if kind == "privacy":
+                _stdout_json(_context_output("SessionStart", _PRIVACY_CONTEXT), stdout)
                 return 0
             _stdout_json(_context_output("SessionStart", _UNAVAILABLE_CONTEXT), stdout)
             return 0

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -1332,6 +1332,11 @@ def handle_observe(
                 # SessionStart-only status/attach helpers: they drag protocol.models
                 # and service.client, which no other event needs (#242).
                 from yoetz.cli.hooks import (
+                    _LOCKED_CONTEXT,  # pyright: ignore[reportPrivateUsage]
+                    _PRIVACY_CONTEXT,  # pyright: ignore[reportPrivateUsage]
+                    _RETRY_CONTEXT,  # pyright: ignore[reportPrivateUsage]
+                    _STALE_MAPPING_CONTEXT,  # pyright: ignore[reportPrivateUsage]
+                    _UNAVAILABLE_CONTEXT,  # pyright: ignore[reportPrivateUsage]
                     _active_context,  # pyright: ignore[reportPrivateUsage]
                     _read_status,  # pyright: ignore[reportPrivateUsage]
                 )
@@ -1374,16 +1379,25 @@ def handle_observe(
                                 store_mapping(updated, _state=_state)
                                 mapping = updated
                                 additional = _active_context(updated, updated.last_frontier)
+                            elif kind == "stale":
+                                # The service answered: only the stored mapping is stale
+                                # (re-started elsewhere). Repair flows through the agent's
+                                # own start via handle_post_tool_use; meanwhile the static
+                                # advisory must not starve pending advice (issue #308).
+                                additional = _STALE_MAPPING_CONTEXT
+                                attach_advisory_only = True
+                                with contextlib.suppress(Exception):
+                                    record_hook_diagnostic(
+                                        "mapping_stale", resolved_event, _state=_state
+                                    )
                             elif kind == "locked":
-                                additional = (
-                                    "Yoetz vault is locked for this mapped session; "
-                                    "no live receipt can be promised."
-                                )
+                                additional = _LOCKED_CONTEXT
+                            elif kind == "retry":
+                                additional = _RETRY_CONTEXT
+                            elif kind == "privacy":
+                                additional = _PRIVACY_CONTEXT
                             else:
-                                additional = (
-                                    "Yoetz service is unavailable for this mapped session; "
-                                    "no live receipt can be promised."
-                                )
+                                additional = _UNAVAILABLE_CONTEXT
                         if not skip_service:
 
                             async def _drain() -> None:

--- a/tests/unit/cli/test_hooks.py
+++ b/tests/unit/cli/test_hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ from yoetz.adapters.integrations.codex_lifecycle import (
     mapping_from_start_ids,
     store_mapping,
 )
+from yoetz.cli import hooks as hooks_module
 from yoetz.cli.hooks import (
     INACTIVE_CONTEXT,
     handle_post_tool_use,
@@ -22,7 +24,9 @@ from yoetz.cli.hooks import (
     intake_cue_text,
 )
 from yoetz.ports.control import ControlClientKind, ControlError
+from yoetz.protocol.errors import PublicErrorCode
 from yoetz.protocol.ids import IdKind, new_id
+from yoetz.protocol.models import OperationFailureModel
 
 
 def _task_ids() -> tuple[str, str, str]:
@@ -277,8 +281,155 @@ def test_session_start_unreachable_service(tmp_path: Path) -> None:
     )
     assert code == 0
     text = json.loads(stdout.getvalue().decode("utf-8"))["hookSpecificOutput"]["additionalContext"]
-    assert "unavailable" in text
-    assert "no live receipt can be promised" in text
+    assert text == hooks_module._UNAVAILABLE_CONTEXT  # pyright: ignore[reportPrivateUsage]
+
+
+def _failure_result(code: PublicErrorCode, *, retryable: bool = False) -> _FakeStatusResult:
+    return _FakeStatusResult(
+        OperationFailureModel.model_validate(
+            {
+                "protocol_version": "0.1",
+                "schema_version": "1.0.0",
+                "ok": False,
+                "error": {
+                    "code": code.value,
+                    "message": "The requested task attachment conflicts.",
+                    "retryable": retryable,
+                    "correlation_id": f"err_{uuid.uuid4()}",
+                },
+            }
+        )
+    )
+
+
+def _session_start_context_for_failure(
+    tmp_path: Path,
+    codex_session_id: str,
+    result: _FakeStatusResult | Exception,
+) -> str:
+    task_id, session_id, writer_id = _task_ids()
+    store_mapping(
+        mapping_from_start_ids(
+            codex_session_id=codex_session_id,
+            yoetz_task_id=task_id,
+            yoetz_session_id=session_id,
+            yoetz_writer_id=writer_id,
+            last_frontier="0:genesis",
+        ),
+        _state=tmp_path,
+    )
+
+    class _Client:
+        async def status(self, request: object, *, deadline_ms: int | None = None) -> object:
+            del request, deadline_ms
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        async def close(self) -> None:
+            return None
+
+    async def connect(_kind: ControlClientKind) -> _Client:
+        return _Client()
+
+    stdout = io.BytesIO()
+    code = handle_session_start(
+        stdin_bytes=json.dumps({"session_id": codex_session_id, "source": "resume"}).encode(),
+        stdout=stdout,
+        _state=tmp_path,
+        connect=connect,  # pyright: ignore[reportArgumentType]
+    )
+    assert code == 0
+    context = json.loads(stdout.getvalue().decode("utf-8"))["hookSpecificOutput"][
+        "additionalContext"
+    ]
+    assert type(context) is str
+    return context
+
+
+@pytest.mark.parametrize(
+    "code", [PublicErrorCode.SESSION_CONFLICT, PublicErrorCode.SESSION_NOT_FOUND]
+)
+def test_session_start_stale_mapping_is_not_reported_unavailable(
+    tmp_path: Path, code: PublicErrorCode
+) -> None:
+    """SESSION_* means the mapping is stale, not that the service is down (#308)."""
+
+    text = _session_start_context_for_failure(tmp_path, "codex-stale", _failure_result(code))
+    assert text == hooks_module._STALE_MAPPING_CONTEXT  # pyright: ignore[reportPrivateUsage]
+    assert "unavailable" not in text
+    assert "start" in text
+    # The mapping is kept: repair flows through the agent's own re-start via
+    # handle_post_tool_use, never through hook-side guessing.
+    assert load_mapping("codex-stale", _state=tmp_path) is not None
+    diagnostics = (tmp_path / "observation" / "hook-diagnostics.jsonl").read_text()
+    assert '"reason":"mapping_stale"' in diagnostics
+
+
+def test_session_start_vault_locked_failure_is_locked(tmp_path: Path) -> None:
+    text = _session_start_context_for_failure(
+        tmp_path, "codex-locked", _failure_result(PublicErrorCode.VAULT_LOCKED, retryable=True)
+    )
+    assert text == hooks_module._LOCKED_CONTEXT  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        PublicErrorCode.BUNDLE_BUSY,
+        PublicErrorCode.OPERATION_PENDING,
+        PublicErrorCode.FRONTIER_CONFLICT,
+    ],
+)
+def test_session_start_transient_failure_is_retry(tmp_path: Path, code: PublicErrorCode) -> None:
+    text = _session_start_context_for_failure(
+        tmp_path, "codex-busy", _failure_result(code, retryable=True)
+    )
+    assert text == hooks_module._RETRY_CONTEXT  # pyright: ignore[reportPrivateUsage]
+    assert "unavailable" not in text
+
+
+def test_session_start_degraded_service_stays_unavailable(tmp_path: Path) -> None:
+    text = _session_start_context_for_failure(
+        tmp_path,
+        "codex-degraded",
+        _failure_result(PublicErrorCode.SERVICE_UNAVAILABLE, retryable=True),
+    )
+    assert text == hooks_module._UNAVAILABLE_CONTEXT  # pyright: ignore[reportPrivateUsage]
+
+
+def test_session_start_privacy_failure_names_the_ceremony(tmp_path: Path) -> None:
+    text = _session_start_context_for_failure(
+        tmp_path,
+        "codex-privacy",
+        _failure_result(PublicErrorCode.PRIVACY_AUTHORITY_REQUIRED),
+    )
+    assert text == hooks_module._PRIVACY_CONTEXT  # pyright: ignore[reportPrivateUsage]
+
+
+def test_session_start_control_timeout_is_retry(tmp_path: Path) -> None:
+    text = _session_start_context_for_failure(
+        tmp_path, "codex-timeout", ControlError("request_timeout", retryable=True)
+    )
+    assert text == hooks_module._RETRY_CONTEXT  # pyright: ignore[reportPrivateUsage]
+
+
+def test_status_error_class_table_is_exhaustive() -> None:
+    """A new PublicErrorCode member must be classified, never silently collapsed."""
+
+    table = hooks_module._STATUS_ERROR_CLASSES  # pyright: ignore[reportPrivateUsage]
+    assert set(table) == set(PublicErrorCode)
+    assert set(table.values()) <= {"stale", "locked", "retry", "privacy", "unavailable"}
+
+
+def test_control_error_class_table_is_exhaustive() -> None:
+    from yoetz.ports.control import (
+        _CONTROL_ERROR_REASONS,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    table = hooks_module._CONTROL_ERROR_CLASSES  # pyright: ignore[reportPrivateUsage]
+    assert set(table) == _CONTROL_ERROR_REASONS
+    assert set(table.values()) <= {"locked", "retry", "privacy", "unavailable"}
 
 
 def test_session_start_clear_removes_mapping(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_hooks.py
+++ b/tests/unit/cli/test_hooks.py
@@ -363,7 +363,7 @@ def test_session_start_stale_mapping_is_not_reported_unavailable(
     # handle_post_tool_use, never through hook-side guessing.
     assert load_mapping("codex-stale", _state=tmp_path) is not None
     diagnostics = (tmp_path / "observation" / "hook-diagnostics.jsonl").read_text()
-    assert '"reason":"mapping_stale"' in diagnostics
+    assert diagnostics.count('"reason":"mapping_stale"') == 1
 
 
 def test_session_start_vault_locked_failure_is_locked(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -871,6 +871,131 @@ def test_skip_service_session_start_never_opens_service_connection(
     assert store.list_pending_outbox(workspace)
 
 
+def test_session_start_stale_mapping_advisory_keeps_advice_delivery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A SESSION_CONFLICT status answer means the mapping is stale, not the
+    service down: the observe path must emit the shared stale advisory (#308)
+    and let pending advice join it instead of being starved."""
+
+    import uuid
+
+    from yoetz.adapters.integrations.codex_lifecycle import (
+        load_mapping,
+        mapping_from_start_ids,
+        store_mapping,
+    )
+    from yoetz.adapters.integrations.observation_local import AdviceDelivery
+    from yoetz.cli import hooks as hooks_module
+    from yoetz.domain.observation import AdviceSnapshot
+    from yoetz.protocol.ids import IdKind, new_id
+    from yoetz.protocol.models import OperationFailureModel
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store_mapping(
+        mapping_from_start_ids(
+            codex_session_id="stale-observe",
+            yoetz_task_id=new_id(IdKind.TASK),
+            yoetz_session_id=new_id(IdKind.SESSION),
+            yoetz_writer_id=new_id(IdKind.WRITER),
+            last_frontier="0:genesis",
+        ),
+        _state=tmp_path,
+    )
+    failure = OperationFailureModel.model_validate(
+        {
+            "protocol_version": "0.1",
+            "schema_version": "1.0.0",
+            "ok": False,
+            "error": {
+                "code": "SESSION_CONFLICT",
+                "message": "The requested task attachment conflicts.",
+                "retryable": False,
+                "correlation_id": f"err_{uuid.uuid4()}",
+            },
+        }
+    )
+
+    class _Result:
+        root = failure
+
+    class _Client:
+        async def status(self, request: object, *, deadline_ms: int | None = None) -> object:
+            del request, deadline_ms
+            return _Result()
+
+        async def observation_ingest(self, body: object, *, deadline_ms: int) -> object:
+            del body, deadline_ms
+            return observation_ingest_result_to_json(
+                ObservationIngestResult(ObservationIngestDisposition.DUPLICATE, None, None)
+            )
+
+        async def close(self) -> None:
+            return None
+
+    async def connect(_kind: object) -> _Client:
+        return _Client()
+
+    advice = AdviceDelivery(
+        snapshot=cast(AdviceSnapshot, object()),
+        item=None,
+        delivery_identity="advice-1",
+        text="Standing advice: connect a provider.",
+    )
+    commits: list[str] = []
+
+    def fake_peek(
+        self: LocalObservationStore,
+        workspace_arg: str,
+        *,
+        yoetz_session_id: str | None = None,
+        allow_standing: bool = True,
+        session_commitment: str | None = None,
+    ) -> AdviceDelivery:
+        del self, workspace_arg, yoetz_session_id, allow_standing, session_commitment
+        return advice
+
+    def fake_commit(
+        self: LocalObservationStore,
+        workspace_arg: str,
+        identity: str,
+        *,
+        yoetz_session_id: str | None = None,
+        session_commitment: str | None = None,
+    ) -> None:
+        del self, workspace_arg, yoetz_session_id, session_commitment
+        commits.append(identity)
+
+    monkeypatch.setattr(LocalObservationStore, "peek_advice_for_delivery", fake_peek)
+    monkeypatch.setattr(LocalObservationStore, "commit_advice_delivery", fake_commit)
+
+    out = io.BytesIO()
+    code = handle_observe(
+        event_name="SessionStart",
+        stdin_bytes=json.dumps(
+            {"session_id": "stale-observe", "hook_event_name": "SessionStart", "cwd": "."}
+        ).encode(),
+        stdout=out,
+        workspace=str(tmp_path),
+        _state=tmp_path,
+        connect=connect,  # type: ignore[arg-type]
+    )
+    assert code == 0
+    context = json.loads(out.getvalue().decode())["hookSpecificOutput"]["additionalContext"]
+    stale_text = hooks_module._STALE_MAPPING_CONTEXT  # pyright: ignore[reportPrivateUsage]
+    assert context.startswith(stale_text)
+    assert "unavailable" not in context
+    # The static stale advisory must not starve pending advice (#241, #280 pattern).
+    assert advice.text in context
+    assert commits == ["advice-1"]
+    # The stale mapping survives: repair belongs to the agent's own re-start.
+    assert load_mapping("stale-observe", _state=tmp_path) is not None
+    diagnostics = (tmp_path / "observation" / "hook-diagnostics.jsonl").read_text()
+    assert '"reason":"mapping_stale"' in diagnostics
+
+
 def test_malformed_stdin_exits_zero(tmp_path: Path) -> None:
     code = handle_observe(
         event_name="Stop",


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #308
- I searched existing issues and PRs for duplicates before opening this PR.
- This is a narrowly scoped hook bugfix outside the repository's design-gated areas.

## Documentation

- Behavior change? yes
- Docs updated: `docs/INTERFACES.md` and `CHANGELOG.md`

## Verification

Commands run:

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit/cli/test_hooks.py tests/unit/cli/test_observe_hooks.py
git diff --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check .
npx --no-install pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Stale Codex lifecycle mappings no longer collapse `SESSION_CONFLICT` and `SESSION_NOT_FOUND` into a false service-unavailable advisory. The hook now uses exhaustive public-error and control-error classifications, preserves the stale mapping until the agent's own successful `start` provides replacement IDs, and continues delivering pending advice alongside the stale-mapping recovery message.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale Codex hook mapping classification for SESSION_CONFLICT and SESSION_NOT_FOUND
> - Replaces the generic 'unavailable' classification for `SESSION_CONFLICT` and `SESSION_NOT_FOUND` daemon responses with a `mapping_stale` outcome, recording a `mapping_stale` diagnostic and advising the agent to call `start` again.
> - Introduces exhaustive classification tables (`_STATUS_ERROR_CLASSES`, `_CONTROL_ERROR_CLASSES`) in [hooks.py](https://github.com/TheGaySupreme123/yoetz/pull/312/files#diff-0243ff7fad9cfc722c0cec30a9da6a09078ddd1c40d60283e9fd2fa38b22e3c5) mapping public error codes and control error reasons to outcome kinds: `stale`, `locked`, `retry`, `privacy`, or `unavailable`.
> - Updates both `handle_session_start` in [hooks.py](https://github.com/TheGaySupreme123/yoetz/pull/312/files#diff-0243ff7fad9cfc722c0cec30a9da6a09078ddd1c40d60283e9fd2fa38b22e3c5) and `handle_observe` in [observe_hooks.py](https://github.com/TheGaySupreme123/yoetz/pull/312/files#diff-cdfa4cdbe7cfccf96a65db7f69d192cac91fad8eba4ec777e16f9a4d177f49c4) to emit specific advisory messages for each outcome kind.
> - Extends `_REASONS` in [hook_diagnostics.py](https://github.com/TheGaySupreme123/yoetz/pull/312/files#diff-da72710d814b3ef19be98f20764a7c58830a1ffedbbea6d6af433d3ce0916441) to include `mapping_stale`.
> - Behavioral Change: missing status error code classifications now raise at import time; stale mapping conditions no longer suppress service health status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1bf26c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex session handling for stale mappings.
  * Stale sessions now prompt a fresh start without incorrectly reporting service outages.
  * Added clearer guidance for locked vaults, privacy authorization, transient errors, and unavailable services.
  * Preserved pending advice delivery during stale-mapping recovery.

* **Documentation**
  * Updated interface documentation and changelog with the revised session-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->