### PR TITLE
Release v0.1.0 to PyPI, npm, and GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 # suites under tests/packaging/ and tests/capability/.
 #
 # Build one immutable candidate from a clean version tag, prove it across advertised environments,
-# assemble honest release evidence, and only then publish the exact tested bytes through protected
+# assemble honest release evidence, and only then publish the exact tested bytes through dedicated
 # environments. Construction, verification, approval, publication, and post-publication download
 # verification are separated so no rebuild occurs between them. Artifact formats and publication
 # environments are centralized under E-008; signing remains a v0.2 deferral — v0.1 requires
@@ -20,9 +20,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing exact tag to dry-run (e.g. v0.1.0). Never publishes.
+        description: Intended exact release tag (e.g. v0.1.0). Need not exist for a dry run.
         required: true
         type: string
+      candidate_ref:
+        description: Current protected-branch ref or commit to test before creating the tag.
+        required: true
+        type: string
+        default: main
       dry_run:
         description: Must be true; manual dispatch can never acquire publish authority.
         required: true
@@ -69,15 +74,16 @@ jobs:
           echo "::error::workflow_dispatch is dry-run only; dry_run must be true"
           exit 1
 
-      - name: Checkout the exact tag (no persisted credentials)
+      - name: Checkout the exact release source (no persisted credentials)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
           submodules: false
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
 
       - name: Verify the ref is an annotated/signed tag reachable from the protected release branch
+        if: github.event_name == 'push'
         run: |
           set -euo pipefail
           tag="${{ github.event.inputs.tag || github.ref_name }}"
@@ -91,6 +97,18 @@ jobs:
             echo "::error::tagged commit is not reachable from the protected release branch"
             exit 1
           fi
+
+      - name: Verify the dry-run candidate is current protected main
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          candidate=$(git rev-parse HEAD)
+          protected=$(git rev-parse origin/main)
+          [ "$candidate" = "$protected" ] || {
+            echo "::error::dry-run candidate ${candidate} is not current origin/main ${protected}"
+            exit 1
+          }
 
       - name: Install uv (locked version)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -173,13 +191,13 @@ jobs:
       candidate-digest: ${{ steps.digest.outputs.value }}
       artifact-name: candidate-${{ needs.validate-release-source.outputs.version }}
     steps:
-      - name: Checkout the exact tag (no persisted credentials)
+      - name: Checkout the exact release source (no persisted credentials)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
           submodules: false
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
 
       - name: Install uv (locked version)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -263,6 +281,119 @@ jobs:
           retention-days: 7
 
   # ---------------------------------------------------------------------------------------------
+  # build-npm-launcher — one immutable dependency-free delegator, version-locked to PyPI.
+  # ---------------------------------------------------------------------------------------------
+  build-npm-launcher:
+    name: build-npm-launcher
+    needs: validate-release-source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      npm-digest: ${{ steps.digest.outputs.value }}
+    steps:
+      - name: Checkout the exact release source (no persisted credentials)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          submodules: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
+
+      - name: Install Node and npm (locked versions, no release cache)
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26.5.0"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Install the locked npm CLI
+        run: npm install --global --ignore-scripts npm@12.0.1
+
+      - name: Verify the public launcher contract and exact version lock
+        run: |
+          set -euo pipefail
+          [ "$(npm --version)" = "12.0.1" ] || {
+            echo "::error::expected npm 12.0.1, got $(npm --version)"
+            exit 1
+          }
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const launcher = JSON.parse(fs.readFileSync("support/npm-launcher/package.json", "utf8"));
+          const pyproject = fs.readFileSync("pyproject.toml", "utf8");
+          const match = pyproject.match(/^version = "([^"]+)"$/m);
+          if (!match || launcher.version !== match[1]) throw new Error("npm/PyPI version drift");
+          if (launcher.private !== false) throw new Error("npm launcher is not public");
+          if (launcher.name !== "yoetz") throw new Error("unexpected npm package name");
+          if (launcher.repository?.url !== "git+https://github.com/TheGaySupreme123/yoetz.git") {
+            throw new Error("npm provenance repository does not match the release repository");
+          }
+          for (const field of ["dependencies", "devDependencies", "optionalDependencies", "scripts"]) {
+            if (field in launcher) throw new Error(`delegation-only package contains ${field}`);
+          }
+          NODE
+
+      - name: Pack the npm launcher once and inspect its complete member set
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/npm-dist" "${{ runner.temp }}/npm-inspect"
+          npm pack ./support/npm-launcher \
+            --pack-destination "${{ runner.temp }}/npm-dist" --json \
+            > "${{ runner.temp }}/npm-pack.json"
+          tar -xzf "${{ runner.temp }}/npm-dist/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz" \
+            -C "${{ runner.temp }}/npm-inspect"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "npm-inspect" / "package"
+          members = sorted(
+              path.relative_to(root).as_posix()
+              for path in root.rglob("*")
+              if path.is_file()
+          )
+          expected = ["README.md", "bin/yoetz.js", "package.json"]
+          if members != expected:
+              raise SystemExit(f"unexpected npm tarball members: {members}")
+          package = json.loads((root / "package.json").read_text(encoding="utf-8"))
+          if package["name"] != "yoetz" or package["version"] != "${{ needs.validate-release-source.outputs.version }}":
+              raise SystemExit("packed npm identity mismatch")
+          PY
+
+      - name: Record npm candidate digest and manifest
+        id: digest
+        run: |
+          set -euo pipefail
+          tgz="${{ runner.temp }}/npm-dist/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz"
+          digest=$(sha256sum "$tgz" | cut -d' ' -f1)
+          sha256sum "$tgz" > "${{ runner.temp }}/npm-dist/NPM_SHA256SUMS"
+          python3 - <<PY
+          import json
+          import os
+          from pathlib import Path
+
+          out = Path(os.environ["RUNNER_TEMP"]) / "npm-dist" / "npm-candidate.json"
+          out.write_text(json.dumps({
+              "tag": "${{ needs.validate-release-source.outputs.tag }}",
+              "version": "${{ needs.validate-release-source.outputs.version }}",
+              "commit": "${{ needs.validate-release-source.outputs.commit }}",
+              "digest": "sha256:${digest}",
+              "node": "26.5.0",
+              "npm": "12.0.1",
+          }, indent=2) + "\n", encoding="utf-8")
+          PY
+          echo "value=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable npm candidate artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/npm-dist
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------------------------
   # verify-linux-x86_64
   # ---------------------------------------------------------------------------------------------
   verify-linux-x86_64:
@@ -279,7 +410,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
           submodules: false
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
 
       - name: Install uv (locked version)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -358,7 +489,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
           submodules: false
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
 
       - name: Install uv (locked version)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -493,7 +624,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: false
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.candidate_ref || github.ref }}
 
       - name: Install uv (locked version)
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -506,12 +637,17 @@ jobs:
       - name: uv sync --locked
         run: uv sync --locked --all-extras --group dev
 
