### PR TITLE
Bound observation noise: outcome semantics, back-pressure classification, and session-scoped advice (#346/#350/#351/#352)

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2433,6 +2433,12 @@ Shared closed types:
   lifecycle event. Once a readable condition finding exists, later evidence-window or frontier
   changes update the observation snapshot and coverage/gap state without appending another
   `finding_recorded` event.
+  Snapshot construction is session-scoped: a mapped session's snapshot is built from that
+  session's own retained envelopes and session-scoped lifecycle/gap health (resolved from the
+  ingest envelope's session commitment or the durable workspace session route), never from every
+  retained workspace envelope. The workspace-wide aggregate remains the operator surface
+  (`yoetz observe status`) and the source of deliberately workspace-standing machine conditions;
+  it is not an input to a mapped task snapshot (ADR-022 decision 14).
   Hook-channel delivery is relevance-scoped: task-scoped conditions come from the mapped Yoetz
   session snapshot when one exists, otherwise from the current Codex session's retained envelopes.
   The workspace-wide snapshot is not a fallback for task-scoped work. Deliberately workspace-
@@ -2491,6 +2497,22 @@ encryption. SQLite/envelopes retain only encrypted object IDs, commitments, clas
 and relations. Vault/service failure records `content_capture_unavailable` and no plaintext spool.
 Unrecognized visible events accept an opaque stable envelope plus encrypted content and
 `unsupported_event`; unknown semantics never infer success.
+
+Outcome semantics and back-pressure vocabulary (ADR-022 decisions 12–13):
+
+- Paired `PostToolUse` materialization consumes `exit_status`, `denied`, boolean `success`, and a
+  closed `result_status` spelling table; a payload with no outcome fact records `UNKNOWN` and its
+  ledger entries carry the `host_outcome_unavailable` known gap. Check coverage and receipts fold
+  that gap into one bounded code regardless of how many observed calls lack outcome semantics; the
+  deterministic research-evidence policy does not mint one `material_limitation_omitted` candidate
+  per such record. Observed work facts (durable per-call action/result records), the acquisition
+  limitation (`host_outcome_unavailable` coverage gap), actionable findings (explicit
+  `FAILURE`/`PARTIAL`, cooperative `UNKNOWN`), and receipt gaps stay distinct surfaces.
+- `operation_pending` is the retryable ingest-rejection reason for designed observation
+  back-pressure (check-acquisition/frozen-case barriers and adjacent transient bundle/frontier
+  contention). It keeps the outbox row pending and annotated, but is never a current observation
+  gap, never a hook failure diagnostic, and never projects `service_unavailable` into status,
+  advice, coverage, or receipt inputs.
 
 Canonical normalization precedes materialization. Equivalent hook/stream host calls share logical
 identity, roles, operation digest, and stable ledger IDs. That canonical logical identity remains

--- a/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
+++ b/docs/adr/ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md
@@ -1,7 +1,8 @@
 # ADR-022 — Harness observation writer identity and observation-tolerant optimistic concurrency
 
 **Status:** Accepted (2026-08-13), recorded for issues #214–#223 and acknowledged in issue #225.
-**Amended:** 2026-08-18 for maintainer-authored issues #320 and #326 and issue #322
+**Amended:** 2026-08-18 for the maintainer-directed issue #346 incident repairs #350, #351, and
+#352 (decisions 12–14); 2026-08-18 for maintainer-authored issues #320 and #326 and issue #322
 (delivered frontier-motion high-water); 2026-08-16 for maintainer-approved issue #224; 2026-08-14
 for moderator-approved issue #244 and the reopened issue #216 recurrence.
 **Implemented by:** `src/yoetz/application/observation_materialize.py`,
@@ -127,6 +128,43 @@ unsupported claims and unbounded duplicate findings.
     motion, and directs callers to use repair facts when an operation still conflicts. The pending notice is
     removed only after its bytes reach the hook consumer. It grants no authority, changes no
     optimistic-concurrency predicate, and adds no MCP operation.
+
+12. Paired `PostToolUse` materialization consumes every host-stated outcome fact: `exit_status`
+    remains authoritative; without it, explicit `denied`, boolean `success`, and a closed
+    `result_status` spelling table map to `SUCCESS`/`FAILURE`/`PARTIAL`. Only a payload with no
+    outcome fact at all records `UNKNOWN` — a missing outcome is never upgraded to success. Such a
+    record keeps its durable per-call action/result identity but carries the
+    `host_outcome_unavailable` known gap on its entry coverage. Because check coverage and receipts
+    fold per-record known gaps into one deduplicated code set, any number of outcome-less observed
+    calls surface as one bounded task/session coverage condition. The research-evidence policy
+    excludes exactly these records — result outcome `UNKNOWN`, no exit status, and source coverage
+    carrying the service-derived `hook_observed` channel that decision 2 keeps unselectable by
+    cooperative requests — from per-result `material_limitation_omitted` candidates. Explicit
+    observed `FAILURE`/`PARTIAL` results and cooperative `UNKNOWN` results remain individually
+    limiting, an outcome-less result still cannot support a completion claim, and the receipt
+    retains the limitation through the coverage gap even when no actionable finding is emitted.
+    Historical rows are not rewritten; mapping identity is unchanged so in-flight outbox replays of
+    committed appends still deduplicate (issues #346/#350).
+
+13. The retryable `OPERATION_PENDING` that decision 4 applies to observation appends during check
+    acquisition or a frozen-case barrier — and the adjacent transient `BUNDLE_BUSY` and
+    `FRONTIER_CONFLICT` coordination shapes — is designed back-pressure, not failure. The
+    coordinator rejects such an ingest with the retryable `operation_pending` reason without an
+    unexpected-exception diagnostic; drain paths keep the row pending without recording a coverage
+    gap or a failure-shaped hook diagnostic, and the reason never projects into observation
+    status, advice, coverage, or receipt inputs. Losing the nonblocking drain lease records
+    nothing: the holder is a live hook or the service sweeper, and flock releases with a dead
+    process. Hook drain-budget expiry records `drain_budget_exhausted` only when the pass moved no
+    backlog; a bounded slice that delivered or quarantined rows and then yielded to the sweeper is
+    working as designed. Genuine `SERVICE_UNAVAILABLE`, vault, storage, and preflight failures
+    keep their existing visibility (issues #346/#351).
+
+14. A mapped session's advice snapshot is constructed from that session's own retained envelopes
+    and session-scoped lifecycle/gap health, resolved from the ingest envelope's session
+    commitment or the durable workspace session route. The workspace-wide aggregate remains the
+    operator surface and the source of deliberately standing machine conditions (composition
+    facts), but is never a silent input to a mapped task snapshot — completing at the construction
+    layer the delivery-selection boundary #250 established (issues #346/#352).
 
 ## Security and privacy consequences
 

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -24,6 +24,7 @@ from typing import Final, cast
 
 from yoetz.config.paths import PathSafetyError, ensure_owner_only_dir, state_dir
 from yoetz.domain.observation import (
+    OBSERVATION_BACKPRESSURE_REASON,
     AdviceItem,
     AdviceSnapshot,
     ObservationControlCommand,
@@ -2714,7 +2715,10 @@ class LocalObservationStore:
         if source_overflow is not None and source_overflow.active:
             current.add(ObservationGapCode.OUTBOX_OVERFLOW.value)
         for row in state.pending_outbox:
-            if row.last_reason is not None:
+            # A row deferred behind an ADR-022 check barrier is designed
+            # back-pressure awaiting retry, never a current coverage gap (#351);
+            # the row keeps its honest last_reason annotation without it.
+            if row.last_reason is not None and row.last_reason != OBSERVATION_BACKPRESSURE_REASON:
                 current.add(row.last_reason)
         # Live mapping presence outranks both the latched code and any stale row reason: a row
         # rejected for a missing mapping keeps that reason after the mapping is restored, and

--- a/src/yoetz/adapters/sqlite/observation.py
+++ b/src/yoetz/adapters/sqlite/observation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Final, cast
 
 import apsw
@@ -339,6 +339,25 @@ class SqliteObservationStore:
         if not isinstance(parsed, Mapping):
             return None
         return advice_snapshot_from_json(JsonObject(cast(Mapping[str, JsonValue], parsed)))
+
+    def codex_session_commitment_for_session(
+        self, *, workspace: str, yoetz_session_id: str
+    ) -> str | None:
+        """Return the mapped Codex session commitment for one Yoetz session, if routed."""
+
+        try:
+            row = self._db.execute(
+                "SELECT codex_session_commitment FROM observation_workspace_session_routes "
+                "WHERE workspace_commitment = ? AND yoetz_session_id = ? AND active = 1",
+                (workspace, yoetz_session_id),
+            ).fetchone()
+        except Exception:
+            # Pre-0004 bundles carry no route table; callers fall back to
+            # workspace-scoped construction exactly as before.
+            return None
+        if row is None or type(row[0]) is not str:
+            return None
+        return row[0]
 
     def workspace_for_yoetz_session(self, yoetz_session_id: str) -> str | None:
         try:
@@ -972,15 +991,24 @@ class SqliteObservationStore:
                 (workspace, excess),
             )
 
-    def _last_receipt(self, workspace: str) -> str | None:
-        row = self._db.execute(
-            "SELECT receipt_time FROM observation_events WHERE workspace_commitment = ? "
-            "ORDER BY id DESC LIMIT 1",
-            (workspace,),
-        ).fetchone()
+    def _last_receipt(self, workspace: str, *, session_commitment: str | None = None) -> str | None:
+        if session_commitment is None:
+            row = self._db.execute(
+                "SELECT receipt_time FROM observation_events WHERE workspace_commitment = ? "
+                "ORDER BY id DESC LIMIT 1",
+                (workspace,),
+            ).fetchone()
+        else:
+            row = self._db.execute(
+                "SELECT receipt_time FROM observation_events WHERE workspace_commitment = ? "
+                "AND session_commitment = ? ORDER BY id DESC LIMIT 1",
+                (workspace, session_commitment),
+            ).fetchone()
         return cast(str, row[0]) if row is not None and type(row[0]) is str else None
 
-    def _status_unlocked(self, workspace_commitment: str) -> ObservationStatus:
+    def _status_unlocked(
+        self, workspace_commitment: str, *, session_commitment: str | None = None
+    ) -> ObservationStatus:
         consent = self._consent_row(workspace_commitment)
         coverage = {
             ObservationSource.CODEX_HOOK: False,
@@ -988,11 +1016,18 @@ class SqliteObservationStore:
         }
         gaps: set[str] = set()
         unsupported: set[str] = set()
-        rows = self._db.execute(
-            "SELECT source, event_kind, gap_codes_json FROM observation_events "
-            "WHERE workspace_commitment = ?",
-            (workspace_commitment,),
-        ).fetchall()
+        if session_commitment is None:
+            rows = self._db.execute(
+                "SELECT source, event_kind, gap_codes_json FROM observation_events "
+                "WHERE workspace_commitment = ?",
+                (workspace_commitment,),
+            ).fetchall()
+        else:
+            rows = self._db.execute(
+                "SELECT source, event_kind, gap_codes_json FROM observation_events "
+                "WHERE workspace_commitment = ? AND session_commitment = ?",
+                (workspace_commitment, session_commitment),
+            ).fetchall()
         for row in rows:
             source = ObservationSource(cast(str, row[0]))
             coverage[source] = True
@@ -1025,7 +1060,7 @@ class SqliteObservationStore:
             if advice_row is not None and type(advice_row[0]) is str
             else None
         )
-        last = self._last_receipt(workspace_commitment)
+        last = self._last_receipt(workspace_commitment, session_commitment=session_commitment)
         return ObservationStatus(
             lifecycle=lifecycle,
             workspace_commitment=workspace_commitment,
@@ -1043,8 +1078,39 @@ class SqliteObservationStore:
             "WHERE workspace_commitment = ? ORDER BY id ASC",
             (workspace,),
         ).fetchall()
+        return self._envelopes_from_rows(rows)
+
+    def list_envelopes_for_session(
+        self, workspace: str, session_commitment: str
+    ) -> tuple[ObservationEnvelope, ...]:
+        """Return only the mapped session's retained envelopes (#352).
+
+        Task-scoped advice construction must not see other sessions' envelopes:
+        a workspace retains history for every consented session, and building a
+        mapped session snapshot from all of it re-attributes unrelated
+        degradation to the current task — the exact #249/#250 failure mode one
+        layer down.
+        """
+
+        rows = self._db.execute(
+            "SELECT structural_json FROM observation_events "
+            "WHERE workspace_commitment = ? AND session_commitment = ? ORDER BY id ASC",
+            (workspace, session_commitment),
+        ).fetchall()
+        return self._envelopes_from_rows(rows)
+
+    async def status_for_session(
+        self, workspace: str, session_commitment: str
+    ) -> ObservationStatus:
+        """Session-scoped lifecycle/gap/coverage health for mapped advice inputs (#352)."""
+
+        async with self._lock:
+            return self._status_unlocked(workspace, session_commitment=session_commitment)
+
+    @staticmethod
+    def _envelopes_from_rows(rows: Iterable[object]) -> tuple[ObservationEnvelope, ...]:
         result: list[ObservationEnvelope] = []
-        for row in rows:
+        for row in cast("Iterable[tuple[object, ...]]", rows):
             blob = row[0]
             if type(blob) is not bytes:
                 continue

--- a/src/yoetz/adapters/sqlite/observation.py
+++ b/src/yoetz/adapters/sqlite/observation.py
@@ -348,7 +348,7 @@ class SqliteObservationStore:
         try:
             row = self._db.execute(
                 "SELECT codex_session_commitment FROM observation_workspace_session_routes "
-                "WHERE workspace_commitment = ? AND yoetz_session_id = ? AND active = 1",
+                "WHERE workspace_commitment = ? AND yoetz_session_id = ?",
                 (workspace, yoetz_session_id),
             ).fetchone()
         except Exception:
@@ -363,7 +363,7 @@ class SqliteObservationStore:
         try:
             row = self._db.execute(
                 "SELECT workspace_commitment FROM observation_workspace_session_routes "
-                "WHERE yoetz_session_id = ? AND active = 1",
+                "WHERE yoetz_session_id = ?",
                 (yoetz_session_id,),
             ).fetchone()
         except Exception:
@@ -1018,29 +1018,66 @@ class SqliteObservationStore:
         unsupported: set[str] = set()
         if session_commitment is None:
             rows = self._db.execute(
-                "SELECT source, event_kind, gap_codes_json FROM observation_events "
-                "WHERE workspace_commitment = ?",
+                "SELECT session_commitment, source, event_kind, gap_codes_json, "
+                "content_refs_json FROM observation_events "
+                "WHERE workspace_commitment = ? ORDER BY id ASC",
                 (workspace_commitment,),
             ).fetchall()
         else:
             rows = self._db.execute(
-                "SELECT source, event_kind, gap_codes_json FROM observation_events "
-                "WHERE workspace_commitment = ? AND session_commitment = ?",
+                "SELECT session_commitment, source, event_kind, gap_codes_json, "
+                "content_refs_json FROM observation_events "
+                "WHERE workspace_commitment = ? AND session_commitment = ? ORDER BY id ASC",
                 (workspace_commitment, session_commitment),
             ).fetchall()
-        for row in rows:
-            source = ObservationSource(cast(str, row[0]))
+        # Event rows are append-only, but ``gap_codes`` describe the condition
+        # observed at that row rather than an everlasting current state. Keep a
+        # small per-session current projection while retaining all rows for the
+        # operator history. In particular, a later accepted observation is live
+        # evidence that an earlier source-lag/cursor-stale condition healed;
+        # another session's healthy event must never clear this session's gap.
+        current_by_session: dict[str, set[str]] = {}
+        unsupported_by_session: dict[str, set[str]] = {}
+        for row in cast("Iterable[tuple[object, ...]]", rows):
+            row_session = row[0]
+            source = ObservationSource(cast(str, row[1]))
+            event_kind = cast(str, row[2])
+            if type(row_session) is not str:
+                continue
+            session_current = current_by_session.setdefault(row_session, set())
+            session_unsupported = unsupported_by_session.setdefault(row_session, set())
             coverage[source] = True
-            event_kind = cast(str, row[1])
-            gap_blob = row[2]
+            gap_codes: set[str] = set()
+            gap_blob = row[3]
             if type(gap_blob) is bytes:
                 parsed = strict_json_parse(gap_blob)
                 if type(parsed) is list:
-                    for item in cast(list[object], parsed):
-                        if type(item) is str:
-                            gaps.add(item)
-                            if item == ObservationGapCode.UNSUPPORTED_EVENT.value:
-                                unsupported.add(event_kind)
+                    gap_codes = {item for item in cast(list[object], parsed) if type(item) is str}
+            # A synthetic observation_gap row records the failure itself and
+            # must not be mistaken for recovery. Any accepted envelope after
+            # it advances the session's source and clears only the transient
+            # conditions whose healing the observation authority can prove.
+            if event_kind != "observation_gap":
+                session_current.discard(ObservationGapCode.SOURCE_LAG.value)
+                session_current.discard(ObservationGapCode.CURSOR_STALE.value)
+                refs_blob = row[4]
+                if type(refs_blob) is bytes:
+                    refs = strict_json_parse(refs_blob)
+                    if type(refs) is list and refs:
+                        session_current.discard(
+                            ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value
+                        )
+            session_current.update(gap_codes)
+            if ObservationGapCode.UNSUPPORTED_EVENT.value in gap_codes:
+                session_unsupported.add(event_kind)
+        if session_commitment is None:
+            for session_current in current_by_session.values():
+                gaps.update(session_current)
+            for session_unsupported in unsupported_by_session.values():
+                unsupported.update(session_unsupported)
+        else:
+            gaps.update(current_by_session.get(session_commitment, ()))
+            unsupported.update(unsupported_by_session.get(session_commitment, ()))
         if consent is None:
             lifecycle = ObservationLifecycle.STOPPED
         elif consent[0] is not None:
@@ -1048,6 +1085,8 @@ class SqliteObservationStore:
         elif consent[1]:
             lifecycle = ObservationLifecycle.STOPPED
         elif not any(coverage.values()):
+            lifecycle = ObservationLifecycle.DEGRADED
+        elif gaps or unsupported:
             lifecycle = ObservationLifecycle.DEGRADED
         else:
             lifecycle = ObservationLifecycle.ACTIVE

--- a/src/yoetz/application/observation_advice.py
+++ b/src/yoetz/application/observation_advice.py
@@ -54,6 +54,8 @@ __all__ = [
     "build_observation_advice_snapshot",
     "hook_advice_context",
     "minimized_semantic_evidence_packet",
+    "scoped_session_envelopes",
+    "scoped_session_status",
     "select_advice_item",
     "select_standing_item",
     "should_reissue_advice",
@@ -121,6 +123,48 @@ class ObservationContextStore(Protocol):
     def load_advice_snapshot(self, workspace: str) -> AdviceSnapshot | None: ...
 
 
+def scoped_session_envelopes(
+    store: ObservationContextStore,
+    workspace: str,
+    session_commitment: str | None,
+) -> tuple[ObservationEnvelope, ...]:
+    """Mapped builds read the mapped session's envelopes, never the workspace's (#352).
+
+    Stores that predate session-scoped listing (or an unmapped build with no
+    session commitment) keep the workspace-wide behavior.
+    """
+
+    if session_commitment is not None:
+        session_list = getattr(store, "list_envelopes_for_session", None)
+        if callable(session_list):
+            loaded = cast(
+                Callable[[str, str], object],
+                session_list,
+            )(workspace, session_commitment)
+            if type(loaded) is tuple:
+                return cast(tuple[ObservationEnvelope, ...], loaded)
+    return store.list_envelopes(workspace)
+
+
+async def scoped_session_status(
+    store: ObservationContextStore,
+    workspace: str,
+    session_commitment: str | None,
+) -> ObservationStatus:
+    """Mapped builds derive lifecycle/gap inputs for the mapped session only (#352)."""
+
+    if session_commitment is not None:
+        session_status = getattr(store, "status_for_session", None)
+        if callable(session_status):
+            loaded = await cast(
+                Callable[[str, str], Awaitable[object]],
+                session_status,
+            )(workspace, session_commitment)
+            if type(loaded) is ObservationStatus:
+                return loaded
+    return await store.status(ObservationStatusQuery(workspace))
+
+
 type CallableFacts = Callable[[str], tuple[ObservationCheckFact, ...]]
 type CallableInspect = Callable[[str], ObservationInspectFact | None]
 type CallablePlans = Callable[[str], tuple[str, ...]]
@@ -181,10 +225,16 @@ class ObservationAdviceContextBuilder:
         store: ObservationContextStore,
         *,
         yoetz_session_id: str | None = None,
+        session_commitment: str | None = None,
     ) -> AdviceSnapshot | None:
-        envelopes = store.list_envelopes(workspace)
+        # Task-scoped conditions come from the mapped session's own evidence and
+        # current health. The workspace-wide aggregate remains the operator
+        # surface (`yoetz observe status --workspace`) and the home of
+        # deliberately workspace-standing machine conditions (composition
+        # facts below); it is never a silent input to a mapped task snapshot.
+        envelopes = scoped_session_envelopes(store, workspace, session_commitment)
         composition = await self._resolve_composition()
-        status = await store.status(ObservationStatusQuery(workspace))
+        status = await scoped_session_status(store, workspace, session_commitment)
         store_check_facts = getattr(store, "load_check_facts", None)
         checks: tuple[ObservationCheckFact, ...] = ()
         if self.check_facts is not None:

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -31,6 +31,7 @@ from yoetz.adapters.integrations.observation_local import (
 from yoetz.adapters.workspace_inspect import LocalWorkspaceInspectAdapter
 from yoetz.application.observation_advice import (
     ObservationAdviceContextBuilder,
+    scoped_session_envelopes,
 )
 from yoetz.application.observation_check_policy import load_observation_check_policy
 from yoetz.application.observation_materialize import (
@@ -81,6 +82,7 @@ from yoetz.domain.findings import (
     FindingOrigin,
 )
 from yoetz.domain.observation import (
+    OBSERVATION_BACKPRESSURE_REASON,
     AdviceItem,
     ObservationContentChunk,
     ObservationContentKind,
@@ -585,10 +587,28 @@ class ObservationCoordinator:
                 )
                 stage = "advice"
                 await self._run_advice(
-                    workspace, runtime, store, legacy_writer_id=mapping.yoetz_writer_id
+                    workspace,
+                    runtime,
+                    store,
+                    legacy_writer_id=mapping.yoetz_writer_id,
+                    session_commitment=envelope.session_commitment,
                 )
                 return result
             except PublicOperationError as exc:
+                if exc.code in {
+                    PublicErrorCode.OPERATION_PENDING,
+                    PublicErrorCode.BUNDLE_BUSY,
+                    PublicErrorCode.FRONTIER_CONFLICT,
+                }:
+                    # Designed back-pressure, not a failure (#351). ADR-022
+                    # decision 4 makes observation appends receive retryable
+                    # OPERATION_PENDING while check acquisition or a frozen-case
+                    # barrier is active; BUNDLE_BUSY and FRONTIER_CONFLICT are
+                    # the same transient coordination one layer down. The
+                    # durable outbox keeps the row pending and retries after the
+                    # barrier clears, so no unexpected-exception diagnostic is
+                    # recorded and no service_unavailable gap is projected.
+                    return _reject(OBSERVATION_BACKPRESSURE_REASON)
                 record_unexpected_exception_without_raising(
                     exc,
                     component="application.observation_coordinator",
@@ -607,7 +627,6 @@ class ObservationCoordinator:
                     return _reject(ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value)
                 if exc.code in {
                     PublicErrorCode.SERVICE_UNAVAILABLE,
-                    PublicErrorCode.BUNDLE_BUSY,
                     PublicErrorCode.SESSION_NOT_FOUND,
                 }:
                     return _reject(ObservationGapCode.SERVICE_UNAVAILABLE.value)
@@ -1196,6 +1215,7 @@ class ObservationCoordinator:
                         deferred_runtime,
                         deferred_store,
                         legacy_writer_id=legacy_writer_id,
+                        session_commitment=envelope.session_commitment,
                     )
 
                 async def _release() -> None:
@@ -1638,19 +1658,35 @@ class ObservationCoordinator:
         store: TaskObservationPort,
         *,
         legacy_writer_id: str | None = None,
+        session_commitment: str | None = None,
     ) -> None:
-        task_id = runtime.task_id if isinstance(runtime, TaskRuntime) else runtime
-        envelopes = store.list_envelopes(workspace)
-        session_id = runtime.session_id if isinstance(runtime, TaskRuntime) else None
+        # A plain string is a bare task id from callers with no runtime in hand;
+        # anything else is runtime-shaped (the concrete TaskRuntime in
+        # production, duck-typed stand-ins in tests).
+        task_id = runtime if isinstance(runtime, str) else runtime.task_id
+        session_id = None if isinstance(runtime, str) else runtime.session_id
+        if session_commitment is None and type(session_id) is str:
+            # Post-commit callers (verification drains, restart rediscovery)
+            # carry no envelope; recover the mapped Codex session commitment
+            # from the durable route so the build stays session-scoped (#352).
+            route_lookup = getattr(store, "codex_session_commitment_for_session", None)
+            if callable(route_lookup):
+                routed = route_lookup(workspace=workspace, yoetz_session_id=session_id)
+                if type(routed) is str:
+                    session_commitment = routed
+        envelopes = scoped_session_envelopes(store, workspace, session_commitment)
         snapshot = await self.advice_context_builder.build(
-            workspace, store, yoetz_session_id=session_id if type(session_id) is str else None
+            workspace,
+            store,
+            yoetz_session_id=session_id if type(session_id) is str else None,
+            session_commitment=session_commitment,
         )
         if snapshot is not None:
             # Materialize before publishing the snapshot to either durable cache.
             # Snapshot identity participates in deterministic suppression, so
             # advancing it first could make a failed ledger append disappear on
             # retry and let the outbox ACK without the finding ever landing.
-            if isinstance(runtime, TaskRuntime):
+            if not isinstance(runtime, str) and runtime.writer_id is not None:
                 await self._materialize_advice_findings(
                     runtime,
                     envelopes,
@@ -1659,7 +1695,6 @@ class ObservationCoordinator:
                 )
             now = timestamp_from_datetime(self.clock.now_utc())
             store.set_advice_snapshot(workspace, snapshot, now)
-            session_id = runtime.session_id if isinstance(runtime, TaskRuntime) else None
             session_setter = getattr(store, "set_session_advice_snapshot", None)
             if callable(session_setter) and type(session_id) is str:
                 session_setter(
@@ -1694,7 +1729,7 @@ class ObservationCoordinator:
                 )
             # Mirror into local store for hook advice delivery.
             await self._local(partial(self.local.set_advice_snapshot, workspace, snapshot))
-            if isinstance(runtime, TaskRuntime) and type(session_id) is str:
+            if not isinstance(runtime, str) and type(session_id) is str:
                 await self._local(
                     partial(
                         self.local.set_session_advice_snapshot,

--- a/src/yoetz/application/observation_drain.py
+++ b/src/yoetz/application/observation_drain.py
@@ -18,6 +18,7 @@ from yoetz.adapters.integrations.observation_local import (
     ObservationOutboxRow,
 )
 from yoetz.domain.observation import (
+    OBSERVATION_BACKPRESSURE_REASON,
     ObservationGapCode,
     ObservationIngestDisposition,
     ObservationIngestRequest,
@@ -26,6 +27,7 @@ from yoetz.domain.observation import (
 
 __all__ = [
     "DEFAULT_OBSERVATION_SWEEP_LIMIT",
+    "EXPECTED_OBSERVATION_BACKPRESSURE_REASONS",
     "ObservationDrainAction",
     "ObservationDrainDecision",
     "ObservationDrainSummary",
@@ -39,11 +41,16 @@ DEFAULT_OBSERVATION_SWEEP_LIMIT: Final = 64
 # handful of stranded threads (a deadline expiring against a parked flock) cannot wedge the
 # next pass outright.
 _SWEEP_EXECUTOR_WORKERS: Final = 4
+# Designed coordination, not delivery failure (#351): the row stays pending and
+# retries, but the reason never becomes a coverage gap or a failure-shaped hook
+# diagnostic. ADR-022's check barrier is the canonical producer.
+EXPECTED_OBSERVATION_BACKPRESSURE_REASONS: Final = frozenset({OBSERVATION_BACKPRESSURE_REASON})
 RETRYABLE_OBSERVATION_REJECTIONS: Final = frozenset(
     {
         ObservationGapCode.SERVICE_UNAVAILABLE.value,
         ObservationGapCode.VAULT_LOCKED.value,
         ObservationGapCode.MAPPING_MISSING.value,
+        OBSERVATION_BACKPRESSURE_REASON,
         "observation_disabled",
         "paused",
     }
@@ -247,9 +254,13 @@ class ObservationOutboxSweeper:
                         continue
                     if decision.reason is not None:
                         reasons[decision.reason] = reasons.get(decision.reason, 0) + 1
-                        await self._off_loop(
-                            partial(self.local.note_coverage_gap, workspace, decision.reason)
-                        )
+                        if decision.reason not in EXPECTED_OBSERVATION_BACKPRESSURE_REASONS:
+                            # A deferral behind a check barrier is designed
+                            # coordination; recording it as a coverage gap would
+                            # project a false current condition (#351).
+                            await self._off_loop(
+                                partial(self.local.note_coverage_gap, workspace, decision.reason)
+                            )
 
                     if decision.action is ObservationDrainAction.RETRY:
                         # The head of this lane stays pending, so no later row of the same

--- a/src/yoetz/application/observation_materialize.py
+++ b/src/yoetz/application/observation_materialize.py
@@ -223,12 +223,6 @@ def _post_outcome(payload: Mapping[str, JsonValue]) -> ResultOutcome:
     return ResultOutcome.UNKNOWN
 
 
-def _explicit_post_failure(payload: Mapping[str, JsonValue]) -> bool:
-    """True when a post-event is an explicit failure or denial, not status-unknown."""
-
-    return _post_outcome(payload) in {ResultOutcome.FAILURE, ResultOutcome.PARTIAL}
-
-
 def _action_kind(tool: str | None) -> ActionKind:
     if tool is None:
         return ActionKind.OTHER
@@ -406,7 +400,12 @@ def materialize_observation_envelope(
         return MaterializedObservationBatch(tuple(drafts), coverage, channel, gaps, None)
 
     if kind == "PostToolUse":
-        if routine_read and not _explicit_post_failure(structural):
+        # A routine read is coalesced only after the host supplied an explicit
+        # successful outcome. An outcome-less result must retain its durable
+        # action/result identity and folded host_outcome_unavailable gap under
+        # ADR-022 decision 12; treating UNKNOWN as a successful read would
+        # discard that limitation before the materializer can record it.
+        if routine_read and _post_outcome(structural) is ResultOutcome.SUCCESS:
             return MaterializedObservationBatch(
                 (), coverage, channel, gaps, "routine_read_coalesced"
             )

--- a/src/yoetz/application/observation_materialize.py
+++ b/src/yoetz/application/observation_materialize.py
@@ -56,6 +56,7 @@ from yoetz.protocol.coverage import (
 from yoetz.protocol.ids import PREFIX_BY_KIND, IdKind
 
 __all__ = [
+    "HOST_OUTCOME_UNAVAILABLE_GAP",
     "approved_check_author",
     "MATERIALIZATION_MAPPING_VERSION",
     "MaterializedObservationBatch",
@@ -68,6 +69,14 @@ __all__ = [
 ]
 
 MATERIALIZATION_MAPPING_VERSION: Final = "obs-ledger/1.2.0"
+# One bounded coverage condition for "the host emitted a paired tool result with
+# no outcome semantics at all" (#350). It rides the entry coverage of the
+# affected action/result records, so any number of outcome-less observed calls
+# fold into a single known-gap code in check coverage and the receipt instead of
+# one material-limitation candidate per call. It is deliberately not an
+# ObservationGapCode: envelopes are complete observations; the gap belongs to
+# the materialized ledger records whose outcome the host did not state.
+HOST_OUTCOME_UNAVAILABLE_GAP: Final = "host_outcome_unavailable"
 _LOGICAL_IDENTITY_DOMAIN: Final = "yoetz/observation-logical-identity/v1"
 _ID_DOMAIN: Final = b"yoetz/observation-materialize-id/v1\x00"
 _FILE_TOOLS: Final = frozenset(
@@ -164,12 +173,60 @@ def _exit_status(payload: Mapping[str, JsonValue]) -> int | None:
     return None
 
 
+# Closed result_status vocabularies. Codex hosts spell tool outcomes several
+# ways; only exact known spellings map to an outcome, and any other string
+# stays UNKNOWN so an unrecognized status is never upgraded to success.
+_RESULT_STATUS_SUCCESS: Final = frozenset({"success", "succeeded", "ok", "completed", "passed"})
+_RESULT_STATUS_FAILURE: Final = frozenset(
+    {
+        "failure",
+        "failed",
+        "error",
+        "errored",
+        "denied",
+        "aborted",
+        "cancelled",
+        "canceled",
+        "timeout",
+        "timed_out",
+        "interrupted",
+    }
+)
+_RESULT_STATUS_PARTIAL: Final = frozenset({"partial", "partially_completed"})
+
+
+def _post_outcome(payload: Mapping[str, JsonValue]) -> ResultOutcome:
+    """Map every host-provided outcome fact to a result outcome (#350).
+
+    The real Codex ``PostToolUse`` payload may state its outcome as
+    ``exit_status``, ``denied``, boolean ``success``, or a ``result_status``
+    string; all of them are consumed rather than discarded. Any explicit
+    failure signal wins over any success signal — conflicting facts must never
+    launder a stated failure into success — and only a payload with no outcome
+    fact at all is UNKNOWN: a missing outcome is never upgraded to success.
+    """
+
+    exit_status = _exit_status(payload)
+    status = payload.get("result_status")
+    lowered = status.lower() if type(status) is str else None
+    if (
+        (exit_status is not None and exit_status != 0)
+        or payload.get("denied") is True
+        or payload.get("success") is False
+        or lowered in _RESULT_STATUS_FAILURE
+    ):
+        return ResultOutcome.FAILURE
+    if lowered in _RESULT_STATUS_PARTIAL:
+        return ResultOutcome.PARTIAL
+    if exit_status == 0 or payload.get("success") is True or lowered in _RESULT_STATUS_SUCCESS:
+        return ResultOutcome.SUCCESS
+    return ResultOutcome.UNKNOWN
+
+
 def _explicit_post_failure(payload: Mapping[str, JsonValue]) -> bool:
     """True when a post-event is an explicit failure or denial, not status-unknown."""
 
-    if _exit_status(payload) not in {None, 0}:
-        return True
-    return payload.get("success") is False or payload.get("denied") is True
+    return _post_outcome(payload) in {ResultOutcome.FAILURE, ResultOutcome.PARTIAL}
 
 
 def _action_kind(tool: str | None) -> ActionKind:
@@ -445,12 +502,23 @@ def materialize_observation_envelope(
             )
         )
         exit_status = _exit_status(structural)
-        if exit_status is None:
-            outcome = ResultOutcome.UNKNOWN
-        elif exit_status == 0:
-            outcome = ResultOutcome.SUCCESS
-        else:
-            outcome = ResultOutcome.FAILURE
+        outcome = _post_outcome(structural)
+        if outcome is ResultOutcome.UNKNOWN:
+            # The host stated no outcome for this call. The per-call record stays
+            # durable, but its coverage names the one standing capability
+            # condition so check/receipt fold every such call into a single
+            # bounded known gap instead of per-result limitation candidates.
+            coverage = Coverage(
+                publication_channels=coverage.publication_channels,
+                authorship_assurance=coverage.authorship_assurance,
+                artifact_observation=coverage.artifact_observation,
+                evidence_immutability=coverage.evidence_immutability,
+                ledger_freshness=coverage.ledger_freshness,
+                check_types=coverage.check_types,
+                known_gaps=tuple(
+                    sorted({*coverage.known_gaps, HOST_OUTCOME_UNAVAILABLE_GAP}, key=str.encode)
+                ),
+            )
         drafts.append(
             _draft(
                 event=result_event,

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -763,13 +763,15 @@ async def _drain_outbox(
 
     Codex runs async hooks concurrently; without the lease every concurrent
     hook re-ingests the identical backlog for zero extra delivery. Losing the
-    lease means another live hook process is already draining — not a failure,
-    so nothing is recorded.
+    lease means another live owner — a concurrent hook or the service sweeper —
+    is already draining. That is the intended coordination, not a failure, so
+    nothing is recorded (#351): one failure-shaped row per contending hook was
+    exactly the diagnostic noise that buried genuine preflight/service faults.
+    A crashed holder cannot wedge the lease; flock releases with its process.
     """
 
     with store.drain_lease(workspace_commitment) as owned:
         if not owned:
-            record_hook_diagnostic("drain_lease_contended", event_name, _state=_state)
             return
         await _drain_outbox_leased(
             store,
@@ -807,6 +809,7 @@ async def _drain_outbox_leased(
     import asyncio
 
     from yoetz.application.observation_drain import (
+        EXPECTED_OBSERVATION_BACKPRESSURE_REASONS,
         ObservationDrainAction,
         route_observation_ingest,
     )
@@ -875,13 +878,19 @@ async def _drain_outbox_leased(
     )
     skipped_sessions: set[str] = set()
     consecutive_unavailable = 0
+    # The hook owns a bounded slice; the service sweeper owns bulk delivery.
+    # Hitting the slice after moving backlog (acknowledged or quarantined rows)
+    # is a capacity yield, not a failed drain, so budget expiry records a
+    # diagnostic only when the pass made no progress at all (#351).
+    progressed = 0
     try:
         for row in pending:
             if row.codex_session_id in skipped_sessions:
                 continue
             remaining = budget_seconds - (monotonic() - started)
             if remaining <= 0:
-                record_hook_diagnostic("drain_budget_exhausted", event_name, _state=_state)
+                if progressed == 0:
+                    record_hook_diagnostic("drain_budget_exhausted", event_name, _state=_state)
                 break
             chunks = (
                 ()
@@ -900,19 +909,21 @@ async def _drain_outbox_leased(
                     timeout=remaining,
                 )
             except TimeoutError:
-                record_hook_diagnostic("drain_budget_exhausted", event_name, _state=_state)
+                if progressed == 0:
+                    record_hook_diagnostic("drain_budget_exhausted", event_name, _state=_state)
                 break
             decision = route_observation_ingest(result)
             # One batch per row, opened only after this row's RPC returned and
             # closed before the next one: the acknowledgement is never durable
             # ahead of the ingest it acknowledges, and the store lock never
             # spans a network wait (#242).
+            expected_backpressure = decision.reason in EXPECTED_OBSERVATION_BACKPRESSURE_REASONS
             with store.batched(workspace_commitment):
                 attempted = store.bump_outbox_row_attempt(
                     workspace_commitment, row, reason=decision.reason
                 )
                 if attempted is not None:
-                    if decision.reason is not None:
+                    if decision.reason is not None and not expected_backpressure:
                         store.note_coverage_gap(workspace_commitment, decision.reason)
                     if chunks and decision.action is not ObservationDrainAction.ACKNOWLEDGE:
                         store.note_coverage_gap(
@@ -925,11 +936,13 @@ async def _drain_outbox_leased(
                             attempted,
                             decision.reason or ObservationGapCode.SERVICE_UNAVAILABLE.value,
                         )
+                        progressed += 1
                     elif decision.action is ObservationDrainAction.ACKNOWLEDGE:
                         store.acknowledge_outbox_row(workspace_commitment, attempted)
+                        progressed += 1
             if attempted is None:
                 continue
-            if decision.reason is not None:
+            if decision.reason is not None and not expected_backpressure:
                 record_hook_diagnostic(decision.reason, event_name, _state=_state)
             if decision.action is ObservationDrainAction.RETRY:
                 if decision.reason in global_stop:

--- a/src/yoetz/domain/observation.py
+++ b/src/yoetz/domain/observation.py
@@ -30,6 +30,7 @@ from yoetz.protocol.errors import PROTOCOL_REASON_CODES, ProtocolValueError
 __all__ = [
     "AdviceItem",
     "AdviceSnapshot",
+    "OBSERVATION_BACKPRESSURE_REASON",
     "OBSERVATION_HOOK_COMMITMENT_DOMAIN",
     "OBSERVATION_STREAM_LINE_DOMAIN",
     "OBSERVATION_WORKSPACE_DOMAIN",
@@ -179,6 +180,16 @@ class ObservationLifecycle(str, Enum):  # noqa: UP042 - exact durable wire enum
     DEGRADED = "degraded"
     STALE = "stale"
     STOPPED = "stopped"
+
+
+# Retryable ingest-rejection reason for designed back-pressure (#351): the
+# observation ledger deferred the append behind an ADR-022 check-acquisition or
+# frozen-case barrier (or equivalent transient bundle/frontier contention). It
+# is deliberately not an ObservationGapCode — a deferral is expected
+# coordination, never a current coverage gap, and must not project into
+# observation status, advice, coverage, or receipt inputs. The durable outbox
+# simply keeps the row pending and retries after the barrier clears.
+OBSERVATION_BACKPRESSURE_REASON: Final = "operation_pending"
 
 
 class ObservationGapCode(str, Enum):  # noqa: UP042 - exact durable wire enum

--- a/src/yoetz/kernel/policies/research_evidence.py
+++ b/src/yoetz/kernel/policies/research_evidence.py
@@ -73,6 +73,7 @@ _RULE_ORDER: Final = (
     FindingKind.QUESTIONABLE_FINDING_REJECTION,
 )
 _MATERIAL_GAPS: Final = BASE_RESPONSE_INADMISSIBLE_GAPS
+_HOST_OUTCOME_UNAVAILABLE_GAP: Final = "host_outcome_unavailable"
 
 
 def _ascii(value: str) -> bytes:
@@ -241,8 +242,13 @@ def _observation_outcome_unavailable(case: DeterministicCase, ref: FindingBasisR
     if record.payload.exit_status is not None:
         return False
     coverage = case.coverage_by_ref.get(ref)
-    return coverage is not None and PublicationChannel.HOOK_OBSERVED in set(
-        coverage.publication_channels
+    # Only newly materialized rows carry the explicit capability gap. Historical
+    # rows have the same outcome/channel shape but no durable cause marker, so
+    # retaining the old limiting finding is the only honest compatibility path.
+    return (
+        coverage is not None
+        and _HOST_OUTCOME_UNAVAILABLE_GAP in coverage.known_gaps
+        and PublicationChannel.HOOK_OBSERVED in set(coverage.publication_channels)
     )
 
 

--- a/src/yoetz/kernel/policies/research_evidence.py
+++ b/src/yoetz/kernel/policies/research_evidence.py
@@ -37,6 +37,7 @@ from yoetz.kernel.policies.response_support import (
     RESEARCH_REJECTION_PRESENT_FACT,
     response_support_admissible,
 )
+from yoetz.protocol.coverage import PublicationChannel
 
 __all__ = [
     "RESEARCH_EVIDENCE_FACT_CODES",
@@ -217,14 +218,47 @@ def _diff_mismatch_findings(case: DeterministicCase) -> list[DeterministicAssess
     return output
 
 
+def _observation_outcome_unavailable(case: DeterministicCase, ref: FindingBasisRef) -> bool:
+    """One host capability limitation, not one omission per observed call (#350).
+
+    The narrowing is provenance- and cause-aware: it applies only to results the
+    service itself materialized from harness observation — their source-event
+    coverage carries the ``hook_observed`` publication channel, which ADR-022
+    decision 2 keeps service-derived and unselectable by cooperative requests —
+    and only when the host stated no outcome at all (``UNKNOWN`` with no exit
+    status). Such records name the standing ``host_outcome_unavailable``
+    coverage condition that check coverage and the receipt already carry, so
+    excluding them here bounds the finding set without hiding the limitation.
+    A cooperative result with an ``UNKNOWN`` outcome remains individually
+    limiting, and explicit ``FAILURE``/``PARTIAL`` observations are unaffected.
+    """
+
+    record = case.projection.results.get(ResultId(ref))
+    if record is None or record.payload is None:
+        return False
+    if record.payload.outcome is not ResultOutcome.UNKNOWN:
+        return False
+    if record.payload.exit_status is not None:
+        return False
+    coverage = case.coverage_by_ref.get(ref)
+    return coverage is not None and PublicationChannel.HOOK_OBSERVED in set(
+        coverage.publication_channels
+    )
+
+
 def _limiting_refs(case: DeterministicCase) -> tuple[FindingBasisRef, ...]:
     limitations: set[FindingBasisRef] = set()
     for result_id, record in case.projection.results.items():
-        if record.payload is not None and record.payload.outcome in {
-            ResultOutcome.FAILURE,
-            ResultOutcome.PARTIAL,
-            ResultOutcome.UNKNOWN,
-        }:
+        if (
+            record.payload is not None
+            and record.payload.outcome
+            in {
+                ResultOutcome.FAILURE,
+                ResultOutcome.PARTIAL,
+                ResultOutcome.UNKNOWN,
+            }
+            and not _observation_outcome_unavailable(case, result_id)
+        ):
             limitations.add(result_id)
     for ref, coverage in case.coverage_by_ref.items():
         if ref.startswith(("obl_", "res_", "evd_")) and _MATERIAL_GAPS & set(coverage.known_gaps):

--- a/tests/unit/adapters/test_sqlite_observation.py
+++ b/tests/unit/adapters/test_sqlite_observation.py
@@ -153,3 +153,95 @@ def test_record_logical_identity_claim_idempotence_union_and_conflict() -> None:
     with pytest.raises(PublicOperationError) as invalid:
         record(source_mask=3)
     assert invalid.value.code is PublicErrorCode.INVALID_REQUEST
+
+
+_SESSION_B = "hmac-sha256:" + "4" * 64
+
+
+def _session_envelope(
+    session: str,
+    identity: str,
+    ordinal: int,
+    *,
+    gaps: tuple[str, ...] = (),
+) -> ObservationEnvelope:
+    return ObservationEnvelope(
+        session_commitment=session,
+        event_kind="PostToolUse",
+        source_identity=identity,
+        source=ObservationSource.CODEX_HOOK,
+        cursor=_cursor(byte_pos=10 * ordinal, event_pos=ordinal),
+        receipt_time=_TIME,
+        structural_payload=JsonObject({"tool_name": "shell", "exit_status": 0}),
+        content_object_refs=(),
+        gap_codes=gaps,
+    )
+
+
+def test_session_scoped_envelopes_and_status_exclude_other_sessions() -> None:
+    """#352: mapped advice inputs must not see another session's envelopes or gaps."""
+
+    async def run() -> None:
+        store = _store()
+        store.grant_consent(_WORKSPACE, _TIME)
+        store.bind_session(_WORKSPACE, _SESSION)
+        store.bind_session(_WORKSPACE, _SESSION_B)
+        # Session A carries degradation; session B is healthy.
+        degraded = await store.ingest(
+            _session_envelope(
+                _SESSION,
+                "hook:degraded-a",
+                1,
+                gaps=(
+                    ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value,
+                    ObservationGapCode.SOURCE_LAG.value,
+                ),
+            )
+        )
+        assert degraded.disposition is ObservationIngestDisposition.ACCEPTED
+        healthy = await store.ingest(_session_envelope(_SESSION_B, "hook:healthy-b", 1))
+        assert healthy.disposition is ObservationIngestDisposition.ACCEPTED
+
+        workspace_wide = store.list_envelopes(_WORKSPACE)
+        assert len(workspace_wide) == 2
+        only_b = store.list_envelopes_for_session(_WORKSPACE, _SESSION_B)
+        assert [env.source_identity for env in only_b] == ["hook:healthy-b"]
+
+        status_b = await store.status_for_session(_WORKSPACE, _SESSION_B)
+        assert status_b.gaps == ()
+        assert status_b.lifecycle is ObservationLifecycle.ACTIVE
+        status_a = await store.status_for_session(_WORKSPACE, _SESSION)
+        assert ObservationGapCode.SOURCE_LAG.value in status_a.gaps
+        assert ObservationGapCode.OBSERVATION_STORAGE_CORRUPT.value in status_a.gaps
+        # The workspace aggregate still retains A's history for the operator surface.
+        aggregate = await store.status(ObservationStatusQuery(_WORKSPACE))
+        assert ObservationGapCode.SOURCE_LAG.value in aggregate.gaps
+
+    asyncio.run(run())
+
+
+def test_codex_session_commitment_for_session_reads_active_route() -> None:
+    store = _store()
+    store.grant_consent(_WORKSPACE, _TIME)
+    store.record_workspace_session_route(
+        workspace=_WORKSPACE,
+        yoetz_session_id="ses_10000000-0000-4000-8000-000000000001",
+        yoetz_task_id="tsk_10000000-0000-4000-8000-000000000001",
+        yoetz_writer_id="wtr_10000000-0000-4000-8000-000000000001",
+        codex_session_commitment=_SESSION,
+        bound_at=_TIME,
+    )
+    assert (
+        store.codex_session_commitment_for_session(
+            workspace=_WORKSPACE,
+            yoetz_session_id="ses_10000000-0000-4000-8000-000000000001",
+        )
+        == _SESSION
+    )
+    assert (
+        store.codex_session_commitment_for_session(
+            workspace=_WORKSPACE,
+            yoetz_session_id="ses_10000000-0000-4000-8000-000000000002",
+        )
+        is None
+    )

--- a/tests/unit/adapters/test_sqlite_observation.py
+++ b/tests/unit/adapters/test_sqlite_observation.py
@@ -220,7 +220,61 @@ def test_session_scoped_envelopes_and_status_exclude_other_sessions() -> None:
     asyncio.run(run())
 
 
-def test_codex_session_commitment_for_session_reads_active_route() -> None:
+def test_session_status_clears_current_gap_without_clearing_other_sessions() -> None:
+    """Historical gap rows remain append-only while current health recovers per session."""
+
+    async def run() -> None:
+        store = _store()
+        store.grant_consent(_WORKSPACE, _TIME)
+        store.bind_session(_WORKSPACE, _SESSION)
+        store.bind_session(_WORKSPACE, _SESSION_B)
+        degraded_a = await store.ingest(
+            _session_envelope(
+                _SESSION,
+                "hook:degraded-a-current",
+                1,
+                gaps=(ObservationGapCode.SOURCE_LAG.value,),
+            )
+        )
+        degraded_b = await store.ingest(
+            _session_envelope(
+                _SESSION_B,
+                "hook:degraded-b-current",
+                1,
+                gaps=(ObservationGapCode.SOURCE_LAG.value,),
+            )
+        )
+        assert degraded_a.disposition is ObservationIngestDisposition.ACCEPTED
+        assert degraded_b.disposition is ObservationIngestDisposition.ACCEPTED
+
+        recovered_b = await store.ingest(
+            _session_envelope(_SESSION_B, "hook:recovered-b-current", 2)
+        )
+        assert recovered_b.disposition is ObservationIngestDisposition.ACCEPTED
+        status_a = await store.status_for_session(_WORKSPACE, _SESSION)
+        status_b = await store.status_for_session(_WORKSPACE, _SESSION_B)
+        assert ObservationGapCode.SOURCE_LAG.value in status_a.gaps
+        assert ObservationGapCode.SOURCE_LAG.value not in status_b.gaps
+        aggregate = await store.status(ObservationStatusQuery(_WORKSPACE))
+        assert ObservationGapCode.SOURCE_LAG.value in aggregate.gaps
+
+        recovered_a = await store.ingest(_session_envelope(_SESSION, "hook:recovered-a-current", 2))
+        assert recovered_a.disposition is ObservationIngestDisposition.ACCEPTED
+        assert (
+            ObservationGapCode.SOURCE_LAG.value
+            not in (await store.status_for_session(_WORKSPACE, _SESSION)).gaps
+        )
+        assert (
+            ObservationGapCode.SOURCE_LAG.value
+            not in (await store.status(ObservationStatusQuery(_WORKSPACE))).gaps
+        )
+        # Recovery changes only the current projection; all observations remain.
+        assert len(store.list_envelopes(_WORKSPACE)) == 4
+
+    asyncio.run(run())
+
+
+def test_codex_session_commitment_for_session_recovers_historical_route() -> None:
     store = _store()
     store.grant_consent(_WORKSPACE, _TIME)
     store.record_workspace_session_route(
@@ -231,6 +285,16 @@ def test_codex_session_commitment_for_session_reads_active_route() -> None:
         codex_session_commitment=_SESSION,
         bound_at=_TIME,
     )
+    # Binding a newer session marks the older route inactive, but the durable
+    # route still identifies the older task and must remain usable for recovery.
+    store.record_workspace_session_route(
+        workspace=_WORKSPACE,
+        yoetz_session_id="ses_10000000-0000-4000-8000-000000000002",
+        yoetz_task_id="tsk_10000000-0000-4000-8000-000000000002",
+        yoetz_writer_id="wtr_10000000-0000-4000-8000-000000000002",
+        codex_session_commitment=_SESSION_B,
+        bound_at=_TIME,
+    )
     assert (
         store.codex_session_commitment_for_session(
             workspace=_WORKSPACE,
@@ -239,9 +303,12 @@ def test_codex_session_commitment_for_session_reads_active_route() -> None:
         == _SESSION
     )
     assert (
+        store.workspace_for_yoetz_session("ses_10000000-0000-4000-8000-000000000001") == _WORKSPACE
+    )
+    assert (
         store.codex_session_commitment_for_session(
             workspace=_WORKSPACE,
             yoetz_session_id="ses_10000000-0000-4000-8000-000000000002",
         )
-        is None
+        == _SESSION_B
     )

--- a/tests/unit/application/test_observation_advice.py
+++ b/tests/unit/application/test_observation_advice.py
@@ -231,6 +231,121 @@ def test_callable_composition_is_resolved_freshly_on_every_build() -> None:
     assert "provider_not_ready" in rule_codes(revoked)
 
 
+def test_mapped_build_uses_session_scoped_envelopes_and_health() -> None:
+    """#352: a mapped session snapshot is built from that session's evidence and
+    current health, never from workspace-wide history."""
+
+    session_a = "hmac-sha256:" + "b" * 64
+    session_b = "hmac-sha256:" + "c" * 64
+
+    def _session_envelope(
+        session: str, identity: str, payload: dict[str, object], pos: int
+    ) -> ObservationEnvelope:
+        base = _envelope(identity, payload, pos=pos)
+        return ObservationEnvelope(
+            session_commitment=session,
+            event_kind=base.event_kind,
+            source_identity=base.source_identity,
+            source=base.source,
+            cursor=base.cursor,
+            receipt_time=base.receipt_time,
+            structural_payload=base.structural_payload,
+            content_object_refs=base.content_object_refs,
+            gap_codes=base.gap_codes,
+        )
+
+    # Session A carries an unresolved failure and degraded health; session B
+    # carries only its own completion-without-verification condition.
+    failed_a = _session_envelope(
+        session_a, "hook:fail-a", {"tool_name": "shell", "exit_status": 2, "tool_call_id": "a1"}, 1
+    )
+    claim_b = _session_envelope(
+        session_b, "hook:claim-b", {"claim_kind": "completion", "result_status": "completed"}, 2
+    )
+
+    class _Store:
+        def __init__(self) -> None:
+            self.workspace_reads = 0
+
+        def list_envelopes(self, workspace: str) -> tuple[ObservationEnvelope, ...]:
+            del workspace
+            self.workspace_reads += 1
+            return (failed_a, claim_b)
+
+        def list_envelopes_for_session(
+            self, workspace: str, session_commitment: str
+        ) -> tuple[ObservationEnvelope, ...]:
+            del workspace
+            return tuple(
+                env for env in (failed_a, claim_b) if env.session_commitment == session_commitment
+            )
+
+        async def status(self, query: ObservationStatusQuery) -> ObservationStatus:
+            self.workspace_reads += 1
+            return ObservationStatus(
+                ObservationLifecycle.STALE,
+                query.workspace_commitment,
+                {},
+                _TIME,
+                0,
+                ("observation_storage_corrupt", "source_lag"),
+                (),
+                None,
+            )
+
+        async def status_for_session(
+            self, workspace: str, session_commitment: str
+        ) -> ObservationStatus:
+            del workspace
+            degraded = session_commitment == session_a
+            return ObservationStatus(
+                ObservationLifecycle.STALE if degraded else ObservationLifecycle.ACTIVE,
+                _COMMITMENT,
+                {},
+                _TIME,
+                0,
+                ("observation_storage_corrupt", "source_lag") if degraded else (),
+                (),
+                None,
+            )
+
+        def load_advice_snapshot(self, workspace: str) -> None:
+            del workspace
+            return None
+
+    def rule_codes(snapshot: object) -> tuple[str, ...]:
+        if snapshot is None:
+            return ()
+        assert isinstance(snapshot, AdviceSnapshot)
+        return tuple(item.rule_code for item in snapshot.ranked_items)
+
+    builder = ObservationAdviceContextBuilder()
+    store = _Store()
+    snapshot_b = asyncio.run(
+        builder.build(_COMMITMENT, store, session_commitment=session_b)  # type: ignore[arg-type]
+    )
+    codes_b = rule_codes(snapshot_b)
+    # B's own condition is visible; A's failure and A's degraded health are not.
+    assert "completion_without_verification" in codes_b
+    assert "failed_command_unresolved" not in codes_b
+    assert "observation_gap_or_stale" not in codes_b
+    assert store.workspace_reads == 0, "a mapped build must not read workspace-wide inputs"
+
+    snapshot_a = asyncio.run(
+        builder.build(_COMMITMENT, store, session_commitment=session_a)  # type: ignore[arg-type]
+    )
+    codes_a = rule_codes(snapshot_a)
+    # A's real degradation stays visible and actionable in A's own snapshot.
+    assert "failed_command_unresolved" in codes_a
+    assert "observation_gap_or_stale" in codes_a
+
+    # Without a session commitment (unmapped build), workspace-wide behavior
+    # is unchanged for the operator surface.
+    aggregate = asyncio.run(builder.build(_COMMITMENT, store))  # type: ignore[arg-type]
+    assert store.workspace_reads == 2
+    assert "failed_command_unresolved" in rule_codes(aggregate)
+
+
 def test_delivery_identity_is_stable_while_the_envelope_stream_grows() -> None:
     """The hook-channel identity keys on rendered content, not on evidence breadth."""
 

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -281,6 +281,29 @@ def test_routine_read_coalescing_respects_result_status_failures() -> None:
     ]
 
 
+def test_statusless_routine_read_keeps_durable_result_and_capability_gap() -> None:
+    """Missing host outcome semantics are not coalesced as a successful read."""
+
+    from yoetz.application.observation_materialize import HOST_OUTCOME_UNAVAILABLE_GAP
+
+    task = _task_id()
+    session = f"hmac-sha256:{'bb' * 32}"
+    post = _envelope(session=session, kind="PostToolUse", identity="hook:read-unknown")
+    unknown = materialize_observation_envelope(
+        replace(
+            post,
+            structural_payload=JsonObject({**post.structural_payload, "action": "routine_read"}),
+        ),
+        task_id=task,
+    )
+    assert unknown.skip_reason is None
+    assert [item.draft.schema.name for item in unknown.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+    assert HOST_OUTCOME_UNAVAILABLE_GAP in unknown.coverage.known_gaps
+
+
 def test_completion_signal_is_evidence_unless_claim_kind_is_explicit() -> None:
     task = _task_id()
     session = f"hmac-sha256:{'ac' * 32}"

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -197,6 +197,90 @@ def test_successful_routine_reads_stay_observation_only_but_failures_materialize
     ]
 
 
+def test_materialize_post_consumes_host_outcome_semantics() -> None:
+    """#350: every host-stated outcome fact is consumed; only a truly outcome-less
+    payload records UNKNOWN, and that record carries the bounded coverage gap."""
+
+    from collections.abc import Mapping as _Mapping
+
+    from yoetz.application.observation_materialize import (
+        HOST_OUTCOME_UNAVAILABLE_GAP,
+        MaterializedObservationBatch,
+    )
+    from yoetz.domain.events import ResultOutcome, ResultRecordedPayload
+
+    task = _task_id()
+    session = f"hmac-sha256:{'aa' * 32}"
+
+    def _outcome(
+        extra: _Mapping[str, object], identity: str
+    ) -> tuple[ResultOutcome, MaterializedObservationBatch]:
+        base = _envelope(session=session, kind="PostToolUse", identity=identity)
+        batch = materialize_observation_envelope(
+            replace(base, structural_payload=JsonObject({**base.structural_payload, **extra})),
+            task_id=task,
+        )
+        payload = cast(ResultRecordedPayload, batch.drafts[1].draft.payload)
+        return payload.outcome, batch
+
+    # The real Codex payload shape from the #346 session: no exit_status, no
+    # success, no result_status. Never upgraded to success; the durable per-call
+    # record stays, and its coverage names the single bounded condition.
+    outcome, batch = _outcome({}, "hook:no-outcome")
+    assert outcome is ResultOutcome.UNKNOWN
+    assert HOST_OUTCOME_UNAVAILABLE_GAP in batch.coverage.known_gaps
+    assert [item.draft.schema.name for item in batch.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+
+    for index, (extra, expected) in enumerate(
+        (
+            ({"exit_status": 0}, ResultOutcome.SUCCESS),
+            ({"exit_status": 3}, ResultOutcome.FAILURE),
+            ({"success": True}, ResultOutcome.SUCCESS),
+            ({"success": False}, ResultOutcome.FAILURE),
+            ({"denied": True}, ResultOutcome.FAILURE),
+            ({"result_status": "completed"}, ResultOutcome.SUCCESS),
+            ({"result_status": "failed"}, ResultOutcome.FAILURE),
+            ({"result_status": "partial"}, ResultOutcome.PARTIAL),
+        )
+    ):
+        outcome, batch = _outcome(extra, f"hook:outcome-{index}")
+        assert outcome is expected, extra
+        assert HOST_OUTCOME_UNAVAILABLE_GAP not in batch.coverage.known_gaps, extra
+
+    # An unrecognized spelling is not an upgrade path.
+    outcome, batch = _outcome({"result_status": "mystery"}, "hook:outcome-mystery")
+    assert outcome is ResultOutcome.UNKNOWN
+    assert HOST_OUTCOME_UNAVAILABLE_GAP in batch.coverage.known_gaps
+
+    # exit_status stays authoritative over softer fields.
+    outcome, _batch = _outcome({"exit_status": 2, "success": True}, "hook:outcome-precedence")
+    assert outcome is ResultOutcome.FAILURE
+
+
+def test_routine_read_coalescing_respects_result_status_failures() -> None:
+    """A routine read that failed via result_status alone still materializes (#350)."""
+
+    task = _task_id()
+    session = f"hmac-sha256:{'ba' * 32}"
+    post = _envelope(session=session, kind="PostToolUse", identity="hook:read-status")
+    failed = materialize_observation_envelope(
+        replace(
+            post,
+            structural_payload=JsonObject(
+                {**post.structural_payload, "action": "routine_read", "result_status": "error"}
+            ),
+        ),
+        task_id=task,
+    )
+    assert [item.draft.schema.name for item in failed.drafts] == [
+        "action_recorded",
+        "result_recorded",
+    ]
+
+
 def test_completion_signal_is_evidence_unless_claim_kind_is_explicit() -> None:
     task = _task_id()
     session = f"hmac-sha256:{'ac' * 32}"
@@ -2291,6 +2375,232 @@ async def test_duplicate_ingest_reconciles_ledger_instead_of_early_return(tmp_pa
     assert result.disposition is ObservationIngestDisposition.DUPLICATE
     assert calls["append"] == 1, "duplicate must still reconcile the ledger append"
     assert calls["advice"] == 1, "duplicate must still refresh advice"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "code",
+    [
+        PublicErrorCode.OPERATION_PENDING,
+        PublicErrorCode.BUNDLE_BUSY,
+        PublicErrorCode.FRONTIER_CONFLICT,
+    ],
+)
+async def test_check_barrier_deferral_is_designed_backpressure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, code: PublicErrorCode
+) -> None:
+    """#351: an ADR-022 barrier deferral keeps the row retryable without an
+    unexpected-exception diagnostic or a false service_unavailable gap."""
+
+    from types import SimpleNamespace
+
+    import yoetz.application.observation_coordinator as coordinator_module
+    from yoetz.domain.observation import OBSERVATION_BACKPRESSURE_REASON
+
+    recorded: list[str] = []
+
+    def _recording(exc: object, *, component: str, operation: str) -> None:
+        del exc, component
+        recorded.append(operation)
+
+    monkeypatch.setattr(
+        coordinator_module, "record_unexpected_exception_without_raising", _recording
+    )
+
+    local, _workspace, session, mapping = _mapped_local(tmp_path, f"barrier-{code.value.lower()}")
+
+    class _BarrierStore:
+        def grant_consent(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        def bind_session(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        async def ingest(self, envelope: ObservationEnvelope) -> ObservationIngestResult:
+            return ObservationIngestResult(
+                ObservationIngestDisposition.ACCEPTED, None, envelope.cursor
+            )
+
+    runtime = SimpleNamespace(
+        task_id=mapping.yoetz_task_id,
+        session_id=mapping.yoetz_session_id,
+        writer_id=observation_writer_id(mapping.yoetz_task_id, mapping.yoetz_session_id),
+        observation=_BarrierStore(),
+    )
+
+    class _RuntimePort:
+        async def route(self, command: object) -> object:
+            del command
+            return runtime
+
+        async def release(self, released: object) -> None:
+            del released
+
+    class _Clock:
+        def now_utc(self) -> datetime:
+            return datetime(2026, 1, 1, tzinfo=UTC)
+
+    class _Coordinator(ObservationCoordinator):
+        async def _capture_content(  # type: ignore[override]
+            self, runtime: object, store: object, **kwargs: object
+        ) -> tuple[tuple[str, ...], bool]:
+            del runtime, store, kwargs
+            return ((), False)
+
+        async def _append_materialized(  # type: ignore[override]
+            self, *args: object, **kwargs: object
+        ) -> tuple[str, str, None]:
+            del args, kwargs
+            raise PublicOperationError(code, "Deferred behind the check barrier.", True)
+
+    coordinator = _Coordinator(
+        runtime=_RuntimePort(),  # type: ignore[arg-type]
+        local=local,
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=object(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+        mapping_loader=lambda *_args, **_kwargs: mapping,  # pyright: ignore[reportUnknownLambdaType, reportUnknownArgumentType]
+    )
+
+    result = await coordinator.ingest_request(
+        ObservationIngestRequest(
+            codex_session_id=f"barrier-{code.value.lower()}",
+            envelope=_envelope(session=session, kind="PostToolUse", identity="hook:barrier"),
+        )
+    )
+
+    assert result.disposition is ObservationIngestDisposition.REJECTED
+    assert result.reason == OBSERVATION_BACKPRESSURE_REASON
+    assert result.reason != ObservationGapCode.SERVICE_UNAVAILABLE.value
+    assert recorded == [], "a designed deferral must not record an unexpected exception"
+
+
+@pytest.mark.anyio
+async def test_run_advice_scopes_envelopes_to_the_mapped_session(tmp_path: Path) -> None:
+    """#352: the advice pipeline sees only the mapped session's envelopes, and a
+    post-commit caller without an envelope recovers the scope from the route."""
+
+    from types import SimpleNamespace
+
+    session_a = f"hmac-sha256:{'0a' * 32}"
+    session_b = f"hmac-sha256:{'0b' * 32}"
+    envelope_a = _envelope(session=session_a, kind="PostToolUse", identity="hook:a", exit_status=2)
+    envelope_b = _envelope(session=session_b, kind="PostToolUse", identity="hook:b", exit_status=0)
+    yoetz_session = PREFIX_BY_KIND[IdKind.SESSION] + str(uuid.uuid4())
+
+    class _Store:
+        def list_envelopes(self, workspace: str) -> tuple[ObservationEnvelope, ...]:
+            del workspace
+            return (envelope_a, envelope_b)
+
+        def list_envelopes_for_session(
+            self, workspace: str, session_commitment: str
+        ) -> tuple[ObservationEnvelope, ...]:
+            del workspace
+            return tuple(
+                env
+                for env in (envelope_a, envelope_b)
+                if env.session_commitment == session_commitment
+            )
+
+        def codex_session_commitment_for_session(
+            self, *, workspace: str, yoetz_session_id: str
+        ) -> str | None:
+            del workspace
+            return session_b if yoetz_session_id == yoetz_session else None
+
+        def load_advice_snapshot(self, workspace: str) -> None:
+            del workspace
+            return None
+
+        async def status(self, query: ObservationStatusQuery) -> object:
+            raise AssertionError("mapped build must not read workspace-wide status")
+
+        async def status_for_session(self, workspace: str, session_commitment: str) -> object:
+            from yoetz.domain.observation import ObservationLifecycle, ObservationStatus
+
+            del workspace
+            return ObservationStatus(
+                ObservationLifecycle.ACTIVE,
+                session_commitment,
+                {},
+                None,
+                0,
+                (),
+                (),
+                None,
+            )
+
+        def set_advice_snapshot(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+    seen: list[tuple[str, ...]] = []
+
+    def _hook(
+        *,
+        workspace_commitment: str,
+        task_id: str,
+        store: object,
+        envelopes: tuple[ObservationEnvelope, ...],
+        frontier: object,
+    ) -> None:
+        del workspace_commitment, task_id, store, frontier
+        seen.append(tuple(env.source_identity for env in envelopes))
+
+    class _Clock:
+        def now_utc(self) -> datetime:
+            return datetime(2026, 1, 1, tzinfo=UTC)
+
+    coordinator = ObservationCoordinator(
+        runtime=object(),  # type: ignore[arg-type]
+        local=LocalObservationStore(_state=tmp_path),
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=object(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+        advice_hook=_hook,
+    )
+    runtime = SimpleNamespace(
+        task_id=_task_id(),
+        session_id=yoetz_session,
+        writer_id=None,
+    )
+
+    # Explicit scope from the ingest path.
+    await coordinator._run_advice(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "hmac-sha256:" + "9" * 64,
+        cast(TaskRuntime, runtime),
+        _Store(),  # type: ignore[arg-type]
+        session_commitment=session_b,
+    )
+    # Route-recovered scope for post-commit callers with no envelope in hand.
+    await coordinator._run_advice(  # pyright: ignore[reportPrivateUsage]  # noqa: SLF001
+        "hmac-sha256:" + "9" * 64,
+        cast(TaskRuntime, runtime),
+        _Store(),  # type: ignore[arg-type]
+    )
+    assert seen == [("hook:b",), ("hook:b",)]
+
+
+def test_backpressure_reason_routes_to_retry_without_gap_projection() -> None:
+    """#351: operation_pending is retryable, safe, and marked as expected."""
+
+    from yoetz.application.observation_drain import (
+        EXPECTED_OBSERVATION_BACKPRESSURE_REASONS,
+        ObservationDrainAction,
+        route_observation_ingest,
+    )
+    from yoetz.domain.observation import OBSERVATION_BACKPRESSURE_REASON
+
+    decision = route_observation_ingest(
+        ObservationIngestResult(
+            ObservationIngestDisposition.REJECTED,
+            OBSERVATION_BACKPRESSURE_REASON,
+            None,
+        )
+    )
+    assert decision.action is ObservationDrainAction.RETRY
+    assert decision.reason == OBSERVATION_BACKPRESSURE_REASON
+    assert OBSERVATION_BACKPRESSURE_REASON in EXPECTED_OBSERVATION_BACKPRESSURE_REASONS
 
 
 @pytest.mark.anyio

--- a/tests/unit/application/test_observation_drain.py
+++ b/tests/unit/application/test_observation_drain.py
@@ -292,6 +292,50 @@ async def test_sweep_routes_rows_persists_attempts_and_marks_success(tmp_path: P
 
 
 @pytest.mark.anyio
+async def test_sweep_backpressure_deferral_never_projects_a_coverage_gap(tmp_path: Path) -> None:
+    """#351: a check-barrier deferral keeps its row pending and annotated, but the
+    workspace's current gaps never report the designed barrier as a condition."""
+
+    from yoetz.domain.observation import OBSERVATION_BACKPRESSURE_REASON
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    session = store.bind_codex_session(workspace, "session-deferred")
+    envelope = _envelope(session, "hook:deferred", 1)
+    store.enqueue_outbox(workspace, "session-deferred", envelope)
+
+    coordinator = _Coordinator(
+        {
+            envelope.source_identity: ObservationIngestResult(
+                ObservationIngestDisposition.REJECTED,
+                OBSERVATION_BACKPRESSURE_REASON,
+                None,
+            ),
+        }
+    )
+    summary = await ObservationOutboxSweeper(store, coordinator).sweep()
+
+    assert summary.retry_pending == 1
+    assert summary.reasons == ((OBSERVATION_BACKPRESSURE_REASON, 1),)
+    pending = store.list_pending_outbox_rows(workspace)
+    assert [row.last_reason for row in pending] == [OBSERVATION_BACKPRESSURE_REASON]
+    status = store.status(ObservationStatusQuery(workspace))
+    assert OBSERVATION_BACKPRESSURE_REASON not in status.gaps
+    assert ObservationGapCode.SERVICE_UNAVAILABLE.value not in status.gaps
+
+    # After the barrier clears, the retried row delivers and the outbox drains.
+    coordinator.outcomes[envelope.source_identity] = ObservationIngestResult(
+        ObservationIngestDisposition.ACCEPTED, None, envelope.cursor
+    )
+    converged = await ObservationOutboxSweeper(store, coordinator).sweep()
+    assert converged.acknowledged == 1
+    assert store.pending_outbox_count(workspace) == 0
+    cleared = store.status(ObservationStatusQuery(workspace))
+    assert OBSERVATION_BACKPRESSURE_REASON not in cleared.gaps
+
+
+@pytest.mark.anyio
 async def test_sweep_round_robins_pending_workspaces_under_limit(tmp_path: Path) -> None:
     store = LocalObservationStore(_state=tmp_path)
     outcomes: dict[str, ObservationIngestResult | Exception] = {}

--- a/tests/unit/cli/test_observe_hooks.py
+++ b/tests/unit/cli/test_observe_hooks.py
@@ -1666,7 +1666,9 @@ async def test_drain_lease_prevents_concurrent_hooks_from_double_draining(
     with store.drain_lease(workspace) as owned:
         assert owned is True
         # A second store instance (another hook process) must lose the lease
-        # and skip the drain entirely — no connect, with a bounded contention diagnostic.
+        # and skip the drain entirely — no connect. Losing to a live owner is
+        # designed coordination, so no failure-shaped diagnostic is recorded
+        # (#351): one row per contending hook buried genuine failures.
         other = LocalObservationStore(_state=tmp_path)
         await observe_hooks_module._drain_outbox(  # pyright: ignore[reportPrivateUsage]
             other,
@@ -1677,8 +1679,123 @@ async def test_drain_lease_prevents_concurrent_hooks_from_double_draining(
         )
     assert connects == []
     diagnostics = tmp_path / "observation/hook-diagnostics.jsonl"
-    assert diagnostics.exists()
-    assert "drain_lease_contended" in diagnostics.read_text(encoding="utf-8")
+    if diagnostics.exists():
+        assert "drain_lease_contended" not in diagnostics.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_budget_expiry_after_delivery_progress_is_a_silent_yield(tmp_path: Path) -> None:
+    """A bounded slice that moved backlog and then yielded is working as designed (#351).
+
+    drain_budget_exhausted remains reserved for a pass that timed out before
+    any progress; a capacity yield to the service sweeper is not a failure.
+    """
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.bind_codex_session(workspace, "yield")
+    for ordinal in (1, 2, 3):
+        store.enqueue_outbox(
+            workspace, "yield", _drain_envelope(store, "yield", "hook:yield", ordinal)
+        )
+
+    clock = {"now": 0.0}
+
+    class OneThenSlowClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def observation_ingest(self, body: object, *, deadline_ms: int):
+            del body, deadline_ms
+            self.calls += 1
+            # First row delivers instantly; afterwards the budget is exhausted.
+            clock["now"] += 0.05 if self.calls == 1 else 1.0
+            return observation_ingest_result_to_json(
+                ObservationIngestResult(ObservationIngestDisposition.DUPLICATE, None, None)
+            )
+
+        async def close(self) -> None:
+            return None
+
+    async def connect(_kind: object):
+        return OneThenSlowClient()
+
+    await observe_hooks_module._drain_outbox(  # pyright: ignore[reportPrivateUsage]
+        store,
+        workspace_commitment=workspace,
+        codex_session_id="yield",
+        connect=connect,  # type: ignore[arg-type]
+        _state=tmp_path,
+        budget_seconds=0.2,
+        monotonic=lambda: clock["now"],
+    )
+    assert store.pending_outbox_count(workspace) == 1, "two rows delivered before the yield"
+    diagnostics = tmp_path / "observation/hook-diagnostics.jsonl"
+    if diagnostics.exists():
+        assert '"reason":"drain_budget_exhausted"' not in diagnostics.read_text()
+
+
+@pytest.mark.anyio
+async def test_operation_pending_deferral_keeps_row_without_gap_or_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """An ADR-022 check-barrier deferral is expected back-pressure, not failure (#351)."""
+
+    from yoetz.domain.observation import OBSERVATION_BACKPRESSURE_REASON
+
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(workspace)
+    store.bind_codex_session(workspace, "deferred")
+    for ordinal in (1, 2):
+        store.enqueue_outbox(
+            workspace, "deferred", _drain_envelope(store, "deferred", "hook:deferred", ordinal)
+        )
+
+    attempts = 0
+
+    class BarrierClient:
+        async def observation_ingest(self, body: object, *, deadline_ms: int):
+            del body, deadline_ms
+            nonlocal attempts
+            attempts += 1
+            return observation_ingest_result_to_json(
+                ObservationIngestResult(
+                    ObservationIngestDisposition.REJECTED,
+                    OBSERVATION_BACKPRESSURE_REASON,
+                    None,
+                )
+            )
+
+        async def close(self) -> None:
+            return None
+
+    async def connect(_kind: object):
+        return BarrierClient()
+
+    await observe_hooks_module._drain_outbox(  # pyright: ignore[reportPrivateUsage]
+        store,
+        workspace_commitment=workspace,
+        codex_session_id="deferred",
+        connect=connect,  # type: ignore[arg-type]
+        _state=tmp_path,
+    )
+    # The deferred head retires its lane for the pass; both rows stay pending
+    # with the honest annotation, and neither a coverage gap nor a hook
+    # diagnostic reports the designed barrier as a failure.
+    assert attempts == 1
+    pending = store.list_pending_outbox_rows(workspace)
+    assert [row.last_reason for row in pending] == [
+        OBSERVATION_BACKPRESSURE_REASON,
+        OBSERVATION_BACKPRESSURE_REASON,
+    ]
+    status = store.status(ObservationStatusQuery(workspace))
+    assert OBSERVATION_BACKPRESSURE_REASON not in status.gaps
+    assert ObservationGapCode.SERVICE_UNAVAILABLE.value not in status.gaps
+    diagnostics = tmp_path / "observation/hook-diagnostics.jsonl"
+    if diagnostics.exists():
+        assert OBSERVATION_BACKPRESSURE_REASON not in diagnostics.read_text()
 
 
 def test_drain_lease_refuses_a_symlink_lock_file(tmp_path: Path) -> None:

--- a/tests/unit/kernel/test_policy_research_evidence.py
+++ b/tests/unit/kernel/test_policy_research_evidence.py
@@ -29,9 +29,13 @@ from yoetz.domain.events import (
 )
 from yoetz.domain.findings import Finding, FindingKind, FindingOrigin
 from yoetz.domain.values import SubjectStateRef, object_id, timestamp_from_string
-from yoetz.kernel.deterministic_checks import run_deterministic_policies
+from yoetz.kernel.deterministic_checks import case_coverage, run_deterministic_policies
 from yoetz.kernel.policies.research_evidence import RESEARCH_EVIDENCE_POLICY_PACK
-from yoetz.protocol.coverage import EvidenceImmutability
+from yoetz.protocol.coverage import (
+    EvidenceImmutability,
+    PublicationChannel,
+    coverage_for_channel,
+)
 
 _NOW = timestamp_from_string("2026-01-01T00:00:00.000Z")
 _DIGEST_A = "sha256:" + "3" * 64
@@ -173,6 +177,140 @@ def test_material_limitation_omitted_and_exact_link_nontrigger() -> None:
         claims={clm(1): record(disclosed, 3)},
     )
     assert FindingKind.MATERIAL_LIMITATION_OMITTED not in _kinds(near)
+
+
+def _hook_observed_coverage() -> object:
+    from dataclasses import replace as dc_replace
+
+    from yoetz.application.observation_materialize import HOST_OUTCOME_UNAVAILABLE_GAP
+
+    base = coverage_for_channel(PublicationChannel.HOOK_OBSERVED)
+    return dc_replace(base, known_gaps=(HOST_OUTCOME_UNAVAILABLE_GAP,))
+
+
+def _observed_unknown_result(number: int) -> ResultRecordedPayload:
+    return ResultRecordedPayload(
+        result_id=res(number),
+        action_id=act(number),
+        outcome=ResultOutcome.UNKNOWN,
+        exit_status=None,
+    )
+
+
+def test_outcome_less_observation_results_collapse_to_one_coverage_condition() -> None:
+    """#350: N outcome-less hook-observed calls yield zero per-result
+    material_limitation_omitted candidates and one bounded coverage code, while
+    an explicit observed FAILURE stays individually actionable."""
+
+    from yoetz.application.observation_materialize import HOST_OUTCOME_UNAVAILABLE_GAP
+
+    hook_coverage = _hook_observed_coverage()
+    count = 70  # deliberately above the 64-gap/ref bounds in the acceptance criteria
+    results = {res(i): record(_observed_unknown_result(i), i) for i in range(1, count + 1)}
+    failure_number = count + 1
+    results[res(failure_number)] = record(
+        ResultRecordedPayload(
+            result_id=res(failure_number),
+            action_id=act(failure_number),
+            outcome=ResultOutcome.FAILURE,
+            exit_status=2,
+        ),
+        failure_number,
+    )
+    claim_number = count + 2
+    claim = ClaimRecordedPayload(
+        claim_id=clm(1),
+        claim_kind=ClaimKind.COMPLETION,
+        statement="Complete",
+        supporting_refs=(),
+    )
+    overrides = {res(i): hook_coverage for i in range(1, count + 1)}
+    overrides[res(failure_number)] = coverage_for_channel(PublicationChannel.HOOK_OBSERVED)
+    case = make_case(
+        results=results,
+        claims={clm(1): record(claim, claim_number)},
+        coverage_overrides=overrides,  # type: ignore[arg-type]
+    )
+    result = run_deterministic_policies(case, RESEARCH_EVIDENCE_POLICY_PACK)
+    limitations = [
+        item
+        for item in result.assessments
+        if item.candidate.kind is FindingKind.MATERIAL_LIMITATION_OMITTED
+    ]
+    # Exactly one finding — the explicit FAILURE — never one per outcome-less call.
+    assert len(limitations) == 1
+    assert res(failure_number) in limitations[0].basis.supporting_refs
+    # The limitation is preserved as one deduplicated coverage code, so the
+    # receipt keeps the honest condition without a finding storm.
+    folded = case_coverage(case)
+    assert folded.known_gaps.count(HOST_OUTCOME_UNAVAILABLE_GAP) == 1
+
+
+def test_cooperative_unknown_result_remains_individually_limiting() -> None:
+    """#350: the narrowing is provenance-aware — a cooperative UNKNOWN result
+    (no hook_observed channel) is not exempted."""
+
+    claim = ClaimRecordedPayload(
+        claim_id=clm(1),
+        claim_kind=ClaimKind.COMPLETION,
+        statement="Complete",
+        supporting_refs=(),
+    )
+    case = make_case(
+        results={res(1): record(_observed_unknown_result(1), 1)},
+        claims={clm(1): record(claim, 2)},
+    )
+    result = run_deterministic_policies(case, RESEARCH_EVIDENCE_POLICY_PACK)
+    assert FindingKind.MATERIAL_LIMITATION_OMITTED in _kinds(case)
+    assert any(
+        res(1) in item.basis.supporting_refs
+        for item in result.assessments
+        if item.candidate.kind is FindingKind.MATERIAL_LIMITATION_OMITTED
+    )
+
+
+def test_hook_observed_unknown_with_exit_status_remains_limiting() -> None:
+    """#350: the narrowing is cause-aware — an UNKNOWN result that carries an
+    exit status was not caused by absent host outcome semantics."""
+
+    payload = ResultRecordedPayload(
+        result_id=res(1),
+        action_id=act(1),
+        outcome=ResultOutcome.UNKNOWN,
+        exit_status=7,
+    )
+    claim = ClaimRecordedPayload(
+        claim_id=clm(1),
+        claim_kind=ClaimKind.COMPLETION,
+        statement="Complete",
+        supporting_refs=(),
+    )
+    case = make_case(
+        results={res(1): record(payload, 1)},
+        claims={clm(1): record(claim, 2)},
+        coverage_overrides={res(1): _hook_observed_coverage()},  # type: ignore[dict-item]
+    )
+    assert FindingKind.MATERIAL_LIMITATION_OMITTED in _kinds(case)
+
+
+def test_outcome_less_observation_result_cannot_support_a_completion_claim() -> None:
+    """#350: exempting the finding storm never upgrades the record — citing an
+    outcome-less observed result as completion support still mismatches."""
+
+    claim = ClaimRecordedPayload(
+        claim_id=clm(1),
+        claim_kind=ClaimKind.COMPLETION,
+        statement="Complete",
+        supporting_refs=(res(1),),
+    )
+    case = make_case(
+        results={res(1): record(_observed_unknown_result(1), 1)},
+        claims={clm(1): record(claim, 2)},
+        coverage_overrides={res(1): _hook_observed_coverage()},  # type: ignore[dict-item]
+    )
+    kinds = _kinds(case)
+    assert FindingKind.EVIDENCE_DOES_NOT_SUPPORT_CLAIM in kinds
+    assert FindingKind.MATERIAL_LIMITATION_OMITTED not in kinds
 
 
 def _recorded_finding() -> Finding:

--- a/tests/unit/kernel/test_policy_research_evidence.py
+++ b/tests/unit/kernel/test_policy_research_evidence.py
@@ -293,6 +293,30 @@ def test_hook_observed_unknown_with_exit_status_remains_limiting() -> None:
     assert FindingKind.MATERIAL_LIMITATION_OMITTED in _kinds(case)
 
 
+def test_historical_hook_observed_unknown_without_capability_gap_remains_limiting() -> None:
+    """Historical rows lack the new cause marker and retain old limitation semantics."""
+
+    claim = ClaimRecordedPayload(
+        claim_id=clm(1),
+        claim_kind=ClaimKind.COMPLETION,
+        statement="Complete",
+        supporting_refs=(),
+    )
+    case = make_case(
+        results={res(1): record(_observed_unknown_result(1), 1)},
+        claims={clm(1): record(claim, 2)},
+        # The channel alone is not enough to prove this is a newly materialized
+        # outcome-less row; historical coverage has no cause-specific gap.
+        coverage_overrides={res(1): coverage_for_channel(PublicationChannel.HOOK_OBSERVED)},  # type: ignore[dict-item]
+    )
+    result = run_deterministic_policies(case, RESEARCH_EVIDENCE_POLICY_PACK)
+    assert any(
+        item.candidate.kind is FindingKind.MATERIAL_LIMITATION_OMITTED
+        and res(1) in item.basis.supporting_refs
+        for item in result.assessments
+    )
+
+
 def test_outcome_less_observation_result_cannot_support_a_completion_claim() -> None:
     """#350: exempting the finding storm never upgrades the record — citing an
     outcome-less observed result as completion support still mismatches."""


### PR DESCRIPTION
Fundamentally repairs the three defects isolated from the #346 live incident (137 diagnostic rows, ~120 observation records, and 45 `material_limitation_omitted` candidates in one healthy 15-minute task). Contracts are recorded as **ADR-022 decisions 12–14** and in `docs/INTERFACES.md`.

Closes #346, closes #350, closes #351, closes #352.

## #350 — outcome-less `PostToolUse` becomes one bounded coverage condition

The incident's 44-candidate storm was the composition of two locally honest layers: materialization mapped every `exit_status`-less paired result to `UNKNOWN` (ignoring `success`/`result_status`), and the research-evidence policy minted one `material_limitation_omitted` per non-success result. Implemented per the recommended contract in #350:

- **Materialization consumes every host-stated outcome fact** (`exit_status`, `denied`, boolean `success`, and a closed `result_status` spelling table). Any explicit failure signal wins over any success signal, so conflicting facts can never launder a stated failure; a payload with no outcome fact at all stays `UNKNOWN` — a missing outcome is never upgraded to success. Routine-read coalescing now also respects `result_status` failures.
- **A truly outcome-less result keeps its durable per-call action/result record** but carries the new `host_outcome_unavailable` known gap on its entry coverage. Check coverage and receipts fold per-record known gaps into one deduplicated code set, so 100 status-less calls surface as **one** bounded task/session condition — the receipt preserves the limitation even though no per-result finding is emitted. `known_gaps` is pattern-open vocabulary, so no schema change was needed.
- **The policy narrowing is provenance- and cause-aware**: only results whose source coverage carries the service-derived `hook_observed` channel (unselectable by cooperative requests per ADR-022 decision 2) with `UNKNOWN` outcome and no exit status are exempted. Cooperative `UNKNOWN` results and explicit observed `FAILURE`/`PARTIAL` remain individually limiting, and citing an outcome-less observed result as completion support still triggers `EVIDENCE_DOES_NOT_SUPPORT_CLAIM`.
- Mapping identity and operation digests are unchanged, so in-flight outbox replays of already-committed appends still deduplicate; historical rows are not rewritten (they simply stop storming under the provenance-aware policy).

## #351 — expected back-pressure is no longer logged or projected as failure

- **Coordinator**: `OPERATION_PENDING` (ADR-022 decision 4's designed check-barrier deferral) and the adjacent transient `BUNDLE_BUSY` / `FRONTIER_CONFLICT` now reject with the retryable `operation_pending` reason — no `record_unexpected_exception_without_raising` row (the incident's `observation_ingest_ledger_append_operation_pending / exception_public_operation_error` signature), and no `service_unavailable` mapping.
- **Drain paths** (hook slice and service sweeper): an `operation_pending` row stays pending with its honest `last_reason` annotation, but never notes a coverage gap, never records a hook diagnostic, and is excluded from current-gap projection — so the deferral cannot reach status, advice, coverage, or receipt inputs. The next drain after the barrier clears converges normally.
- **Lease loss records nothing**: contention means a live hook or the sweeper is already draining (flock dies with its holder), matching what the code's own docstring always claimed. This removes the incident's 46 `drain_lease_contended` rows.
- **Budget expiry distinguishes yield from failure**: `drain_budget_exhausted` is recorded only when a pass moved no backlog at all; a bounded slice that delivered/quarantined rows and then yielded to the sweeper (the intended division of labor) is silent. This removes the bulk of the incident's 68 rows while keeping the genuine zero-progress timeout visible.
- Genuine `SERVICE_UNAVAILABLE`, vault, storage-corrupt, and preflight failures keep their exact existing classification and visibility.

## #352 — mapped advice snapshots are built from session-scoped inputs

`ObservationAdviceContextBuilder.build` used the mapped session id only for routing while its deterministic inputs stayed workspace-wide (`list_envelopes(workspace)` + workspace `status`), so a fresh mapped task inherited other sessions' `source_lag`/`observation_storage_corrupt`/failed-command history — the #249/#250 failure mode one layer below the delivery fix.

- New `SqliteObservationStore.list_envelopes_for_session` / `status_for_session` derive envelopes and lifecycle/gap health for exactly the mapped Codex session; `codex_session_commitment_for_session` recovers the scope from the durable workspace session route for post-commit callers (verification drains, restart rediscovery) that hold no envelope.
- The builder and `_run_advice` (including advice-finding materialization and the hook channel) consume those session-scoped inputs whenever a session commitment is known; the ingest path passes the envelope's commitment directly. Pre-0004 bundles and unmapped builds keep the previous workspace-wide behavior.
- The workspace aggregate remains fully available as the operator surface (`yoetz observe status`) and as the home of deliberately workspace-standing machine conditions (composition facts) — separation is by scope, so one session's recovery never clears another's real condition.

## Verification

- New regressions per each issue's acceptance criteria: outcome-mapping table against the real status-less Codex payload shape; 70 outcome-less hook-observed results → zero per-result candidates + exactly one folded `host_outcome_unavailable` code while an explicit `FAILURE` in the same case still yields its one finding; cooperative-`UNKNOWN` and exit-status non-triggers; barrier deferral → retryable reject with no unexpected-exception record (parametrized over all three codes); sweeper deferral → no gap projection, then convergence after the barrier clears; hook drain lease/budget/deferral behavior; SQLite session scoping; builder A/B cross-session contamination (A degraded, B healthy — B sees only its own conditions, A keeps its own, aggregate unchanged); `_run_advice` explicit and route-recovered scoping.
- Full suite: **3271 passed, 0 failed** across `tests/unit`, `tests/integration`, `tests/conformance`, and `tests/property`; `ruff format --check` + `ruff check` clean, `pyright` 0 errors, `scan_public_boundary` PASS, `verify_resource_manifest` PASS. No guidance/schema resources were touched, so no regeneration ripple applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-review fixes

Independent review found four edge cases, fixed in `7bcf41a`:

- historical hook-observed `UNKNOWN` results lacking the new cause gap retain their per-result limitation instead of being silently exempted;
- exact durable session routes remain recoverable after a newer route becomes active, preventing workspace-wide advice fallback for older mapped sessions;
- session current-gap projection now allows healthy accepted observations to clear transient `source_lag`/`cursor_stale` for that session without deleting append-only history or clearing another session;
- status-less routine reads keep durable action/result identity and `host_outcome_unavailable`; only explicitly successful routine reads coalesce.

Regressions cover all four. Post-fix verification: full unit suite 2,501 passed; parent rerun 188 focused observation tests; additional integration/conformance slices passed; Ruff check/format, pinned Pyright, public-boundary scan, and resource manifest passed. Maintainer acknowledgements are recorded on [#350](https://github.com/TheGaySupreme123/yoetz/issues/350#issuecomment-5332296115), [#351](https://github.com/TheGaySupreme123/yoetz/issues/351#issuecomment-5332985302), and [#352](https://github.com/TheGaySupreme123/yoetz/issues/352#issuecomment-5332985443).

Done by ChatGPT.