### PR TITLE
Keep status freshness consistent with coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ describes behavior intended for the first release rather than a change from a pr
 
 ### Added
 
+- A `status` item's `freshness` scalar no longer contradicts the `coverage.ledger_freshness` in the
+  same item. A check that declared a coverage gap records `partial` freshness, but the projection
+  reported that only while folding the check itself and reverted to `current` on the next event of
+  any family — a receipt or a re-attach was enough — while the item's coverage kept the gaps. The
+  projection scalar is now derived from the retained check rather than from whichever event is being
+  folded, so it holds `partial` for as long as that check governs, and the compact item reports the
+  weaker of the scalar and its own coverage the way the evidence view already did. An agent reading
+  the summary line is no longer told the ledger is clean while the structured coverage records the
+  gaps (issue #307).
+
 - `provenance_disputed` is a fourth `respond` disposition. It records that the responder contests
   the finding's authorship or provenance premise rather than its conclusion, requires a reason, may
   carry evidence, and is not scored as an evidence-free rejection by either deterministic policy

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -822,6 +822,13 @@ deciding between the two, shared by the receipt and by compact status coverage.
   `freshness` folds staleness under the same supersession rule as
   `kernel/reducers.invalidates_recorded_check`: a readable `response_recorded` answering a finding
   in `latest_tested_state.returned_finding_ids` never by itself marks the ledger stale.
+  `freshness` is a function of carried state alone, never of which event is being folded. Its
+  precedence is unchanged — genesis, `redacted_*` markers, `unknown_event:`/`missing_ref:` markers,
+  supersession — and below those it reports `latest_tested_state.coverage.ledger_freshness`, so a
+  check that recorded `partial` holds the scalar at `partial` for as long as it is the retained
+  check. Only supersession, a redaction removing that check, or a later check replacing it moves
+  the scalar off that value. The scalar therefore cannot read cleaner than the coverage of the
+  very check reported beside it (issue #307).
   `CurrentPlanScope` and `current_plan_scope`, owned by `kernel/plan_scope.py`, are the one shared
   readable-plan-chain derivation consumed by status, check, and receipt: effective obligation refs,
   their declared count, and the current `no_obligations_reason`. A revision applies its obligation
@@ -1199,7 +1206,11 @@ five seconds ahead of acceptance and `ahead_of_forward_skew_allowance` beyond it
 outside clock. Ordering remains ingestion sequence and caller time is never a sort or filter key.
 New check cases carry both clocks and this classification in their bounded frozen timelines;
 versions is one verified runtime manifest; compact uses exact structural counters and bounded
-summaries.
+summaries. The compact singleton's `freshness` follows the same weaker-of-two rule as the evidence
+view: it is the weaker of the projection scalar and the `ledger_freshness` of the applicable-check
+coverage reported in the same item, so the summary line an agent reads can never claim the ledger
+is cleaner than the coverage vector beside it. `StatusCompactItemModel` rejects the inverse
+(issue #307).
 
 Finding response does not resolve. The issue key is `(origin, policy_id, policy_version, kind,
 complete canonical subject_refs)`. A later same-key row supersedes the old and starts unresolved.

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -1006,6 +1006,13 @@ def _projection_items(
                 for obligation in scope_refs
             )
         )
+        item_coverage = compact_status_coverage(records, projection)
+        # The scalar and the coverage beside it are two derivations of one fact: the projection
+        # folds events, the coverage re-folds the applicable check over the newest record's
+        # envelope. An import-channel envelope reads `partial` where the projection reads
+        # `current`, so reporting the projection scalar raw lets the headline read cleaner than
+        # the coverage it summarizes. Report the weaker of the two (issue #307).
+        item_freshness = min(projection.freshness, item_coverage.ledger_freshness)
         return (
             StatusCompactItemModel(
                 task_id=task,
@@ -1023,10 +1030,8 @@ def _projection_items(
                 receipt_blocking_finding_count=str(receipt_blocking_count),
                 open_obligations=open_obligations[:10],
                 unanswered_findings=unanswered_findings[:10],
-                freshness=projection.freshness.value,
-                coverage=CoverageModel.model_validate(
-                    coverage_to_json(compact_status_coverage(records, projection))
-                ),
+                freshness=item_freshness.value,
+                coverage=CoverageModel.model_validate(coverage_to_json(item_coverage)),
                 gaps=_status_gap_codes(projection.coverage_gaps),
             ),
         )

--- a/src/yoetz/kernel/reducers.py
+++ b/src/yoetz/kernel/reducers.py
@@ -717,6 +717,16 @@ def _freshness(
     stale: bool,
     check_freshness: LedgerFreshness | None,
 ) -> LedgerFreshness:
+    """Fold the projection scalar from carried state alone.
+
+    ``check_freshness`` is the retained check's own recorded freshness, not a signal that decays
+    with the event that recorded it: a check that reported ``partial`` coverage keeps the
+    projection at ``partial`` for as long as that check is the retained one. Only supersession
+    (``stale``), a redaction of the check itself, or a later check replacing it may move the
+    scalar off that value, so the scalar can never read cleaner than the coverage of the very
+    check reported beside it (issue #307).
+    """
+
     if frontier == 0:
         return LedgerFreshness.UNKNOWN
     if any(marker.startswith("redacted_") for marker in gaps):
@@ -755,7 +765,6 @@ def reduce_event(
     latest = state.latest_tested_state
     unknown_count = state.unknown_event_count
     stale = state.freshness is LedgerFreshness.STALE_AFTER_MATERIAL_CHANGE
-    check_freshness: LedgerFreshness | None = None
 
     if type(event) is UnknownEvent:
         unknown_count += 1
@@ -878,8 +887,9 @@ def reduce_event(
                     suppressed_count=check.suppressed_count,
                     coverage=check.coverage,
                 )
-                check_freshness = check.coverage.ledger_freshness
-                stale = check_freshness is LedgerFreshness.STALE_AFTER_MATERIAL_CHANGE
+                stale = (
+                    check.coverage.ledger_freshness is LedgerFreshness.STALE_AFTER_MATERIAL_CHANGE
+                )
         elif family == "redaction_recorded":
             event_targets = set(accepted.projection_locator.redaction_target_event_ids)
             object_targets = accepted.projection_locator.redaction_target_object_ids
@@ -948,7 +958,7 @@ def reduce_event(
         frontier,
         coverage_gaps,
         stale=stale,
-        check_freshness=check_freshness,
+        check_freshness=None if latest is None else latest.coverage.ledger_freshness,
     )
     return ProjectionState(
         frontier=frontier,

--- a/src/yoetz/protocol/models.py
+++ b/src/yoetz/protocol/models.py
@@ -2458,6 +2458,12 @@ class StatusCompactItemModel(_ClosedModel):
             raise ValueError("task_omission_category_invalid")
         if len(self.open_obligations) > 10 or len(self.unanswered_findings) > 10:
             raise ValueError("compact_item_limit")
+        # One item carries two statements of freshness: this scalar, which an agent reads off the
+        # summary line, and the coverage vector it stands in for. The scalar may report the
+        # weaker fact but never the cleaner one, or the summary line tells the reader the ledger
+        # is clean while the coverage beside it records the gaps (issue #307).
+        if LedgerFreshness(self.freshness) > self.coverage.ledger_freshness:
+            raise ValueError("compact_freshness_above_coverage")
         _require_unique(self.gaps, limit=64)
         unknown = self.declared_obligation_count is None or self.open_obligation_count is None
         if unknown and (

--- a/tests/integration/application/test_respond_status_receipt.py
+++ b/tests/integration/application/test_respond_status_receipt.py
@@ -1474,6 +1474,73 @@ async def test_check_respond_recheck_reaches_a_fixed_point() -> None:
     assert f"receipt-blocking findings: {item.receipt_blocking_finding_count}" in summary
 
 
+async def test_status_freshness_scalar_survives_immaterial_events() -> None:
+    """Issue #307: a check that declared coverage gaps recorded ``partial`` freshness. The
+    projection scalar reported that only on the event that recorded the check and reverted to
+    ``current`` on the next event of any family, while the item's own
+    ``coverage.ledger_freshness`` kept the gaps. One item then carried two disagreeing freshness
+    fields, and an agent reading the summary line was told the ledger was clean.
+
+    A receipt and a re-attach change nothing but the frontier and the session id, so the retained
+    check still governs and its recorded freshness must still be what the item reports.
+    """
+
+    app, _runtime, _ = _build_app(seed_offset=27)
+    started, checked, _obligation = await _bootstrap_finding(app, seed=1900)
+
+    # `deterministic_only` declines the semantic review, which is a declared coverage gap, so the
+    # check downgraded its own freshness. This is the precondition the bug needs.
+    assert checked.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+    assert "semantic_review_not_requested" in checked.coverage.known_gaps
+
+    def status_wire(seed: int) -> dict[str, JsonValue]:
+        return {
+            **_request_base(protocol_id("req_", seed)),
+            "session_id": started.session_id,
+            "writer_id": started.writer_id,
+            "view": "compact",
+            "limit": "10",
+        }
+
+    status = await app.status(StatusRequest.model_validate(status_wire(1910)))
+    item = cast(StatusCompactPageModel, status.page).items[0]
+    # Immediately after the check both fields already agreed; the bug was never visible here.
+    assert item.freshness == "partial"
+    assert item.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+
+    # A receipt appends one engine-derived `receipt_recorded`. It is not a material family, so it
+    # cannot supersede the check, and nothing in the ledger changed except the frontier.
+    receipt = await app.receipt(
+        ReceiptRequest.model_validate(
+            {
+                **_request_base(protocol_id("req_", 1911)),
+                "task_id": started.task_id,
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": _frontier(checked.result_frontier),
+                "format": "json",
+                "include": "standard",
+                "redaction_profile": "full_local",
+            }
+        )
+    )
+    assert "check_not_applicable" not in receipt.coverage.known_gaps
+
+    after_receipt = await app.status(StatusRequest.model_validate(status_wire(1912)))
+    item_after = cast(StatusCompactPageModel, after_receipt.page).items[0]
+    # The retained check still carries the gaps, so the scalar still has to report them.
+    assert item_after.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+    assert "semantic_review_not_requested" in item_after.coverage.known_gaps
+    assert item_after.freshness == "partial"
+    assert item_after.freshness == item_after.coverage.ledger_freshness.value
+
+    # The summary line an agent reads is derived from the scalar, so it must not read clean while
+    # the structured coverage beside it records the gaps.
+    summary = summary_for_status(after_receipt.as_json())
+    assert "freshness: partial" in summary
+    assert "freshness: current" not in summary
+
+
 def _receipt_wire(
     request_seed: int,
     *,

--- a/tests/unit/kernel/test_reducers_each_family.py
+++ b/tests/unit/kernel/test_reducers_each_family.py
@@ -27,6 +27,7 @@ from yoetz.domain.values import (
     ActorType,
     actor_id,
     event_id,
+    finding_id,
     freeze_json,
     object_id,
     request_id,
@@ -49,6 +50,7 @@ from yoetz.protocol.canonical import entry_digest
 from yoetz.protocol.coverage import (
     AuthorshipAssurance,
     Coverage,
+    LedgerFreshness,
     PublicationChannel,
     coverage_from_json,
 )
@@ -439,3 +441,113 @@ def test_missing_evidence_index_association_is_projection_corruption() -> None:
     )
     with pytest.raises(ValueError, match="projection_corrupt"):
         reduce_event(state, records[7], corrupt)
+
+
+def _check_with_partial_coverage(
+    records: tuple[LedgerRecord, ...],
+    *,
+    returned: tuple[Any, ...] | None = None,
+) -> tuple[LedgerRecord, ...]:
+    """Rewrite the fixture's ``check_recorded`` to the coverage a gap-declaring check records.
+
+    ``application/check.py`` downgrades a check's own ``ledger_freshness`` to ``partial`` when the
+    check declares a coverage gap — a declined semantic review, for instance. No reviewed replay
+    fixture carries such a check, so the projection's handling of one is rewritten here rather
+    than by editing a frozen fixture. ``returned`` overrides the check's returned findings, which
+    is what decides whether the fixture's later response supersedes it.
+    """
+
+    from yoetz.domain.events import encode_payload
+    from yoetz.protocol.canonical import canonical_digest
+
+    rewritten: list[LedgerRecord] = []
+    for record in records:
+        if record.schema.name != "check_recorded":
+            rewritten.append(record)
+            continue
+        accepted = cast(AcceptedEvent, record)
+        payload = cast(Any, accepted.payload)
+        coverage = replace(
+            payload.coverage,
+            ledger_freshness=LedgerFreshness.PARTIAL,
+            known_gaps=("semantic_review_not_requested",),
+        )
+        rewired = replace(payload, coverage=coverage)
+        if returned is not None:
+            rewired = replace(rewired, returned_finding_ids=returned)
+        rewritten.append(
+            replace(
+                accepted,
+                payload=rewired,
+                projection_locator=replace(
+                    accepted.projection_locator,
+                    canonical_payload_digest=canonical_digest(encode_payload(rewired)),
+                ),
+            )
+        )
+    return tuple(rewritten)
+
+
+def test_retained_check_freshness_outlives_the_event_that_recorded_it() -> None:
+    """Issue #307: the projection scalar reported a gap-declaring check's ``partial`` freshness
+    only while folding the check itself and reverted to ``current`` on the next event of any
+    family, while ``latest_tested_state.coverage`` kept the gaps. One status item then carried two
+    disagreeing freshness fields.
+
+    The retained check governs the scalar for as long as it is the retained check, so the scalar
+    is now a function of carried state rather than of which event happens to be folding.
+    """
+
+    records = _check_with_partial_coverage(_records("all-event-families"))
+    families = tuple(record.schema.name for record in records)
+    assert families[10] == "check_recorded"
+    # The response answers a finding the check itself returned, so it never supersedes the check;
+    # the receipt's family is not material at all. Neither may clear the recorded gaps.
+    assert families[11:13] == ("response_recorded", "receipt_recorded")
+
+    at_check = replay(records[:11])
+    assert at_check.latest_tested_state is not None
+    assert at_check.latest_tested_state.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+    assert at_check.freshness is LedgerFreshness.PARTIAL
+
+    for through in (12, 13):
+        later = replay(records[:through])
+        retained = later.latest_tested_state
+        assert retained is not None, f"the check must still be retained at {through}"
+        assert retained.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+        # The scalar and the retained check's own coverage are one fact, so they cannot diverge.
+        assert later.freshness is retained.coverage.ledger_freshness
+
+
+def test_material_change_still_outranks_a_retained_partial_check() -> None:
+    """Carrying the check's freshness must not mask supersession: material work published after a
+    ``partial`` check leaves the ledger stale, which is the stronger statement about the same
+    check and the one the receipt applicability rule already makes.
+
+    The fixture's ``response_recorded`` answers a finding the check returned, which is the one
+    material-family record that deliberately does not supersede. Pointing the check at a different
+    finding makes that same record work the check never covered.
+    """
+
+    records = _check_with_partial_coverage(
+        _records("all-event-families"),
+        returned=(finding_id("fnd_20000002-0000-4000-8000-0000000001ff"),),
+    )
+    assert records[11].schema.name == "response_recorded"
+    superseded = replay(records[:12])
+    assert superseded.freshness is LedgerFreshness.STALE_AFTER_MATERIAL_CHANGE
+    # The retained check is untouched; the scalar reports the newer, stronger fact about it.
+    assert superseded.latest_tested_state is not None
+    assert superseded.latest_tested_state.coverage.ledger_freshness is LedgerFreshness.PARTIAL
+
+
+def test_redacting_a_partial_check_clears_its_carried_freshness() -> None:
+    """A redaction that removes the check removes what the scalar was reporting. The projection
+    drops ``latest_tested_state``, so the carried ``partial`` goes with it and the redaction's own
+    marker governs instead of a value with no surviving check behind it.
+    """
+
+    records = _check_with_partial_coverage(_records("all-event-families"))
+    assert records[13].schema.name == "redaction_recorded"
+    redacted = replay(records[:14])
+    assert redacted.freshness is LedgerFreshness.REDACTED_GAP


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #307
- Duplicate search is recorded on the issue.
- Maintainer acknowledgement: https://github.com/TheGaySupreme123/yoetz/issues/307#issuecomment-5317908919

## Documentation

- Behavior change? yes
- Docs updated: `docs/INTERFACES.md` and `CHANGELOG.md`

## Verification

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/integration/application/test_respond_status_receipt.py tests/unit/kernel/test_reducers_each_family.py
PYTHONHASHSEED=0 UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit tests/property tests/conformance -m 'not fault and not soak and not live' -q --timeout=120
# 2723 passed
git diff --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check .
npx --no-install pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
```

## Boundaries

- [x] No private drafting inputs are included.
- [x] Every review comment will be dispositioned before merge.

## Summary

Carry the retained check's recorded freshness across later immaterial events and report the weaker of projection and applicable-check coverage in compact status. Add protocol validation preventing a compact freshness scalar from reading cleaner than its adjacent coverage vector, with integration coverage through receipt creation and reducer-level supersession/redaction cases.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status freshness scalar to never report cleaner than coverage
> - `ProjectionState.freshness` now derives from the retained check's coverage (`latest.coverage.ledger_freshness`) rather than the currently folded event, preventing the scalar from flipping to `current` on immaterial events while a partial check remains retained.
> - Compact status items now set `freshness = min(projection.freshness, item_coverage.ledger_freshness)`, ensuring the scalar is never cleaner than the accompanying coverage.
> - `StatusCompactItemModel` adds a validator that rejects items where scalar freshness exceeds coverage `ledger_freshness`, enforcing the invariant at the model level.
> - Integration and unit tests cover the retained-check freshness lifecycle, material-change precedence, and redaction clearing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6918c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->