-      - name: Download candidate and every gate's structural manifest
+      - name: Download the exact Python candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: "candidate-*,nightly-*,capability-*,security-*"
-          path: ${{ runner.temp }}/inputs
-          merge-multiple: false
+          name: candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/inputs/candidate-${{ needs.validate-release-source.outputs.version }}
+
+      - name: Download the exact capability matrix
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: capability-matrix
+          path: ${{ runner.temp }}/inputs/capability-matrix
 
       - name: Build the release-inputs manifest for the evidence generator
         run: |
@@ -575,14 +711,14 @@ jobs:
           retention-days: 90
 
   # ---------------------------------------------------------------------------------------------
-  # approve-publication — protected-environment human gate; publication only, never for dry runs.
+  # approve-publication — digest-bound environment checkpoint; never runs for dry runs.
   # ---------------------------------------------------------------------------------------------
   approve-publication:
     name: approve-publication
-    needs: [validate-release-source, build-candidate, assemble-release-evidence]
+    needs: [validate-release-source, build-candidate, build-npm-launcher, assemble-release-evidence]
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
-    timeout-minutes: 1440 # environment reviewer wait; no workflow input can shorten or waive it
+    timeout-minutes: 10
     environment: release-approval
     permissions:
       contents: read
@@ -591,7 +727,8 @@ jobs:
         run: |
           {
             echo "tag: ${{ needs.validate-release-source.outputs.tag }}"
-            echo "candidate digest: ${{ needs.build-candidate.outputs.candidate-digest }}"
+            echo "Python candidate digest: ${{ needs.build-candidate.outputs.candidate-digest }}"
+            echo "npm candidate digest: ${{ needs.build-npm-launcher.outputs.npm-digest }}"
             echo "evidence digest: ${{ needs.assemble-release-evidence.outputs.evidence-digest }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -642,6 +779,70 @@ jobs:
           print-hash: true
 
   # ---------------------------------------------------------------------------------------------
+  # publish-npm — after PyPI because the launcher delegates to that exact Python version.
+  # ---------------------------------------------------------------------------------------------
+  publish-npm:
+    name: publish-npm
+    needs: [validate-release-source, build-npm-launcher, approve-publication, publish-pypi]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: npm
+    permissions:
+      id-token: write # npm Trusted Publishing only; no long-lived package token
+      contents: read
+    steps:
+      - name: Install Node and npm for trusted publication
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26.5.0"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Install the locked npm CLI
+        run: npm install --global --ignore-scripts npm@12.0.1
+
+      - name: Download the prebuilt npm candidate (never rebuild)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/npm-dist
+
+      - name: Verify npm candidate digest before publication
+        run: |
+          set -euo pipefail
+          tgz="${{ runner.temp }}/npm-dist/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz"
+          digest=$(sha256sum "$tgz" | cut -d' ' -f1)
+          [ "$digest" = "${{ needs.build-npm-launcher.outputs.npm-digest }}" ] || {
+            echo "::error::npm candidate digest mismatch before publish"
+            exit 1
+          }
+          [ "$(npm --version)" = "12.0.1" ] || {
+            echo "::error::expected npm 12.0.1, got $(npm --version)"
+            exit 1
+          }
+
+      - name: Verify the version is absent from npm (existing different digest is terminal)
+        run: |
+          set -euo pipefail
+          status=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://registry.npmjs.org/yoetz/${{ needs.validate-release-source.outputs.version }}")
+          case "$status" in
+            404) ;;
+            200)
+              echo "::error::yoetz@${{ needs.validate-release-source.outputs.version }} already exists on npm"
+              exit 1
+              ;;
+            *)
+              echo "::error::npm registry preflight returned HTTP ${status}"
+              exit 1
+              ;;
+          esac
+
+      - name: Publish the exact tarball through npm Trusted Publishing
+        run: npm publish "${{ runner.temp }}/npm-dist/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz" --access public
+
+  # ---------------------------------------------------------------------------------------------
   # publish-github-release
   # ---------------------------------------------------------------------------------------------
   publish-github-release:
@@ -649,9 +850,11 @@ jobs:
     needs:
       - validate-release-source
       - build-candidate
+      - build-npm-launcher
       - assemble-release-evidence
       - capability-release-profile
       - publish-pypi
+      - publish-npm
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -660,41 +863,7 @@ jobs:
       contents: write # bounded, this job only, after approval + successful PyPI publish
       id-token: write # provenance attestation verification path
     steps:
-      - name: Download the built candidate and release evidence (never rebuild)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: "candidate-${{ needs.validate-release-source.outputs.version }},release-evidence-${{ needs.validate-release-source.outputs.version }},capability-matrix"
-          path: ${{ runner.temp }}/release-assets
-          merge-multiple: true
-
-      - name: Create the GitHub Release with candidate artifacts, checksums, SBOM, evidence, matrices
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.validate-release-source.outputs.tag }}
-          name: ${{ needs.validate-release-source.outputs.tag }}
-          prerelease: ${{ needs.validate-release-source.outputs.is-prerelease == 'true' }}
-          generate_release_notes: true
-          files: |
-            ${{ runner.temp }}/release-assets/**/*.whl
-            ${{ runner.temp }}/release-assets/**/*.tar.gz
-            ${{ runner.temp }}/release-assets/**/SHA256SUMS
-            ${{ runner.temp }}/release-assets/**/*.md
-            ${{ runner.temp }}/release-assets/**/*.json
-
-  # ---------------------------------------------------------------------------------------------
-  # publish-schema-site
-  # ---------------------------------------------------------------------------------------------
-  publish-schema-site:
-    name: publish-schema-site
-    needs: [validate-release-source, build-candidate, assemble-release-evidence]
-    if: github.event_name == 'push'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    environment: schema-site
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout the exact tag (no persisted credentials)
+      - name: Checkout release notes from the exact tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -702,39 +871,82 @@ jobs:
           submodules: false
           ref: ${{ needs.validate-release-source.outputs.tag }}
 
