### PR TITLE
Stabilize observation-drain CI timing

### DIFF
--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -1164,6 +1164,7 @@ async def test_drain_is_round_robin_across_all_workspace_sessions(
         workspace_commitment=workspace,
         codex_session_id="current",
         connect=connect,  # type: ignore[arg-type]
+        monotonic=lambda: 0.0,
     )
     assert calls == ["current", "recovered", "current", "recovered"]
     assert store.pending_outbox_count(workspace) == 0
@@ -1297,6 +1298,7 @@ async def test_drain_probes_a_mapping_missing_session_once_per_pass(tmp_path: Pa
         codex_session_id="dead",
         connect=connect,  # type: ignore[arg-type]
         _state=tmp_path,
+        monotonic=lambda: 0.0,
     )
     assert attempts.count("dead") == 1, "a mapping_missing session must be probed once per pass"
     assert attempts.count("healthy") == 2, "healthy sessions must still deliver in the same pass"

--- a/tests/unit/service/test_elevated_bootstrap.py
+++ b/tests/unit/service/test_elevated_bootstrap.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Barrier
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -131,10 +130,8 @@ def test_review_consumes_denial_cancellation_and_failure(tmp_path: Path, outcome
 
 def test_concurrent_review_has_one_winner(tmp_path: Path) -> None:
     prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
-    barrier = Barrier(2)
 
     def claim() -> tuple[str, object]:
-        barrier.wait()
         try:
             return "ok", claim_pending_for_review(_state=tmp_path)
         except ElevatedBootstrapError as exc:
@@ -149,7 +146,6 @@ def test_concurrent_review_has_one_winner(tmp_path: Path) -> None:
     winners = [value for status, value in outcomes if status == "ok"]
     losers = [value for status, value in outcomes if status == "error"]
     assert len(winners) == 1
-    assert len(losers) == 1
     assert losers[0] in {"pending_absent", "review_in_progress"}
     complete_review(cast(Any, winners[0]), outcome="cancelled", _state=tmp_path)
 

--- a/tests/unit/service/test_elevated_bootstrap.py
+++ b/tests/unit/service/test_elevated_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -130,8 +131,10 @@ def test_review_consumes_denial_cancellation_and_failure(tmp_path: Path, outcome
 
 def test_concurrent_review_has_one_winner(tmp_path: Path) -> None:
     prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
+    barrier = Barrier(2)
 
     def claim() -> tuple[str, object]:
+        barrier.wait()
         try:
             return "ok", claim_pending_for_review(_state=tmp_path)
         except ElevatedBootstrapError as exc:
@@ -146,6 +149,7 @@ def test_concurrent_review_has_one_winner(tmp_path: Path) -> None:
     winners = [value for status, value in outcomes if status == "ok"]
     losers = [value for status, value in outcomes if status == "error"]
     assert len(winners) == 1
+    assert len(losers) == 1
     assert losers[0] in {"pending_absent", "review_in_progress"}
     complete_review(cast(Any, winners[0]), outcome="cancelled", _state=tmp_path)
 


### PR DESCRIPTION
Fixes #343 after the production consent-claim race is repaired by #349.

## What changed

- Drive the two observer-drain unit tests with their injected monotonic clock, so immediate fake-client assertions do not consume the production 0.20-second drain budget under CI scheduling pressure.
- Removed the earlier `Barrier`-only change to `test_concurrent_review_has_one_winner`: independent review reproduced the zero-winner production race at this PR’s prior head, and PR #349 owns the atomic claim repair plus deterministic regression.

## Why

Two diff-unrelated observation-drain tests failed under CI scheduling pressure while passing locally. Their fake clients are immediate, so the tests should use the drain loop’s injected clock rather than wall time.

## Validation

- `uv run pytest tests/unit/cli/test_observe_hooks.py tests/unit/service/test_elevated_bootstrap.py -q --timeout=120` — 88 passed
- Ruff check and format check on both affected test files
- Independent review reproduced the removed consent-claim race and verified PR #349’s production fix

## Merge relationship

Merge #349 first, then this PR. With the misleading consent-test hunk removed, this PR retains only the observation-drain timing stabilization.

Done by ChatGPT.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky CI timing in observation-drain tests by stubbing `monotonic`
> Passes a fixed `monotonic` lambda returning `0.0` to `_drain_outbox` in two tests in [test_observe_hooks.py](https://github.com/TheGaySupreme123/yoetz/pull/345/files#diff-6635a1b7b8d3c01092c93a0734fe92f9289dff65c95e28574a59620bc0bc1b8b), removing dependence on real wall-clock time and eliminating intermittent timing-related failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1c2a20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->