### PR TITLE
Stop frontier-motion notices from re-announcing delivered appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ describes behavior intended for the first release rather than a change from a pr
   task frontier, including the bounded sequence range and observation-record count. The notice map
   is capped, drops ended-session entries, and is reconstructed on retry from a completed append's
   frontier metadata when the local write did not land. A per-session delivered high-water
-  `to_sequence` survives notice deletion so a replayed append is not re-announced. Successful
+  `to_sequence`, scoped to the announced task ledger, survives notice deletion so a replayed
+  append is not re-announced. Successful
   routine reads remain available in the local observation store but are rate-limited out of the
   task ledger; failures, denials, path-qualified executables, and conservatively unrecognized
   commands still materialize normally (issues #244 and #322, ADR-022 amendment).
@@ -459,7 +460,9 @@ carried them; they are listed because each one describes the behavior that now s
   outbox redelivers a committed envelope. The local store keeps a per-session delivered high-water
   `to_sequence` after the hook consumer receives the notice; `note_frontier_motion` drops
   candidates at or behind that mark and clamps overlapping ranges so later genuine motion starts
-  from the announced head and record counts do not double-count (issue #322).
+  from the announced head and record counts do not double-count. The mark is scoped to the
+  announced task ledger: when a session's mapping moves to a different task, the stale mark is
+  discarded rather than silently suppressing the new ledger's motion (issue #322).
 
 - The MCP initialize `instructions` string had no size bound and had grown to 41 KB by inlining
   three guidance documents. Codex copies that string into the `description` of every advertised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,11 @@ describes behavior intended for the first release rather than a change from a pr
 - Cooperative writers now receive a one-shot, coalesced notice when the observation writer moves the
   task frontier, including the bounded sequence range and observation-record count. The notice map
   is capped, drops ended-session entries, and is reconstructed on retry from a completed append's
-  frontier metadata when the local write did not land. Successful routine reads remain available in
-  the local observation store but are rate-limited out of the task ledger; failures, denials,
-  path-qualified executables, and conservatively unrecognized commands still materialize normally
-  (issue #244, ADR-022 amendment).
+  frontier metadata when the local write did not land. A per-session delivered high-water
+  `to_sequence` survives notice deletion so a replayed append is not re-announced. Successful
+  routine reads remain available in the local observation store but are rate-limited out of the
+  task ledger; failures, denials, path-qualified executables, and conservatively unrecognized
+  commands still materialize normally (issues #244 and #322, ADR-022 amendment).
 
 - Consent-based Codex observation activation and durable delivery repair (issues #204 and #205,
   ADR-012 amendment): setup now distinguishes installed hook sources from an active plugin, previews
@@ -453,6 +454,12 @@ carried them; they are listed because each one describes the behavior that now s
   are untested.
 
 ### Fixed
+
+- Frontier-motion notices no longer re-announce already-delivered observation appends when the
+  outbox redelivers a committed envelope. The local store keeps a per-session delivered high-water
+  `to_sequence` after the hook consumer receives the notice; `note_frontier_motion` drops
+  candidates at or behind that mark and clamps overlapping ranges so later genuine motion starts
+  from the announced head and record counts do not double-count (issue #322).
 
 - The MCP initialize `instructions` string had no size bound and had grown to 41 KB by inlining
   three guidance documents. Codex copies that string into the `description` of every advertised

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2538,12 +2538,15 @@ The local observation state also owns a sparse, one-shot `FrontierMotionNotice` 
 `from_sequence`, `to_sequence`, final `head_digest`, and exact accepted observation-record count.
 A newly accepted observation append creates it. Idempotent replay of a completed append
 reconciles a missing pending notice from that append's committed frontier metadata; a still-pending
-notice is coalesced rather than duplicated. The mapping is capped and drops ended-session entries
-before serialization; a malformed stored value is ignored as empty. Contiguous pending notices
-coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after emitting its
-bounded agent context. This context is informational: it neither weakens exact-frontier checks
-nor expands the ADR-022 predicate that permits a cooperative publish to retain a stale frontier
-across observation-authored records.
+notice is coalesced rather than duplicated. After the hook consumer receives the notice bytes, the
+store keeps that session's delivered high-water `to_sequence`. A later replay at or behind that
+mark is dropped; an overlapping candidate is clamped so `from` and record count cover only the
+undelivered remainder. The notice and delivered-mark maps are capped and drop ended-session
+entries before serialization; a malformed stored value is ignored as empty. Contiguous pending
+notices coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after
+emitting its bounded agent context. This context is informational: it neither weakens
+exact-frontier checks nor expands the ADR-022 predicate that permits a cooperative publish to
+retain a stale frontier across observation-authored records.
 
 `hook_observed` (publication channel and artifact-observation class) and `harness_observed`
 authorship require real observation evidence under an active consented observation arm — never a

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2539,9 +2539,12 @@ The local observation state also owns a sparse, one-shot `FrontierMotionNotice` 
 A newly accepted observation append creates it. Idempotent replay of a completed append
 reconciles a missing pending notice from that append's committed frontier metadata; a still-pending
 notice is coalesced rather than duplicated. After the hook consumer receives the notice bytes, the
-store keeps that session's delivered high-water `to_sequence`. A later replay at or behind that
-mark is dropped; an overlapping candidate is clamped so `from` and record count cover only the
-undelivered remainder. The notice and delivered-mark maps are capped and drop ended-session
+store keeps that session's delivered high-water `to_sequence`, scoped to the announced task
+ledger. A later replay at or behind that mark is dropped; an overlapping candidate is clamped so
+`from` and record count cover only the undelivered remainder. A mark recorded for a different
+task never suppresses or clamps: when the session's mapping moves to another task, the stale
+mark and any pending notice for the old task are discarded and announcements restart from the
+new ledger's motion. The notice and delivered-mark maps are capped and drop ended-session
 entries before serialization; a malformed stored value is ignored as empty. Contiguous pending
 notices coalesce, and an advice-safe `PostToolUse` hook consumes the exact notice only after
 emitting its bounded agent context. This context is informational: it neither weakens

--- a/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
@@ -2,13 +2,15 @@
 
 **Status:** Accepted (2026-08-13), recorded for issues #214–#223 and acknowledged in issue #225.
 **Amended:** 2026-08-16 for maintainer-approved issue #224; 2026-08-14 for moderator-approved
-issue #244 and the reopened issue #216 recurrence.
+issue #244 and the reopened issue #216 recurrence; 2026-08-18 for issue #322 (delivered
+frontier-motion high-water).
 **Implemented by:** `src/yoetz/application/observation_materialize.py`,
 `src/yoetz/application/observation_coordinator.py`, `src/yoetz/adapters/memory/ledger.py`,
-`src/yoetz/application/publish_work.py`, `src/yoetz/kernel/policies/observation_advice.py`, and
-`src/yoetz/service/ready_composition.py`.
+`src/yoetz/application/publish_work.py`, `src/yoetz/kernel/policies/observation_advice.py`,
+`src/yoetz/service/ready_composition.py`, and
+`src/yoetz/adapters/integrations/observation_local.py`.
 **Relates to:** ADR-009, ADR-010, ADR-020, and
-issues #214, #216, #217, #223, #224, #225, #226, #227, and #244.
+issues #214, #216, #217, #223, #224, #225, #226, #227, #244, and #322.
 
 **Proposed amendment for issue #231:** `provider_not_ready` remains bounded local advice, but the
 observation coordinator does not materialize it as an agent-facing finding. Provider readiness is a
@@ -98,13 +100,17 @@ unsupported claims and unbounded duplicate findings.
 10. Every newly accepted observation-authored append records one bounded pending frontier-motion
     notice for the originating Codex session. A retry of a completed append whose local notice
     write did not land reconstructs that notice from the committed append's frontier metadata.
-    Contiguous undelivered appends coalesce their from/to sequences and record count. The
-    per-workspace notice map is capped and drops ended-session entries before serialization. A
-    later advice-safe `PostToolUse` hook surfaces that the motion was hook-observed, explains that
-    held cooperative publish frontiers remain admissible only across observation-authored motion,
-    and directs exact-frontier operations to refresh status. The notice is removed only after its
-    bytes reach the hook consumer. It grants no authority, changes no optimistic-concurrency
-    predicate, and adds no MCP operation.
+    After the notice's bytes reach the hook consumer, the store retains that session's delivered
+    high-water `to_sequence` so a later replay of the same append is not re-announced. Candidates
+    at or behind that mark are dropped; overlapping candidates are clamped to the undelivered
+    remainder so `from` and record count describe only motion not yet announced. Contiguous
+    undelivered appends coalesce their from/to sequences and record count. The per-workspace
+    notice and delivered-mark maps are capped and drop ended-session entries before serialization.
+    A later advice-safe `PostToolUse` hook surfaces that the motion was hook-observed, explains
+    that held cooperative publish frontiers remain admissible only across observation-authored
+    motion, and directs exact-frontier operations to refresh status. The pending notice is
+    removed only after its bytes reach the hook consumer. It grants no authority, changes no
+    optimistic-concurrency predicate, and adds no MCP operation.
 
 ## Security and privacy consequences
 

--- a/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
@@ -101,9 +101,12 @@ unsupported claims and unbounded duplicate findings.
     notice for the originating Codex session. A retry of a completed append whose local notice
     write did not land reconstructs that notice from the committed append's frontier metadata.
     After the notice's bytes reach the hook consumer, the store retains that session's delivered
-    high-water `to_sequence` so a later replay of the same append is not re-announced. Candidates
-    at or behind that mark are dropped; overlapping candidates are clamped to the undelivered
-    remainder so `from` and record count describe only motion not yet announced. Contiguous
+    high-water `to_sequence`, scoped to the announced task ledger, so a later replay of the same
+    append is not re-announced. Candidates at or behind that mark are dropped; overlapping
+    candidates are clamped to the undelivered remainder so `from` and record count describe only
+    motion not yet announced. A mark recorded for a different task neither drops nor clamps:
+    when a session's mapping moves to another task, the stale mark and any pending notice for
+    the old task are discarded so the new ledger's motion is announced from its start. Contiguous
     undelivered appends coalesce their from/to sequences and record count. The per-workspace
     notice and delivered-mark maps are capped and drop ended-session entries before serialization.
     A later advice-safe `PostToolUse` hook surfaces that the motion was hook-observed, explains

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -331,12 +331,15 @@ class FrontierMotionNotice:
     to_sequence: int
     head_digest: str
     observation_record_count: int
+    task_id: str
 
     def __post_init__(self) -> None:
         if (
             type(self.from_sequence) is not int
             or type(self.to_sequence) is not int
             or type(self.observation_record_count) is not int
+            or type(self.task_id) is not str
+            or not self.task_id
             or not 0 <= self.from_sequence < self.to_sequence <= _MAX_SAFE_INTEGER
             or not 1 <= self.observation_record_count <= self.to_sequence - self.from_sequence
         ):
@@ -351,6 +354,7 @@ class FrontierMotionNotice:
                     "from_sequence": self.from_sequence,
                     "head_digest": self.head_digest,
                     "observation_record_count": self.observation_record_count,
+                    "task_id": self.task_id,
                     "to_sequence": self.to_sequence,
                 }
             )
@@ -381,6 +385,7 @@ def _clamp_frontier_motion_notice(
         notice.to_sequence,
         notice.head_digest,
         remainder_count,
+        notice.task_id,
     )
 
 
@@ -462,7 +467,7 @@ class _WorkspaceState:
     frontier_motion_notices: dict[str, FrontierMotionNotice] | None = None
     # Last delivered notice ``to_sequence`` per Codex session. Survives notice
     # deletion so a replayed append cannot re-announce already-delivered motion.
-    frontier_motion_delivered: dict[str, int] | None = None
+    frontier_motion_delivered: dict[str, tuple[str, int]] | None = None
     open_pre: dict[str, str] | None = None
     stream_cursors: dict[str, ObservationCursor] | None = None
     stream_partials: dict[str, bytes] | None = None
@@ -574,22 +579,28 @@ def _load_frontier_motion_notices(raw: object) -> dict[str, FrontierMotionNotice
                 cast(int, notice.get("to_sequence")),
                 cast(str, notice.get("head_digest")),
                 cast(int, notice.get("observation_record_count")),
+                cast(str, notice.get("task_id")),
             )
         except ProtocolValueError, TypeError, ValueError:
             continue
     return result
 
 
-def _load_frontier_motion_delivered(raw: object) -> dict[str, int]:
+def _load_frontier_motion_delivered(raw: object) -> dict[str, tuple[str, int]]:
     if not isinstance(raw, Mapping):
         return {}
-    result: dict[str, int] = {}
+    result: dict[str, tuple[str, int]] = {}
     for key, value in cast(Mapping[str, JsonValue], raw).items():
-        if type(key) is not str or type(value) is not int or isinstance(value, bool):
+        if type(key) is not str or not isinstance(value, Mapping):
             continue
-        if not 1 <= value <= _MAX_SAFE_INTEGER:
+        entry = cast(Mapping[str, JsonValue], value)
+        task_id = entry.get("task_id")
+        to_sequence = entry.get("to_sequence")
+        if type(task_id) is not str or not task_id or type(to_sequence) is not int:
             continue
-        result[key] = value
+        if not 1 <= to_sequence <= _MAX_SAFE_INTEGER:
+            continue
+        result[key] = (task_id, to_sequence)
     return result
 
 
@@ -1263,6 +1274,7 @@ class LocalObservationStore:
         to_sequence: int,
         head_digest: str,
         observation_record_count: int,
+        task_id: str,
     ) -> None:
         """Merge contiguous undelivered observation appends into one pending notice."""
 
@@ -1271,15 +1283,30 @@ class LocalObservationStore:
             to_sequence,
             head_digest,
             observation_record_count,
+            task_id,
         )
         with self._lock:
             state = self._load(workspace)
             assert state.frontier_motion_notices is not None
             assert state.frontier_motion_delivered is not None
             notices = state.frontier_motion_notices
