### PR TITLE
Classify receipt object-store faults instead of INTERNAL_ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,6 +464,12 @@ carried them; they are listed because each one describes the behavior that now s
   announced task ledger: when a session's mapping moves to a different task, the stale mark is
   discarded rather than silently suppressing the new ledger's motion (issue #322).
 
+- Receipt replay of a completed `request_id` no longer collapses a failed object verification
+  (tampered or missing envelope, wrong key slot, or I/O while reading) into non-retryable
+  `INTERNAL_ERROR`. That path now returns `STORAGE_CORRUPT` with the stored-receipt-invalid
+  family. Pre-append object `stage`/`finalize` I/O on a fresh receipt is retryable
+  `STORAGE_UNSAFE` because nothing has committed (issue #325).
+
 - The MCP initialize `instructions` string had no size bound and had grown to 41 KB by inlining
   three guidance documents. Codex copies that string into the `description` of every advertised
   tool, so it was charged seven times on every turn of every session — roughly 288 KB of advertised

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1148,7 +1148,11 @@ next step.
 last_ingestion_sequence: int | None, result_object_ref: ObjectRef | None,
 structural_ids: tuple[str, ...])` requires both sequence fields absent or both present and ordered;
 `structural_ids` is sorted unique and has at most `MAX_EVENTS_PER_BATCH + 1` members. Receipt
-replay uses this locator; it never scans an unbounded ledger or rebuilds the receipt.
+replay uses this locator; it never scans an unbounded ledger or rebuilds the receipt. A failed
+verified read of that stored object (tampered envelope, missing file, wrong key slot, or I/O
+while reading) is `STORAGE_CORRUPT` with the stored-receipt-invalid family, never unclassified
+`INTERNAL_ERROR`. Pre-append object `stage`/`finalize` I/O on a fresh receipt is retryable
+`STORAGE_UNSAFE` because nothing has committed.
 
 `freeze_case` uses one closed ordering for both adapters. For an absent operation: (1) a bounded
 prepare snapshot establishes absent idempotency, no pending import, `expected_frontier`, head `F`,

--- a/src/yoetz/application/receipt.py
+++ b/src/yoetz/application/receipt.py
@@ -223,11 +223,30 @@ def _identity(request: ReceiptRequest, versions: ReceiptVersionSlice) -> JsonVal
 
 
 async def _read_object(runtime: TaskRuntime, ref: ObjectRef) -> bytes:
-    chunks = [chunk async for chunk in runtime.objects.open_verified(ref)]
-    data = b"".join(chunks)
+    try:
+        chunks = [chunk async for chunk in runtime.objects.open_verified(ref)]
+        data = b"".join(chunks)
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        raise _error(PublicErrorCode.STORAGE_CORRUPT, "The stored receipt is invalid.") from exc
     if len(data) != ref.plaintext_size:
         raise _error(PublicErrorCode.STORAGE_CORRUPT, "The receipt object is invalid.")
     return data
+
+
+async def _persist_object(
+    runtime: TaskRuntime, source: ObjectSource, metadata: ObjectMetadata
+) -> ObjectRef:
+    """Stage and finalize one receipt object before the ledger append."""
+
+    try:
+        staged = await runtime.objects.stage(source, metadata)
+        return await runtime.objects.finalize(staged)
+    except OSError as exc:
+        raise _error(
+            PublicErrorCode.STORAGE_UNSAFE,
+            "Receipt object storage is unavailable.",
+            retryable=True,
+        ) from exc
 
 
 async def _preflight(
@@ -589,11 +608,11 @@ async def execute_receipt(app: Application, request: ReceiptRequest) -> ReceiptI
         document_json = cast(JsonValue, receipt_document_to_json(document))
         document_bytes = canonical_encode(document_json)
         digest = canonical_digest(document_json)
-        receipt_staged = await runtime.objects.stage(
+        receipt_ref = await _persist_object(
+            runtime,
             ObjectSource(data=document_bytes, declared_size=len(document_bytes)),
             ObjectMetadata(ObjectKind.RECEIPT, _RECEIPT_MEDIA_TYPE, runtime.task_id, now),
         )
-        receipt_ref = await runtime.objects.finalize(receipt_staged)
         payload = ReceiptRecordedPayload(
             document.receipt_id,
             frontier,
@@ -618,10 +637,11 @@ async def execute_receipt(app: Application, request: ReceiptRequest) -> ReceiptI
             runtime.task_id,
             now,
         )
-        payload_staged = await runtime.objects.stage(
-            ObjectSource(data=payload_bytes, declared_size=len(payload_bytes)), payload_metadata
+        payload_ref = await _persist_object(
+            runtime,
+            ObjectSource(data=payload_bytes, declared_size=len(payload_bytes)),
+            payload_metadata,
         )
-        payload_ref = await runtime.objects.finalize(payload_staged)
         coverage = coverage_for_channel(PublicationChannel.ENGINE_DERIVED)
         command = AppendCommand(
             runtime.task_id,

--- a/tests/conformance/operations/test_receipt_contract.py
+++ b/tests/conformance/operations/test_receipt_contract.py
@@ -63,6 +63,7 @@ from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
 from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
 from yoetz.protocol.canonical import JsonValue, canonical_digest, canonical_encode
 from yoetz.protocol.coverage import coverage_to_json
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
 from yoetz.protocol.models import (
     CheckRequest,
     FrontierModel,
@@ -790,3 +791,64 @@ async def test_receipt_context_uses_same_availability_snapshot() -> None:
     assert canonical_encode(
         cast(JsonValue, status_item.coverage.model_dump(mode="json"))
     ) == canonical_encode(cast(JsonValue, receipt_finding["coverage"]))
+
+
+async def test_receipt_replay_object_verification_failure_is_storage_corrupt() -> None:
+    app, runtime, _projection = _build_app(seed_offset=22)
+    started, checked, _obligation = await _bootstrap_finding(app, seed=2200)
+    receipt_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 2210)),
+        "task_id": started.task_id,
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(checked.result_frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+    first = await _receipt(app, receipt_wire)
+    assert first.ok is True
+
+    _task_id, resources = next(iter(runtime.resources.items()))
+    _ledger, objects = resources
+
+    def _failing_open(_ref: object) -> object:
+        raise ValueError("object_verification_failed")
+
+    objects.open_verified = _failing_open  # pyright: ignore[reportAttributeAccessIssue]
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _receipt(app, receipt_wire)
+    assert caught.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert caught.value.message == "The stored receipt is invalid."
+    assert caught.value.retryable is False
+
+
+async def test_receipt_stage_oserror_is_retryable_storage_unsafe() -> None:
+    app, runtime, _projection = _build_app(seed_offset=23)
+    started, checked, _obligation = await _bootstrap_finding(app, seed=2300)
+    receipt_wire: dict[str, JsonValue] = {
+        **_request_base(protocol_id("req_", 2310)),
+        "task_id": started.task_id,
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(checked.result_frontier),
+        "format": "json",
+        "include": "standard",
+        "redaction_profile": "full_local",
+    }
+
+    _task_id, resources = next(iter(runtime.resources.items()))
+    _ledger, objects = resources
+
+    async def _failing_stage(_source: object, _metadata: object) -> object:
+        raise OSError("No space left on device")
+
+    objects.stage = _failing_stage  # pyright: ignore[reportAttributeAccessIssue]
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _receipt(app, receipt_wire)
+    assert caught.value.code is PublicErrorCode.STORAGE_UNSAFE
+    assert caught.value.message == "Receipt object storage is unavailable."
+    assert caught.value.retryable is True
+    assert "No space left on device" not in caught.value.message

--- a/tests/unit/application/test_error_mapping.py
+++ b/tests/unit/application/test_error_mapping.py
@@ -151,6 +151,7 @@ _MODULE_CODE_INVENTORY: dict[str, frozenset[PublicErrorCode]] = {
             PublicErrorCode.OPERATION_PENDING,
             PublicErrorCode.SESSION_CONFLICT,
             PublicErrorCode.STORAGE_CORRUPT,
+            PublicErrorCode.STORAGE_UNSAFE,
         }
     ),
 }
@@ -250,6 +251,11 @@ def test_retryability_tracks_operation_state() -> None:
         for code_name in ("IDEMPOTENCY_CONFLICT", "STORAGE_CORRUPT"):
             for window in _call_windows(source, code_name):
                 assert not _is_retryable_call(window), (name, code_name, window)
+
+    receipt_unsafe = _call_windows(_application_source("receipt.py"), "STORAGE_UNSAFE")
+    assert receipt_unsafe
+    for window in receipt_unsafe:
+        assert _is_retryable_call(window), window
 
     for name in ("check.py", "status.py", "start.py"):
         source = _application_source(name)

--- a/tests/unit/application/test_receipt_object_errors.py
+++ b/tests/unit/application/test_receipt_object_errors.py
@@ -1,0 +1,114 @@
+"""Receipt object-store faults stay classified instead of becoming INTERNAL_ERROR."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from yoetz.application.receipt import (  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    _persist_object,
+    _read_object,
+)
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource
+from yoetz.ports.runtime import TaskRuntime
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+
+pytestmark = pytest.mark.anyio
+
+
+def _receipt_ref(*, plaintext_size: int = 2) -> ObjectRef:
+    return ObjectRef(
+        "obj_ffffffff-0000-4000-8000-000000000001",
+        plaintext_size,
+        "hmac-sha256:" + "a" * 64,
+        "sha256:" + "b" * 64,
+        "yoetz-object/1",
+        "test-key-1",
+        ObjectMetadata(
+            ObjectKind.RECEIPT,
+            "application/vnd.yoetz.receipt+json",
+            "tsk_ffffffff-0000-4000-8000-000000000001",
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def _runtime_with_open(open_verified: object) -> TaskRuntime:
+    return cast(TaskRuntime, SimpleNamespace(objects=SimpleNamespace(open_verified=open_verified)))
+
+
+def _runtime_with_store(*, stage: object, finalize: object) -> TaskRuntime:
+    return cast(
+        TaskRuntime,
+        SimpleNamespace(objects=SimpleNamespace(stage=stage, finalize=finalize)),
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    (
+        ValueError("object_verification_failed"),
+        OSError("read failed"),
+        KeyError("missing"),
+        TypeError("bad chunk"),
+    ),
+)
+async def test_read_object_maps_store_faults_to_storage_corrupt(error: Exception) -> None:
+    def open_verified(_ref: ObjectRef) -> AsyncIterator[bytes]:
+        raise error
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _read_object(_runtime_with_open(open_verified), _receipt_ref())
+    assert caught.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert caught.value.message == "The stored receipt is invalid."
+    assert caught.value.retryable is False
+
+
+async def test_read_object_maps_size_mismatch_to_storage_corrupt() -> None:
+    async def open_verified(_ref: ObjectRef) -> AsyncIterator[bytes]:
+        yield b"x"
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _read_object(_runtime_with_open(open_verified), _receipt_ref(plaintext_size=2))
+    assert caught.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert caught.value.message == "The receipt object is invalid."
+    assert caught.value.retryable is False
+
+
+async def test_persist_object_maps_stage_oserror_to_retryable_storage_unsafe() -> None:
+    async def stage(_source: ObjectSource, _metadata: ObjectMetadata) -> object:
+        raise OSError("No space left on device")
+
+    async def finalize(_staged: object) -> ObjectRef:
+        raise AssertionError("finalize must not run after stage failure")
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _persist_object(
+            _runtime_with_store(stage=stage, finalize=finalize),
+            ObjectSource(data=b"{}", declared_size=2),
+            _receipt_ref().metadata,
+        )
+    assert caught.value.code is PublicErrorCode.STORAGE_UNSAFE
+    assert caught.value.message == "Receipt object storage is unavailable."
+    assert caught.value.retryable is True
+
+
+async def test_persist_object_maps_finalize_oserror_to_retryable_storage_unsafe() -> None:
+    async def stage(_source: ObjectSource, _metadata: ObjectMetadata) -> object:
+        return object()
+
+    async def finalize(_staged: object) -> ObjectRef:
+        raise OSError("object_destination_collision")
+
+    with pytest.raises(PublicOperationError) as caught:
+        await _persist_object(
+            _runtime_with_store(stage=stage, finalize=finalize),
+            ObjectSource(data=b"{}", declared_size=2),
+            _receipt_ref().metadata,
+        )
+    assert caught.value.code is PublicErrorCode.STORAGE_UNSAFE
+    assert caught.value.retryable is True

--- a/tests/unit/application/test_receipt_object_errors.py
+++ b/tests/unit/application/test_receipt_object_errors.py
@@ -9,9 +9,9 @@ from typing import cast
 
 import pytest
 
-from yoetz.application.receipt import (  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
-    _persist_object,
-    _read_object,
+from yoetz.application.receipt import (  # noqa: SLF001
+    _persist_object,  # pyright: ignore[reportPrivateUsage]
+    _read_object,  # pyright: ignore[reportPrivateUsage]
 )
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource
 from yoetz.ports.runtime import TaskRuntime


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: `Fixes #325`
- I searched existing issues and PRs for duplicates before opening this PR. Related but distinct: #200 (session-filtered `load_events`), #42/#30 (post-commit projection), #253/#259/#262 (receipt case construction). No open PR classified replay-path object verification or pre-append `stage`/`finalize` faults.
- This change is not a new storage design. It is the owner-authored classification for an already-durable receipt replay and for environmental object I/O before append. ADR/OPEN_QUESTIONS are unchanged.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (receipt replay locator), `CHANGELOG.md`.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/application/test_receipt_object_errors.py tests/unit/application/test_error_mapping.py tests/conformance/operations/test_receipt_contract.py -q --tb=short
# 31 passed
uv run ruff check src/yoetz/application/receipt.py tests/unit/application/test_receipt_object_errors.py tests/unit/application/test_error_mapping.py tests/conformance/operations/test_receipt_contract.py
# All checks passed
npx --no-install pyright src/yoetz/application/receipt.py tests/unit/application/test_receipt_object_errors.py tests/unit/application/test_error_mapping.py tests/conformance/operations/test_receipt_contract.py
# 0 errors, 0 warnings, 0 informations
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [ ] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Receipt guidance tells the agent to retry a completed `request_id` to recover the stored outcome. On that replay path, a failed verified object read (`ValueError("object_verification_failed")`, missing file, wrong key slot, or I/O) escaped `execute_receipt`'s `ProtocolValueError` handler and became non-retryable `INTERNAL_ERROR` — for a receipt that already exists. Pre-append `stage`/`finalize` `OSError` (disk full, destination collision) took the same unclassified dead end even though nothing had committed.

