### PR TITLE
fix: declare release attestation permissions at job scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     outputs:
       candidate-digest: ${{ steps.digest.outputs.value }}
       artifact-name: candidate-${{ needs.validate-release-source.outputs.version }}
@@ -267,9 +269,6 @@ jobs:
         if: github.event_name == 'push'
         id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        permissions:
-          id-token: write
-          attestations: write
         with:
           subject-path: "${{ runner.temp }}/dist/*.whl,${{ runner.temp }}/dist/*.tar.gz"
 


### PR DESCRIPTION
## Summary

Moves the build-provenance permissions from the individual action step to the `build-candidate` job. GitHub rejected the pre-tag v0.1.0 rehearsal because step-level `permissions` is not valid workflow syntax.

## Verification

- `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/packaging/test_release_workflow_contract.py tests/packaging/test_npm_launcher.py -q` (13 passed)
- `UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check tests/packaging/test_release_workflow_contract.py tests/packaging/test_npm_launcher.py`
- `git diff --check`

Relates to #366.