-            delivered_to = state.frontier_motion_delivered.get(codex_session_id, 0)
-            prior = notices.get(codex_session_id)
+            delivered = state.frontier_motion_delivered
             mutated = False
+            # The delivered mark is scoped to the task ledger it was announced
+            # for. A session whose mapping moves to another task (or whose
+            # prior ledger was announced under a different task id) must not
+            # have the new ledger's motion suppressed by the old mark.
+            delivered_entry = delivered.get(codex_session_id)
+            if delivered_entry is not None and delivered_entry[0] != task_id:
+                del delivered[codex_session_id]
+                delivered_entry = None
+                mutated = True
+            delivered_to = delivered_entry[1] if delivered_entry is not None else 0
+            prior = notices.get(codex_session_id)
+            if prior is not None and prior.task_id != task_id:
+                del notices[codex_session_id]
+                prior = None
+                mutated = True
             if prior is not None and prior.to_sequence <= delivered_to:
                 del notices[codex_session_id]
                 prior = None
@@ -1294,6 +1321,7 @@ class LocalObservationStore:
                     candidate.to_sequence,
                     candidate.head_digest,
                     prior.observation_record_count + candidate.observation_record_count,
+                    candidate.task_id,
                 )
             elif prior is not None and candidate.to_sequence <= prior.to_sequence:
                 if mutated:
