### PR TITLE
Fix onboarding documentation guidance

### DIFF
--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -141,7 +141,9 @@ No disposition resolves the finding: a provenance dispute contests its authorshi
 premise, while a waiver is scoped, has an expiry, and requires explicit interactive human
 confirmation. Waiver is unavailable to an MCP caller, importer, or noninteractive client. A
 response is history, never deletion: the original finding remains in the ledger. Any material
-change or a new response requires a recheck before a receipt can rely on the updated disposition.
+change requires a recheck before a receipt can rely on the updated disposition. A readable response
+to a finding returned by the current check does not require one; a redacted or unreadable response
+does.
 
 `Coverage` has six dimensions: `publication_channels` (a set drawn from `cooperative_mcp`,
 `local_cli`, `codex_jsonl_import`, `hook_observed`, `engine_derived`, `human_import`),
@@ -189,11 +191,12 @@ A minimal, honest client workflow:
 4. If multiple writers contribute (e.g. a subagent), each uses its own writer identity from its own
    `start` attach.
 5. After a resume, call `status` to re-ground before publishing more work.
-6. Run `check` at the current frontier.
-7. `respond` to any findings honestly (acknowledge, reject with evidence, or waive with an
+6. Publish the intended completion `claim_recorded` and current evidence.
+7. Run `check` at the current frontier.
+8. `respond` to any findings honestly (acknowledge, reject with evidence, or waive with an
    interactive human confirmation).
-8. Recheck after any material change or response.
-9. Once satisfied, publish a completion `claim_recorded`.
+9. Recheck after any material change. A readable response to a finding returned by that check
+   needs no recheck; a redacted or unreadable response does.
 10. Call `receipt` for the frontier-bound final wording — and only assert what the receipt's
     coverage actually supports.
 

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -36,7 +36,7 @@ string or successful file install never promotes an unprofiled release to suppor
 Always run status first:
 
 ```text
-yoetz integrate skill status codex --json
+yoetz integrate codex skill status --json
 ```
 
 Destination states: `absent`, `installed_exact`, `modified`/`unmanaged`, `partial`, `unsafe`.
@@ -48,8 +48,8 @@ does **not** by itself prove Codex has discovered the skill or that MCP is avail
 ## 4. First install
 
 ```text
-yoetz integrate skill preview codex --json
-yoetz integrate skill install codex --json
+yoetz integrate codex skill preview --json
+yoetz integrate codex skill install --json
 ```
 
 1. Preview shows the fixed destination and scope, the source skill/protocol/resource/Codex-tested
@@ -196,8 +196,8 @@ evidence boundary explicitly.
 ## 8. Remove
 
 ```text
-yoetz integrate skill preview codex --json
-yoetz integrate skill remove codex --json
+yoetz integrate codex skill preview --json
+yoetz integrate codex skill remove --json
 ```
 
 Confirm the exact preview digest. Removal deletes only a valid managed marker plus its byte-exact

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -130,7 +130,7 @@ standalone Codex CLI and does not fabricate an app installation that OpenAI does
 
 Re-run any time with `yoetz setup run` (the prompt-driven wizard, unchanged) or `/connect` in the
 interface. Change privacy any time with `yoetz --privacy`. Inspect posture read-only with
-`yoetz setup status`. Manage registration directly with `yoetz integrate mcp
+`yoetz setup status`. Manage registration directly with `yoetz integrate codex mcp
 status|preview|install`.
 
 ## Re-run or repair a ceremony

--- a/docs/usage/six-operations.md
+++ b/docs/usage/six-operations.md
@@ -79,7 +79,8 @@ Answers a finding: accept and act, supply evidence, revise the claim, dispute wi
 state an unresolved limitation. **A response does not erase a finding**, and no disposition
 resolves one: an actionable finding keeps the receipt conclusion at `unresolved_findings_remain`
 for the rest of the task, whichever disposition is recorded. Recheck after any material edit,
-evidence change, plan change, or response.
+evidence change, or plan change. A readable response to a finding returned by the current check
+does not require a recheck; a redacted or unreadable response does.
 
 ### `status`
 Reads current state — use it after a resume, a compaction, a handoff, or any uncertainty about what
@@ -128,7 +129,7 @@ See [Receipts and coverage](receipts-and-coverage.md) for how to read one.
 | `start` | Once per task, before substantive work. On resume, attach to the existing task instead of starting a second one. |
 | `publish_work` | One batch per material transition, roughly one to eight events. A normal session is a handful of batches, never one per file, tool call, or message. |
 | `status` | After resume, compaction, or delegate handoff, and before any completion claim. Not between routine tool calls. |
-| `check` | After publishing the completion claim and its evidence, and again after any material edit, new evidence, or finding response. A check with no new events since the last one adds nothing. |
+| `check` | After publishing the completion claim and its evidence, and again after any material edit or new evidence. A readable response to a finding returned by that check needs no recheck; a redacted or unreadable response does. A check with no new events since the last one adds nothing. |
 | `respond` | Once per finding, at that finding's recorded frontier. |
 | `receipt` | Once at the end, and again only if material state changed after the previous receipt. |
 


### PR DESCRIPTION
Closes #359

## What changed

- Corrected Codex skill and MCP integration command paths.
- Documented the precise recheck rule for finding responses.
- Corrected the protocol's minimal workflow to publish the completion claim before checking it.

## Why

The guides had diverged from the current CLI command tree and canonical Yoetz workflow guidance, which could lead users to invoke invalid commands or run an unnecessary check.

## Validation

- `uv run yoetz integrate codex skill --help`
- `uv run yoetz integrate codex mcp --help`
- `uv run pytest tests/subprocess/test_cli_invocations.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix onboarding documentation for recheck rules and CLI command ordering
> - Clarifies recheck guidance across docs: only redacted or unreadable responses require a recheck, while readable responses from the current check do not
> - Reorders CLI command syntax examples to place `codex` before the resource type and action (e.g., `codex mcp status`) in [codex-integration.md](https://github.com/TheGaySupreme123/yoetz/pull/360/files#diff-879a4e754d62c2c66c8ed47cd522f1043905af25fa84b3a649280ba303a7bb43) and [install-and-first-run.md](https://github.com/TheGaySupreme123/yoetz/pull/360/files#diff-8cb48bd9a1635ead5145725cbc69420b56ad183a909a0757496d49908608d3da)
> - Updates the minimal client workflow in [README.md](https://github.com/TheGaySupreme123/yoetz/pull/360/files#diff-5e98b9759c0d01f9fc9d15497f5c8e392cf139fe618974b829335d074804034d) to publish the completion claim before running check, with renumbered steps
> - Aligns the 'How often to call each one' table in [six-operations.md](https://github.com/TheGaySupreme123/yoetz/pull/360/files#diff-6578c54af103a05f5990caca873d8b3f433786ac573b63140df32d6f2607b26c) with the new recheck rule
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3495e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->