-      - name: Deploy the already-tested schemas/ bytes byte-for-byte at /0.1/
-        # Deploys the reviewed, untouched schemas/ tree exactly as checked in — no regeneration or
-        # renaming. Exact publication environment/provider is centralized under E-008; provider
-        # credentials/origin details are environment-only and never enter artifacts or logs.
-        env:
-          SCHEMA_SITE_DEPLOY_TARGET: ${{ secrets.SCHEMA_SITE_DEPLOY_TARGET }}
-          SCHEMA_SITE_API_TOKEN: ${{ secrets.SCHEMA_SITE_API_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${SCHEMA_SITE_DEPLOY_TARGET:-}" ]; then
-            echo "::error::schema-site deploy target is not configured (E-008 publication environment pending)"
-            exit 1
-          fi
-          find schemas -type f -name '*.schema.json' -print
-          echo "publishing schemas/ (manifest $(sha256sum schemas/manifest.json | cut -d' ' -f1)) to https://schemas.yoetz.dev/0.1/"
-          # The deploy client itself is provider-specific and configured out-of-band per E-008;
-          # this workflow only asserts the exact reviewed source tree and immutable member set.
+      - name: Download the Python candidate (never rebuild)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/release-assets/python
 
-      - name: Verify no digest was overwritten at an existing versioned schema path
+      - name: Download the npm candidate (never rebuild)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/release-assets/npm
+
+      - name: Download the release evidence (never regenerate)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-evidence-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/release-assets/evidence
+
+      - name: Download the capability matrix (never regenerate)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: capability-matrix
+          path: ${{ runner.temp }}/release-assets/capability
+
+      - name: Create the GitHub Release with candidate artifacts, checksums, SBOM, evidence, matrices
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ needs.validate-release-source.outputs.tag }}
+          name: Yoetz ${{ needs.validate-release-source.outputs.tag }} — public alpha
+          prerelease: ${{ needs.validate-release-source.outputs.is-prerelease == 'true' || needs.validate-release-source.outputs.version == '0.1.0' }}
+          body_path: docs/releases/v0.1.0.md
+          files: |
+            ${{ runner.temp }}/release-assets/**/*.whl
+            ${{ runner.temp }}/release-assets/**/*.tar.gz
+            ${{ runner.temp }}/release-assets/**/*.tgz
+            ${{ runner.temp }}/release-assets/evidence/**/SHA256SUMS
+            ${{ runner.temp }}/release-assets/**/NPM_SHA256SUMS
+            ${{ runner.temp }}/release-assets/**/REPRODUCIBILITY.txt
+            ${{ runner.temp }}/release-assets/**/*.md
+            ${{ runner.temp }}/release-assets/**/*.json
+
+  # ---------------------------------------------------------------------------------------------
+  # verify-schema-site — deployment is a pre-tag maintainer ceremony; this job proves exact bytes.
+  # ---------------------------------------------------------------------------------------------
+  verify-schema-site:
+    name: verify-schema-site
+    needs: [validate-release-source, build-candidate, assemble-release-evidence]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: schema-site
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout the exact release source (no persisted credentials)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          submodules: false
+          ref: ${{ needs.validate-release-source.outputs.commit }}
+
+      - name: Verify every hosted v0.1 file exists and equals the tagged bytes
         run: |
           set -euo pipefail
-          for f in $(find schemas -name '*.schema.json'); do
+          while IFS= read -r -d '' f; do
             url="https://schemas.yoetz.dev/0.1/${f#schemas/}"
-            code=$(curl -s -o /dev/null -w '%{http_code}' "$url" || echo 000)
-            if [ "$code" = "200" ]; then
-              remote_hash=$(curl -s "$url" | sha256sum | cut -d' ' -f1)
-              local_hash=$(sha256sum "$f" | cut -d' ' -f1)
-              if [ "$remote_hash" != "$local_hash" ]; then
-                echo "::error::$url already exists with a different digest; immutable paths cannot be overwritten"
-                exit 1
-              fi
-            fi
-          done
+            remote="${{ runner.temp }}/schema-$(sha256sum <<<"$f" | cut -d' ' -f1)"
+            curl --fail --silent --show-error --location "$url" --output "$remote" || {
+              echo "::error::missing hosted schema file: $url"
+              exit 1
+            }
+            cmp -s "$remote" "$f" || {
+              echo "::error::$url differs from the immutable tagged bytes"
+              exit 1
+            }
+          done < <(find schemas -type f -print0 | sort -z)
 
   # ---------------------------------------------------------------------------------------------
   # verify-published
@@ -747,7 +959,7 @@ jobs:
       - assemble-release-evidence
       - publish-pypi
       - publish-github-release
-      - publish-schema-site
+      - verify-schema-site
     if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -816,6 +1028,82 @@ jobs:
           "${{ runner.temp }}/published-venv/bin/python" -c "import yoetz"
 
   # ---------------------------------------------------------------------------------------------
+  # verify-npm-published
+  # ---------------------------------------------------------------------------------------------
+  verify-npm-published:
+    name: verify-npm-published
+    needs:
+      - validate-release-source
+      - build-npm-launcher
+      - publish-npm
+      - publish-github-release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Install the release Node version
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "26.5.0"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Download the approved npm candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-candidate-${{ needs.validate-release-source.outputs.version }}
+          path: ${{ runner.temp }}/npm-candidate
+
+      - name: Wait for npm registry availability and download the public tarball
+        run: |
+          set -euo pipefail
+          version="${{ needs.validate-release-source.outputs.version }}"
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/yoetz/${version}")
+            [ "$code" = "200" ] && break
+            sleep 20
+          done
+          [ "$code" = "200" ] || {
+            echo "::error::yoetz@${version} not visible on npm within bound"
+            exit 1
+          }
+          curl -sL "https://registry.npmjs.org/yoetz/${version}" -o "${{ runner.temp }}/npm-meta.json"
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"])
+          meta = json.loads((root / "npm-meta.json").read_text(encoding="utf-8"))
+          urllib.request.urlretrieve(meta["dist"]["tarball"], root / "npm-published.tgz")
+          PY
+
+      - name: Verify public npm bytes and exact-version delegation
+        run: |
+          set -euo pipefail
+          candidate="${{ runner.temp }}/npm-candidate/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz"
+          cmp -s "${{ runner.temp }}/npm-published.tgz" "$candidate" || {
+            echo "::error::published npm tarball differs from the approved candidate"
+            exit 1
+          }
+          mkdir -p "${{ runner.temp }}/npm-published" "${{ runner.temp }}/shims"
+          tar -xzf "${{ runner.temp }}/npm-published.tgz" -C "${{ runner.temp }}/npm-published"
+          printf '#!/bin/sh\nexit 0\n' > "${{ runner.temp }}/shims/uv"
+          printf '#!/bin/sh\nprintf "%%s\\n" "$*" > "$RUNNER_TEMP/uvx-args"\nexit 0\n' \
+            > "${{ runner.temp }}/shims/uvx"
+          chmod +x "${{ runner.temp }}/shims/uv" "${{ runner.temp }}/shims/uvx"
+          PATH="${{ runner.temp }}/shims:$PATH" \
+            node "${{ runner.temp }}/npm-published/package/bin/yoetz.js" version --json
+          [ "$(cat "${{ runner.temp }}/uvx-args")" = \
+            "yoetz==${{ needs.validate-release-source.outputs.version }} version --json" ] || {
+            echo "::error::published npm launcher did not delegate to the exact PyPI version"
+            exit 1
+          }
+
+  # ---------------------------------------------------------------------------------------------
   # release-required
   # ---------------------------------------------------------------------------------------------
   release-required:
@@ -823,6 +1111,7 @@ jobs:
     needs:
       - validate-release-source
       - build-candidate
