### PR TITLE
Separate observation claims by materialization phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,15 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
+- Correlated Codex `PreToolUse` and `PostToolUse` phases no longer claim one SQLite logical identity
+  with incompatible operation digests. The canonical host-call identity remains the content and
+  ledger-dedup key, while the durable claim key is additionally scoped by the materialization
+  version and exact draft-role tuple; pre-action and paired-result phases therefore cannot collide,
+  and hook/stream copies of the same paired phase still merge to `source_mask == 3`. Claims record
+  the source-independent materialization version rather than the source cursor version. A genuine
+  claim conflict now quarantines only that envelope as `dedup_conflict`; only bundle corruption arms
+  the READY-generation session latch (issue #309).
+
 - The end-to-end hook budget was smaller than the budgets enforced inside a single pass, so
   `hook_budget_exceeded` fired on healthy hooks — 253 of 833 diagnostics on one workspace — and
   carried no signal about the regressions it was added for. The total is now derived from the

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2464,8 +2464,13 @@ Unrecognized visible events accept an opaque stable envelope plus encrypted cont
 `unsupported_event`; unknown semantics never infer success.
 
 Canonical normalization precedes materialization. Equivalent hook/stream host calls share logical
-identity, roles, operation digest, and stable ledger IDs. The logical-identity repository merges a
-two-bit source mask; duplicates retry incomplete content/store/ledger/verification/advice work
+identity, roles, operation digest, and stable ledger IDs. That canonical logical identity remains
+the content and ledger-dedup key. The durable repository claim is separately domain-scoped by the
+materialization mapping version and exact draft-role tuple, so phases of one host call with
+different materializations (for example pre-action versus paired action/result) cannot collide,
+while hook/stream copies of the same phase still share a claim and merge its two-bit source mask.
+The claim stores the source-independent materialization version, never the hook/stream cursor
+version (issue #309). Duplicates retry incomplete content/store/ledger/verification/advice work
 idempotently. Stream cursor advancement occurs only after outbox insertion. Session end is
 generation-scoped; a newer start clears only the old stopped fence. Drain is bounded round-robin
 across workspace sessions under a nonblocking per-workspace lease; within one pass a
@@ -2476,11 +2481,13 @@ Turn-boundary hooks retry auto-attach under a bounded budget and record a payloa
 when no mapping results. Workspace-global rejections (`vault_locked`, disabled, paused) end the pass.
 A `service_unavailable` rejection retires that session's lane for the pass while other sessions
 remain eligible; no later row may step over a failed lane head. Local observation-store acquisition is capped at two
-seconds for both the process-local reentrant lock and the cross-process flock. Coordinator and
+seconds for both the process-local reentrant lock and the cross-process flock. A conflicting
+logical-identity claim rejects and quarantines only its own envelope as `dedup_conflict`; it does
+not establish bundle corruption or arm the session latch (issue #309). Coordinator and
 sweeper calls use separate bounded executors, so cancellation cannot strand an exit-blocking flock
 wait or exhaust the shared default executor. `observation_storage_corrupt` is terminal for its Codex
-session in the current READY generation: the coordinator remembers that session after the first
-bundle `STORAGE_CORRUPT`, later ingests are rejected without reopening the bundle, and the sweeper
+session in the current READY generation: the coordinator remembers that session only after a
+bundle-level `STORAGE_CORRUPT`, later ingests are rejected without reopening the bundle, and the sweeper
 atomically moves that session's pending backlog to quarantine while healthy lanes continue. A new
 READY generation clears the in-memory suppression and permits one recovery probe. A successful
 probe removes that session from the local corruption set and resolves the workspace corruption gap

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -178,9 +178,11 @@ records a private workspace commitment, structural outbox/quarantine evidence, a
 identities—never raw task content or a raw path in logs/status/SQLite.
 
 Hook `PostToolUse` and stream `item.completed` for one host call normalize before materialization to
-the same semantic kind, correlation identity, roles, operation digest, and ledger IDs. A durable
-logical-identity claim merges source coverage and prevents duplicate action/result appends while
-allowing later encrypted content references. Cursor advancement is coupled to durable outbox
+the same semantic kind, correlation identity, roles, operation digest, and ledger IDs. The canonical
+host-call identity remains the content and ledger-dedup key; the durable claim identity additionally
+binds the materialization version and exact draft-role tuple. Thus distinct phases such as
+`PreToolUse` action and paired `PostToolUse` action/result never contend, while hook/stream copies of
+the same phase merge source coverage and prevent duplicate appends (issue #309). Cursor advancement is coupled to durable outbox
 insertion; overflow leaves later stream input replayable. Unsupported visible future events retain
 an opaque envelope, encrypted visible payload when available, and an explicit gap. Session stop is
 source-generation fenced, pending work drains fairly across mapped sessions, and quarantine is bounded by
@@ -190,6 +192,8 @@ operator reclaims counted separately.
 
 An observation route that encounters bundle `STORAGE_CORRUPT` records the exact terminal
 `observation_storage_corrupt` gap and quarantines that Codex session's pending delivery backlog.
+An identity-claim conflict is instead envelope-scoped `dedup_conflict`: it quarantines that row and
+does not arm the generation latch (issue #309).
 The READY-generation coordinator suppresses further recovery attempts for that Codex session so a
 poisoned mapped task cannot starve healthy sessions or ordinary control. The suppression is not a
 durable claim that repair is impossible: composing a new READY generation clears it and permits one

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -34,12 +34,14 @@ from yoetz.application.observation_advice import (
 )
 from yoetz.application.observation_check_policy import load_observation_check_policy
 from yoetz.application.observation_materialize import (
+    MATERIALIZATION_MAPPING_VERSION,
     MaterializedObservationBatch,
     approved_check_author,
     canonical_logical_identity,
     materialize_observation_envelope,
     media_type_for_schema,
     observation_author,
+    observation_claim_identity,
     observation_operation_digest,
     observation_writer_id,
     stable_observation_id,
@@ -541,15 +543,24 @@ class ObservationCoordinator:
                     )
                     if claim is not None:
                         operation_id, materialization_digest, append_result = claim
+                        # The claim key is role-scoped so the phases of one host
+                        # call (pre action, paired result, permission, subagent)
+                        # never contend, and the recorded mapping version is the
+                        # source-independent materialization one so hook/stream
+                        # copies of a phase can union their source masks.
+                        stage = "identity_claim"
                         store.record_logical_identity_claim(
                             workspace=workspace,
-                            logical_identity=canonical_logical_identity(envelope),
+                            logical_identity=observation_claim_identity(
+                                envelope, tuple(item.role for item in batch.drafts)
+                            ),
                             materialization_digest=materialization_digest,
                             operation_id=operation_id,
                             source_mask=1 if envelope.source.value == "codex_hook" else 2,
-                            mapping_version=envelope.cursor.mapping_version,
+                            mapping_version=MATERIALIZATION_MAPPING_VERSION,
                             materialized_at=timestamp_from_datetime(self.clock.now_utc()),
                         )
+                        stage = "ledger_append"
                         if append_result is not None:
                             await self._local(
                                 partial(
@@ -585,6 +596,12 @@ class ObservationCoordinator:
                 if exc.code is PublicErrorCode.VAULT_LOCKED:
                     return _reject(ObservationGapCode.VAULT_LOCKED.value)
                 if exc.code is PublicErrorCode.STORAGE_CORRUPT:
+                    if stage == "identity_claim":
+                        # A conflicting logical-identity claim poisons one
+                        # envelope, not the bundle. ADR-010 scopes the
+                        # generation latch to bundle corruption, so reject just
+                        # this envelope and keep the session observable.
+                        return _reject(ObservationGapCode.DEDUP_CONFLICT.value)
                     self._storage_corrupt_sessions.add(codex_session_id)
                     return _reject(ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
                 if exc.code in {

--- a/src/yoetz/application/observation_materialize.py
+++ b/src/yoetz/application/observation_materialize.py
@@ -62,6 +62,7 @@ __all__ = [
     "MaterializedObservationDraft",
     "canonical_logical_identity",
     "materialize_observation_envelope",
+    "observation_claim_identity",
     "observation_writer_id",
     "stable_observation_id",
 ]
@@ -654,6 +655,29 @@ def canonical_logical_identity(envelope: ObservationEnvelope) -> str:
         return _logical_identity_digest(("opaque", envelope.source.value, envelope.source_identity))
     family = _action_kind(_tool_name(structural)).value
     return _logical_identity_digest(("action", envelope.session_commitment, host_call, family))
+
+
+def observation_claim_identity(envelope: ObservationEnvelope, draft_roles: tuple[str, ...]) -> str:
+    """Return the role-scoped key for one durable logical-identity claim.
+
+    One host call legitimately materializes several role-sets against the same
+    canonical logical identity: hook ``PreToolUse`` (``action``), a paired
+    ``PostToolUse`` (``action`` + ``result``), unpaired evidence, permission and
+    subagent events carrying the call id, and opaque stream phases. Each has its
+    own operation digest, so claims keyed on the bare logical identity conflict
+    with their own siblings. Scoping the claim by roles (and by the mapping
+    version, matching the digest) keeps each phase's claim independent while
+    cross-source copies of the *same* phase still merge their source masks.
+    """
+
+    return _logical_identity_digest(
+        (
+            "claim",
+            MATERIALIZATION_MAPPING_VERSION,
+            canonical_logical_identity(envelope),
+            *draft_roles,
+        )
+    )
 
 
 def _logical_identity_digest(components: tuple[str, ...]) -> str:

--- a/tests/integration/observation/test_production_composition.py
+++ b/tests/integration/observation/test_production_composition.py
@@ -35,7 +35,6 @@ from tests.integration.observation.composition_harness import (
     resolve_production_surface,
     run_unified_setup,
     setup_returns_early_when_mcp_registered,
-    try_import,
 )
 
 from yoetz.adapters.approved_checks import (
@@ -335,6 +334,17 @@ async def test_hook_and_stream_copies_materialize_once(tmp_path: Path) -> None:
     try:
         pipeline.auto_attach("dedupe-1")
         pipeline.observe_hook(
+            "PreToolUse",
+            {
+                "session_id": "dedupe-1",
+                "tool_name": "shell",
+                "tool_call_id": "shared-1",
+                "correlation_id": "shared-1",
+                "event_ordinal": 1,
+            },
+            drain=False,
+        )
+        pipeline.observe_hook(
             "PostToolUse",
             {
                 "session_id": "dedupe-1",
@@ -342,7 +352,7 @@ async def test_hook_and_stream_copies_materialize_once(tmp_path: Path) -> None:
                 "exit_status": 1,
                 "tool_call_id": "shared-1",
                 "correlation_id": "shared-1",
-                "event_ordinal": 1,
+                "event_ordinal": 2,
             },
             drain=False,
         )
@@ -388,12 +398,31 @@ async def test_hook_and_stream_copies_materialize_once(tmp_path: Path) -> None:
         # Dual-source envelopes remain distinct by source_identity until coordinator
         # materializes one logical action/result into the ledger.
         assert second_count >= first_count
-        materialize = try_import(
-            "yoetz.application.observation_coordinator", "materialize_observation"
-        ) or try_import("yoetz.service.observation_coordinator", "materialize_observation")
-        if materialize is not None and second_count > first_count + 0:
-            # Keep the contract visible: materialization must collapse copies when used.
-            assert callable(materialize)
+        from yoetz.application.observation_materialize import (
+            canonical_logical_identity,
+            materialize_observation_envelope,
+            observation_claim_identity,
+        )
+
+        hook_post = next(
+            item
+            for item in pipeline.sqlite.list_envelopes(pipeline.workspace)
+            if item.source is ObservationSource.CODEX_HOOK and item.event_kind == "PostToolUse"
+        )
+        # The hook Post and the stream item.completed for one host call must
+        # collapse to one canonical identity, materialize the same paired
+        # action+result roles, and share one role-scoped claim so the
+        # coordinator appends once and unions source coverage (issue #309).
+        assert canonical_logical_identity(hook_post) == canonical_logical_identity(stream_env)
+
+        def _roles(envelope: ObservationEnvelope) -> tuple[str, ...]:
+            batch = materialize_observation_envelope(envelope, task_id=pipeline.task_id)
+            return tuple(item.role for item in batch.drafts)
+
+        assert _roles(hook_post) == _roles(stream_env) == ("action", "result")
+        assert observation_claim_identity(
+            hook_post, _roles(hook_post)
+        ) == observation_claim_identity(stream_env, _roles(stream_env))
     finally:
         pipeline.close()
 

--- a/tests/unit/adapters/test_sqlite_observation.py
+++ b/tests/unit/adapters/test_sqlite_observation.py
@@ -21,7 +21,7 @@ from yoetz.domain.observation import (
     ObservationStatusQuery,
 )
 from yoetz.domain.values import JsonObject, Timestamp
-from yoetz.protocol.errors import PublicOperationError
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 
 _WORKSPACE = "hmac-sha256:" + "1" * 64
 _SESSION = "hmac-sha256:" + "2" * 64
@@ -109,3 +109,47 @@ def test_sqlite_resume_without_consent_fails() -> None:
             await store.resume(ObservationControlCommand(_WORKSPACE))
 
     asyncio.run(run())
+
+
+def test_record_logical_identity_claim_idempotence_union_and_conflict() -> None:
+    db = apsw.Connection(":memory:")
+    initialize_bundle(db, {"task_id": "task_obs", "owner_generation": "1"})
+    store = SqliteObservationStore(db)
+    logical_identity = "sha256:" + "a" * 64
+    materialization_digest = "sha256:" + "b" * 64
+    operation_id = "op_" + "1" * 32
+    mapping_version = "obs-ledger/1.2.0"
+
+    def record(*, source_mask: int, digest: str = materialization_digest) -> None:
+        store.record_logical_identity_claim(
+            workspace=_WORKSPACE,
+            logical_identity=logical_identity,
+            materialization_digest=digest,
+            operation_id=operation_id,
+            mapping_version=mapping_version,
+            source_mask=source_mask,
+            materialized_at=_TIME,
+        )
+
+    record(source_mask=1)
+    # A replay of the same source is idempotent.
+    record(source_mask=1)
+    # The other source's copy of the same materialization unions coverage.
+    record(source_mask=2)
+    row = db.execute(
+        "SELECT source_mask FROM observation_logical_identity "
+        "WHERE workspace_commitment=? AND logical_identity=?",
+        (_WORKSPACE, logical_identity),
+    ).fetchone()
+    assert row == (3,)
+
+    # A different materialization of the same claim key is corruption.
+    with pytest.raises(PublicOperationError) as conflict:
+        record(source_mask=1, digest="sha256:" + "c" * 64)
+    assert conflict.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert conflict.value.retryable is False
+
+    # Only the two per-source masks are valid inputs; 3 is a stored union.
+    with pytest.raises(PublicOperationError) as invalid:
+        record(source_mask=3)
+    assert invalid.value.code is PublicErrorCode.INVALID_REQUEST

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -2112,3 +2112,284 @@ async def test_control_handlers_accept_ingest_request(tmp_path: Path) -> None:
     )
     result = await handlers[ControlMethod.OBSERVATION_INGEST](body)
     assert result["disposition"] == "accepted"
+
+
+def test_materialization_phases_claim_distinct_role_scoped_identities() -> None:
+    from yoetz.application.observation_materialize import (
+        canonical_logical_identity,
+        observation_claim_identity,
+    )
+
+    session = f"hmac-sha256:{'67' * 32}"
+
+    def _claim(env: ObservationEnvelope) -> str:
+        roles = tuple(
+            item.role for item in materialize_observation_envelope(env, task_id="task_x").drafts
+        )
+        assert roles
+        return observation_claim_identity(env, roles)
+
+    pre = _envelope(session=session, kind="PreToolUse", identity="hook:pre:call-9")
+    post = _envelope(
+        session=session, kind="PostToolUse", identity="hook:post:call-9", exit_status=0
+    )
+    unpaired = _envelope(
+        session=session,
+        kind="PostToolUse",
+        identity="hook:post-unpaired:call-9",
+        exit_status=0,
+        gaps=(ObservationGapCode.UNPAIRED_EVENT.value,),
+    )
+    stream = replace(
+        _envelope(session=session, kind="item.completed", identity="stream:post:call-9"),
+        source=ObservationSource.CODEX_SESSION_STREAM,
+    )
+
+    # One host call, one canonical identity: the content-dedup key is unchanged.
+    assert len({canonical_logical_identity(env) for env in (pre, post, unpaired, stream)}) == 1
+    # The pre-action, paired-result, and unpaired-evidence phases never contend
+    # for one claim row (issue #309), while cross-source copies of the same
+    # phase still share theirs so the source-mask union stays reachable.
+    assert _claim(pre) != _claim(post)
+    assert _claim(unpaired) != _claim(post)
+    assert _claim(post) == _claim(stream)
+
+
+def _mapped_local(
+    tmp_path: Path, codex_id: str
+) -> tuple[LocalObservationStore, str, str, LifecycleMapping]:
+    local = LocalObservationStore(_state=tmp_path)
+    workspace = local.workspace_commitment(str(tmp_path.resolve()))
+    local.grant_consent(workspace)
+    session = local.bind_codex_session(workspace, codex_id)
+    mapping = LifecycleMapping(
+        mapping_version=1,
+        codex_session_id=codex_id,
+        yoetz_task_id=_task_id(),
+        yoetz_session_id=PREFIX_BY_KIND[IdKind.SESSION] + str(uuid.uuid4()),
+        yoetz_writer_id=PREFIX_BY_KIND[IdKind.WRITER] + str(uuid.uuid4()),
+        last_frontier=None,
+    )
+    return local, workspace, session, mapping
+
+
+@pytest.mark.anyio
+async def test_pre_post_and_stream_copies_claim_without_storage_corrupt(tmp_path: Path) -> None:
+    """Regression for issue #309 against the real SQLite claim repository.
+
+    A Pre/Post pair for one ``tool_call_id`` must both materialize without
+    ``STORAGE_CORRUPT``, and a hook/stream copy of the paired result must merge
+    to ``source_mask == 3``.
+    """
+
+    from types import SimpleNamespace
+
+    import apsw
+
+    from yoetz.application.observation_materialize import (
+        canonical_logical_identity as _identity,
+    )
+    from yoetz.application.observation_materialize import (
+        observation_operation_digest as _digest,
+    )
+
+    local, _workspace, session, mapping = _mapped_local(tmp_path, "claim-repro-309")
+    db = apsw.Connection(":memory:")
+    initialize_bundle(db, {"task_id": mapping.yoetz_task_id, "owner_generation": "1"})
+    store = SqliteObservationStore(db)
+    runtime = SimpleNamespace(
+        task_id=mapping.yoetz_task_id,
+        session_id=mapping.yoetz_session_id,
+        writer_id=observation_writer_id(mapping.yoetz_task_id, mapping.yoetz_session_id),
+        observation=store,
+    )
+
+    class _RuntimePort:
+        async def route(self, command: object) -> object:
+            del command
+            return runtime
+
+        async def release(self, released: object) -> None:
+            del released
+
+    class _Clock:
+        def now_utc(self) -> datetime:
+            return datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _Coordinator(ObservationCoordinator):
+        async def _capture_content(  # type: ignore[override]
+            self, runtime: object, store: object, **kwargs: object
+        ) -> tuple[tuple[str, ...], bool]:
+            del runtime, store, kwargs
+            return ((), False)
+
+        async def _append_materialized(  # type: ignore[override]
+            self,
+            runtime: object,
+            envelope: ObservationEnvelope,
+            batch: object,
+            *,
+            legacy_writer_id: str | None = None,
+        ) -> tuple[str, str, None]:
+            del legacy_writer_id
+            digest = _digest(
+                task_id=runtime.task_id,  # type: ignore[attr-defined]
+                session_id=runtime.session_id,  # type: ignore[attr-defined]
+                writer_id=runtime.writer_id,  # type: ignore[attr-defined]
+                logical_identity=_identity(envelope),
+                draft_roles=tuple(item.role for item in batch.drafts),  # type: ignore[attr-defined]
+            )
+            return self._stable_operation_id(digest), digest, None
+
+        async def _enqueue_verification(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+            del args, kwargs
+
+        async def _run_advice(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+            del args, kwargs
+
+    coordinator = _Coordinator(
+        runtime=_RuntimePort(),  # type: ignore[arg-type]
+        local=local,
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=object(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+        mapping_loader=lambda *_args, **_kwargs: mapping,  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+
+    pre = _envelope(session=session, kind="PreToolUse", identity="hook:pre:call-309", ordinal=1)
+    post = _envelope(
+        session=session,
+        kind="PostToolUse",
+        identity="hook:post:call-309",
+        ordinal=2,
+        exit_status=0,
+    )
+    stream_post = replace(
+        _envelope(
+            session=session,
+            kind="item.completed",
+            identity="stream:post:call-309",
+            ordinal=3,
+        ),
+        source=ObservationSource.CODEX_SESSION_STREAM,
+    )
+
+    for envelope in (pre, post, stream_post):
+        result = await coordinator.ingest_request(
+            ObservationIngestRequest(codex_session_id="claim-repro-309", envelope=envelope)
+        )
+        assert result.disposition is ObservationIngestDisposition.ACCEPTED, result.reason
+
+    assert not coordinator._storage_corrupt_sessions  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    rows = db.execute(
+        "SELECT source_mask FROM observation_logical_identity ORDER BY source_mask"
+    ).fetchall()
+    # Pre keeps its own hook-only claim; the paired result claim unions hook and
+    # stream coverage into source_mask == 3 (previously dead code, issue #309).
+    assert [row[0] for row in rows] == [1, 3]
+
+
+@pytest.mark.anyio
+async def test_identity_claim_conflict_rejects_one_envelope_without_latching(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    local, _workspace, session, mapping = _mapped_local(tmp_path, "claim-conflict-309")
+    ingested: list[str] = []
+
+    class _ConflictStore:
+        def grant_consent(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        def bind_session(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        async def ingest(self, envelope: ObservationEnvelope) -> ObservationIngestResult:
+            ingested.append(envelope.source_identity)
+            return ObservationIngestResult(
+                ObservationIngestDisposition.ACCEPTED, None, envelope.cursor
+            )
+
+        def record_logical_identity_claim(self, **kwargs: object) -> None:
+            del kwargs
+            raise PublicOperationError(
+                PublicErrorCode.STORAGE_CORRUPT,
+                "Observation logical identity conflicts.",
+                False,
+            )
+
+    runtime = SimpleNamespace(
+        task_id=mapping.yoetz_task_id,
+        session_id=mapping.yoetz_session_id,
+        writer_id=observation_writer_id(mapping.yoetz_task_id, mapping.yoetz_session_id),
+        observation=_ConflictStore(),
+    )
+
+    class _RuntimePort:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def route(self, command: object) -> object:
+            del command
+            self.calls += 1
+            return runtime
+
+        async def release(self, released: object) -> None:
+            del released
+
+    class _Clock:
+        def now_utc(self) -> datetime:
+            return datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _Coordinator(ObservationCoordinator):
+        async def _capture_content(  # type: ignore[override]
+            self, runtime: object, store: object, **kwargs: object
+        ) -> tuple[tuple[str, ...], bool]:
+            del runtime, store, kwargs
+            return ((), False)
+
+        async def _append_materialized(  # type: ignore[override]
+            self, *args: object, **kwargs: object
+        ) -> tuple[str, str, None]:
+            del args, kwargs
+            return ("op_" + "0" * 32, "sha256:" + "ab" * 32, None)
+
+        async def _enqueue_verification(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+            del args, kwargs
+
+        async def _run_advice(self, *args: object, **kwargs: object) -> None:  # type: ignore[override]
+            del args, kwargs
+
+    runtime_port = _RuntimePort()
+    coordinator = _Coordinator(
+        runtime=runtime_port,  # type: ignore[arg-type]
+        local=local,
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=object(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+        mapping_loader=lambda *_args, **_kwargs: mapping,  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+
+    first = await coordinator.ingest_request(
+        ObservationIngestRequest(
+            codex_session_id="claim-conflict-309",
+            envelope=_envelope(session=session, kind="PostToolUse", identity="hook:c1"),
+        )
+    )
+    second = await coordinator.ingest_request(
+        ObservationIngestRequest(
+            codex_session_id="claim-conflict-309",
+            envelope=_envelope(session=session, kind="PostToolUse", identity="hook:c2", ordinal=2),
+        )
+    )
+
+    # A claim conflict rejects only its own envelope as dedup_conflict; the
+    # session is never latched, so the next envelope still reaches the store
+    # (issue #309: one conflict previously quarantined 187 envelopes).
+    assert first.disposition is ObservationIngestDisposition.REJECTED
+    assert first.reason == ObservationGapCode.DEDUP_CONFLICT.value
+    assert second.reason == ObservationGapCode.DEDUP_CONFLICT.value
+    assert runtime_port.calls == 2
+    assert ingested == ["hook:c1", "hook:c2"]
+    assert not coordinator._storage_corrupt_sessions  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001

--- a/tests/unit/application/test_observation_drain.py
+++ b/tests/unit/application/test_observation_drain.py
@@ -95,6 +95,16 @@ def _envelope(session: str, identity: str, ordinal: int) -> ObservationEnvelope:
             ),
             ObservationDrainAction.QUARANTINE,
         ),
+        (
+            # A logical-identity claim conflict quarantines exactly one row
+            # (issue #309); only observation_storage_corrupt retires a session.
+            ObservationIngestResult(
+                ObservationIngestDisposition.REJECTED,
+                ObservationGapCode.DEDUP_CONFLICT.value,
+                None,
+            ),
+            ObservationDrainAction.QUARANTINE,
+        ),
     ],
 )
 def test_route_observation_ingest_is_pure(
@@ -785,3 +795,39 @@ async def test_sweep_uses_its_own_pool_and_releases_it_on_close(tmp_path: Path) 
 
     sweeper.close()
     assert sweeper._executor is None  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+async def test_sweep_quarantines_single_row_on_dedup_conflict_and_lane_continues(
+    tmp_path: Path,
+) -> None:
+    """Issue #309: a per-envelope claim conflict must not retire the session."""
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    session = store.bind_codex_session(workspace, "session-claim-conflict")
+    conflicted = _envelope(session, "hook:conflicted", 1)
+    healthy = _envelope(session, "hook:healthy", 2)
+    store.enqueue_outbox(workspace, "session-claim-conflict", conflicted)
+    store.enqueue_outbox(workspace, "session-claim-conflict", healthy)
+
+    coordinator = _Coordinator(
+        {
+            conflicted.source_identity: ObservationIngestResult(
+                ObservationIngestDisposition.REJECTED,
+                ObservationGapCode.DEDUP_CONFLICT.value,
+                None,
+            ),
+            healthy.source_identity: ObservationIngestResult(
+                ObservationIngestDisposition.ACCEPTED, None, healthy.cursor
+            ),
+        }
+    )
+    summary = await ObservationOutboxSweeper(store, coordinator).sweep()
+
+    assert summary.attempted == 2
+    assert summary.quarantined == 1
+    assert summary.acknowledged == 1
+    assert store.quarantined_count(workspace) == 1
+    assert store.list_pending_outbox_rows(workspace) == ()


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #309
- Duplicate search is recorded on the issue.
- Maintainer acknowledgement: https://github.com/TheGaySupreme123/yoetz/issues/309#issuecomment-5317908929

## Documentation

- Behavior change? yes
- Docs updated: `docs/adr/ADR-010-harness-integration-port.md`, `docs/INTERFACES.md`, and `CHANGELOG.md`

## Verification

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/integration/observation/test_production_composition.py tests/unit/adapters/test_sqlite_observation.py tests/unit/application/test_observation_coordinator.py tests/unit/application/test_observation_drain.py
PYTHONHASHSEED=0 UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit tests/property tests/conformance -m 'not fault and not soak and not live' -q --timeout=120
# 2726 passed
git diff --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check .
npx --no-install pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
```

## Boundaries

- [x] No private drafting inputs are included.
- [x] Every review comment will be dispositioned before merge.

## Summary

Keep the canonical host-call identity for content and ledger deduplication while scoping durable claims by the materialization version and exact draft-role tuple. This separates legitimate Pre/Post phases, restores hook/stream source-mask union for the same phase, and confines a genuine identity-claim conflict to one quarantined envelope instead of permanently latching the whole session as storage-corrupt.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope observation claims by materialization phase to prevent PreToolUse/PostToolUse conflicts
> - Adds `observation_claim_identity` in [`observation_materialize.py`](https://github.com/TheGaySupreme123/yoetz/pull/316/files#diff-1de83d62d0cc1aefdc476012f9a551f77580154e24747fb3875d6824270f5e2b) that computes a claim key scoped by `MATERIALIZATION_MAPPING_VERSION` and draft-role tuple, distinct from the canonical logical identity used for ledger dedup.
> - PreToolUse and PostToolUse phases now hold separate claim keys, while hook and stream copies of the same phase share a claim and union a two-bit source mask.
> - A conflicting identity claim now rejects only the affected envelope with `DEDUP_CONFLICT` instead of latching the session as `observation_storage_corrupt`; only bundle-level `STORAGE_CORRUPT` still latches the session.
> - Behavioral Change: `dedup_conflict` rejections are quarantined per-envelope by the sweeper; the lane continues processing subsequent rows rather than retiring the session.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de88d1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->