### PR TITLE
Make elevated-consent review claims atomic

### DIFF
--- a/docs/adr/ADR-015-elevated-bootstrap-consent.md
+++ b/docs/adr/ADR-015-elevated-bootstrap-consent.md
@@ -1,10 +1,11 @@
 # ADR-015 — OS-presence-gated elevated bootstrap consent
 
 **Status:** Amended 2026-07-31; amended 2026-08-09 for agent-attested chat authorize
-(issue #164). Superseded in scope by ADR-016 for the general non-default consent catalog.
-Console `yoetz consent review` remains fail-closed until a verified OS-presence adapter is
-installed; allowlisted first-party agents may use `yoetz consent authorize` for exact prepared
-operations that advertise delegated chat authority.
+(issue #164); amended 2026-08-18 for atomic concurrent review claims (issue #344). Superseded in
+scope by ADR-016 for the general non-default consent catalog. Console `yoetz consent review`
+remains fail-closed until a verified OS-presence adapter is installed; allowlisted first-party
+agents may use `yoetz consent authorize` for exact prepared operations that advertise delegated
+chat authority.
 **Implemented by:** `src/yoetz/service/elevated_bootstrap.py`,
 `src/yoetz/cli/elevated.py`, `src/yoetz/cli/trusted_console.py`,
 `src/yoetz/protocol/consent.py`, and `src/yoetz/protocol/chat_user_authority.py`.
@@ -56,10 +57,14 @@ still must not accept an agent-selected passphrase.
    pending, catalog, result, log, error, or agent projection. `vault_initialize` remains
    console/helper-only. Trusted CLI/TUI remains the stronger recommended path.
 
-4. **Single-shot state.** A review claim consumes the public pending name. Approval, denial,
+4. **Single-shot state.** Atomically creating the no-clobber hard-link review marker is the
+   linearization point that transfers ownership from pending state to one reviewer. The winner
+   removes the public pending name as cleanup; concurrent losers that observe the marker do not
+   mutate either name, and cleanup cannot revoke the winner's marker. Approval, denial,
    cancellation, expiry, and post-claim failure consume the claim once. Concurrent and duplicate
-   reviewers fail closed. An ambiguous crash may leave the private reviewing marker in place; that
-   blocks both reuse and a new preparation until an explicit repair path is designed.
+   reviewers fail closed. An ambiguous crash may leave the private reviewing marker (and, if the
+   crash preceded winner cleanup, its public hard-link name) in place; the marker blocks both reuse
+   and a new preparation until an explicit repair path is designed.
 
 5. **Vault initialization secret.** The trusted helper generates a high-entropy passphrase,
    round-trips it through the exact bundle-scoped platform credential store, and submits it

--- a/docs/adr/ADR-016-human-review-non-default-actions.md
+++ b/docs/adr/ADR-016-human-review-non-default-actions.md
@@ -1,7 +1,8 @@
 # ADR-016 — Human review for non-default actions
 
 **Status:** Working decision; amended 2026-07-31 to require action-bound OS user presence before
-console review; amended 2026-08-09 for agent-attested current-chat authorize (issue #164).
+console review; amended 2026-08-09 for agent-attested current-chat authorize (issue #164); amended
+2026-08-18 for atomic concurrent review claims (issue #344).
 **Implemented by:** `src/yoetz/service/elevated_bootstrap.py`,
 `src/yoetz/cli/elevated.py`, `src/yoetz/cli/trusted_console.py`,
 `src/yoetz/protocol/consent.py`, `src/yoetz/protocol/chat_user_authority.py`, and
@@ -40,8 +41,9 @@ documents that Yoetz cannot independently authenticate its chat provenance.
    that actually support agent-chat authorization.
 
 3. **One pending request.** One owner-only request with a 15-minute TTL may exist. The trusted
-   reviewer atomically claims it. Every terminal decision and every post-claim failure is
-   single-shot.
+   reviewer atomically claims it by creating a no-clobber hard-link review marker. Marker creation
+   is the ownership transition; only the winner cleans up the public pending name, while concurrent
+   losers are read-only. Every terminal decision and every post-claim failure is single-shot.
 
 4. **Verified presence before console review.** The fixed `yoetz consent review` command takes no
    authority-bearing arguments. An independently authenticated, action-bound, one-use

--- a/src/yoetz/service/elevated_bootstrap.py
+++ b/src/yoetz/service/elevated_bootstrap.py
@@ -9,11 +9,21 @@ import hmac
 import json
 import os
 import secrets
+import stat
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Literal, NoReturn, cast
+from typing import Any, Final, Literal, NoReturn, cast
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows uses msvcrt below
+    fcntl = None  # type: ignore[assignment]
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX uses fcntl above
+    msvcrt = None  # type: ignore[assignment]
 
 from yoetz.config.paths import ensure_owner_only_dir, state_dir
 from yoetz.domain.values import ProtocolValueError, validate_commitment, validate_sha256_digest
@@ -72,6 +82,7 @@ _LEGACY_SCHEMA: Final = "yoetz.elevated-bootstrap.pending/1"
 _TTL_SECONDS: Final = 15 * 60
 _PENDING_NAME: Final = "elevated-bootstrap-pending.json"
 _REVIEW_NAME: Final = "elevated-bootstrap-reviewing.json"
+_REVIEW_LOCK_NAME: Final = ".elevated-bootstrap.lock"
 _AUDIT_NAME: Final = "elevated-bootstrap-audit.jsonl"
 _FORBIDDEN: Final = ("mcp", "argv", "env", "stdin", "config", "transcript")
 _PROVIDER_BINDING_KEYS: Final = (
@@ -352,6 +363,84 @@ def review_path(*, _state: Path | None = None) -> Path:
     return elevated_dir(_state=_state) / _REVIEW_NAME
 
 
+class _PendingStateLock:
+    """Owner-only advisory lock spanning every pending-state transition."""
+
+    def __init__(self, state: Path | None) -> None:
+        self._path = elevated_dir(_state=state) / _REVIEW_LOCK_NAME
+        self._descriptor: int | None = None
+
+    def __enter__(self) -> None:
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor: int | None = None
+        try:
+            try:
+                existing = self._path.lstat()
+            except FileNotFoundError:
+                existing = None
+            if existing is not None and stat.S_ISLNK(existing.st_mode):
+                raise OSError("pending_lock_unsafe")
+            descriptor = os.open(self._path, flags, 0o600)
+            facts = os.fstat(descriptor)
+            effective_uid = (
+                os.geteuid()
+                if hasattr(os, "geteuid")
+                else os.getuid()
+                if hasattr(os, "getuid")
+                else None
+            )
+            if not stat.S_ISREG(facts.st_mode) or (
+                effective_uid is not None
+                and hasattr(facts, "st_uid")
+                and facts.st_uid != effective_uid
+            ):
+                raise OSError("pending_lock_unsafe")
+            fchmod = getattr(os, "fchmod", None)
+            if fchmod is not None:
+                fchmod(descriptor, 0o600)
+            if fcntl is not None:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+            elif msvcrt is not None:
+                self._acquire_windows(descriptor)
+            else:
+                raise OSError("pending_lock_unsupported")
+        except OSError as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise ElevatedBootstrapError("pending_lock_failed") from exc
+        self._descriptor = descriptor
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        del exc_type, exc, traceback
+        descriptor = self._descriptor
+        self._descriptor = None
+        if descriptor is not None:
+            try:
+                if fcntl is None and msvcrt is not None:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    windows_msvcrt = cast(Any, msvcrt)
+                    windows_msvcrt.locking(descriptor, windows_msvcrt.LK_UNLCK, 1)
+            finally:
+                os.close(descriptor)
+
+    @staticmethod
+    def _acquire_windows(descriptor: int) -> None:
+        if msvcrt is None:  # pragma: no cover - guarded by __enter__
+            raise OSError("pending_lock_unsupported")
+        if os.fstat(descriptor).st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        windows_msvcrt = cast(Any, msvcrt)
+        while True:
+            try:
+                windows_msvcrt.locking(descriptor, windows_msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time.sleep(0.05)
+
+
 def audit_path(*, _state: Path | None = None) -> Path:
     return elevated_dir(_state=_state) / _AUDIT_NAME
 
@@ -410,49 +499,50 @@ def prepare_pending(
         validated_digest = validate_sha256_digest(target_digest)
     except ProtocolValueError as exc:
         raise ElevatedBootstrapError("target_digest_invalid") from exc
-    if review_path(_state=_state).is_file():
-        raise ElevatedBootstrapError("review_in_progress")
-    existing = load_pending(_state=_state)
-    if existing is not None and existing.expires_at_unix > int(time.time()):
-        raise ElevatedBootstrapError("pending_already_active")
-    now = int(time.time())
-    pending_id = secrets.token_hex(32)
-    text = spec.danger_text
-    expires = now + _TTL_SECONDS
-    digest = _danger_digest(
-        operation=operation,
-        risk_class=spec.risk_class,
-        danger_text=text,
-        target_digest=validated_digest,
-        pending_id=pending_id,
-        expires_at_unix=expires,
-        provider_binding=binding,
-        grant_binding=grant,
-    )
-    pending = PendingElevatedConsent(
-        pending_id=pending_id,
-        operation=operation,
-        risk_class=spec.risk_class,
-        danger_text=text,
-        danger_digest=digest,
-        created_at_unix=now,
-        expires_at_unix=expires,
-        target_digest=validated_digest,
-        provider_binding=binding,
-        grant_binding=grant,
-    )
-    _write_pending(pending, _state=_state)
-    _audit(
-        {
-            "event": "prepare",
-            "operation": operation,
-            "risk_class": spec.risk_class,
-            "pending_id": pending_id,
-            "danger_digest": digest,
-            "expires_at_unix": expires,
-        },
-        _state=_state,
-    )
+    with _PendingStateLock(_state):
+        if review_path(_state=_state).is_file():
+            raise ElevatedBootstrapError("review_in_progress")
+        existing = _load_pending_unlocked(_state=_state)
+        if existing is not None and existing.expires_at_unix > int(time.time()):
+            raise ElevatedBootstrapError("pending_already_active")
+        now = int(time.time())
+        pending_id = secrets.token_hex(32)
+        text = spec.danger_text
+        expires = now + _TTL_SECONDS
+        digest = _danger_digest(
+            operation=operation,
+            risk_class=spec.risk_class,
+            danger_text=text,
+            target_digest=validated_digest,
+            pending_id=pending_id,
+            expires_at_unix=expires,
+            provider_binding=binding,
+            grant_binding=grant,
+        )
+        pending = PendingElevatedConsent(
+            pending_id=pending_id,
+            operation=operation,
+            risk_class=spec.risk_class,
+            danger_text=text,
+            danger_digest=digest,
+            created_at_unix=now,
+            expires_at_unix=expires,
+            target_digest=validated_digest,
+            provider_binding=binding,
+            grant_binding=grant,
+        )
+        _write_pending(pending, _state=_state)
+        _audit(
+            {
+                "event": "prepare",
+                "operation": operation,
+                "risk_class": spec.risk_class,
+                "pending_id": pending_id,
+                "danger_digest": digest,
+                "expires_at_unix": expires,
+            },
+            _state=_state,
+        )
     return pending
 
 
@@ -696,7 +786,7 @@ def _load_pending_path(
     return pending
 
 
-def load_pending(*, _state: Path | None = None) -> PendingElevatedConsent | None:
+def _load_pending_unlocked(*, _state: Path | None = None) -> PendingElevatedConsent | None:
     claim = review_path(_state=_state)
     path = pending_path(_state=_state)
     if claim.is_file():
@@ -708,12 +798,18 @@ def load_pending(*, _state: Path | None = None) -> PendingElevatedConsent | None
     return _load_pending_path(path, _state=_state, expire=True)
 
 
+def load_pending(*, _state: Path | None = None) -> PendingElevatedConsent | None:
+    with _PendingStateLock(_state):
+        return _load_pending_unlocked(_state=_state)
+
+
 def clear_pending(*, _state: Path | None = None) -> None:
-    path = pending_path(_state=_state)
-    try:
-        path.unlink(missing_ok=True)
-    except OSError as exc:
-        raise ElevatedBootstrapError("pending_clear_failed") from exc
+    with _PendingStateLock(_state):
+        path = pending_path(_state=_state)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise ElevatedBootstrapError("pending_clear_failed") from exc
 
 
 def _exact_match(left: str, right: str) -> bool:
@@ -725,57 +821,58 @@ def _exact_match(left: str, right: str) -> bool:
 def claim_pending_for_review(*, _state: Path | None = None) -> PendingElevatedConsent:
     """Atomically consume one pending request for a verified-console review."""
 
-    pending = load_pending(_state=_state)
-    if pending is None:
-        raise ElevatedBootstrapError("pending_absent")
-    if not operation_spec(pending.operation).implemented:
-        raise ElevatedBootstrapError("operation_not_implemented")
-    source = pending_path(_state=_state)
-    claim = review_path(_state=_state)
-    try:
-        os.link(source, claim)
-    except FileExistsError as exc:
-        raise ElevatedBootstrapError("review_in_progress") from exc
-    except FileNotFoundError as exc:
-        raise ElevatedBootstrapError("pending_absent") from exc
-    except OSError as exc:
-        raise ElevatedBootstrapError("pending_claim_failed") from exc
-    try:
-        source.unlink()
-    except FileNotFoundError:
-        # The hard link already made this caller the winner. Concurrent cancellation or
-        # cleanup of the public name cannot revoke ownership of the private review marker.
-        pass
-    except OSError as exc:
+    with _PendingStateLock(_state):
+        pending = _load_pending_unlocked(_state=_state)
+        if pending is None:
+            raise ElevatedBootstrapError("pending_absent")
+        if not operation_spec(pending.operation).implemented:
+            raise ElevatedBootstrapError("operation_not_implemented")
+        source = pending_path(_state=_state)
+        claim = review_path(_state=_state)
         try:
-            claim.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise ElevatedBootstrapError("pending_claim_failed") from exc
-    claimed = _load_pending_path(claim, _state=_state, expire=False)
-    if claimed is None or claimed != pending:
+            os.link(source, claim)
+        except FileExistsError as exc:
+            raise ElevatedBootstrapError("review_in_progress") from exc
+        except FileNotFoundError as exc:
+            raise ElevatedBootstrapError("pending_absent") from exc
+        except OSError as exc:
+            raise ElevatedBootstrapError("pending_claim_failed") from exc
         try:
-            claim.unlink(missing_ok=True)
-        except OSError:
+            source.unlink()
+        except FileNotFoundError:
+            # The hard link already made this caller the winner. Concurrent cancellation or
+            # cleanup of the public name cannot revoke ownership of the private review marker.
             pass
-        raise ElevatedBootstrapError("pending_tampered")
-    if claimed.expires_at_unix <= int(time.time()):
-        complete_review(claimed, outcome="expired", _state=_state)
-        raise ElevatedBootstrapError("pending_expired")
-    _audit(
-        {
-            "event": "review_claimed",
-            "pending_id": pending.pending_id,
-            "operation": pending.operation,
-            "risk_class": pending.risk_class,
-            "danger_digest": pending.danger_digest,
-        },
-        _state=_state,
-    )
-    return claimed
+        except OSError as exc:
+            try:
+                claim.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise ElevatedBootstrapError("pending_claim_failed") from exc
+        claimed = _load_pending_path(claim, _state=_state, expire=False)
+        if claimed is None or claimed != pending:
+            try:
+                claim.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise ElevatedBootstrapError("pending_tampered")
+        if claimed.expires_at_unix <= int(time.time()):
+            _complete_review_unlocked(claimed, outcome="expired", _state=_state)
+            raise ElevatedBootstrapError("pending_expired")
+        _audit(
+            {
+                "event": "review_claimed",
+                "pending_id": pending.pending_id,
+                "operation": pending.operation,
+                "risk_class": pending.risk_class,
+                "danger_digest": pending.danger_digest,
+            },
+            _state=_state,
+        )
+        return claimed
 
 
-def complete_review(
+def _complete_review_unlocked(
     pending: PendingElevatedConsent,
     *,
     outcome: str,
@@ -806,6 +903,18 @@ def complete_review(
         },
         _state=_state,
     )
+
+
+def complete_review(
+    pending: PendingElevatedConsent,
+    *,
+    outcome: str,
+    _state: Path | None = None,
+) -> None:
+    """Consume the claimed request exactly once for approval, denial, cancellation, or expiry."""
+
+    with _PendingStateLock(_state):
+        _complete_review_unlocked(pending, outcome=outcome, _state=_state)
 
 
 def projection_for_status(

--- a/src/yoetz/service/elevated_bootstrap.py
+++ b/src/yoetz/service/elevated_bootstrap.py
@@ -700,11 +700,10 @@ def load_pending(*, _state: Path | None = None) -> PendingElevatedConsent | None
     claim = review_path(_state=_state)
     path = pending_path(_state=_state)
     if claim.is_file():
-        # Complete an interrupted hard-link claim by ensuring the public pending name is gone.
-        try:
-            path.unlink(missing_ok=True)
-        except OSError as exc:
-            raise ElevatedBootstrapError("pending_clear_failed") from exc
+        # Creating the hard-link marker is the atomic ownership transition. A reader that
+        # observes it is a loser and must not mutate either name: the winning claimant owns
+        # removal of the public pending name, and an interrupted winner deliberately leaves
+        # the private marker in place to block reuse.
         return None
     return _load_pending_path(path, _state=_state, expire=True)
 
@@ -743,6 +742,10 @@ def claim_pending_for_review(*, _state: Path | None = None) -> PendingElevatedCo
         raise ElevatedBootstrapError("pending_claim_failed") from exc
     try:
         source.unlink()
+    except FileNotFoundError:
+        # The hard link already made this caller the winner. Concurrent cancellation or
+        # cleanup of the public name cannot revoke ownership of the private review marker.
+        pass
     except OSError as exc:
         try:
             claim.unlink(missing_ok=True)

--- a/tests/unit/service/test_elevated_bootstrap.py
+++ b/tests/unit/service/test_elevated_bootstrap.py
@@ -6,16 +6,18 @@ import json
 import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Event
+from threading import Event, get_ident
 from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
+import yoetz.service.elevated_bootstrap as elevated_bootstrap
 from yoetz.protocol.canonical import canonical_digest
 from yoetz.protocol.schemas import validate_schema_instance
 from yoetz.service.elevated_bootstrap import (
     ElevatedBootstrapError,
+    PendingElevatedConsent,
     catalog_payload,
     claim_pending_for_review,
     complete_review,
@@ -157,13 +159,13 @@ def test_concurrent_loser_cannot_consume_atomic_review_claim(tmp_path: Path) -> 
     pending = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-pending.json"
     reviewing = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-reviewing.json"
     claim_published = Event()
-    loser_finished = Event()
+    release_winner = Event()
     real_link = os.link
 
     def pause_winner_after_atomic_claim(source: Any, claim: Any) -> None:
         real_link(source, claim)
         claim_published.set()
-        assert loser_finished.wait(timeout=5), "concurrent loser did not finish"
+        assert release_winner.wait(timeout=5), "winner was not released"
 
     def claim() -> tuple[str, object]:
         try:
@@ -179,15 +181,14 @@ def test_concurrent_loser_cannot_consume_atomic_review_claim(tmp_path: Path) -> 
             winner_future = pool.submit(claim)
             assert claim_published.wait(timeout=5), "winner did not publish its review marker"
             loser_future = pool.submit(claim)
-            try:
-                loser = loser_future.result(timeout=5)
-                assert loser == ("error", "pending_absent")
-                assert pending.is_file(), "loser removed the winner-owned pending name"
-                assert reviewing.is_file(), "loser removed the winner-owned review marker"
-            finally:
-                loser_finished.set()
+            assert not loser_future.done(), "loser bypassed the winner's state lock"
+            assert pending.is_file(), "winner removed the public name before claiming"
+            assert reviewing.is_file(), "winner did not publish the review marker"
+            release_winner.set()
             winner = winner_future.result(timeout=5)
+            loser = loser_future.result(timeout=5)
 
+    assert loser == ("error", "pending_absent")
     assert winner == ("ok", prepared)
     assert not pending.exists()
     assert reviewing.is_file()
@@ -214,6 +215,80 @@ def test_public_name_cleanup_cannot_revoke_atomic_review_claim(tmp_path: Path) -
     assert not pending.exists()
     assert reviewing.is_file()
     complete_review(claimed, outcome="cancelled", _state=tmp_path)
+
+
+def test_expiry_reprepare_cannot_replace_claimed_record(
+    tmp_path: Path,
+) -> None:
+    """The claim transition serializes expiry cleanup and replacement preparation (#344)."""
+
+    claim_loaded = Event()
+    release_claim = Event()
+    replacement_started = Event()
+    claim_thread_id: list[int | None] = [None]
+
+    def clock() -> float:
+        if claim_thread_id[0] == get_ident():
+            return 1_899 if not release_claim.is_set() else 1_901
+        return 1_000 if claim_thread_id[0] is None else 1_901
+
+    real_load = elevated_bootstrap._load_pending_path  # pyright: ignore[reportPrivateUsage]
+
+    def pause_claim_load(
+        path: Path,
+        *,
+        _state: Path | None,
+        expire: bool,
+    ) -> object:
+        loaded = real_load(path, _state=_state, expire=expire)
+        if (
+            claim_thread_id[0] == get_ident()
+            and expire
+            and path.name == "elevated-bootstrap-pending.json"
+            and loaded is not None
+        ):
+            claim_loaded.set()
+            assert release_claim.wait(timeout=5), "claim did not release its state lock"
+        return loaded
+
+    def claim() -> tuple[str, object]:
+        claim_thread_id[0] = get_ident()
+        try:
+            return "ok", claim_pending_for_review(_state=tmp_path)
+        except ElevatedBootstrapError as exc:
+            return "error", exc.reason
+
+    def reprepare() -> tuple[str, object]:
+        replacement_started.set()
+        try:
+            return "ok", prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
+        except ElevatedBootstrapError as exc:
+            return "error", exc.reason
+
+    with (
+        patch("yoetz.service.elevated_bootstrap.time.time", side_effect=clock),
+        patch(
+            "yoetz.service.elevated_bootstrap._load_pending_path",
+            side_effect=pause_claim_load,
+        ),
+        ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        prepared = prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
+        claim_future = pool.submit(claim)
+        assert claim_loaded.wait(timeout=5), "claim did not load the original pending record"
+        replacement_future = pool.submit(reprepare)
+        assert replacement_started.wait(timeout=5), "replacement did not start"
+        assert not replacement_future.done(), "replacement bypassed the claim state lock"
+        release_claim.set()
+        claim_result = claim_future.result(timeout=5)
+        replacement_result = replacement_future.result(timeout=5)
+        replacement_present = load_pending(_state=tmp_path)
+
+    assert claim_result == ("error", "pending_expired")
+    assert replacement_result[0] == "ok"
+    replacement = cast(PendingElevatedConsent, replacement_result[1])
+    assert replacement != prepared
+    assert replacement_present == replacement
 
 
 def test_interrupted_review_marker_blocks_reuse_and_new_prepare(tmp_path: Path) -> None:

--- a/tests/unit/service/test_elevated_bootstrap.py
+++ b/tests/unit/service/test_elevated_bootstrap.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -148,6 +150,70 @@ def test_concurrent_review_has_one_winner(tmp_path: Path) -> None:
     assert len(winners) == 1
     assert losers[0] in {"pending_absent", "review_in_progress"}
     complete_review(cast(Any, winners[0]), outcome="cancelled", _state=tmp_path)
+
+
+def test_concurrent_loser_cannot_consume_atomic_review_claim(tmp_path: Path) -> None:
+    prepared = prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
+    pending = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-pending.json"
+    reviewing = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-reviewing.json"
+    claim_published = Event()
+    loser_finished = Event()
+    real_link = os.link
+
+    def pause_winner_after_atomic_claim(source: Any, claim: Any) -> None:
+        real_link(source, claim)
+        claim_published.set()
+        assert loser_finished.wait(timeout=5), "concurrent loser did not finish"
+
+    def claim() -> tuple[str, object]:
+        try:
+            return "ok", claim_pending_for_review(_state=tmp_path)
+        except ElevatedBootstrapError as exc:
+            return "error", exc.reason
+
+    with patch(
+        "yoetz.service.elevated_bootstrap.os.link",
+        side_effect=pause_winner_after_atomic_claim,
+    ):
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            winner_future = pool.submit(claim)
+            assert claim_published.wait(timeout=5), "winner did not publish its review marker"
+            loser_future = pool.submit(claim)
+            try:
+                loser = loser_future.result(timeout=5)
+                assert loser == ("error", "pending_absent")
+                assert pending.is_file(), "loser removed the winner-owned pending name"
+                assert reviewing.is_file(), "loser removed the winner-owned review marker"
+            finally:
+                loser_finished.set()
+            winner = winner_future.result(timeout=5)
+
+    assert winner == ("ok", prepared)
+    assert not pending.exists()
+    assert reviewing.is_file()
+    complete_review(prepared, outcome="cancelled", _state=tmp_path)
+
+
+def test_public_name_cleanup_cannot_revoke_atomic_review_claim(tmp_path: Path) -> None:
+    prepared = prepare_pending("vault_initialize", target_digest=_TARGET, _state=tmp_path)
+    pending = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-pending.json"
+    reviewing = tmp_path / "elevated-bootstrap" / "elevated-bootstrap-reviewing.json"
+    real_link = os.link
+
+    def remove_public_name_after_atomic_claim(source: Any, claim: Any) -> None:
+        real_link(source, claim)
+        Path(source).unlink()
+
+    with patch(
+        "yoetz.service.elevated_bootstrap.os.link",
+        side_effect=remove_public_name_after_atomic_claim,
+    ):
+        claimed = claim_pending_for_review(_state=tmp_path)
+
+    assert claimed == prepared
+    assert not pending.exists()
+    assert reviewing.is_file()
+    complete_review(claimed, outcome="cancelled", _state=tmp_path)
 
 
 def test_interrupted_review_marker_blocks_reuse_and_new_prepare(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #344

## What changed

- Makes creation of the no-clobber hard-link review marker the explicit linearization point for pending-to-review ownership.
- Makes claim losers read-only once they observe a review marker, so they cannot remove the winner's public pending name or private review marker.
- Treats public-name removal after marker creation as cleanup; a concurrent removal can no longer revoke an already-acquired claim.
- Amends ADR-015 and ADR-016 to lock the storage/authority contract.
- Adds a deterministic forced-interleaving regression for the zero-winner race and coverage for cleanup after atomic claim acquisition.

## Root cause

`claim_pending_for_review()` created the review hard link and then removed the public pending name. During that gap, a second claimant entered `load_pending()`, observed the review marker, removed the pending name, and returned as a loser. The first claimant then treated the missing public name as claim failure and rolled back its marker. Both callers lost and the request was consumed.

The hard-link creation was already the only atomic no-clobber operation, but readers and cleanup did not consistently treat it as the ownership boundary.

## Contract and impact

Exactly one claimant owns a valid pending review. Concurrent losers receive a bounded failure and cannot mutate winner-owned state. Existing fail-closed validation, expiry, single-pending-action behavior, and ambiguous-crash blocking remain intact.

The durable maintainer contract acknowledgement is recorded on #344. This follows the concurrency-repair discipline used in PR #245—an explicit ownership boundary, non-mutating losers, and deterministic regression coverage—at the elevated-consent storage boundary.

## Relationship to #343 / PR #345

Issue #343 and draft PR #345 classified the observed failure as a test flake and add test synchronization. The forced interleaving here demonstrates a production claim-state race. This PR is the owning fix for the elevated-consent failure; PR #345 can retain its unrelated observation-drain test stabilization.

## Verification

- `uv run pytest tests/unit/service/test_elevated_bootstrap.py tests/unit/cli/test_elevated.py tests/subprocess/test_consent_review_cli.py tests/conformance/surfaces/test_consent_public_boundary.py tests/unit/privacy/test_catalog_audit.py -q` — 85 passed
- `uv run ruff format --check src/yoetz/service/elevated_bootstrap.py tests/unit/service/test_elevated_bootstrap.py`
- `uv run ruff check src/yoetz/service/elevated_bootstrap.py tests/unit/service/test_elevated_bootstrap.py`
- `npx --no-install pyright src/yoetz/service/elevated_bootstrap.py tests/unit/service/test_elevated_bootstrap.py`
- 2,000-iteration two-claimant stress harness — `{one: 2000, zero: 0, other: 0}`

The full repository suite was not run locally; GitHub CI supplies the broader matrix.

Done by ChatGPT.

## Post-review fix

Independent review reproduced an expiry/reprepare interleaving that could replace the pending pathname after a stale claimant loaded the old record, causing the claimant to consume the valid replacement. Commit `3619b62` adds an owner-only cross-process pending-state lock spanning prepare, expiry cleanup, load, claim, clear, and completion. POSIX uses `fcntl`; Windows uses `msvcrt` byte-range locking. The lock file is checked for symlink, regular-file, ownership, and mode safety.

A deterministic forced interleaving now proves an expiring claimant cannot delete a concurrently prepared replacement: the stale claim returns `pending_expired`, replacement preparation proceeds after the serialized transition, and the replacement remains loadable. Post-fix verification: 86 focused consent tests passed; Ruff check/format and pinned Pyright passed.

Done by ChatGPT.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make elevated-consent review claims atomic using hard-link markers and advisory locking
> - Introduces `_PendingStateLock`, an advisory per-owner lock file that serializes all pending-state reads and mutations in [elevated_bootstrap.py](https://github.com/TheGaySupreme123/yoetz/pull/349/files#diff-c86ab674b2f1850fc62e239ed77df095523c1f42e089c29972abd0c7334054f4), preventing races between `prepare_pending`, `claim_pending_for_review`, `load_pending`, `clear_pending`, and `complete_review`.
> - Makes the hard-link review marker creation the linearization point for claim ownership: a winner's claim cannot be revoked by concurrent removal of the public pending name, and losers receive `review_in_progress` or `pending_absent` deterministically.
> - Extracts `_load_pending_unlocked` and `_complete_review_unlocked` as internal helpers so logic can run inside the critical section without re-acquiring the lock.
> - Adds three concurrency tests covering: loser blocking on the state lock, public-name cleanup not revoking a won claim, and expiry-during-claim serialization with re-prepare.
> - Updates [ADR-015](https://github.com/TheGaySupreme123/yoetz/pull/349/files#diff-83cbdedd9dd7ad067c3701afe61b978218273c1e42feca09d4cf84898f763b5c) and [ADR-016](https://github.com/TheGaySupreme123/yoetz/pull/349/files#diff-bb56a06fe86600786997a5d14f11e79b4a32d90c466bc4f70d767e17a457cb2f) to document the atomic hard-link claim as the defined linearization point.
> - Risk: callers that encounter lock setup failures now receive `pending_lock_failed` instead of proceeding; lock acquisition polls on Windows via `msvcrt.locking`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3619b62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->