### PR TITLE
Supersede outdated deterministic checkpoints instead of STORAGE_CORRUPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,16 @@ carried them; they are listed because each one describes the behavior that now s
 
 ### Fixed
 
+- A finding-wording change no longer wedges an in-flight check on its own `request_id`. The
+  persisted deterministic-result checkpoint requires byte-equal rendered finding text on replay,
+  so any wording edit made every pre-change checkpoint replay as non-retryable `STORAGE_CORRUPT`
+  ("The deterministic checkpoint is corrupt.") while the continuation kept pointing at the same
+  request. The checkpoint now stamps the kernel's rendered finding-text contract digest; on
+  replay, a checkpoint whose bindings verify but whose stamp is absent (pre-change format) or
+  from different wording is treated as superseded and the deterministic phase recomputes from the
+  unchanged digest-verified frozen case in the same invocation. Genuinely broken checkpoint
+  content still replays as `STORAGE_CORRUPT` (issue #340).
+
 - Frontier-motion notices no longer re-announce already-delivered observation appends when the
   outbox redelivers a committed envelope. The local store keeps a per-session delivered high-water
   `to_sequence` after the hook consumer receives the notice; `note_frontier_motion` drops

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1136,7 +1136,12 @@ records carry only their listed durable state. `advance_check_phase` binds the d
 local-result/case object when that transition promises recoverability. The pending operation's
 `resume_object_ref` is the sole current row pointer: `CHECK_RESUME` at `reserved`, atomically
 replaced by `DETERMINISTIC_RESULT` at `local_ready` and retained through later nonterminal phases;
-the deterministic envelope authenticates its prior full-case pointer for verified reopen. No
+the deterministic envelope authenticates its prior full-case pointer for verified reopen. The
+deterministic envelope also stamps the kernel's rendered finding-text contract digest
+(`DETERMINISTIC_TEXT_CONTRACT_DIGEST`); on replay, a checkpoint whose bindings verify but whose
+stamp is absent or from different wording is superseded — the deterministic phase recomputes from
+the unchanged frozen case — never `STORAGE_CORRUPT`, so a finding-wording upgrade cannot wedge an
+in-flight check on its own request id. No
 memory-only phase-object map is recovery authority. Every successful phase
 advance, renewal, or reclaim returns a replacement current lease; the prior lease is spent and the
 application reconstructs `FrozenCase` with the unchanged case and replacement lease before the

--- a/src/yoetz/adapters/memory/ledger.py
+++ b/src/yoetz/adapters/memory/ledger.py
@@ -349,7 +349,7 @@ async def load_frozen_case_from_resume(
     source = _strict_mapping(parsed, reason="resume_object_shape_invalid")
 
     if current.metadata.kind is ObjectKind.DETERMINISTIC_RESULT:
-        if frozenset(source) != frozenset(
+        deterministic_result_keys = frozenset(
             {
                 "schema_version",
                 "request_id",
@@ -359,11 +359,21 @@ async def load_frozen_case_from_resume(
                 "writer_id",
                 "subject_frontier",
                 "dependency_digest",
+                "text_contract_digest",
                 "prior_resume",
                 "policy_executions",
                 "assessments",
             }
-        ):
+        )
+        # A checkpoint without the text-contract stamp predates issue #340. Its case pointer and
+        # bindings are still authoritative for reopening the frozen case; only the application's
+        # finding-text replay treats the missing stamp as superseded.
+        if frozenset(source) not in {
+            deterministic_result_keys,
+            deterministic_result_keys - {"text_contract_digest"},
+        }:
+            raise ValueError("deterministic_result_shape_invalid")
+        if "text_contract_digest" in source and type(source["text_contract_digest"]) is not str:
             raise ValueError("deterministic_result_shape_invalid")
         if (
             source["schema_version"] != "1.0.0"

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -593,10 +593,11 @@ async def _load_deterministic_result(
         ):
             raise ValueError("deterministic_result_pointer_invalid")
         await _read_all(prior, runtime)
-        # The bindings above verified, so a missing or different text-contract stamp is not
-        # corruption: the checkpoint was written by different wording code and is superseded.
-        if source.get("text_contract_digest") != DETERMINISTIC_TEXT_CONTRACT_DIGEST:
-            raise _DeterministicCheckpointSuperseded()
+        # Defer supersession until every persisted result field has been decoded and validated.
+        # A stale stamp does not make otherwise malformed checkpoint content safe to ignore.
+        checkpoint_superseded = (
+            source.get("text_contract_digest") != DETERMINISTIC_TEXT_CONTRACT_DIGEST
+        )
         raw_executions = source["policy_executions"]
         raw_assessments = source["assessments"]
         if type(raw_executions) is not list or type(raw_assessments) is not list:
@@ -645,18 +646,37 @@ async def _load_deterministic_result(
                 finding.provenance,
             )
             # A matching contract stamp with drifted text means a wording branch the contract
-            # corpus missed. The bindings still verified, so recompute rather than fail.
-            if (finding.summary, finding.detail) != render_deterministic_finding_text(
+            # corpus missed. Keep validating the finding and basis, but defer recomputation
+            # until every assessment has been checked.
+            rendered_text = render_deterministic_finding_text(
                 finding.kind,
                 finding.subject_refs,
                 basis.coverage_gaps,
                 basis.observed_facts,
-            ):
-                raise _DeterministicCheckpointSuperseded()
+            )
+            if (finding.summary, finding.detail) != rendered_text:
+                checkpoint_superseded = True
+                # Validate the deterministic assessment against the current rendering while
+                # preserving the stored finding's structural fields for Finding validation.
+                candidate = CandidateFinding(
+                    finding.kind,
+                    finding.origin,
+                    finding.priority,
+                    rendered_text[0],
+                    rendered_text[1],
+                    finding.subject_refs,
+                    finding.policy_id,
+                    finding.policy_version,
+                    finding.subject_frontier,
+                    finding.coverage,
+                    finding.provenance,
+                )
             DeterministicAssessment(candidate, basis)
             findings.append(finding)
         if len({item.finding_id for item in findings}) != len(findings):
             raise ValueError("deterministic_result_finding_invalid")
+        if checkpoint_superseded:
+            raise _DeterministicCheckpointSuperseded()
         return _DurableDeterministicResult(tuple(findings), executions)
     except PublicOperationError, _DeterministicCheckpointSuperseded:
         raise

--- a/src/yoetz/application/check.py
+++ b/src/yoetz/application/check.py
@@ -44,12 +44,14 @@ from yoetz.domain.values import (
     obligation_id,
 )
 from yoetz.kernel.deterministic_checks import (
+    DETERMINISTIC_TEXT_CONTRACT_DIGEST,
     DeterministicAssessment,
     DeterministicCase,
     FindingBasisRef,
     case_coverage,
     finding_basis_from_json,
     finding_basis_to_json,
+    render_deterministic_finding_text,
 )
 from yoetz.kernel.policies.research_evidence import research_evidence_findings
 from yoetz.kernel.policies.response_support import (
@@ -488,6 +490,36 @@ class _DurableDeterministicResult:
     executions: tuple[CheckPolicyExecution, ...]
 
 
+class _DeterministicCheckpointSuperseded(Exception):
+    """The persisted deterministic result predates the current finding-text contract.
+
+    The checkpoint's bindings verified, so this is not corruption: the same digest-verified
+    frozen case is still available and the deterministic phase recomputes from it instead of
+    failing the request (issue #340).
+    """
+
+
+_DETERMINISTIC_RESULT_KEYS: Final = frozenset(
+    {
+        "schema_version",
+        "request_id",
+        "request_digest",
+        "task_id",
+        "session_id",
+        "writer_id",
+        "subject_frontier",
+        "dependency_digest",
+        "text_contract_digest",
+        "prior_resume",
+        "policy_executions",
+        "assessments",
+    }
+)
+# Checkpoints written before the text-contract stamp existed. Their wording generation is
+# unknowable, so they are always superseded, never validated byte-for-byte.
+_LEGACY_DETERMINISTIC_RESULT_KEYS: Final = _DETERMINISTIC_RESULT_KEYS - {"text_contract_digest"}
+
+
 def _object_pointer(ref: ObjectRef) -> dict[str, JsonValue]:
     return {
         "object_id": ref.object_id,
@@ -532,21 +564,10 @@ async def _load_deterministic_result(
         if canonical_encode(parsed) != raw:
             raise ValueError("deterministic_result_noncanonical")
         source = _mapping(parsed)
-        if frozenset(source) != frozenset(
-            {
-                "schema_version",
-                "request_id",
-                "request_digest",
-                "task_id",
-                "session_id",
-                "writer_id",
-                "subject_frontier",
-                "dependency_digest",
-                "prior_resume",
-                "policy_executions",
-                "assessments",
-            }
-        ):
+        if frozenset(source) not in {
+            _DETERMINISTIC_RESULT_KEYS,
+            _LEGACY_DETERMINISTIC_RESULT_KEYS,
+        }:
             raise ValueError("deterministic_result_shape_invalid")
         if (
             source["schema_version"] != "1.0.0"
@@ -572,6 +593,10 @@ async def _load_deterministic_result(
         ):
             raise ValueError("deterministic_result_pointer_invalid")
         await _read_all(prior, runtime)
+        # The bindings above verified, so a missing or different text-contract stamp is not
+        # corruption: the checkpoint was written by different wording code and is superseded.
+        if source.get("text_contract_digest") != DETERMINISTIC_TEXT_CONTRACT_DIGEST:
+            raise _DeterministicCheckpointSuperseded()
         raw_executions = source["policy_executions"]
         raw_assessments = source["assessments"]
         if type(raw_executions) is not list or type(raw_assessments) is not list:
@@ -619,12 +644,21 @@ async def _load_deterministic_result(
                 finding.coverage,
                 finding.provenance,
             )
+            # A matching contract stamp with drifted text means a wording branch the contract
+            # corpus missed. The bindings still verified, so recompute rather than fail.
+            if (finding.summary, finding.detail) != render_deterministic_finding_text(
+                finding.kind,
+                finding.subject_refs,
+                basis.coverage_gaps,
+                basis.observed_facts,
+            ):
+                raise _DeterministicCheckpointSuperseded()
             DeterministicAssessment(candidate, basis)
             findings.append(finding)
         if len({item.finding_id for item in findings}) != len(findings):
             raise ValueError("deterministic_result_finding_invalid")
         return _DurableDeterministicResult(tuple(findings), executions)
-    except PublicOperationError:
+    except PublicOperationError, _DeterministicCheckpointSuperseded:
         raise
     except Exception as exc:
         raise PublicOperationError(
@@ -894,6 +928,7 @@ async def _publish_deterministic_result(
                 "writer_id": runtime.writer_id,
                 "subject_frontier": dict(frozen.case.frontier.as_wire().items()),
                 "dependency_digest": frozen.lease.dependency_digest,
+                "text_contract_digest": DETERMINISTIC_TEXT_CONTRACT_DIGEST,
                 "prior_resume": _object_pointer(prior_resume),
                 "policy_executions": tuple(
                     {
@@ -1308,14 +1343,35 @@ async def execute_check_commit(
                 digest,
             )
         else:
-            checkpoint = await _load_deterministic_result(
-                runtime,
-                request,
-                digest,
-                frozen,
-            )
-            deterministic = checkpoint.findings
-            executions = checkpoint.executions
+            try:
+                checkpoint = await _load_deterministic_result(
+                    runtime,
+                    request,
+                    digest,
+                    frozen,
+                )
+            except _DeterministicCheckpointSuperseded:
+                # The checkpoint's bindings verified but its finding wording predates the
+                # current text contract. The frozen case is unchanged and digest-verified, so
+                # the deterministic phase recomputes from it instead of wedging the request
+                # behind a non-retryable STORAGE_CORRUPT (issue #340). The stale checkpoint
+                # keeps serving as the durable case pointer until commit clears it.
+                record_bounded_counts_without_raising(
+                    component="check",
+                    operation="deterministic_checkpoint_superseded",
+                    outcome="recomputed",
+                    request_id=request.request_id,
+                    counts={"superseded_checkpoints": 1},
+                )
+                assessments, executions = run_deterministic_policies(frozen.case, scope, packs)
+                deterministic = allocate_findings(
+                    app.ids,
+                    tuple(item.candidate for item in assessments),
+                    prior_finding_ids(frozen.case.projection),
+                )
+            else:
+                deterministic = checkpoint.findings
+                executions = checkpoint.executions
         semantic_wait = (
             request.mode != "deterministic_only"
             and RuntimeCapability.SEMANTIC in runtime.capabilities

--- a/src/yoetz/kernel/deterministic_checks.py
+++ b/src/yoetz/kernel/deterministic_checks.py
@@ -87,6 +87,7 @@ from yoetz.protocol.coverage import (
 
 __all__ = [
     "DETERMINISTIC_FINDING_TEMPLATES",
+    "DETERMINISTIC_TEXT_CONTRACT_DIGEST",
     "EVIDENCE_PROVENANCE_GAPS",
     "CaseAvailabilityFacts",
     "CaseGap",
@@ -509,6 +510,49 @@ def render_deterministic_finding_text(
                 "no individual limitation record was available."
             )
     return template.summary, detail
+
+
+def _text_contract_corpus() -> tuple[JsonValue, ...]:
+    """Render every finding-text wording branch once, on fixed synthetic inputs.
+
+    The corpus must cover each branch of ``render_deterministic_finding_text`` that can produce
+    distinct wording: every template, the ledger-stale gap listing, the evidence-provenance
+    addendum, and each omitted-limitation basis label. A new wording branch must add a corpus
+    entry here, or checkpoints written before that branch changes will replay as corrupt instead
+    of superseded.
+    """
+
+    subject = (event_id("evt_00000000-0000-4000-8000-000000000000"),)
+    limitation_result = FindingFact(
+        "material_limitation_present",
+        (result_id("res_00000000-0000-4000-8000-000000000000"),),
+    )
+    limitation_record = FindingFact(
+        "material_limitation_present",
+        (event_id("evt_00000000-0000-4000-8000-000000000001"),),
+    )
+    branches: tuple[tuple[str, FindingKind, tuple[str, ...], tuple[FindingFact, ...]], ...] = (
+        *(("template", kind, (), ()) for kind in FindingKind),
+        ("stale_gap_listing", FindingKind.LEDGER_STALE_OR_INCOMPLETE, ("missing_ref",), ()),
+        (
+            "stale_provenance_addendum",
+            FindingKind.LEDGER_STALE_OR_INCOMPLETE,
+            ("evidence_content_withheld",),
+            (),
+        ),
+        ("limitation_result", FindingKind.MATERIAL_LIMITATION_OMITTED, (), (limitation_result,)),
+        ("limitation_record", FindingKind.MATERIAL_LIMITATION_OMITTED, (), (limitation_record,)),
+    )
+    return tuple(
+        [label, kind.value, *render_deterministic_finding_text(kind, subject, gaps, facts)]
+        for label, kind, gaps, facts in branches
+    )
+
+
+# The exact rendered-text contract of deterministic findings. A persisted DETERMINISTIC_RESULT
+# checkpoint stamps this digest; on replay, a stamp from different wording marks the checkpoint
+# superseded (recompute from the frozen case) instead of corrupt (issue #340).
+DETERMINISTIC_TEXT_CONTRACT_DIGEST: Final[str] = canonical_digest(_text_contract_corpus())
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/integration/application/test_check_checkpoint_compat.py
+++ b/tests/integration/application/test_check_checkpoint_compat.py
@@ -265,6 +265,23 @@ def _mark_stale_wording(source: dict[str, JsonValue]) -> None:
         finding["detail"] = cast(str, finding["detail"]) + _STALE_WORDING_MARKER
 
 
+def _remove_text_contract_stamp(source: dict[str, JsonValue]) -> None:
+    del source["text_contract_digest"]
+
+
+def _use_prior_text_contract(source: dict[str, JsonValue]) -> None:
+    assert source["text_contract_digest"] != "sha256:" + "0" * 64
+    source["text_contract_digest"] = "sha256:" + "0" * 64
+
+
+def _break_policy_executions(source: dict[str, JsonValue]) -> None:
+    source["policy_executions"] = [{"policy_id": "work-integrity"}]
+
+
+def _break_assessments(source: dict[str, JsonValue]) -> None:
+    source["assessments"] = [{}]
+
+
 async def test_pre_stamp_checkpoint_with_old_wording_recomputes_on_the_same_request_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -328,10 +345,38 @@ async def test_broken_checkpoint_content_stays_storage_corrupt(
 
     wedged = await _wedge_check_at_local_ready(monkeypatch)
 
-    def break_policy_executions(source: dict[str, JsonValue]) -> None:
-        source["policy_executions"] = [{"policy_id": "work-integrity"}]
+    await _swap_checkpoint(wedged, _break_policy_executions)
+    wedged.clock.advance(61)
 
-    await _swap_checkpoint(wedged, break_policy_executions)
+    with pytest.raises(PublicOperationError) as corrupt:
+        await wedged.app.check(wedged.request)
+    assert corrupt.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert corrupt.value.retryable is False
+
+
+@pytest.mark.parametrize(
+    ("stamp_mutator", "content_mutator"),
+    (
+        pytest.param(_remove_text_contract_stamp, _break_policy_executions, id="legacy-policy"),
+        pytest.param(_use_prior_text_contract, _break_policy_executions, id="mismatched-policy"),
+        pytest.param(_remove_text_contract_stamp, _break_assessments, id="legacy-assessments"),
+        pytest.param(_use_prior_text_contract, _break_assessments, id="mismatched-assessments"),
+    ),
+)
+async def test_malformed_superseded_checkpoint_content_stays_storage_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+    stamp_mutator: Callable[[dict[str, JsonValue]], None],
+    content_mutator: Callable[[dict[str, JsonValue]], None],
+) -> None:
+    """Supersession cannot hide malformed legacy or mismatched-stamp content."""
+
+    wedged = await _wedge_check_at_local_ready(monkeypatch)
+
+    def mutate(source: dict[str, JsonValue]) -> None:
+        stamp_mutator(source)
+        content_mutator(source)
+
+    await _swap_checkpoint(wedged, mutate)
     wedged.clock.advance(61)
 
     with pytest.raises(PublicOperationError) as corrupt:

--- a/tests/integration/application/test_check_checkpoint_compat.py
+++ b/tests/integration/application/test_check_checkpoint_compat.py
@@ -1,0 +1,340 @@
+"""Replay compatibility for persisted deterministic-result checkpoints (issue #340).
+
+A checkpoint written before a finding-wording change must replay as "superseded — recompute"
+on the same request id, never as non-retryable ``STORAGE_CORRUPT``; a checkpoint whose content
+is actually broken must stay corrupt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import NoReturn, cast
+
+import pytest
+
+from builders.ledger_adapters import MemoryObjects, ownership_fence
+from builders.start_application import (
+    MemoryStartRuntime,
+    StartTestClock,
+    protocol_id,
+    start_composition,
+    start_request,
+)
+from yoetz.adapters.memory.ledger import MemoryLedgerAdapter
+from yoetz.application.egress import PrivacyCoordinator
+from yoetz.application.service import Application, VerificationPolicy
+from yoetz.domain.events import RuntimeProfile
+from yoetz.domain.values import Frontier, session_id
+from yoetz.ports.diagnostics import RuntimeCapability
+from yoetz.ports.importer import ImporterPort, ImportStatusSnapshot
+from yoetz.ports.ledger import (
+    CheckCommitResult,
+    CheckPhase,
+    OperationLease,
+    OperationState,
+)
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource
+from yoetz.ports.publish_response_catalog import PublishResponseCatalogPort
+from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
+from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
+from yoetz.protocol.errors import PublicErrorCode, PublicOperationError
+from yoetz.protocol.models import CheckRequest, FrontierModel, PublishWorkRequest
+
+pytestmark = pytest.mark.anyio
+
+_DIGEST = "sha256:" + "7" * 64
+_STALE_WORDING_MARKER = " [pre-upgrade wording]"
+
+
+class _IdleImporter:
+    async def status(self, session: str) -> ImportStatusSnapshot:
+        return ImportStatusSnapshot(session_id(session), 0, 0, (), ())
+
+
+class _CheckRuntime(MemoryStartRuntime):
+    """Extend the START memory composition with ready writer routing."""
+
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        assert command.writer_id is not None
+        task_id, resources = next(iter(self.resources.items()))
+        ledger, objects = resources
+        assert (command.session_id, command.writer_id) in self.owners
+        return TaskRuntime(
+            task_id,
+            command.session_id,
+            command.writer_id,
+            frozenset(
+                {
+                    RuntimeCapability.WRITE,
+                    RuntimeCapability.STRUCTURAL_READ,
+                    RuntimeCapability.PAYLOAD_READ,
+                }
+            ),
+            ledger,
+            objects,
+            cast(ImporterPort, _IdleImporter()),
+            "0.1.0",
+            "0.1.0",
+            "0.1",
+            "1.0.0",
+            ownership_fence(),
+        )
+
+
+async def _semantic_disabled(frozen: object, findings: object) -> object:
+    del frozen, findings
+    raise AssertionError("semantic_evaluator_called_in_deterministic_mode")
+
+
+def _unused(*args: object, **kwargs: object) -> NoReturn:
+    raise AssertionError("privacy_or_receipt_path_reached_in_checkpoint_compat_test")
+
+
+def _request_base(request_id: str) -> dict[str, JsonValue]:
+    return {
+        "protocol_version": "0.1",
+        "schema_version": "1.0.0",
+        "request_id": request_id,
+        "actor": {"actor_id": "harness:test", "actor_type": "harness"},
+        "client": {"kind": "test_client", "version": "0.1.0", "integration": "local_cli"},
+    }
+
+
+def _frontier(value: Frontier | FrontierModel) -> JsonValue:
+    if isinstance(value, Frontier):
+        return cast(JsonValue, dict(value.as_wire().items()))
+    return cast(JsonValue, value.model_dump(mode="json"))
+
+
+@dataclass(slots=True)
+class _WedgedCheck:
+    app: Application
+    clock: StartTestClock
+    ledger: MemoryLedgerAdapter
+    objects: MemoryObjects
+    writer_id: str
+    request: CheckRequest
+
+
+async def _wedge_check_at_local_ready(monkeypatch: pytest.MonkeyPatch) -> _WedgedCheck:
+    """Drive one deterministic check to a durable LOCAL_READY checkpoint, then crash it."""
+
+    start_app, start_runtime, clock, catalog = start_composition()
+    runtime = _CheckRuntime(clock, start_runtime.ids)
+    app = Application(
+        start_catalog=catalog.delegate,
+        publish_responses=cast(PublishResponseCatalogPort, catalog.delegate),
+        runtime=cast(BundleRuntimePort, runtime),
+        clock=clock,
+        ids=start_runtime.ids,
+        verification_policy=VerificationPolicy(semantic="disabled", max_findings=3),
+        privacy=cast(PrivacyCoordinator, object()),
+        status_cursor_key=b"checkpoint-compat-cursor-key",
+        waiver_policy_digest=_DIGEST,
+        semantic_evaluator=_semantic_disabled,
+        disclosure_scope_for=_unused,
+        receipt_version_resolver=_unused,
+        waiver_authorizer=lambda _: False,
+        import_publication_authorizer=lambda _: False,
+        profile=RuntimeProfile.TEST_FAKE,
+        policy_packs=("research-evidence/0.1.0", "work-integrity/0.1.0"),
+        version_manifest=start_app.version_manifest,
+        enforce_repository_identity=False,
+    )
+
+    started = await app.start(start_request(910, title="Checkpoint compat"))
+    obligation_id = protocol_id("obl_", 911)
+    obligation_event_id = protocol_id("evt_", 913)
+    publish_wire = {
+        **_request_base(protocol_id("req_", 912)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(started.frontier),
+        "event_drafts": (
+            {
+                "event_id": obligation_event_id,
+                "schema": {"name": "obligation_published", "version": "1.0.0"},
+                "occurred_at": "2026-07-19T12:00:00.000Z",
+                "causal_parents": (),
+                "payload": {
+                    "obligation_id": obligation_id,
+                    "description": "Publish a result for the checkpoint-compat exercise.",
+                    "acceptance_criteria": "A result is recorded in the task ledger.",
+                    "evidence_expectation": "A linked immutable result record.",
+                    "requested_items": ({"item_kind": "change", "value": "compat-result"},),
+                    "status": "open",
+                },
+                "artifact_refs": (),
+                "evidence_refs": (),
+            },
+            {
+                "event_id": protocol_id("evt_", 918),
+                "schema": {"name": "claim_recorded", "version": "1.0.0"},
+                "occurred_at": "2026-07-19T12:00:01.000Z",
+                "causal_parents": (obligation_event_id,),
+                "payload": {
+                    "claim_id": protocol_id("clm_", 919),
+                    "claim_kind": "completion",
+                    "statement": "The checkpoint-compat workflow is complete.",
+                    "supporting_refs": (obligation_id,),
+                    "obligation_refs": (obligation_id,),
+                },
+                "artifact_refs": (),
+                "evidence_refs": (),
+            },
+        ),
+    }
+    published = await app.publish_work(PublishWorkRequest.model_validate(publish_wire))
+
+    check_wire = {
+        **_request_base(protocol_id("req_", 914)),
+        "session_id": started.session_id,
+        "writer_id": started.writer_id,
+        "expected_frontier": _frontier(published.result_frontier),
+        "mode": "deterministic_only",
+        "max_findings": "3",
+    }
+    check_request = CheckRequest.model_validate(check_wire)
+    ledger, objects = runtime.resources[started.task_id]
+    advance = ledger.advance_check_phase
+    crash_pending = True
+
+    async def crash_after_local_ready(
+        lease: OperationLease,
+        expected_phase: CheckPhase,
+        next_phase: CheckPhase,
+        durable_object_ref: ObjectRef | None = None,
+    ) -> OperationLease:
+        nonlocal crash_pending
+        replacement = await advance(lease, expected_phase, next_phase, durable_object_ref)
+        if crash_pending and next_phase is CheckPhase.LOCAL_READY:
+            crash_pending = False
+            raise RuntimeError("simulated_post_local_ready_crash")
+        return replacement
+
+    monkeypatch.setattr(ledger, "advance_check_phase", crash_after_local_ready)
+    with pytest.raises(PublicOperationError) as failure:
+        await app.check(check_request)
+    assert failure.value.code is PublicErrorCode.INTERNAL_ERROR
+    monkeypatch.setattr(ledger, "advance_check_phase", advance)
+
+    record = await ledger.lookup_operation(started.writer_id, check_request.request_id)
+    assert record is not None
+    assert record.state is OperationState.PENDING
+    assert record.phase is CheckPhase.LOCAL_READY
+    assert record.resume_object_ref is not None
+    assert record.resume_object_ref.metadata.kind is ObjectKind.DETERMINISTIC_RESULT
+    return _WedgedCheck(app, clock, ledger, objects, started.writer_id, check_request)
+
+
+async def _swap_checkpoint(
+    wedged: _WedgedCheck,
+    mutate: Callable[[dict[str, JsonValue]], None],
+) -> None:
+    """Replace the durable checkpoint with a mutated re-canonicalized copy."""
+
+    record = await wedged.ledger.lookup_operation(wedged.writer_id, wedged.request.request_id)
+    assert record is not None
+    ref = record.resume_object_ref
+    assert ref is not None
+    raw = b"".join([chunk async for chunk in wedged.objects.open_verified(ref)])
+    source = cast(dict[str, JsonValue], strict_json_parse(raw))
+    mutate(source)
+    data = canonical_encode(source)
+    staged = await wedged.objects.stage(
+        ObjectSource(data=data, declared_size=len(data)),
+        ObjectMetadata(
+            ObjectKind.DETERMINISTIC_RESULT,
+            "application/vnd.yoetz.deterministic-result+json",
+            ref.metadata.task_id,
+            wedged.clock.now_utc(),
+        ),
+    )
+    swapped_ref = await wedged.objects.finalize(staged)
+    key = (wedged.writer_id, wedged.request.request_id)
+    state = wedged.ledger._state  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    row = state.operations[key]
+    state.operations[key] = (replace(row[0], resume_object_ref=swapped_ref), row[1])
+
+
+def _mark_stale_wording(source: dict[str, JsonValue]) -> None:
+    assessments = cast(list[JsonValue], source["assessments"])
+    for raw_assessment in assessments:
+        finding = cast(dict[str, JsonValue], cast(dict[str, JsonValue], raw_assessment)["finding"])
+        finding["detail"] = cast(str, finding["detail"]) + _STALE_WORDING_MARKER
+
+
+async def test_pre_stamp_checkpoint_with_old_wording_recomputes_on_the_same_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkpoint written before the text-contract stamp existed replays as superseded."""
+
+    wedged = await _wedge_check_at_local_ready(monkeypatch)
+
+    def to_pre_stamp_format(source: dict[str, JsonValue]) -> None:
+        del source["text_contract_digest"]
+        _mark_stale_wording(source)
+
+    await _swap_checkpoint(wedged, to_pre_stamp_format)
+    wedged.clock.advance(61)
+
+    checked = await wedged.app.check(wedged.request)
+    assert type(checked) is CheckCommitResult, f"unexpected nonterminal check: {type(checked)}"
+    assert checked.findings
+    assert all(_STALE_WORDING_MARKER not in finding.detail for finding in checked.findings)
+
+
+async def test_stamped_checkpoint_from_different_wording_recomputes_on_the_same_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A checkpoint stamped under a different text contract replays as superseded."""
+
+    wedged = await _wedge_check_at_local_ready(monkeypatch)
+
+    def restamp_from_older_contract(source: dict[str, JsonValue]) -> None:
+        assert source["text_contract_digest"] != "sha256:" + "0" * 64
+        source["text_contract_digest"] = "sha256:" + "0" * 64
+        _mark_stale_wording(source)
+
+    await _swap_checkpoint(wedged, restamp_from_older_contract)
+    wedged.clock.advance(61)
+
+    checked = await wedged.app.check(wedged.request)
+    assert type(checked) is CheckCommitResult, f"unexpected nonterminal check: {type(checked)}"
+    assert checked.findings
+    assert all(_STALE_WORDING_MARKER not in finding.detail for finding in checked.findings)
+
+
+async def test_uncorpused_wording_drift_under_a_current_stamp_still_recomputes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text drift the contract digest failed to cover is superseded, not corrupt."""
+
+    wedged = await _wedge_check_at_local_ready(monkeypatch)
+    await _swap_checkpoint(wedged, _mark_stale_wording)
+    wedged.clock.advance(61)
+
+    checked = await wedged.app.check(wedged.request)
+    assert type(checked) is CheckCommitResult, f"unexpected nonterminal check: {type(checked)}"
+    assert checked.findings
+    assert all(_STALE_WORDING_MARKER not in finding.detail for finding in checked.findings)
+
+
+async def test_broken_checkpoint_content_stays_storage_corrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Supersession must not swallow genuine corruption under a current stamp."""
+
+    wedged = await _wedge_check_at_local_ready(monkeypatch)
+
+    def break_policy_executions(source: dict[str, JsonValue]) -> None:
+        source["policy_executions"] = [{"policy_id": "work-integrity"}]
+
+    await _swap_checkpoint(wedged, break_policy_executions)
+    wedged.clock.advance(61)
+
+    with pytest.raises(PublicOperationError) as corrupt:
+        await wedged.app.check(wedged.request)
+    assert corrupt.value.code is PublicErrorCode.STORAGE_CORRUPT
+    assert corrupt.value.retryable is False

--- a/tests/unit/kernel/test_deterministic_checks.py
+++ b/tests/unit/kernel/test_deterministic_checks.py
@@ -38,6 +38,7 @@ from yoetz.domain.values import (
 from yoetz.kernel import deterministic_checks
 from yoetz.kernel.deterministic_checks import (
     DETERMINISTIC_FINDING_TEMPLATES,
+    DETERMINISTIC_TEXT_CONTRACT_DIGEST,
     CaseAvailabilityFacts,
     FindingFact,
     PolicyPack,
@@ -332,6 +333,35 @@ def test_templates_are_complete_exact_and_structural() -> None:
         "obl_00000000-0000-4000-8000-000000000001. Main agent: "
         "Resolve the obligation or revise the completion claim.",
     )
+
+
+def test_text_contract_digest_pins_every_rendered_wording_branch() -> None:
+    corpus = deterministic_checks._text_contract_corpus()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    assert canonical_digest(corpus) == DETERMINISTIC_TEXT_CONTRACT_DIGEST
+    assert len(corpus) == len(FindingKind) + 4
+    rendered = canonical_encode(corpus).decode("utf-8")
+    assert "Gaps: missing_ref." in rendered
+    assert "evidence-provenance gap" in rendered
+    assert "limiting result res_" in rendered
+    assert "material coverage-gap record evt_" in rendered
+    assert "task-level material coverage gap" in rendered
+
+
+def test_text_contract_digest_tracks_template_wording(monkeypatch: pytest.MonkeyPatch) -> None:
+    reworded = dict(DETERMINISTIC_FINDING_TEMPLATES)
+    template = reworded[FindingKind.ACTION_WITHOUT_RESULT]
+    reworded[FindingKind.ACTION_WITHOUT_RESULT] = replace(
+        template, summary=template.summary + " (reworded)"
+    )
+    monkeypatch.setattr(
+        deterministic_checks,
+        "DETERMINISTIC_FINDING_TEMPLATES",
+        MappingProxyType(reworded),
+    )
+    reworded_digest = canonical_digest(
+        deterministic_checks._text_contract_corpus()  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+    )
+    assert reworded_digest != DETERMINISTIC_TEXT_CONTRACT_DIGEST
 
 
 def test_material_limitation_detail_names_the_safe_limiting_record() -> None:


### PR DESCRIPTION
Fixes #340.

## Problem

`DeterministicAssessment.__post_init__` requires byte-equal rendered finding text when `_load_deterministic_result` replays a persisted `DETERMINISTIC_RESULT` checkpoint. Any finding-wording change (e.g. #329's "Omitted limitation basis…" suffix) therefore made every pre-change checkpoint replay as non-retryable `STORAGE_CORRUPT` on its own `request_id` — the continuation instructs replaying the same request, which fails identically, so recovery required abandoning the request. Nothing in `schema_version` (`"1.0.0"`) or `dependency_digest` (projection + availability only) gated the text contract.

## Fix

Per the issue's direction (renderer version stamped into the checkpoint; mismatch → "checkpoint superseded — recompute"):

- **Kernel** (`deterministic_checks.py`): new `DETERMINISTIC_TEXT_CONTRACT_DIGEST`, a canonical digest over a fixed corpus that renders every wording branch of `render_deterministic_finding_text` (all 14 templates, the ledger-stale gap listing, the evidence-provenance addendum, both omitted-limitation basis labels, and the task-level fallback). Any wording edit — template or inline — changes the digest automatically; no manual version bump to forget.
- **Writer** (`_publish_deterministic_result`): stamps `text_contract_digest` into the checkpoint envelope. The case-scoped `dependency_digest` is deliberately untouched — the frozen case (`CHECK_RESUME`) is wording-independent and must stay loadable.
- **Replay** (`_load_deterministic_result`): binding checks run first and unchanged, so a checkpoint with broken bindings or content is still non-retryable `STORAGE_CORRUPT`. After the bindings verify, a stamp that is absent (pre-change format) or differs from the current digest raises an internal supersession signal instead. As a safety net for a wording branch the corpus might miss, each assessment's stored text is also compared against a fresh render before revalidation; drift under a current stamp supersedes too — recompute is always safe because the result derives deterministically from the digest-verified frozen case.
- **Recovery** (`execute_check_commit`): on supersession, the deterministic phase recomputes from `frozen.case` (`run_deterministic_policies` + `allocate_findings` with `prior_finding_ids`) in the same invocation — no retryable-error round trip that could livelock — and records a bounded `deterministic_checkpoint_superseded` count. The stale checkpoint keeps serving as the durable case pointer (its prior-resume binding is unaffected by wording) until commit clears it.
- **Adapter** (`load_frozen_case_from_resume`): accepts both checkpoint shapes for verified case reopen, following the existing `_LEGACY_CASE_JSON_KEYS` precedent.

## Residual (accepted)

A superseded checkpoint is not re-published (no same-phase resume-ref swap edge exists), so repeated crash-replays of one operation across the upgrade window may re-mint unrecorded finding IDs per replay; a semantic judgment referencing a stale ID degrades to an honest rejected-challenge gap rather than a wedge. The window closes at the operation's commit.

## Tests

- `tests/integration/application/test_check_checkpoint_compat.py` — the checkpoint-compat replay tests the issue asked for, on the real memory ledger/object store: a check is crashed at `LOCAL_READY`, the durable checkpoint is swapped for (a) a pre-stamp-format copy with old wording, (b) a differently-stamped copy, (c) a current-stamp copy with uncorpused wording drift — each replays on the same `request_id` to a committed result carrying current wording — and (d) a broken-content copy, which stays non-retryable `STORAGE_CORRUPT`. Verified the three supersession tests fail against the pre-fix code and the corruption pin passes on both.
- `tests/unit/kernel/test_deterministic_checks.py` — pins that the contract digest covers every wording branch and tracks template rewording.

`ruff format`/`ruff check`/pinned pyright clean; `tests/unit/kernel`, `tests/integration/application`, and `tests/conformance/adapters` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Intake and boundaries

- Duplicate search: exact searches for deterministic checkpoint/text-contract replay found issue #340 as the owning report and no competing open implementation PR.
- Design gate: maintainer acknowledgement is recorded on [issue #340](https://github.com/TheGaySupreme123/yoetz/issues/340#issuecomment-5332965985).
- Documentation: `docs/INTERFACES.md` and `CHANGELOG.md` are updated; no ADR or `OPEN_QUESTIONS` flip is introduced.
- No material from ignored private drafting inputs under `docs/architecture/` is included.
- Every human and code-review-agent comment will be fixed or dispositioned before merge.

## Post-review verification

- Fixed structural validation ordering so malformed legacy/mismatched checkpoints remain `STORAGE_CORRUPT` before supersession is honored.
- Added malformed legacy and mismatched-stamp policy/assessment regressions.
- 88 focused integration/unit/conformance tests passed; Ruff check/format and pinned Pyright passed.

Done by ChatGPT.