@@ -1328,8 +1356,14 @@ class LocalObservationStore:
             del notices[codex_session_id]
             assert state.frontier_motion_delivered is not None
             delivered = state.frontier_motion_delivered
-            previous = delivered.pop(codex_session_id, 0)
-            delivered[codex_session_id] = max(previous, current.to_sequence)
+            previous = delivered.pop(codex_session_id, None)
+            previous_to = (
+                previous[1] if previous is not None and previous[0] == current.task_id else 0
+            )
+            delivered[codex_session_id] = (
+                current.task_id,
+                max(previous_to, current.to_sequence),
+            )
             self._save(workspace, state)
 
     def advice_snapshot_for(self, workspace: str) -> AdviceSnapshot | None:
@@ -2876,6 +2910,7 @@ class LocalObservationStore:
                             "from_sequence": notice.from_sequence,
                             "head_digest": notice.head_digest,
                             "observation_record_count": notice.observation_record_count,
+                            "task_id": notice.task_id,
                             "to_sequence": notice.to_sequence,
                         }
                     )
@@ -2888,7 +2923,7 @@ class LocalObservationStore:
         if state.frontier_motion_delivered:
             payload["frontier_motion_delivered"] = JsonObject(
                 {
-                    key: value
+                    key: JsonObject({"task_id": value[0], "to_sequence": value[1]})
                     for key, value in sorted(
                         state.frontier_motion_delivered.items(),
                         key=lambda item: item[0].encode(),

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -357,6 +357,33 @@ class FrontierMotionNotice:
         )
 
 
+def _clamp_frontier_motion_notice(
+    notice: FrontierMotionNotice, delivered_to: int
+) -> FrontierMotionNotice | None:
+    """Drop or trim a candidate so it describes only motion past ``delivered_to``."""
+
+    if notice.to_sequence <= delivered_to:
+        return None
+    if notice.from_sequence >= delivered_to:
+        return notice
+    remainder_span = notice.to_sequence - delivered_to
+    original_span = notice.to_sequence - notice.from_sequence
+    if notice.observation_record_count == original_span:
+        remainder_count = remainder_span
+    else:
+        delivered_span = delivered_to - notice.from_sequence
+        remainder_count = min(
+            max(notice.observation_record_count - delivered_span, 1),
+            remainder_span,
+        )
+    return FrontierMotionNotice(
+        delivered_to,
+        notice.to_sequence,
+        notice.head_digest,
+        remainder_count,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class LocalObservationConsent:
     workspace_commitment: str
@@ -433,6 +460,9 @@ class _WorkspaceState:
     session_advice: dict[str, AdviceSnapshot] | None = None
     session_advice_suppression: dict[str, str] | None = None
     frontier_motion_notices: dict[str, FrontierMotionNotice] | None = None
+    # Last delivered notice ``to_sequence`` per Codex session. Survives notice
+    # deletion so a replayed append cannot re-announce already-delivered motion.
+    frontier_motion_delivered: dict[str, int] | None = None
     open_pre: dict[str, str] | None = None
     stream_cursors: dict[str, ObservationCursor] | None = None
     stream_partials: dict[str, bytes] | None = None
@@ -506,6 +536,8 @@ class _WorkspaceState:
             self.session_advice_suppression = {}
         if self.frontier_motion_notices is None:
             self.frontier_motion_notices = {}
+        if self.frontier_motion_delivered is None:
+            self.frontier_motion_delivered = {}
 
 
 def _cursor_key(source: ObservationSource, session_commitment: str) -> str:
@@ -545,6 +577,19 @@ def _load_frontier_motion_notices(raw: object) -> dict[str, FrontierMotionNotice
             )
         except ProtocolValueError, TypeError, ValueError:
             continue
+    return result
+
+
+def _load_frontier_motion_delivered(raw: object) -> dict[str, int]:
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, int] = {}
+    for key, value in cast(Mapping[str, JsonValue], raw).items():
+        if type(key) is not str or type(value) is not int or isinstance(value, bool):
+            continue
+        if not 1 <= value <= _MAX_SAFE_INTEGER:
+            continue
+        result[key] = value
     return result
 
 
@@ -622,6 +667,7 @@ def _copy_state(state: _WorkspaceState) -> _WorkspaceState:
         session_advice=dict(state.session_advice or {}),
         session_advice_suppression=dict(state.session_advice_suppression or {}),
         frontier_motion_notices=dict(state.frontier_motion_notices or {}),
+        frontier_motion_delivered=dict(state.frontier_motion_delivered or {}),
         open_pre=dict(state.open_pre or {}),
         stream_cursors=dict(state.stream_cursors or {}),
         stream_partials=dict(state.stream_partials or {}),
@@ -1218,7 +1264,7 @@ class LocalObservationStore:
         head_digest: str,
         observation_record_count: int,
     ) -> None:
-        """Merge contiguous observation appends into one pending agent notice."""
+        """Merge contiguous undelivered observation appends into one pending notice."""
 
         candidate = FrontierMotionNotice(
             from_sequence,
@@ -1229,7 +1275,19 @@ class LocalObservationStore:
         with self._lock:
             state = self._load(workspace)
             assert state.frontier_motion_notices is not None
-            prior = state.frontier_motion_notices.get(codex_session_id)
+            assert state.frontier_motion_delivered is not None
+            notices = state.frontier_motion_notices
+            delivered_to = state.frontier_motion_delivered.get(codex_session_id, 0)
+            prior = notices.get(codex_session_id)
+            mutated = False
+            if prior is not None and prior.to_sequence <= delivered_to:
+                del notices[codex_session_id]
+                prior = None
+                mutated = True
+            if candidate.to_sequence <= delivered_to:
+                if mutated:
+                    self._save(workspace, state)
+                return
             if prior is not None and prior.to_sequence == candidate.from_sequence:
                 candidate = FrontierMotionNotice(
                     prior.from_sequence,
@@ -1238,8 +1296,15 @@ class LocalObservationStore:
                     prior.observation_record_count + candidate.observation_record_count,
                 )
             elif prior is not None and candidate.to_sequence <= prior.to_sequence:
+                if mutated:
+                    self._save(workspace, state)
                 return
-            state.frontier_motion_notices[codex_session_id] = candidate
+            clamped = _clamp_frontier_motion_notice(candidate, delivered_to)
+            if clamped is None:
+                notices.pop(codex_session_id, None)
+                self._save(workspace, state)
+                return
+            notices[codex_session_id] = clamped
             self._save(workspace, state)
 
     def peek_frontier_motion(
@@ -1261,6 +1326,10 @@ class LocalObservationStore:
             if current is None or current.delivery_identity != delivery_identity:
                 return
             del notices[codex_session_id]
+            assert state.frontier_motion_delivered is not None
+            delivered = state.frontier_motion_delivered
+            previous = delivered.pop(codex_session_id, 0)
+            delivered[codex_session_id] = max(previous, current.to_sequence)
             self._save(workspace, state)
 
     def advice_snapshot_for(self, workspace: str) -> AdviceSnapshot | None:
@@ -2266,19 +2335,29 @@ class LocalObservationStore:
             state.quarantine[:] = kept
 
     def _prune_frontier_motion_notices(self, state: _WorkspaceState) -> None:
-        """Drop ended-session notices and cap the per-workspace mapping."""
+        """Drop ended-session notices and delivered marks; cap both mappings."""
 
-        notices = state.frontier_motion_notices
-        if not notices:
-            return
         ended = state.ended_sessions or set()
         bindings = state.codex_session_bindings or {}
-        for session_id in tuple(notices):
+
+        def _session_ended(session_id: str) -> bool:
             commitment = bindings.get(session_id)
-            if commitment is not None and commitment in ended:
-                del notices[session_id]
-        while len(notices) > _MAX_FRONTIER_MOTION_NOTICES:
-            del notices[next(iter(notices))]
+            return commitment is not None and commitment in ended
+
+        notices = state.frontier_motion_notices
+        if notices:
+            for session_id in tuple(notices):
+                if _session_ended(session_id):
+                    del notices[session_id]
+            while len(notices) > _MAX_FRONTIER_MOTION_NOTICES:
+                del notices[next(iter(notices))]
+        delivered = state.frontier_motion_delivered
+        if delivered:
+            for session_id in tuple(delivered):
+                if _session_ended(session_id):
+                    del delivered[session_id]
+            while len(delivered) > _MAX_FRONTIER_MOTION_NOTICES:
+                del delivered[next(iter(delivered))]
 
     def _encode_state(self, workspace_commitment: str, state: _WorkspaceState) -> bytes:
         """Encode one state to its on-disk bytes, attributing the cost (#290)."""
@@ -2326,6 +2405,7 @@ class LocalObservationStore:
         path = self._workspace_path(workspace_commitment)
         quarantined_before = len(state.quarantine or ())
         notices_before = len(state.frontier_motion_notices or ())
+        delivered_before = len(state.frontier_motion_delivered or ())
         self._prune_expired_quarantine(state)
         self._prune_frontier_motion_notices(state)
         partials_dropped = self._drop_oversized_stream_partials(state)
@@ -2334,6 +2414,7 @@ class LocalObservationStore:
             and not partials_dropped
             and len(state.quarantine or ()) == quarantined_before
             and len(state.frontier_motion_notices or ()) == notices_before
+            and len(state.frontier_motion_delivered or ()) == delivered_before
         ):
             payload = projected
         else:
@@ -2804,6 +2885,16 @@ class LocalObservationStore:
                     )
                 }
             )