+      - build-npm-launcher
       - verify-linux-x86_64
       - verify-macos-arm64
       - fault-release-profile
@@ -831,9 +1120,11 @@ jobs:
       - assemble-release-evidence
       - approve-publication
       - publish-pypi
+      - publish-npm
       - publish-github-release
-      - publish-schema-site
+      - verify-schema-site
       - verify-published
+      - verify-npm-published
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -846,12 +1137,14 @@ jobs:
           declare -A always_required=(
             [validate-release-source]="${{ needs.validate-release-source.result }}"
             [build-candidate]="${{ needs.build-candidate.result }}"
+            [build-npm-launcher]="${{ needs.build-npm-launcher.result }}"
             [verify-linux-x86_64]="${{ needs.verify-linux-x86_64.result }}"
             [verify-macos-arm64]="${{ needs.verify-macos-arm64.result }}"
             [fault-release-profile]="${{ needs.fault-release-profile.result }}"
             [capability-release-profile]="${{ needs.capability-release-profile.result }}"
             [security-privacy-release]="${{ needs.security-privacy-release.result }}"
             [assemble-release-evidence]="${{ needs.assemble-release-evidence.result }}"
+            [verify-schema-site]="${{ needs.verify-schema-site.result }}"
           )
           failed=0
           for job in "${!always_required[@]}"; do
@@ -866,9 +1159,10 @@ jobs:
             declare -A publish_required=(
               [approve-publication]="${{ needs.approve-publication.result }}"
               [publish-pypi]="${{ needs.publish-pypi.result }}"
+              [publish-npm]="${{ needs.publish-npm.result }}"
               [publish-github-release]="${{ needs.publish-github-release.result }}"
-              [publish-schema-site]="${{ needs.publish-schema-site.result }}"
               [verify-published]="${{ needs.verify-published.result }}"
+              [verify-npm-published]="${{ needs.verify-npm-published.result }}"
             )
             for job in "${!publish_required[@]}"; do
               outcome="${publish_required[$job]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable user-visible changes to Yoetz are documented in this file. Format is
 project-native heading style that marks the pending version as unreleased above
 reverse-chronological released versions.
 
-## 0.1.0 — Public alpha (unreleased)
+## 0.1.0 — Public alpha (2026-08-20)
 
-Planned initial public alpha release. No version has shipped before it, so every entry below
-describes behavior intended for the first release rather than a change from a previous release.
+Initial public alpha release. The earlier 0.0.1 registry packages only reserved the project name
+and contained no usable Yoetz implementation.
 
 ### Added
 
@@ -124,7 +124,8 @@ describes behavior intended for the first release rather than a change from a pr
   flip configuration or Codex activation silently. Initial consumers cover observation enablement,
   Codex plugin activation, and the existing policy-gated PyPI update advisory. The durable
   `update_checks` channel remains the only update-check flag, accepts only bounded package identity,
-  and never auto-upgrades; Yoetz has no npm update check because it ships only on PyPI.
+  and never auto-upgrades; Yoetz has no npm update check because the npm package delegates to the
+  canonical exact-version PyPI distribution.
 
 - Typed evidence digest provenance (`evidence_recorded/1.1.0`) records the exact closed byte
   subject, availability, byte count, and authority that established each new digest. Kind/subject
@@ -266,9 +267,9 @@ describes behavior intended for the first release rather than a change from a pr
   hand-derive action/result/evidence/claim shapes from a large `oneOf`. `check`, `respond`, and
   `receipt` carry worked examples too.
 
-- Publish-ready npm launcher at `support/npm-launcher/` for a future `npx yoetz`: a
-  dependency-free delegator to the exact pinned `uvx yoetz==<version>`, kept deliberately
-  unpublished (`"private": true`) until a separate release decision. It propagates signal
+- Public npm launcher at `support/npm-launcher/` for `npx yoetz`: a dependency-free delegator to
+  the exact pinned `uvx yoetz==<version>`, published only after the matching Python artifact by the
+  protected tagged workflow. It propagates signal
   termination as the conventional `128+n` exit code and gives actionable, platform-specific
   guidance when `uv` is absent; it installs nothing, bundles nothing, and duplicates no setup or
   interface logic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,9 @@ Silence, ignoring a thread, or "will do later" without maintainer agreement is n
   `pyproject.toml` and the development-only `package.json` are the only ones this project uses.
 - Don't add a new distribution surface without design-gate acknowledgement. The end-user install
   path is Python/`uv` (see [`README.md`](README.md)); the one reviewed exception is the
