### PR TITLE
Add recency and attribution to hook diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,6 +639,31 @@ carried them; they are listed because each one describes the behavior that now s
   so on stderr and records an `observation_storage_corrupt` coverage gap for the bound workspace so
   `observe status` can see the drop (issue #273).
 
+- `hook_diagnostics` in `observe status` was an all-time tally with no recency, so a failure that
+  was diagnosed and fixed days earlier read exactly like one happening now: one machine reported
+  `runtime_gate_unsafe: 97` for two days after issue #273's fix ended it, and a `max_ms` of 60001
+  from a single pre-fix pass alongside a healthy median of 789 ms. Every count is now paired with
+  a count over the last `window_seconds`, every reason carries `first_seen`/`last_seen`, and the
+  all-time `max_ms` carries the `max_ts` it happened at next to a `recent_max_ms` for the live
+  window. Nothing is discarded — a stale failure is dated rather than dropped — and a row whose
+  timestamp cannot be read is never counted as recent (issue #310).
+
+- The `truncated_payload` coverage gap had note call sites and no resolution path, so one
+  size-pressure eviction reported the workspace as currently losing observations forever. A save
+  that sheds nothing and lands with a headroom margin under the state bound now clears the active
+  flag; merely landing under the bound does not, because that is the state an eviction itself
+  leaves behind. Renewed shedding reopens it, and `gap_history` keeps the sighting either way
+  (issue #310).
+
+- Hook timing rows attributed as little as 14% of the pass they measured, so `hook_budget_exceeded`
+  could not distinguish real work from queueing. Time spent acquiring the interprocess store lock
+  is now reported as `store_lock_wait` wherever in the pass it occurs, including on the timeout
+  path; the two formerly unwindowed regions — workspace resolution and the consent probe before
+  the store window, advice selection and the stdout write after the drain window — are reported as
+  `resolve` and `deliver`; and whatever the partition still misses is reported as `unattributed`
+  rather than left for a reader to derive. A contended pass that spent 707 of 711 ms queueing
+  previously showed `store: 4` and nothing else (issues #310 and #311).
+
 ### Security
 
 - Losing the session-event monitor no longer auto-re-opens the vault on the next ordinary call.

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2473,10 +2473,18 @@ across workspace sessions under a nonblocking per-workspace lease; within one pa
 and an ended unmapped session is terminally quarantined because no future mapping can deliver it,
 but only after atomically acquiring its lifecycle lock so an attach already in flight wins.
 Turn-boundary hooks retry auto-attach under a bounded budget and record a payload-free diagnostic
-when no mapping results. Workspace-global rejections (`vault_locked`, disabled, paused) end the pass.
+when no mapping results. `observe status` retains the current and rotated hook-diagnostic history,
+but pairs every all-time reason count with `first_seen`, `last_seen`, and a count in the closed
+one-hour `window_seconds`; timings likewise date the all-time maximum and report a separate recent
+maximum. Unreadable or future timestamps remain retained but are never classified as recent, so a
+fixed historical failure cannot masquerade as live degradation (issue #310). Workspace-global
+rejections (`vault_locked`, disabled, paused) end the pass.
 A `service_unavailable` rejection retires that session's lane for the pass while other sessions
 remain eligible; no later row may step over a failed lane head. Local observation-store acquisition is capped at two
-seconds for both the process-local reentrant lock and the cross-process flock. Coordinator and
+seconds for both the process-local reentrant lock and the cross-process flock. Hook timing rows
+attribute that queueing as `store_lock_wait`, cover the previously unwindowed resolve/deliver
+regions, and name any remaining wall-time difference as `unattributed`; nested store sub-stages are
+reported separately from the end-to-end partition (issues #310 and #311). Coordinator and
 sweeper calls use separate bounded executors, so cancellation cannot strand an exit-blocking flock
 wait or exhaust the shared default executor. `observation_storage_corrupt` is terminal for its Codex
 session in the current READY generation: the coordinator remembers that session after the first
@@ -2489,7 +2497,10 @@ budget, and by a 14-day age measured from a store-authored
 quarantined-at time behind the trusted-clock epoch fence; an operator can drop it explicitly with
 `yoetz observe reclaim`. Every drop — cap, age, or reclaim — retains aggregate commitment, count
 (evictions and reclaims counted separately), first/last receipt times, and
-`quarantine_detail_evicted`.
+`quarantine_detail_evicted`. The `truncated_payload` gap is live rather than permanent: a later
+save resolves its active flag only when that save evicts nothing and leaves one-eighth of the state
+budget free. Merely landing under the cap cannot clear the same loss it just recorded; the durable
+gap history remains after recovery, and renewed shedding reactivates it (issue #310).
 
 Routine-read materialization follows ADR-022's rate policy. A service-owned structural
 `action=routine_read` label is derived only for the closed direct-read tool set or a conservatively

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -16,7 +16,7 @@ import re
 import stat
 import threading
 import time
-from collections.abc import Callable, Generator, Mapping
+from collections.abc import Callable, Generator, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -128,6 +128,9 @@ _LOCAL_STREAM_PARTIAL_DROPPED_GAP: Final = "_local_stream_partial_dropped"
 _LEGACY_STREAM_PARTIAL_DROPPED_SESSION: Final = "_legacy_unknown"
 _STORE_LOCK_TIMEOUT_SECONDS: Final = 2.0
 _STORE_LOCK_POLL_SECONDS: Final = 0.01
+# Fraction of the state bound a save must leave free before an eviction gap is
+# treated as healed (#310).
+_STATE_HEADROOM_DIVISOR: Final = 8
 
 YOETZ_TOOL_NAMES: Final = frozenset(
     {
@@ -163,15 +166,32 @@ _STORE_LOCK_REGISTRY: dict[str, _StoreLockState] = {}
 class _InterprocessStoreLock:
     """Reentrant process-local lock plus POSIX serialization across hook/daemon."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, waits_ms: MutableMapping[str, float] | None = None) -> None:
         self._path = path
+        # Queueing behind another process is real hook wall time that no stage
+        # window could see: the wait lands inside and outside the timed 'store'
+        # window alike, so it accumulates here, once per acquisition, wherever
+        # in the pass it happens (#310/#311). Reentrant acquisitions return
+        # immediately and contribute ~0.
+        self._waits_ms = waits_ms
         key = str(path.absolute())
         with _STORE_LOCK_REGISTRY_GUARD:
             self._state = _STORE_LOCK_REGISTRY.setdefault(key, _StoreLockState())
 
     def __enter__(self) -> _InterprocessStoreLock:
+        started = time.monotonic()
+        try:
+            return self._acquire(started + _STORE_LOCK_TIMEOUT_SECONDS)
+        finally:
+            if self._waits_ms is not None:
+                # Recorded on the timeout path too: a pass that waited two
+                # seconds and then failed spent those seconds queueing.
+                self._waits_ms["lock_wait"] = (
+                    self._waits_ms.get("lock_wait", 0.0) + (time.monotonic() - started) * 1000
+                )
+
+    def _acquire(self, deadline: float) -> _InterprocessStoreLock:
         state = self._state
-        deadline = time.monotonic() + _STORE_LOCK_TIMEOUT_SECONDS
         if not state.thread_lock.acquire(timeout=_STORE_LOCK_TIMEOUT_SECONDS):
             raise TimeoutError("observation_store_lock_timeout")
         if state.depth == 0:
@@ -644,7 +664,20 @@ class LocalObservationStore:
     ) -> None:
         self._root = observation_dir(_state=_state)
         self._state_root = self._root.parent
-        self._lock = _InterprocessStoreLock(self._root / ".store.lock")
+        # Monotonic milliseconds accumulated per store sub-stage since
+        # construction. Hooks fold these into their pass-timing rows so the
+        # formerly opaque 'store' stage is attributable (#290), and so time
+        # spent queueing for the store lock is reported as queueing rather
+        # than as unexplained wall time (#310).
+        self.stage_timings_ms: dict[str, float] = {
+            "hydrate": 0.0,
+            "encode": 0.0,
+            "lock_wait": 0.0,
+            "write": 0.0,
+        }
+        self._lock = _InterprocessStoreLock(
+            self._root / ".store.lock", waits_ms=self.stage_timings_ms
+        )
         self._monotonic = _monotonic
         self._wall = _wall
         # Parse cache keyed by workspace commitment, validated by the state
@@ -664,10 +697,6 @@ class LocalObservationStore:
         # 10-18 times measured on a lived-in store (#242).
         self._batch: dict[str, _WorkspaceState] = {}
         self._batch_dirty: set[str] = set()
-        # Monotonic milliseconds accumulated per store sub-stage since
-        # construction. Hooks fold these into their pass-timing rows so the
-        # formerly opaque 'store' stage is attributable (#290).
-        self.stage_timings_ms: dict[str, float] = {"hydrate": 0.0, "encode": 0.0, "write": 0.0}
 
     def _now_mono(self) -> float:
         import time
@@ -2322,6 +2351,7 @@ class LocalObservationStore:
             dropped_sessions.add(largest)
             self._note_gap_state(state, _LOCAL_STREAM_PARTIAL_DROPPED_GAP)
             payload = self._encode_state(workspace_commitment, state)
+        truncated = False
         if len(payload) > _MAX_STATE_BYTES:
             # Retain authority state and make every observation-detail loss explicit.
             assert state.envelopes is not None
@@ -2329,6 +2359,7 @@ class LocalObservationStore:
                 del state.envelopes[0]
                 assert state.gaps is not None
                 self._note_gap_state(state, ObservationGapCode.TRUNCATED_PAYLOAD.value)
+                truncated = True
                 payload = self._encode_state(workspace_commitment, state)
         assert state.pending_outbox is not None
         assert state.quarantine is not None
@@ -2363,6 +2394,22 @@ class LocalObservationStore:
                 "Observation state exceeds its safe local bound.",
                 retryable=False,
             )
+        truncation = state.gaps.get(ObservationGapCode.TRUNCATED_PAYLOAD.value)
+        if (
+            not truncated
+            and truncation is not None
+            and truncation.active
+            and len(payload) + _MAX_STATE_BYTES // _STATE_HEADROOM_DIVISOR <= _MAX_STATE_BYTES
+        ):
+            # Landing with a full headroom margin, having shed nothing, is live
+            # proof the store is no longer losing observations to the bound.
+            # Landing merely *under* the bound proves nothing — that is the
+            # state an eviction itself leaves behind, so clearing there would
+            # retire the gap in the same pass that opened it. History stays in
+            # gap_history; only the active flag, which reports live
+            # degradation, is cleared (#310).
+            self._resolve_gap_state(state, ObservationGapCode.TRUNCATED_PAYLOAD.value)
+            payload = self._encode_state(workspace_commitment, state)
         write_started = self._now_mono()
         _atomic_write(path, payload)
         self.stage_timings_ms["write"] += (self._now_mono() - write_started) * 1000

--- a/src/yoetz/cli/hook_diagnostics.py
+++ b/src/yoetz/cli/hook_diagnostics.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 import os
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import Lock
 from typing import Final, cast
@@ -71,16 +72,32 @@ _STAGES: Final = frozenset(
         "drain",
         "import",
         "store",
+        # Formerly unwindowed regions of the pass (#310/#311): workspace
+        # resolution and the consent probe before the store window opens, and
+        # advice selection, the stdout write and both delivery commits after
+        # the drain window closes. Together with 'import' and 'store' they
+        # partition the pass, and 'unattributed' names whatever they miss.
+        "deliver",
+        "resolve",
+        "unattributed",
         # Store sub-stage attribution (#290): parse+hydrate of the state file,
         # canonical encode of every size projection and save, and the fsync'd
-        # atomic write. The remainder of 'store' is mutation time.
+        # atomic write. The remainder of 'store' is mutation time. Lock wait
+        # (#310) is queueing behind another process, not work, and spans the
+        # whole pass rather than partitioning any one window.
         "store_encode",
         "store_hydrate",
+        "store_lock_wait",
         "store_write",
         "total",
     }
 )
 _MAX_STAGE_MS: Final = 3_600_000
+# The retained file spans days, so an all-time tally reports a failure that was
+# diagnosed and fixed two days ago exactly like one happening right now (#310).
+# Every count is therefore paired with a recent-window count, and every extreme
+# with the moment it was observed, so a reader can date what it is looking at.
+_RECENT_WINDOW_SECONDS: Final = 3_600
 _thread_lock = Lock()
 
 
@@ -90,11 +107,27 @@ def _closed(value: object, allowed: frozenset[str], fallback: str) -> str:
     return fallback
 
 
-def _timestamp() -> str:
-    now = datetime.now(UTC)
+def _render(moment: datetime) -> str:
     return (
-        now.replace(microsecond=(now.microsecond // 1000) * 1000).isoformat().replace("+00:00", "Z")
+        moment.astimezone(UTC)
+        .replace(microsecond=(moment.microsecond // 1000) * 1000)
+        .isoformat()
+        .replace("+00:00", "Z")
     )
+
+
+def _timestamp() -> str:
+    return _render(datetime.now(UTC))
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    """Return the recorded moment, or None when the row's stamp is unreadable."""
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def record_hook_diagnostic(
@@ -209,13 +242,78 @@ def record_hook_timing(
     )
 
 
-def hook_diagnostic_summary(*, _state: Path | None = None) -> JsonObject:
-    """Return a bounded structural summary of the current and rotated diagnostics."""
+@dataclass(slots=True)
+class _Recency:
+    """One reason's tally paired with the span of moments it actually covers."""
 
-    root = state_dir() if _state is None else _state
-    directory = root / "observation"
+    count: int = 0
+    recent: int = 0
+    first: datetime | None = None
+    last: datetime | None = None
+
+    def observe(self, moment: datetime | None, *, fresh: bool) -> None:
+        self.count += 1
+        if fresh:
+            self.recent += 1
+        if moment is None:
+            return
+        if self.first is None or moment < self.first:
+            self.first = moment
+        if self.last is None or moment > self.last:
+            self.last = moment
+
+    def as_json(self) -> JsonObject:
+        return JsonObject(
+            {
+                "count": self.count,
+                "first_seen": None if self.first is None else _render(self.first),
+                "last_seen": None if self.last is None else _render(self.last),
+                "recent": self.recent,
+            }
+        )
+
+
+@dataclass(slots=True)
+class _Timings:
+    """Timing rows, kept datable so a one-off extreme is not read as the norm."""
+
+    count: int = 0
+    recent: int = 0
+    last_ms: int | None = None
+    max_ms: int | None = None
+    max_at: datetime | None = None
+    recent_max_ms: int | None = None
+
+    def observe(self, ms: int, moment: datetime | None, *, fresh: bool) -> None:
+        self.count += 1
+        self.last_ms = ms
+        if self.max_ms is None or ms > self.max_ms:
+            self.max_ms = ms
+            self.max_at = moment
+        if not fresh:
+            return
+        self.recent += 1
+        if self.recent_max_ms is None or ms > self.recent_max_ms:
+            self.recent_max_ms = ms
+
+    def as_json(self) -> JsonObject:
+        return JsonObject(
+            {
+                "count": self.count,
+                "last_ms": self.last_ms,
+                "max_ms": self.max_ms,
+                "max_ts": None if self.max_at is None else _render(self.max_at),
+                "recent_count": self.recent,
+                "recent_max_ms": self.recent_max_ms,
+            }
+        )
+
+
+def _read_rows(directory: Path) -> tuple[list[dict[str, str]], list[tuple[int, str]]]:
+    """Return retained failure rows and timing rows, oldest retained file first."""
+
     rows: list[dict[str, str]] = []
-    timings: list[int] = []
+    timings: list[tuple[int, str]] = []
     try:
         ensure_owner_only_dir(directory)
         for path in (
@@ -248,8 +346,9 @@ def hook_diagnostic_summary(*, _state: Path | None = None) -> JsonObject:
                     # Timing rows are a second shape on the same file; they must
                     # never inflate the failure-reason counts.
                     total = row.get("ms")
-                    if row.get("kind") == "timing" and type(total) is int:
-                        timings.append(total)
+                    stamp = row.get("ts")
+                    if row.get("kind") == "timing" and type(total) is int and type(stamp) is str:
+                        timings.append((total, stamp))
                     continue
                 if set(row) != {"event", "reason", "ts"} or any(
                     type(row.get(key)) is not str for key in ("event", "reason", "ts")
@@ -263,32 +362,55 @@ def hook_diagnostic_summary(*, _state: Path | None = None) -> JsonObject:
                     }
                 )
     except OSError, PathSafetyError:
-        return JsonObject(
-            {
-                "count": 0,
-                "last_event": None,
-                "last_reason": None,
-                "reasons": JsonObject({}),
-                "timings": JsonObject({"count": 0, "last_ms": None, "max_ms": None}),
-            }
-        )
-    reasons: dict[str, int] = {}
+        return [], []
+    return rows, timings
+
+
+def hook_diagnostic_summary(
+    *,
+    _state: Path | None = None,
+    _now: datetime | None = None,
+) -> JsonObject:
+    """Return a bounded structural summary of the current and rotated diagnostics.
+
+    Every tally is reported twice — over everything retained, and over the last
+    `window_seconds` — and every count carries the span it covers, so a reader
+    can tell a live failure from one that was fixed days ago (#310).
+    """
+
+    root = state_dir() if _state is None else _state
+    rows, timings = _read_rows(root / "observation")
+    now = datetime.now(UTC) if _now is None else _now.astimezone(UTC)
+    horizon = now - timedelta(seconds=_RECENT_WINDOW_SECONDS)
+    overall = _Recency()
+    reasons: dict[str, _Recency] = {}
     for row in rows:
-        reason = row["reason"]
-        reasons[reason] = reasons.get(reason, 0) + 1
+        moment = _parse_timestamp(row["ts"])
+        # An unreadable stamp is never counted as recent: an undatable row is
+        # exactly the thing this summary must stop presenting as live.
+        fresh = moment is not None and horizon <= moment <= now
+        overall.observe(moment, fresh=fresh)
+        reasons.setdefault(row["reason"], _Recency()).observe(moment, fresh=fresh)
+    timing = _Timings()
+    for total, stamp in timings:
+        moment = _parse_timestamp(stamp)
+        timing.observe(total, moment, fresh=moment is not None and horizon <= moment <= now)
     last = rows[-1] if rows else None
     return JsonObject(
         {
-            "count": len(rows),
+            "count": overall.count,
+            "first_seen": None if overall.first is None else _render(overall.first),
             "last_event": None if last is None else last["event"],
             "last_reason": None if last is None else last["reason"],
-            "reasons": JsonObject(dict(sorted(reasons.items(), key=lambda item: item[0].encode()))),
-            "timings": JsonObject(
+            "last_seen": None if overall.last is None else _render(overall.last),
+            "reasons": JsonObject(
                 {
-                    "count": len(timings),
-                    "last_ms": timings[-1] if timings else None,
-                    "max_ms": max(timings) if timings else None,
+                    name: tally.as_json()
+                    for name, tally in sorted(reasons.items(), key=lambda item: item[0].encode())
                 }
             ),
+            "recent_count": overall.recent,
+            "timings": timing.as_json(),
+            "window_seconds": _RECENT_WINDOW_SECONDS,
         }
     )

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -145,6 +145,10 @@ _HOOK_TOTAL_BUDGET_SECONDS: Final = (
     + _HOOK_LOCAL_STAGE_ALLOWANCE_SECONDS
 )
 _TIMING_REPORT_EVENTS: Final = frozenset({"SessionStart", "Stop", "SessionEnd"})
+# The stages that partition one pass end to end, in order. 'advice' is nested
+# inside 'store' and every 'store_*' accumulator spans the whole pass, so
+# neither belongs in a sum against the total.
+_PASS_PARTITION_STAGES: Final = ("import", "resolve", "store", "drain", "deliver")
 _ROUTINE_READ_TOOLS: Final = frozenset(
     {
         "glob",
@@ -658,7 +662,21 @@ def _record_pass_timing(
             return
         if over:
             record_hook_diagnostic("hook_budget_exceeded", event, _state=_state)
-        record_hook_timing(event, ms=total_ms, stages={**stages, "total": total_ms}, _state=_state)
+        # What the partition does not cover is reported as its own term rather
+        # than left for a reader to derive by knowing which stages nest. A row
+        # whose stages sum to half its total said nothing about the other half
+        # (#310/#311); now it names it.
+        attributed = sum(stages.get(name, 0) for name in _PASS_PARTITION_STAGES)
+        record_hook_timing(
+            event,
+            ms=total_ms,
+            stages={
+                **stages,
+                "total": total_ms,
+                "unattributed": max(0, total_ms - attributed),
+            },
+            _state=_state,
+        )
 
 
 def _cached_recommendation_context(*, _state: Path | None) -> str:
@@ -1094,7 +1112,8 @@ def handle_observe(
     stages: dict[str, int] = {}
     try:
         store = LocalObservationStore(_state=_state)
-        stages["import"] = _elapsed_ms(entry_started, _monotonic())
+        resolve_started = _monotonic()
+        stages["import"] = _elapsed_ms(entry_started, resolve_started)
         raw_stdout_json = hook_io.stdout_json
 
         def _resolve_runner() -> AsyncRunner:
@@ -1192,6 +1211,11 @@ def handle_observe(
 
         assert workspace_commitment is not None
         store_started = _monotonic()
+        # Payload parse, runtime gate, workspace resolution and the consent
+        # probe ran between 'import' and here, unwindowed. Three of those calls
+        # take the store lock, so a contended pass spent real time in a region
+        # no stage could name (#310/#311).
+        stages["resolve"] = _elapsed_ms(resolve_started, store_started)
         # One flush for the whole local pass. The batch is closed before any
         # service RPC so an outbox acknowledgement can never become durable
         # ahead of the ingest it acknowledges, and it never spans a network
@@ -1473,7 +1497,8 @@ def handle_observe(
                 ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value,
             )
 
-        stages["drain"] = _elapsed_ms(drain_started, _monotonic())
+        deliver_started = _monotonic()
+        stages["drain"] = _elapsed_ms(drain_started, deliver_started)
 
         # Advice selection and commit are serialized with the stdout write by a
         # dedicated delivery lease. The lease is independent of workspace state:
@@ -1551,6 +1576,10 @@ def handle_observe(
                         codex_session_id,
                         pending_frontier_notice.delivery_identity,
                     )
+        # Advice selection, the lease, the stdout write itself and both delivery
+        # commits sit past the 'drain' window; a blocked host pipe or a
+        # contended commit was previously invisible (#310/#311).
+        stages["deliver"] = _elapsed_ms(deliver_started, _monotonic())
         # Attribute the whole pass's store work (#290), folded in last because
         # the store keeps saving after the 'store' stage window closes: the
         # drain saves once per delivered row and advice commits its own. A

--- a/tests/unit/adapters/test_observation_state_bounds.py
+++ b/tests/unit/adapters/test_observation_state_bounds.py
@@ -257,6 +257,65 @@ def test_dropped_unterminated_long_line_recovers_when_newline_arrives(tmp_path: 
     )
 
 
+def _force_envelope_eviction(
+    store: LocalObservationStore,
+    workspace: str,
+    session: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    for ordinal in range(1, 12):
+        store.ingest(_envelope(session=session, identity=f"hook:evict:{ordinal}", ordinal=ordinal))
+    state_path = next((tmp_path / "observation" / "workspaces").glob("*.json"))
+    # Below the current size, so the next save must shed durable envelopes.
+    monkeypatch.setattr(local_mod, "_MAX_STATE_BYTES", state_path.stat().st_size - 1_024)
+    store.note_coverage_gap(workspace, ObservationGapCode.SERVICE_UNAVAILABLE.value)
+
+
+def test_truncation_gap_clears_once_the_store_stops_shedding_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#310: the eviction gap had no resolution path and latched forever."""
+
+    store, workspace, session = _consented_store(tmp_path)
+    _force_envelope_eviction(store, workspace, session, monkeypatch, tmp_path)
+    truncated = ObservationGapCode.TRUNCATED_PAYLOAD.value
+    assert truncated in store.status(ObservationStatusQuery(workspace)).gaps
+
+    # Still pressed against the bound: landing merely under it proves nothing.
+    store.note_coverage_gap(workspace, ObservationGapCode.SOURCE_LAG.value)
+    assert truncated in store.status(ObservationStatusQuery(workspace)).gaps
+
+    # Pressure gone: the next save lands with headroom and sheds nothing.
+    monkeypatch.setattr(local_mod, "_MAX_STATE_BYTES", 1_048_576)
+    store.note_coverage_gap(workspace, ObservationGapCode.SERVICE_UNAVAILABLE.value)
+    assert truncated not in store.status(ObservationStatusQuery(workspace)).gaps
+
+    # Cleared, not erased: the loss stays in history with the moment it happened.
+    persisted = _state_json(tmp_path)
+    history = cast(dict[str, dict[str, object]], persisted["gap_history"])
+    assert history[truncated]["active"] is False
+    assert history[truncated]["first_seen"]
+    reopened = LocalObservationStore(_state=tmp_path)
+    assert truncated not in reopened.status(ObservationStatusQuery(workspace)).gaps
+
+
+def test_renewed_shedding_reopens_the_truncation_gap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Clearing is a live signal, not a one-way retirement."""
+
+    store, workspace, session = _consented_store(tmp_path)
+    truncated = ObservationGapCode.TRUNCATED_PAYLOAD.value
+    _force_envelope_eviction(store, workspace, session, monkeypatch, tmp_path)
+    monkeypatch.setattr(local_mod, "_MAX_STATE_BYTES", 1_048_576)
+    store.note_coverage_gap(workspace, ObservationGapCode.SERVICE_UNAVAILABLE.value)
+    assert truncated not in store.status(ObservationStatusQuery(workspace)).gaps
+
+    _force_envelope_eviction(store, workspace, session, monkeypatch, tmp_path)
+    assert truncated in store.status(ObservationStatusQuery(workspace)).gaps
+
+
 def test_store_stage_timings_attribute_hydrate_encode_write(tmp_path: Path) -> None:
     """The store accounts its hydrate/encode/write cost for hook timing rows (#290)."""
 
@@ -264,8 +323,15 @@ def test_store_stage_timings_attribute_hydrate_encode_write(tmp_path: Path) -> N
     seeded.ingest(_envelope(session=session, identity="hook:timed", ordinal=1))
 
     store = LocalObservationStore(_state=tmp_path)
-    assert store.stage_timings_ms == {"hydrate": 0.0, "encode": 0.0, "write": 0.0}
+    assert store.stage_timings_ms == {
+        "hydrate": 0.0,
+        "encode": 0.0,
+        "lock_wait": 0.0,
+        "write": 0.0,
+    }
     store.note_coverage_gap(workspace, ObservationGapCode.SERVICE_UNAVAILABLE.value)
     assert store.stage_timings_ms["hydrate"] > 0.0
     assert store.stage_timings_ms["encode"] > 0.0
     assert store.stage_timings_ms["write"] > 0.0
+    # Uncontended acquisition still registers as time spent on the lock (#310).
+    assert store.stage_timings_ms["lock_wait"] > 0.0

--- a/tests/unit/adapters/test_observation_store_lock.py
+++ b/tests/unit/adapters/test_observation_store_lock.py
@@ -27,3 +27,29 @@ def test_interprocess_store_lock_wait_is_bounded(
     finally:
         local.fcntl.flock(descriptor, local.fcntl.LOCK_UN)
         os.close(descriptor)
+
+
+@pytest.mark.skipif(local.fcntl is None, reason="POSIX flock is unavailable")
+def test_contended_wait_is_attributed_even_when_it_times_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#310/#311: queueing was charged to the pass but named by no stage."""
+
+    lock_path = tmp_path / "store.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    assert local.fcntl is not None
+    local.fcntl.flock(descriptor, local.fcntl.LOCK_EX | local.fcntl.LOCK_NB)
+    monkeypatch.setattr(local, "_STORE_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(local, "_STORE_LOCK_POLL_SECONDS", 0.005)
+    waits: dict[str, float] = {"lock_wait": 0.0}
+    try:
+        with pytest.raises(TimeoutError, match="observation_store_lock_timeout"):
+            with local._InterprocessStoreLock(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+                lock_path, waits_ms=waits
+            ):
+                pytest.fail("the contended lock must not be entered")
+    finally:
+        local.fcntl.flock(descriptor, local.fcntl.LOCK_UN)
+        os.close(descriptor)
+    # A pass that waited out the ceiling and then failed still spent that time.
+    assert waits["lock_wait"] >= 50.0

--- a/tests/unit/cli/test_hook_diagnostics.py
+++ b/tests/unit/cli/test_hook_diagnostics.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 import sys
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -112,11 +113,172 @@ def test_timing_rows_round_trip_and_reason_counts_are_unpolluted(tmp_path: Path)
 
     summary = hook_diagnostic_summary(_state=tmp_path)
     assert summary["count"] == 1
+    assert summary["recent_count"] == 1
     assert summary["last_reason"] == "hook_budget_exceeded"
     reasons = dict(cast(Mapping[str, object], summary["reasons"]))
-    assert reasons == {"hook_budget_exceeded": 1}
+    assert set(reasons) == {"hook_budget_exceeded"}
+    budget = dict(cast(Mapping[str, object], reasons["hook_budget_exceeded"]))
+    assert budget["count"] == 1
+    assert budget["recent"] == 1
+    assert budget["first_seen"] == budget["last_seen"] == summary["last_seen"]
     timings = dict(cast(Mapping[str, object], summary["timings"]))
-    assert timings == {"count": 1, "last_ms": 1_842, "max_ms": 1_842}
+    assert timings["count"] == 1
+    assert timings["recent_count"] == 1
+    assert timings["last_ms"] == timings["max_ms"] == timings["recent_max_ms"] == 1_842
+    assert timings["max_ts"] is not None
+
+
+def _seed(directory: Path, rows: list[dict[str, object]]) -> None:
+    directory.mkdir(mode=0o700, exist_ok=True)
+    path = directory / "hook-diagnostics.jsonl"
+    path.write_text(
+        "".join(f"{json.dumps(row, sort_keys=True)}\n" for row in rows), encoding="utf-8"
+    )
+    path.chmod(0o600)
+
+
+def test_fixed_and_gone_failures_are_dated_rather_than_reported_as_live(tmp_path: Path) -> None:
+    """#310: an all-time tally read a two-day-old, since-fixed failure as live."""
+
+    _seed(
+        tmp_path / "observation",
+        [
+            {"event": "PreToolUse", "reason": "runtime_gate_unsafe", "ts": "2026-08-15T18:49:51Z"},
+            {"event": "Stop", "reason": "runtime_gate_unsafe", "ts": "2026-08-15T19:00:00Z"},
+            {
+                "event": "Stop",
+                "kind": "timing",
+                "ms": 60_001,
+                "stages": {"store": 59_780},
+                "ts": "2026-08-15T22:29:17Z",
+            },
+            {
+                "event": "Stop",
+                "kind": "timing",
+                "ms": 789,
+                "stages": {"store": 247},
+                "ts": "2026-08-17T12:00:00Z",
+            },
+        ],
+    )
+    summary = hook_diagnostic_summary(
+        _state=tmp_path, _now=datetime(2026, 8, 17, 12, 30, tzinfo=UTC)
+    )
+
+    assert summary["count"] == 2
+    assert summary["recent_count"] == 0
+    assert summary["first_seen"] == "2026-08-15T18:49:51Z"
+    assert summary["last_seen"] == "2026-08-15T19:00:00Z"
+    assert summary["window_seconds"] == 3_600
+    reasons = dict(cast(Mapping[str, object], summary["reasons"]))
+    assert dict(cast(Mapping[str, object], reasons["runtime_gate_unsafe"])) == {
+        "count": 2,
+        "first_seen": "2026-08-15T18:49:51Z",
+        "last_seen": "2026-08-15T19:00:00Z",
+        "recent": 0,
+    }
+    # The all-time extreme is retained, but dated, and the live window has its own.
+    timings = dict(cast(Mapping[str, object], summary["timings"]))
+    assert timings == {
+        "count": 2,
+        "last_ms": 789,
+        "max_ms": 60_001,
+        "max_ts": "2026-08-15T22:29:17Z",
+        "recent_count": 1,
+        "recent_max_ms": 789,
+    }
+
+
+def test_a_live_failure_is_still_counted_as_recent(tmp_path: Path) -> None:
+    _seed(
+        tmp_path / "observation",
+        [
+            {"event": "PreToolUse", "reason": "runtime_gate_unsafe", "ts": "2026-08-15T18:49:51Z"},
+            {"event": "PostToolUse", "reason": "service_unavailable", "ts": "2026-08-17T12:25:00Z"},
+        ],
+    )
+    summary = hook_diagnostic_summary(
+        _state=tmp_path, _now=datetime(2026, 8, 17, 12, 30, tzinfo=UTC)
+    )
+    assert summary["count"] == 2
+    assert summary["recent_count"] == 1
+    reasons = dict(cast(Mapping[str, object], summary["reasons"]))
+    assert dict(cast(Mapping[str, object], reasons["service_unavailable"]))["recent"] == 1
+    assert dict(cast(Mapping[str, object], reasons["runtime_gate_unsafe"]))["recent"] == 0
+
+
+def test_a_future_diagnostic_is_retained_but_not_called_recent(tmp_path: Path) -> None:
+    """Clock-skewed rows must not remain live until their future timestamp arrives."""
+
+    _seed(
+        tmp_path / "observation",
+        [{"event": "Stop", "reason": "timeout", "ts": "2026-08-18T12:30:00+02:00"}],
+    )
+    summary = hook_diagnostic_summary(
+        _state=tmp_path, _now=datetime(2026, 8, 17, 12, 30, tzinfo=UTC)
+    )
+    assert summary["count"] == 1
+    assert summary["recent_count"] == 0
+    # Dated fields are normalized to the same UTC wire form as writer-created rows.
+    assert summary["last_seen"] == "2026-08-18T10:30:00Z"
+
+
+def test_an_undatable_row_is_counted_but_never_called_recent(tmp_path: Path) -> None:
+    """An unreadable stamp is exactly what must stop being presented as live."""
+
+    _seed(
+        tmp_path / "observation",
+        [
+            {"event": "Stop", "reason": "timeout", "ts": "not-a-timestamp"},
+            {
+                "event": "Stop",
+                "kind": "timing",
+                "ms": 4_000,
+                "stages": {"store": 1},
+                "ts": "not-a-timestamp",
+            },
+        ],
+    )
+    summary = hook_diagnostic_summary(
+        _state=tmp_path, _now=datetime(2026, 8, 17, 12, 30, tzinfo=UTC)
+    )
+    assert summary["count"] == 1
+    assert summary["recent_count"] == 0
+    assert summary["first_seen"] is None
+    assert summary["last_seen"] is None
+    assert summary["last_reason"] == "timeout"
+    reasons = dict(cast(Mapping[str, object], summary["reasons"]))
+    assert dict(cast(Mapping[str, object], reasons["timeout"])) == {
+        "count": 1,
+        "first_seen": None,
+        "last_seen": None,
+        "recent": 0,
+    }
+    timings = dict(cast(Mapping[str, object], summary["timings"]))
+    assert timings["count"] == 1
+    assert timings["max_ms"] == 4_000
+    assert timings["max_ts"] is None
+    assert timings["recent_count"] == 0
+    assert timings["recent_max_ms"] is None
+
+
+def test_an_absent_diagnostics_file_summarizes_to_an_empty_dated_shape(tmp_path: Path) -> None:
+    summary = hook_diagnostic_summary(_state=tmp_path)
+    assert summary["count"] == 0
+    assert summary["recent_count"] == 0
+    assert summary["first_seen"] is None
+    assert summary["last_seen"] is None
+    assert summary["last_event"] is None
+    assert summary["last_reason"] is None
+    assert dict(cast(Mapping[str, object], summary["reasons"])) == {}
+    assert dict(cast(Mapping[str, object], summary["timings"])) == {
+        "count": 0,
+        "last_ms": None,
+        "max_ms": None,
+        "max_ts": None,
+        "recent_count": 0,
+        "recent_max_ms": None,
+    }
 
 
 def test_budget_reason_is_an_admitted_token_and_unknown_reasons_are_closed(

--- a/tests/unit/cli/test_observe_cli.py
+++ b/tests/unit/cli/test_observe_cli.py
@@ -93,7 +93,12 @@ def test_status_separates_undelivered_from_lag_and_reports_ambiguous_activation(
     assert payload["last_successful_drain"] == "never"
     assert payload["mapping_present"] is False
     assert payload["plugin_activation"] == "unknown"
-    assert payload["hook_diagnostics"]["reasons"]["service_unavailable"] == 1
+    unavailable = payload["hook_diagnostics"]["reasons"]["service_unavailable"]
+    assert unavailable["count"] == 1
+    # A live failure reads as live; a stale one is dated instead of tallied (#310).
+    assert unavailable["recent"] == 1
+    assert unavailable["first_seen"] == unavailable["last_seen"]
+    assert payload["hook_diagnostics"]["recent_count"] == 1
 
 
 def test_status_surfaces_quarantine_depth_and_reclaim_empties_it(

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -2005,6 +2005,39 @@ def test_timing_rows_attribute_the_store_stage(tmp_path: Path) -> None:
     assert {"store", "store_hydrate", "store_encode", "store_write"} <= set(stages)
 
 
+def test_timing_rows_partition_the_whole_pass(tmp_path: Path) -> None:
+    """#310/#311: stage sums covered as little as 14% of the reported total."""
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+
+    out = io.BytesIO()
+    code = handle_observe(
+        event_name="Stop",
+        stdin_bytes=json.dumps({"session_id": "partitioned", "tool_name": "shell"}).encode(),
+        stdout=out,
+        workspace=str(tmp_path),
+        _state=tmp_path,
+        skip_service=True,
+    )
+    assert code == 0
+    rows = [
+        cast(dict[str, object], json.loads(line))
+        for line in (tmp_path / "observation/hook-diagnostics.jsonl").read_text().splitlines()
+    ]
+    stages = cast(
+        Mapping[str, int], [row for row in rows if row.get("kind") == "timing"][-1]["stages"]
+    )
+    # The formerly unwindowed regions, plus lock queueing wherever it happened.
+    assert {"resolve", "deliver", "store_lock_wait", "unattributed"} <= set(stages)
+    partition = ("import", "resolve", "store", "drain", "deliver")
+    total = stages["total"]
+    assert sum(stages[name] for name in partition) + stages["unattributed"] >= total - 5
+    # Nothing is left unexplained on an uncontended local pass.
+    assert stages["unattributed"] <= max(5, total // 4)
+
+
 def test_hook_total_budget_covers_the_budgets_nested_inside_one_pass() -> None:
     """The end-to-end contract must be satisfiable by a healthy pass (#288).
 
@@ -2092,6 +2125,8 @@ def test_end_to_end_hook_budget_is_recorded_and_exceeding_it_is_diagnosed(
     assert out.getvalue().endswith(b"\n")
     summary = hook_diagnostic_summary(_state=tmp_path)
     reasons = dict(cast(Mapping[str, object], summary["reasons"]))
-    assert reasons.get("hook_budget_exceeded") == 1
+    budget = dict(cast(Mapping[str, object], reasons["hook_budget_exceeded"]))
+    assert budget["count"] == 1
+    assert budget["recent"] == 1
     timings = dict(cast(Mapping[str, object], summary["timings"]))
     assert timings["count"] == 1


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #310
- Includes the diagnostics-stage work consolidated from #311.
- Duplicate search is recorded on the issue.
- Maintainer acknowledgement: https://github.com/TheGaySupreme123/yoetz/issues/310#issuecomment-5317908881

## Documentation

- Behavior change? yes
- Docs updated: `docs/INTERFACES.md` and `CHANGELOG.md`

## Verification

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit/adapters/test_observation_state_bounds.py tests/unit/adapters/test_observation_store_lock.py tests/unit/cli/test_hook_diagnostics.py tests/unit/cli/test_observe_cli.py tests/unit/cli/test_observe_hooks.py
PYTHONHASHSEED=0 UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit tests/property tests/conformance -m 'not fault and not soak and not live' -q --timeout=120
# 2729 passed
git diff --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check .
npx --no-install pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
```

## Boundaries

- [x] No private drafting inputs are included.
- [x] Every review comment will be dispositioned before merge.

## Summary

Make hook diagnostics recency-legible without discarding history: all-time counts and extrema now carry timestamps beside a one-hour recent window. Resolve `truncated_payload` only after a no-shedding save with real headroom, attribute cross-process lock waits and formerly unwindowed hook regions, and report any remaining wall-time difference explicitly as `unattributed`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recency attribution and timing stage breakdown to hook diagnostics
> - `hook_diagnostic_summary` now pairs all-time failure counts with recent counts (1-hour window), and adds `first_seen`/`last_seen` timestamps and `recent` counts per reason; timing rows gain `max_ts`, `recent_max_ms`, and `recent_count`.
> - The observe pass now records `resolve` and `deliver` stage durations for previously unwindowed regions, and emits an `unattributed` field for any pass wall-time not covered by the partition stages.
> - Store lock wait time is now tracked under a `store_lock_wait` timing key, accumulated by `_InterprocessStoreLock` into the `stage_timings_ms` mapping.
> - The `TRUNCATED_PAYLOAD` coverage gap is now cleared only when a subsequent save evicts nothing and leaves at least 1/8 headroom under the state bound; previously, landing under the bound was sufficient to clear it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 381027e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->