+        if state.frontier_motion_delivered:
+            payload["frontier_motion_delivered"] = JsonObject(
+                {
+                    key: value
+                    for key, value in sorted(
+                        state.frontier_motion_delivered.items(),
+                        key=lambda item: item[0].encode(),
+                    )
+                }
+            )
         if state.stream_partial_dropped_sessions:
             payload["stream_partial_dropped_sessions"] = tuple(
                 sorted(state.stream_partial_dropped_sessions, key=str.encode)
@@ -3066,6 +3157,9 @@ class LocalObservationStore:
             raw_quarantine_reclaimed_count if type(raw_quarantine_reclaimed_count) is int else 0
         )
         frontier_motion_notices = _load_frontier_motion_notices(raw.get("frontier_motion_notices"))
+        frontier_motion_delivered = _load_frontier_motion_delivered(
+            raw.get("frontier_motion_delivered")
+        )
         return _WorkspaceState(
             consent=consent,
             session_workspaces=session_workspaces,
@@ -3090,6 +3184,7 @@ class LocalObservationStore:
                 if type(key) is str and type(value) is str
             },
             frontier_motion_notices=frontier_motion_notices,
+            frontier_motion_delivered=frontier_motion_delivered,
             open_pre=open_pre,
             stream_cursors=stream_cursors,
             stream_partials=stream_partials,

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -571,6 +571,7 @@ class ObservationCoordinator:
                                     to_sequence=append_result.result_frontier.sequence,
                                     head_digest=append_result.result_frontier.head_digest,
                                     observation_record_count=len(append_result.accepted),