-  delegation-only npm launcher at `support/npm-launcher/` (ADR-012), which must stay unpublished
-  (`"private": true`) — publishing it is a separate deliberate release decision, never a side effect
-  of another change.
+  delegation-only npm launcher at `support/npm-launcher/` (ADR-012). Its deliberate public-release
+  decision is recorded for v0.1.0 in issue #366; later changes must keep it version-locked to PyPI,
+  dependency-free, and inside the protected tagged-release workflow.
 
 ## Security and conduct
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ uv tool install --managed-python --python 3.14.6 "yoetz==0.1.0"
 yoetz
 ```
 
-The supported install path is Python via [`uv`](https://docs.astral.sh/uv/); `uvx yoetz` works for a
-one-off run.
+Or, with `uv` already installed:
+
+```text
+npx yoetz
+```
+
+The canonical distribution is Python via [`uv`](https://docs.astral.sh/uv/); `uvx yoetz` works for
+a one-off run. The dependency-free npm package is only a launcher for the exact matching Python
+distribution. It bundles no Python or Yoetz code and never installs `uv` itself.
 
 `yoetz` at a terminal opens a full-screen interface, and the first run walks setup inside it:
 what was detected, whether you trust this project, the exact proposed change, and an explicit
@@ -108,7 +115,7 @@ See [Architecture](docs/architecture.md).
 
 ## Status
 
-v0.1.0 is intended to ship as a **public alpha** after the remaining release gate closes. Every
+v0.1.0 is the first **public alpha**. Every
 public claim in [`docs/public-claims.json`](docs/public-claims.json) is bound to real checked-in
 evidence: a claim flagged `evidenced` has concrete test or fixture coverage, with its non-live
 suites exercised in per-PR CI; a claim whose own wording names still-missing capability or drill

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -6,7 +6,7 @@
 ## Purpose
 
 This file is the one canonical ledger of the decisions taken for v0.1 and the dated dispositions
-of every release gate. As of the v0.1.0 public-alpha reconciliation (2026-08-19) it holds no open
+of every release gate. As of the v0.1.0 public-alpha reconciliation (2026-08-20) it holds no open
 questions: every founder item is resolved, every empirical gate carries a disposition, and the two
 independent reviews are deferred with binding conditions. A public claim may strengthen only by
 adding the evidence its gate names and updating this ledger in the same review.
@@ -22,9 +22,9 @@ in its owning ADR and moving a short result into the resolved-decisions section 
 Before implementation starts, all `founder` items must be accepted or deliberately amended. Before
 the affected release claim ships, all `empirical` and `independent-review` items must have dated,
 artifact-bound evidence. `deferred` items do not block v0.1 and may not leak into v0.1 help,
-schemas, capability claims, or implicit adapter behavior. As of 2026-08-19 every item is either
-resolved, dispositioned for the v0.1.0 public alpha, or deferred; the sole action still blocking
-the v0.1.0 tag is the E-012 checklist in the disposition table below.
+schemas, capability claims, or implicit adapter behavior. As of 2026-08-20 every item is either
+resolved, dispositioned for the v0.1.0 public alpha, or deferred; none of the E-gate ledger entries
+blocks the v0.1.0 tag under the dated maintainer decisions below.
 
 ## Errors and edge cases
 
@@ -114,10 +114,10 @@ that evidence.
 | E-015 | Exact structural subject-state capture matrix | No support claim until installed-artifact tests freeze Git/object-format and OS cells, symlink/submodule/racy-worktree behavior, file/byte caps, exclusions, sanitized environment, path/content-free output, and no network or trusted-service reachability. | ADR-011 CLI/subprocess, packaging-boundary, privacy, and capability evidence. |
 | E-016 | TOML as alternate nonsecret settings surface, including official OpenAI vs owner-declared OpenAI-compatible HTTPS origin+model | **Working (ADR-014).** Config validates constrained `https_origin`, rejects secrets/free `base_url`, mutual-excludes official vs owner-declared, and writes the same fields from wizard/menu/`yoetz provider endpoint`. Owner-declared data-use defaults to `unknown` (never `assisted`). Privacy desired-state export/apply classifies widen vs tighten and never silently widens. Remaining: optional live owner-declared host probe before advertising verified interoperability beyond the protocol cell. | ADR-014, ADR-006/009 amendments, config/privacy/openai_responses specs, unit fixtures; live probe optional. |
 
-### v0.1.0 public-alpha gate dispositions — 2026-08-19
+### v0.1.0 public-alpha gate dispositions — 2026-08-20
 
-v0.1.0 may ship as a **public alpha** under a maintainer-accepted narrowed claim set once E-012
-closes. Each empirical gate below carries exactly one dated disposition:
+v0.1.0 may ship as a **public alpha** under a maintainer-accepted narrowed claim set. Each
+empirical gate below carries exactly one dated disposition:
 
 - **Closed by decision** — a dated product decision replaces the calibration or refresh for the
   alpha; the decision itself is the recorded answer and manufactures no support evidence.
@@ -142,7 +142,7 @@ affected claim, and for the first non-alpha release regardless.
 | E-009 | Not applicable (narrowed) — the shipped skill examples remain as authored with the explicit-activation preference; no activation-quality or materiality-threshold claim ships. |
 | E-010 | Narrowed — local service endpoint, lifecycle, and secret-boundary behavior is evidenced by the per-PR subprocess suites on the CI platforms; no broader platform relock/keyring/memory-protection matrix ships. |
 | E-011 | Narrowed — privacy enforcement claims are bounded to the per-PR conformance, property, integration, and subprocess evidence; no live-profile claim ships. |
-| E-012 | **Open — the only gate still blocking the v0.1.0 tag.** Verified 2026-08-19: GitHub private vulnerability reporting is enabled, `yoetz.dev` is registered with active MX records, and the maintained `support@yoetz.dev` mailbox exists (2026-08-20 F-006 amendment: one private mailbox serves security fallback, conduct, and support). Remaining before tagging: a dated maintainer delivery/response drill on `support@yoetz.dev`; `https://schemas.yoetz.dev/0.1/` deploys as part of the release publish step per the resolved schema-hosting decision. |
+| E-012 | Closed by decision (2026-08-20, issue #366) — GitHub private vulnerability reporting is enabled, `yoetz.dev` is registered with active MX records, and the maintained `support@yoetz.dev` mailbox exists. The maintainer accepts those routes for the public alpha without making a delivery-time, response-time, availability, or monitored-SLA claim; a completed delivery/response drill is required before any later release makes one. `https://schemas.yoetz.dev/0.1/` is deployed from the exact candidate before tagging and every hosted byte is re-fetched and compared by the tagged workflow. |
 | E-013 | Not applicable (narrowed) — no trigger arm and no observation arm ships; every capability cell remains `None`/empty, `hook_observed` is unearnable in v0.1.0, and unprofiled harnesses stay cooperative-only. |
 | E-014 | Closed by decision — publication-ceremony guidance remains qualitative, informed by bounded dogfood use; no numeric budget or grouping-threshold claim ships, and measurement is required before any later budget claim. |
 | E-015 | Narrowed — `yoetz state capture` ships fail-closed with no advertised capability cells; `support.structural_subject_state_capture` stays `not_yet_evidenced`. |
@@ -213,10 +213,10 @@ for the first release that drops the alpha designation or widens any claim they 
 
 ### Resolved founder and working decisions reflected across the tree
 
-- **v0.1.0 public-alpha reconciliation (2026-08-19):** R-001/R-002 are deferred to the first
+- **v0.1.0 public-alpha reconciliation (2026-08-20):** R-001/R-002 are deferred to the first
   non-alpha release under the binding conditions recorded above; every empirical gate carries a
-  dated disposition in the v0.1.0 disposition table, with E-012 the sole gate still blocking the
-  tag; and `docs/public-claims.json` is reconciled so `evidenced` means the claim has concrete
+  dated disposition in the v0.1.0 disposition table, and none blocks the public-alpha tag;
+  `docs/public-claims.json` is reconciled so `evidenced` means the claim has concrete
   checked-in test or fixture coverage and its non-live suites run in per-PR CI, while the three
   claims whose own wording names missing capability or drill evidence
   (`integration.codex_exact_version_support`,
@@ -238,8 +238,9 @@ for the first release that drops the alpha designation or widens any claim they 
 - **F-005:** The official npm Pyright package remains an exactly pinned contributor/CI tool only.
   Node/npm are not Yoetz runtime requirements. The formerly deferred `npx yoetz` launcher is now
   built as its own reviewed distribution surface under ADR-012: a dependency-free delegation-only
-  package at `support/npm-launcher/` pinned to the exact PyPI version, kept deliberately
-  unpublished (`"private": true`) until a separate publication decision.
+  package at `support/npm-launcher/` pinned to the exact PyPI version. The separate publication
+  decision was made for v0.1.0 on 2026-08-20 (issue #366); npm publication follows PyPI inside the
+  protected tag workflow and the downloaded public tarball must match the approved bytes.
 - **F-020 (ADR-012, 2026-07-21):** Founder-authorized first-run setup wizard. `yoetz setup
   run|status` and `yoetz integrate <harness> mcp status|preview|install` automate Codex discovery
   and the runbook's check-then-add MCP registration behind preview→confirm→execute; bare `yoetz`
@@ -252,8 +253,8 @@ for the first release that drops the alpha designation or widens any claim they 
   as fallback; private conduct reports use the same mailbox with a "Code of conduct" subject;
   ordinary support and bug reports use repository issues. The original decision named distinct
   `security@`/`conduct@` routes; the maintainer consolidated to one monitored mailbox for the
-  solo-maintained v0.1 era — the routes may split again without a claim change. E-012 verifies
-  these routes before release rather than treating prose as operational proof.
+  solo-maintained v0.1 era — the routes may split again without a claim change. The v0.1.0 alpha
+  makes no mailbox delivery-time, response-time, availability, or monitored-SLA claim.
 - The persistent per-user local service is in v0.1 and is the sole owner of keys, decrypted state,
   durable writers, privacy policy enforcement, and outbound dispatch. CLI, MCP, and UI are clients.
 - **F-007:** v0.1 keeps vault keys, provider-credential handles, and decrypted state inside the

--- a/docs/adr/ADR-004-threat-crypto-key-recovery.md
+++ b/docs/adr/ADR-004-threat-crypto-key-recovery.md
@@ -3,7 +3,7 @@
 **Status:** Founder-directed working decision (2026-07-14). The service-owned trust boundary and
 forbidden secret channels are binding. The concrete cryptographic envelope remains subject to an
 independent threat review before the first non-alpha release; the v0.1.0 public alpha may ship
-without that review after its remaining release gate closes, by maintainer decision (2026-08-19,
+without that review by maintainer decision (2026-08-19,
 `docs/OPEN_QUESTIONS.md` R-001 disposition), and no public surface claims a reviewed design.
 **Implemented by:** `docs/adr/ADR-008-local-service-vault-trust-boundary.md`,
 `src/yoetz/service/vault.py`, `src/yoetz/service/unlock.py`,

--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -42,8 +42,9 @@ manifests, the packaging/capability suites, and the release workflows under `.gi
    by `npm run typecheck` is the reproducible invocation. Node/npm are not end-user runtime
    requirements. Amended by ADR-012: the npm launcher now exists at `support/npm-launcher/` with
    its own provenance/delegation/upgrade contract — a dependency-free delegator to
-   `uvx yoetz==<version>` — and remains deliberately unpublished (`"private": true`); publishing
-   is a separate future release decision.
+   `uvx yoetz==<version>`. Maintainer release decision (2026-08-20, issue #366): v0.1.0 publishes
+   that launcher as the public `yoetz` npm package through the protected tagged workflow, after
+   PyPI publication and with trusted-publisher provenance plus byte-for-byte download verification.
 8. **Release artifacts:** sdist + wheel, SHA-256 checksums, CycloneDX SBOM via `uv export`,
    dependency lock, support matrix, conformance summary, known limitations, changelog, security
    policy. Sigstore signing deferred until a documented verification command exists (a signature

--- a/docs/adr/ADR-008-local-service-vault-trust-boundary.md
+++ b/docs/adr/ADR-008-local-service-vault-trust-boundary.md
@@ -3,7 +3,7 @@
 **Status:** Founder-selected working decision (2026-07-14), amended 2026-07-25 to permit
 bundle-scoped passphrase auto-unlock through an allowlisted platform credential store. Binding for
 v0.1 specification work; independent security review remains required before the first non-alpha
-release — the v0.1.0 public alpha may ship without it after its remaining release gate closes, by
+release — the v0.1.0 public alpha may ship without it by
 maintainer decision (2026-08-19, `docs/OPEN_QUESTIONS.md` R-002 disposition), and no public surface
 claims a reviewed boundary.
 **Related:** ADR-001 owns single-writer lifecycle; ADR-004 owns cryptography and recovery; ADR-006

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -214,14 +214,15 @@ availability, structured-output interoperability, provider data use, or E-007 ca
    or presented as an installation. macOS and Windows therefore combine app and CLI installations;
    Linux uses the identical selection flow for the official CLI surfaces that actually exist.
 
-6. **The npm launcher exists, publish-ready and deliberately unpublished (amends ADR-007
-   decision 7).** `support/npm-launcher/` contains a dependency-free `package.json` (registry name
+6. **The npm launcher is a protected public distribution surface (amends ADR-007 decision 7).**
+   `support/npm-launcher/` contains a dependency-free `package.json` (registry name
    `yoetz`, version locked to the PyPI version) and `bin/yoetz.js`, which requires `uv` on PATH
    (printing install guidance and exiting nonzero otherwise) and delegates to
    `uvx yoetz==<version>` with untouched arguments and the child's exact exit code. It bundles no
    Python, downloads nothing itself, and duplicates no wizard logic — first-run behavior lives
-   once, in the Python CLI. `"private": true` is the load-bearing unpublished guarantee; flipping
-   it is a separate deliberate release decision with its own review, never a side effect.
+   once, in the Python CLI. The separate deliberate release decision was made for v0.1.0 on
+   2026-08-20 (issue #366): the tagged workflow publishes the exact prebuilt npm tarball only after
+   matching PyPI publication, using npm trusted publishing and post-publication byte verification.
 
 7. **The confidential boundaries remain exact.** The wizard never accepts a secret by flag,
    ordinary stdin, environment, config, report, or MCP. A local interactive run may enter the

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,92 @@
+# Yoetz v0.1.0 — public alpha
+
+Yoetz v0.1.0 is the first usable public release: a local-first evidence ledger and review engine
+for agent work. It records bounded facts that participants publish, checks that record with
+versioned policy packs, and produces receipts whose wording stays inside the evidence actually
+available.
+
+## Highlights
+
+- **A six-operation protocol:** `start`, `publish_work`, `check`, `respond`, `status`, and
+  `receipt`, with the same contracts over CLI and MCP.
+- **Local-first trust:** one per-user service owns keys, decrypted state, SQLite writers, privacy
+  policy, and provider dispatch. CLI, MCP, and the terminal interface are bounded clients.
+- **Honest completion receipts:** coverage, provenance, freshness, findings, and limitations remain
+  separate. A clean deterministic check is never presented as proof that work is correct.
+- **A full-screen terminal experience:** first run, status, privacy, provider, integration, service,
+  and receipt flows share one interface without moving confidential input into the UI.
+- **Privacy-gated semantic review:** optional model review stays behind explicit provider binding,
+  reauthenticated policy authority, minimization, secret scanning, and durable egress receipts.
+- **Codex integration without inflated claims:** Yoetz ships Codex skill, plugin, MCP, hook, and
+  observation machinery, but v0.1.0 deliberately advertises no tested Codex version or capability
+  profile. Installation or registration alone is not support evidence.
+- **Recoverable local durability:** encrypted task bundles, generation-fenced SQLite writers,
+  backup/restore, forward-only migrations, and explicit operational recovery surfaces.
+
+## Install
+
+The canonical package is the Python distribution:
+
+```text
+uv tool install --managed-python --python 3.14.6 "yoetz==0.1.0"
+yoetz
+```
+
+For a one-off run:
+
+```text
+uvx "yoetz==0.1.0"
+```
+
+Or, when `uv` is already installed:
+
+```text
+npx yoetz@0.1.0
+```
+
+The npm package is a dependency-free launcher. It bundles no Python and no Yoetz implementation;
+it delegates unchanged arguments and terminal I/O to `uvx yoetz==0.1.0`.
+
+## What the alpha does not claim
+
+- It has not received the two independent threat reviews required for the first non-alpha release.
+- It publishes no verified Codex-version, hook-observation, provider-endpoint, keyring/platform, or
+  structural subject-capture support cell where release-bound evidence is absent.
+- It makes no support-mailbox availability or response-time promise.
+- It does not claim bit-for-bit reproducible Python archives, package signing, or broad platform
+  support beyond the exact release jobs and artifacts that passed.
+- Semantic output is advisory. Yoetz records challenges and provenance; it does not replace code,
+  security, or maintainer review.
+
+These are bounded release statements, not fine print. The exact claim inventory and dated
+dispositions are in
+[`docs/public-claims.json`](https://github.com/TheGaySupreme123/yoetz/blob/v0.1.0/docs/public-claims.json)
+and
+[`docs/OPEN_QUESTIONS.md`](https://github.com/TheGaySupreme123/yoetz/blob/v0.1.0/docs/OPEN_QUESTIONS.md).
+
+## Release integrity
+
+The tag workflow builds each distribution once, tests the candidate artifacts, records SHA-256
+checksums and build provenance, assembles the release evidence and capability matrices, then
+crosses dedicated publication environments. PyPI publishes first. npm then publishes the exact
+approved launcher tarball through trusted publishing. The GitHub release attaches both candidates
+and the evidence bundle. Post-publication jobs download the public artifacts and compare them to
+the approved bytes. The immutable schema tree is deployed from the exact candidate before tagging
+and the workflow re-fetches every hosted file for byte comparison.
+
+Inspect the attached `SHA256SUMS`, npm checksum file, candidate manifests, SBOM, support matrix,
+known limitations, and release-evidence bundle alongside the wheel, source archive, and npm
+tarball.
+
+## Security and support
+
+Report vulnerabilities through GitHub private vulnerability reporting, with
+`support@yoetz.dev` as the fallback. Use repository issues for ordinary bugs and support. See
+[`SECURITY.md`](https://github.com/TheGaySupreme123/yoetz/blob/v0.1.0/SECURITY.md) and
+[`CODE_OF_CONDUCT.md`](https://github.com/TheGaySupreme123/yoetz/blob/v0.1.0/CODE_OF_CONDUCT.md).
+
+## Full changelog
+
+This first public alpha has no previous usable release to compare against. The complete feature,
+fix, privacy, durability, integration, and upgrade notes are in
+[`CHANGELOG.md`](https://github.com/TheGaySupreme123/yoetz/blob/v0.1.0/CHANGELOG.md).

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -11,9 +11,8 @@ yoetz
 
 `uvx yoetz` works for a one-off run. If you are a coding agent installing Yoetz on a user's
 behalf, follow [Agent start](agent-start.md) instead — setup's questions require the human's own
-terminal. `npx yoetz` will delegate to the same `uvx` path once the
-prepared launcher in [`support/npm-launcher/`](../../support/npm-launcher/) is published; it is
-deliberately unpublished today, so npm is not currently an install route. The launcher pins the
+terminal. With `uv` already installed, `npx yoetz` delegates to the same exact-version `uvx` path.
+The launcher pins the
 exact Python distribution, passes arguments through unchanged, inherits stdio so the child sees
 your real terminal, and propagates exit codes — including `128+n` for a signal. It installs
 nothing itself: when `uv` is missing it prints the install command and stops.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,16 @@ readme = "README.md"
 requires-python = ">=3.14,<3.15"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
+authors = [{ name = "Shay Ben Shabtay" }]
+keywords = ["agents", "evidence", "local-first", "mcp", "verification"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
 dependencies = [
     "anyio==4.14.2",
     "apsw==3.53.3.1",
@@ -40,6 +50,13 @@ semantic-openai = [
 
 [project.scripts]
 yoetz = "yoetz.cli.entry:main"
+
+[project.urls]
+Homepage = "https://yoetz.dev"
+Documentation = "https://github.com/TheGaySupreme123/yoetz/tree/main/docs"
+Repository = "https://github.com/TheGaySupreme123/yoetz"
+Issues = "https://github.com/TheGaySupreme123/yoetz/issues"
+Changelog = "https://github.com/TheGaySupreme123/yoetz/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [

--- a/support/npm-launcher/README.md
+++ b/support/npm-launcher/README.md
@@ -1,6 +1,6 @@
 # yoetz npm launcher
 
-This package is a **delegation launcher only**. `npx yoetz` (once published) runs the exact
+This package is a **delegation launcher only**. `npx yoetz` runs the exact
 pinned Python distribution `yoetz==<this package's version>` through
 [`uv`](https://docs.astral.sh/uv/), which must already be installed. The launcher:
 
@@ -25,9 +25,14 @@ The packaging contract forbids bootstrapping a runtime from here, so the launche
 It prints what is missing, the platform-appropriate install command, and the fact that it
 installs nothing itself — then exits 1 without running anything.
 
-## Publication status
+## Publication and provenance
 
-**This package is deliberately unpublished.** `"private": true` in `package.json` makes
-`npm publish` refuse it. Publishing is a separate, deliberate release decision recorded in
-ADR-012: flip `private` to `false`, verify the registry name, and follow the ordinary release
-review — never publish as a side effect of another change.
+The v0.1.0 maintainer decision publishes this launcher as the public `yoetz` package. The tagged
+release workflow builds its tarball once, records its SHA-256, publishes the exact tarball through
+npm trusted publishing only after the matching `yoetz==0.1.0` Python distribution is live, and
+downloads it back for byte comparison. npm's package provenance binds the public tarball to that
+GitHub Actions workflow.
+
+The launcher remains only a delegator. npm installation does not install Python, `uv`, Yoetz's
+Python code, or any runtime dependency; it selects the same exact-version PyPI distribution that
+the release workflow already published and verified.

--- a/support/npm-launcher/package.json
+++ b/support/npm-launcher/package.json
@@ -2,8 +2,20 @@
   "name": "yoetz",
   "version": "0.1.0",
   "description": "Delegation launcher for the Python yoetz distribution via uv. Installs nothing itself.",
-  "private": true,
+  "private": false,
   "license": "Apache-2.0",
+  "author": "Shay Ben Shabtay",
+  "homepage": "https://yoetz.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheGaySupreme123/yoetz.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TheGaySupreme123/yoetz/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "yoetz": "./bin/yoetz.js"
   },

--- a/tests/packaging/test_npm_launcher.py
+++ b/tests/packaging/test_npm_launcher.py
@@ -1,4 +1,4 @@
-"""npm launcher: publish-ready shape, delegation-only behavior, unpublished guarantee."""
+"""npm launcher: public package shape and delegation-only behavior."""
 
 from __future__ import annotations
 
@@ -20,13 +20,19 @@ def _package() -> dict[str, object]:
 def test_package_shape_is_delegation_only() -> None:
     package = _package()
     assert package["name"] == "yoetz"
-    # The load-bearing "not published yet" guarantee: npm publish refuses it.
-    assert package["private"] is True
+    assert package["private"] is False
     assert package["bin"] == {"yoetz": "./bin/yoetz.js"}
     # No runtime dependencies: the launcher may never bundle or fetch code itself.
     for forbidden in ("dependencies", "devDependencies", "optionalDependencies", "scripts"):
         assert forbidden not in package, forbidden
     assert package["license"] == "Apache-2.0"
+    assert package["homepage"] == "https://yoetz.dev"
+    assert package["repository"] == {
+        "type": "git",
+        "url": "git+https://github.com/TheGaySupreme123/yoetz.git",
+    }
+    assert package["bugs"] == {"url": "https://github.com/TheGaySupreme123/yoetz/issues"}
+    assert package["publishConfig"] == {"access": "public"}
 
 
 def test_version_stays_in_lockstep_with_the_python_distribution() -> None:

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -19,8 +19,11 @@ def test_dry_run_retains_builder_backed_release_evidence_bundle() -> None:
     assert "workflow_dispatch:" in workflow
     assert "DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}" in workflow
     assert "workflow_dispatch is dry-run only; dry_run must be true" in workflow
+    assert "candidate_ref:" in workflow
+    assert "dry-run candidate ${candidate} is not current origin/main ${protected}" in workflow
     assert "scripts/build_release_inputs.py" in assembly
     assert "generate_release_evidence.py" in assembly
+    assert 'pattern: "candidate-*,nightly-*,capability-*,security-*"' not in assembly
     assert "python -c" not in assembly
     assert "--candidate-commit" in assembly
     assert (
@@ -56,3 +59,50 @@ def test_dry_run_retains_builder_backed_release_evidence_bundle() -> None:
     assert "if:" not in upload
     assert "path: ${{ runner.temp }}/release-evidence" in upload
     assert "retention-days: 90" in upload
+
+
+def test_npm_release_is_built_once_published_after_pypi_and_download_verified() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    build = workflow.split("  build-npm-launcher:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # verify-linux",
+        1,
+    )[0]
+    publish = workflow.split("  publish-npm:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # publish-github-release",
+        1,
+    )[0]
+    verify = workflow.split("  verify-npm-published:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # release-required",
+        1,
+    )[0]
+
+    assert "npm pack ./support/npm-launcher" in build
+    assert "npm install --global --ignore-scripts npm@12.0.1" in build
+    assert "npm-candidate-${{ needs.validate-release-source.outputs.version }}" in build
+    assert "NPM_SHA256SUMS" in build
+    assert '"npm": "12.0.1"' in build
+
+    assert "publish-pypi" in "\n".join(publish.split("\n", 8)[0:8])
+    assert "environment: npm" in publish
+    assert "id-token: write" in publish
+    assert "npm install --global --ignore-scripts npm@12.0.1" in publish
+    assert "npm publish" in publish
+    assert "npm pack" not in publish
+    assert "skip-existing" not in publish
+
+    assert "npm-published.tgz" in verify
+    assert "cmp -s" in verify
+    assert "yoetz==${{ needs.validate-release-source.outputs.version }} version --json" in verify
+
+
+def test_tag_workflow_rejects_missing_or_drifted_hosted_schema_bytes() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    verify = workflow.split("  verify-schema-site:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # verify-published",
+        1,
+    )[0]
+
+    assert "find schemas -type f -print0 | sort -z" in verify
+    assert "curl --fail --silent --show-error --location" in verify
+    assert "cmp -s" in verify
+    assert "|| true" not in verify


### PR DESCRIPTION
## Summary

Enables the maintainer-approved official Yoetz v0.1.0 public-alpha release from current `main`.

Relates to #366 and the release cockpit #101. This PR intentionally does not close either issue before registry publication and post-publication verification.

## Release contract

- Publishes the dependency-free `yoetz@0.1.0` npm launcher as a deliberate reviewed distribution surface.
- Builds the npm tarball once, binds its digest at the publication checkpoint, publishes only after `yoetz==0.1.0` is live on PyPI, and downloads the public tarball for byte comparison and exact-version delegation verification.
- Uses npm Trusted Publishing/OIDC with the exact `release.yml` workflow and `npm` environment; no npm token enters the workflow.
- Fixes exact artifact downloads in the release-evidence and GitHub-release jobs; comma-separated strings were not valid multi-artifact globs.
- Adds a true pre-tag dry run for the current `origin/main`, while retaining the annotated-tag and protected-main ancestry checks for the production tag event.
- Creates a detailed GitHub release body and attaches Python, npm, checksum, evidence, limitation, and capability artifacts without duplicate asset names.
- Reconciles E-012 by the dated maintainer alpha decision without adding an unproved mailbox availability or response-time claim.
- Verifies every public `https://schemas.yoetz.dev/0.1/` byte against the tagged tree. The dedicated Vercel project is live at production deployment `dpl_9F5RBqu3m3BYpFiut6RuXBPbqWt7`; all 72 tracked files matched locally.
- Completes professional PyPI/npm metadata and documents both install paths and their trust boundary.

## Verification

- Focused release slice: 59 passed, 2 expected xfails.
- Locked dependency/license slice: 16 passed, 1 platform skip.
- Earlier combined slice: 71 passed, 1 skip, 2 expected xfails; its four sandbox-DNS failures are the same cases rerun successfully above with registry access.
- `uv run ruff check .` — passed.
- `npx --no-install pyright` — 0 errors.
- Public-boundary scan — passed, 952 files.
- Resource fixed point, check-continuation schema parity, and resource manifest — passed.
- Release workflow YAML parse — valid, 17 jobs.
- Local artifacts built: wheel, sdist, and three-member npm tarball.
- Hosted schemas: 72/72 live files matched byte-for-byte.

## Publication order after merge

1. Dispatch the dry-run workflow on exact current `main` for intended tag `v0.1.0`.
2. Create an annotated `v0.1.0` tag at that exact verified commit and push it once.
3. Supervise candidate verification, evidence assembly, PyPI Trusted Publishing, npm Trusted Publishing, GitHub release creation, hosted-schema verification, and public artifact download comparison.
4. Re-query registry metadata, tag target, release assets/body, all workflow jobs, and close #101/#366 only after the published state is confirmed.