`_read_object` now converts `(KeyError, OSError, TypeError, ValueError)` to `STORAGE_CORRUPT` with the stored-receipt-invalid family. `_persist_object` converts `OSError` on the fresh path to retryable `STORAGE_UNSAFE`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf542437-cf8b-44bf-9b70-cc8a5d4f9709?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf542437-cf8b-44bf-9b70-cc8a5d4f9709&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Classify receipt object-store faults as `STORAGE_CORRUPT` or `STORAGE_UNSAFE` instead of `INTERNAL_ERROR`
> - Verified read failures in [`receipt.py`](https://github.com/TheGaySupreme123/yoetz/pull/330/files#diff-3440c59540bf832be672ceb269bd86832a48647ef853b0c678432008d55bde40) (tampered/missing/wrong key slot/I-O) now raise `STORAGE_CORRUPT` with message `'The stored receipt is invalid.'` instead of propagating as unclassified `INTERNAL_ERROR`.
> - A new `_persist_object` helper consolidates stage/finalize calls and maps `OSError` from either to retryable `STORAGE_UNSAFE` with message `'Receipt object storage is unavailable.'`.
> - Conformance and unit tests cover all new error mappings, and the locked error-code inventory for `receipt.py` is updated to include `STORAGE_UNSAFE`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37d8f37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->