+                                    task_id=runtime.task_id,
                                 )
                             )
 

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -395,6 +395,7 @@ def test_frontier_motion_notice_merges_contiguous_appends_and_is_one_shot(
         to_sequence=9,
         head_digest="sha256:" + "1" * 64,
         observation_record_count=2,
+        task_id="tsk-frontier-test",
     )
     store.note_frontier_motion(
         workspace,
@@ -403,6 +404,7 @@ def test_frontier_motion_notice_merges_contiguous_appends_and_is_one_shot(
         to_sequence=10,
         head_digest="sha256:" + "2" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
 
     reloaded = LocalObservationStore(_state=tmp_path)
@@ -430,6 +432,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         to_sequence=81,
         head_digest="sha256:" + "7" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     notice = store.peek_frontier_motion(workspace, "replay-session")
     assert notice is not None
@@ -444,6 +447,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         to_sequence=81,
         head_digest="sha256:" + "7" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     assert reloaded.peek_frontier_motion(workspace, "replay-session") is None
 
@@ -454,6 +458,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         to_sequence=92,
         head_digest="sha256:" + "8" * 64,
         observation_record_count=12,
+        task_id="tsk-frontier-test",
     )
     clamped = reloaded.peek_frontier_motion(workspace, "replay-session")
     assert clamped is not None
@@ -471,6 +476,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         to_sequence=92,
         head_digest="sha256:" + "8" * 64,
         observation_record_count=11,
+        task_id="tsk-frontier-test",
     )
     assert reloaded.peek_frontier_motion(workspace, "replay-session") is None
 
@@ -481,6 +487,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         to_sequence=105,
         head_digest="sha256:" + "9" * 64,
         observation_record_count=13,
+        task_id="tsk-frontier-test",
     )
     advanced = reloaded.peek_frontier_motion(workspace, "replay-session")
     assert advanced is not None
@@ -489,6 +496,88 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         105,
         13,
     )
+
+
+def test_frontier_motion_delivered_mark_is_scoped_to_the_announced_task(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.note_frontier_motion(
+        workspace,
+        "remap-session",
+        from_sequence=220,
+        to_sequence=221,
+        head_digest="sha256:" + "c" * 64,
+        observation_record_count=1,
+        task_id="tsk-original",
+    )
+    original = store.peek_frontier_motion(workspace, "remap-session")
+    assert original is not None
+    store.commit_frontier_motion_delivery(workspace, "remap-session", original.delivery_identity)
+
+    # The session's mapping moves to a fresh task whose ledger restarts at a
+    # low sequence. The old task's delivered mark must not suppress it.
+    reloaded = LocalObservationStore(_state=tmp_path)
+    reloaded.note_frontier_motion(
+        workspace,
+        "remap-session",
+        from_sequence=0,
+        to_sequence=5,
+        head_digest="sha256:" + "d" * 64,
+        observation_record_count=5,
+        task_id="tsk-remapped",
+    )
+    remapped = reloaded.peek_frontier_motion(workspace, "remap-session")
+    assert remapped is not None
+    assert (remapped.from_sequence, remapped.to_sequence, remapped.observation_record_count) == (
+        0,
+        5,
+        5,
+    )
+    reloaded.commit_frontier_motion_delivery(workspace, "remap-session", remapped.delivery_identity)
+
+    # Replay suppression still works for the task now owning the mark.
+    reloaded.note_frontier_motion(
+        workspace,
+        "remap-session",
+        from_sequence=0,
+        to_sequence=5,
+        head_digest="sha256:" + "d" * 64,
+        observation_record_count=5,
+        task_id="tsk-remapped",
+    )
+    assert reloaded.peek_frontier_motion(workspace, "remap-session") is None
+
+    # A pending undelivered notice for the old task is replaced, not merged,
+    # when the next announcement belongs to a different task.
+    reloaded.note_frontier_motion(
+        workspace,
+        "pending-remap-session",
+        from_sequence=10,
+        to_sequence=12,
+        head_digest="sha256:" + "e" * 64,
+        observation_record_count=2,
+        task_id="tsk-original",
+    )
+    reloaded.note_frontier_motion(
+        workspace,
+        "pending-remap-session",
+        from_sequence=12,
+        to_sequence=15,
+        head_digest="sha256:" + "f" * 64,
+        observation_record_count=3,
+        task_id="tsk-remapped",
+    )
+    replaced = reloaded.peek_frontier_motion(workspace, "pending-remap-session")
+    assert replaced is not None
+    assert (replaced.from_sequence, replaced.to_sequence, replaced.observation_record_count) == (
+        12,
+        15,
+        3,
+    )
+    assert replaced.task_id == "tsk-remapped"
 
 
 def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
@@ -505,6 +594,7 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
         to_sequence=2,
         head_digest="sha256:" + "4" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     state_path = store._workspace_path(workspace)  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
     raw = json.loads(state_path.read_text(encoding="utf-8"))
@@ -525,6 +615,7 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
         to_sequence=3,
         head_digest="sha256:" + "5" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     store.note_session_end(workspace, ended)
     assert store.peek_frontier_motion(workspace, "ended-session") is None
@@ -537,6 +628,7 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
         to_sequence=4,
         head_digest="sha256:" + "a" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     delivered_notice = store.peek_frontier_motion(workspace, "ended-delivered")
     assert delivered_notice is not None
@@ -556,6 +648,7 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
         to_sequence=5,
         head_digest="sha256:" + "b" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     malformed_notice = store.peek_frontier_motion(workspace, "malformed-delivered")
     assert malformed_notice is not None
@@ -573,6 +666,7 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
         to_sequence=5,
         head_digest="sha256:" + "b" * 64,
         observation_record_count=1,
+        task_id="tsk-frontier-test",
     )
     replayed = broken.peek_frontier_motion(workspace, "malformed-delivered")
     assert replayed is not None
@@ -593,6 +687,7 @@ def test_frontier_motion_notices_are_capped(tmp_path: Path) -> None:
             to_sequence=index + 2,
             head_digest=digest,
             observation_record_count=1,
+            task_id="tsk-frontier-test",
         )
     reloaded = LocalObservationStore(_state=tmp_path)
     surviving = [

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -462,9 +462,7 @@ def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_fro
         92,
         11,
     )
-    reloaded.commit_frontier_motion_delivery(
-        workspace, "replay-session", clamped.delivery_identity
-    )
+    reloaded.commit_frontier_motion_delivery(workspace, "replay-session", clamped.delivery_identity)
 
     reloaded.note_frontier_motion(
         workspace,

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -417,6 +417,82 @@ def test_frontier_motion_notice_merges_contiguous_appends_and_is_one_shot(
     assert reloaded.peek_frontier_motion(workspace, "motion-session") is None
 
 
+def test_frontier_motion_renote_after_delivery_drops_replay_and_clamps_stale_from(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.note_frontier_motion(
+        workspace,
+        "replay-session",
+        from_sequence=80,
+        to_sequence=81,
+        head_digest="sha256:" + "7" * 64,
+        observation_record_count=1,
+    )
+    notice = store.peek_frontier_motion(workspace, "replay-session")
+    assert notice is not None
+    store.commit_frontier_motion_delivery(workspace, "replay-session", notice.delivery_identity)
+    assert store.peek_frontier_motion(workspace, "replay-session") is None
+
+    reloaded = LocalObservationStore(_state=tmp_path)
+    reloaded.note_frontier_motion(
+        workspace,
+        "replay-session",
+        from_sequence=80,
+        to_sequence=81,
+        head_digest="sha256:" + "7" * 64,
+        observation_record_count=1,
+    )
+    assert reloaded.peek_frontier_motion(workspace, "replay-session") is None
+
+    reloaded.note_frontier_motion(
+        workspace,
+        "replay-session",
+        from_sequence=80,
+        to_sequence=92,
+        head_digest="sha256:" + "8" * 64,
+        observation_record_count=12,
+    )
+    clamped = reloaded.peek_frontier_motion(workspace, "replay-session")
+    assert clamped is not None
+    assert (clamped.from_sequence, clamped.to_sequence, clamped.observation_record_count) == (
+        81,
+        92,
+        11,
+    )
+    reloaded.commit_frontier_motion_delivery(
+        workspace, "replay-session", clamped.delivery_identity
+    )
+
+    reloaded.note_frontier_motion(
+        workspace,
+        "replay-session",
+        from_sequence=81,
+        to_sequence=92,
+        head_digest="sha256:" + "8" * 64,
+        observation_record_count=11,
+    )
+    assert reloaded.peek_frontier_motion(workspace, "replay-session") is None
+
+    reloaded.note_frontier_motion(
+        workspace,
+        "replay-session",
+        from_sequence=92,
+        to_sequence=105,
+        head_digest="sha256:" + "9" * 64,
+        observation_record_count=13,
+    )
+    advanced = reloaded.peek_frontier_motion(workspace, "replay-session")
+    assert advanced is not None
+    assert (advanced.from_sequence, advanced.to_sequence, advanced.observation_record_count) == (
+        92,
+        105,
+        13,
+    )
+
+
 def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
     tmp_path: Path,
 ) -> None:
@@ -454,6 +530,55 @@ def test_frontier_motion_notices_ignore_malformed_and_prune_ended_sessions(
     )
     store.note_session_end(workspace, ended)
     assert store.peek_frontier_motion(workspace, "ended-session") is None
+
+    delivered_session = store.bind_codex_session(workspace, "ended-delivered")
+    store.note_frontier_motion(
+        workspace,
+        "ended-delivered",
+        from_sequence=3,
+        to_sequence=4,
+        head_digest="sha256:" + "a" * 64,
+        observation_record_count=1,
+    )
+    delivered_notice = store.peek_frontier_motion(workspace, "ended-delivered")
+    assert delivered_notice is not None
+    store.commit_frontier_motion_delivery(
+        workspace, "ended-delivered", delivered_notice.delivery_identity
+    )
+    store.note_session_end(workspace, delivered_session)
+    raw_after_end = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "ended-delivered" not in (raw_after_end.get("frontier_motion_delivered") or {})
+
+    store.grant_consent(workspace)
+    store.bind_codex_session(workspace, "malformed-delivered")
+    store.note_frontier_motion(
+        workspace,
+        "malformed-delivered",
+        from_sequence=4,
+        to_sequence=5,
+        head_digest="sha256:" + "b" * 64,
+        observation_record_count=1,
+    )
+    malformed_notice = store.peek_frontier_motion(workspace, "malformed-delivered")
+    assert malformed_notice is not None
+    store.commit_frontier_motion_delivery(
+        workspace, "malformed-delivered", malformed_notice.delivery_identity
+    )
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    raw["frontier_motion_delivered"] = []
+    state_path.write_text(json.dumps(raw), encoding="utf-8")
+    broken = LocalObservationStore(_state=tmp_path)
+    broken.note_frontier_motion(
+        workspace,
+        "malformed-delivered",
+        from_sequence=4,
+        to_sequence=5,
+        head_digest="sha256:" + "b" * 64,
+        observation_record_count=1,
+    )
+    replayed = broken.peek_frontier_motion(workspace, "malformed-delivered")
+    assert replayed is not None
+    assert (replayed.from_sequence, replayed.to_sequence) == (4, 5)
 
 
 def test_frontier_motion_notices_are_capped(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -283,6 +283,52 @@ def test_post_tool_hook_delivers_pending_frontier_motion_once(tmp_path: Path) ->
     )
     assert "task frontier moved" not in second.getvalue().decode()
 
+    store.note_frontier_motion(
+        workspace,
+        "frontier-motion",
+        from_sequence=4,
+        to_sequence=6,
+        head_digest="sha256:" + "3" * 64,
+        observation_record_count=2,
+    )
+    replayed = io.BytesIO()
+    assert (
+        handle_observe(
+            event_name="PostToolUse",
+            stdin_bytes=payload,
+            stdout=replayed,
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+    assert "task frontier moved" not in replayed.getvalue().decode()
+
+    store.note_frontier_motion(
+        workspace,
+        "frontier-motion",
+        from_sequence=6,
+        to_sequence=8,
+        head_digest="sha256:" + "4" * 64,
+        observation_record_count=2,
+    )
+    advanced = io.BytesIO()
+    assert (
+        handle_observe(
+            event_name="PostToolUse",
+            stdin_bytes=payload,
+            stdout=advanced,
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+    advanced_context = json.loads(advanced.getvalue())["hookSpecificOutput"]["additionalContext"]
+    assert "task frontier moved from 6 to 8" in advanced_context
+    assert "observation writer appended 2 ledger record(s)" in advanced_context
+
 
 def test_stdout_teardown_failure_exits_zero_and_records_diagnostic(tmp_path: Path) -> None:
     class _ClosedStdout(io.BytesIO):

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -247,6 +247,7 @@ def test_post_tool_hook_delivers_pending_frontier_motion_once(tmp_path: Path) ->
         to_sequence=6,
         head_digest="sha256:" + "3" * 64,
         observation_record_count=2,
+        task_id="tsk-frontier-test",
     )
 
     payload = json.dumps(
@@ -290,6 +291,7 @@ def test_post_tool_hook_delivers_pending_frontier_motion_once(tmp_path: Path) ->
         to_sequence=6,
         head_digest="sha256:" + "3" * 64,
         observation_record_count=2,
+        task_id="tsk-frontier-test",
     )
     replayed = io.BytesIO()
     assert (
@@ -312,6 +314,7 @@ def test_post_tool_hook_delivers_pending_frontier_motion_once(tmp_path: Path) ->
         to_sequence=8,
         head_digest="sha256:" + "4" * 64,
         observation_record_count=2,
+        task_id="tsk-frontier-test",
     )
     advanced = io.BytesIO()
     assert (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: `Fixes #322`
- I searched existing issues and PRs for duplicates before opening this PR. No open PR covered notice duplication/staleness. Related but distinct: #244 (channel introduction), #310 (`hook_diagnostics` tally), #320 (`FRONTIER_CONFLICT` livelock).
- This change is not design-gated. It is a bug fix to the existing #244 channel. The owner filed a concrete mechanism and preferred the delivered high-water direction. ADR-022 decision 10 is amended in this change.

## Documentation

- Behavior change? `yes`
- Docs updated: ADR-022 decision 10, `docs/INTERFACES.md` local observation notice paragraph, `CHANGELOG.md`.

## Verification

Commands run (paste):

```text
uv sync
uv run pytest tests/unit/application/test_observation_coordinator.py tests/unit/cli/test_observe_hooks.py -q --tb=short
# 115 passed
uv run ruff check src/yoetz/adapters/integrations/observation_local.py tests/unit/application/test_observation_coordinator.py tests/unit/cli/test_observe_hooks.py
# All checks passed
npx --no-install pyright src/yoetz/adapters/integrations/observation_local.py tests/unit/application/test_observation_coordinator.py tests/unit/cli/test_observe_hooks.py
# 0 errors, 0 warnings, 0 informations
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [ ] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

The #244 frontier-motion channel re-announced historical motion when an already-committed observation envelope was redelivered. After `commit_frontier_motion_delivery` deleted the pending notice, the delivered head was lost, so a replay landed as a fresh notice and later genuine motion chain-merged onto it (stale `from`, double-counted records).

This keeps crash-recovery (a motion whose note was lost before delivery is still reconstructed) but persists a per-session delivered high-water `to_sequence`. `note_frontier_motion` drops candidates at or behind that mark and clamps overlapping ranges to the undelivered remainder so notices stay monotonic and counts partition observation appends.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf542437-cf8b-44bf-9b70-cc8a5d4f9709?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf542437-cf8b-44bf-9b70-cc8a5d4f9709&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop frontier-motion notices from re-announcing already-delivered appends
> - Introduces a per-session delivered high-water mark (`frontier_motion_delivered`) in [`observation_local.py`](https://github.com/TheGaySupreme123/yoetz/pull/327/files#diff-dcc1feb8bc7f834d09056738e52fec58f85bdd06640418a241feda997cb5be82) that persists across restarts and advances monotonically on each successful delivery.
> - Adds `_clamp_frontier_motion_notice` to trim or drop incoming notices that overlap or fall entirely within the already-delivered range, preserving accurate record counts for partial overlaps.
> - `note_frontier_motion` now checks the high-water mark before storing a candidate, dropping replays and clamping overlapping notices to the undelivered remainder.
> - Pruning extended to also evict delivered-mark entries for ended sessions and cap the map size to prevent unbounded growth.
> - Behavioral Change: notices replayed at or behind the delivered high-water are silently dropped rather than re-announced; overlapping notices are clamped so record counts reflect only undelivered sequences.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10275e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->