### PR TITLE
fix: make release rehearsal consume exact candidates

### DIFF
--- a/.github/workflows/capability.yml
+++ b/.github/workflows/capability.yml
@@ -103,25 +103,27 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build exactly one clean candidate (dispatch/schedule mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           uv sync --locked --all-extras --group dev
           rm -rf "${{ runner.temp }}/export"
           git worktree add --detach "${{ runner.temp }}/export" HEAD
           (cd "${{ runner.temp }}/export" && uv build --no-sources --out-dir "${{ runner.temp }}/dist")
+          (cd "${{ runner.temp }}/dist" && sha256sum ./*.whl ./*.tar.gz > SHA256SUMS)
 
       - name: Record and verify package/resource/commit digest
         id: digest
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/dist" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
+          (cd "${{ runner.temp }}/dist" && sha256sum --check SHA256SUMS)
+          digest=$(sha256sum "${{ runner.temp }}/dist/SHA256SUMS" | cut -d' ' -f1)
           if [ -n "${{ inputs.candidate-digest }}" ] && [ "${{ inputs.candidate-digest }}" != "$digest" ]; then
             echo "::error::built/consumed artifact digest does not match the supplied candidate-digest"
             exit 1

--- a/.github/workflows/nightly-fault.yml
+++ b/.github/workflows/nightly-fault.yml
@@ -95,14 +95,14 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build one clean candidate (scheduled/manual source mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           uv sync --locked --all-extras --group dev
           rm -rf "${{ runner.temp }}/export"
@@ -198,14 +198,14 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build one clean candidate (scheduled/manual source mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           uv sync --locked --all-extras --group dev
           rm -rf "${{ runner.temp }}/export"
@@ -365,14 +365,14 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build one clean candidate (scheduled/manual source mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           uv sync --locked --all-extras --group dev
           rm -rf "${{ runner.temp }}/export"
@@ -401,15 +401,26 @@ jobs:
             -k "replay or resource or scale" \
             -m "not soak and not live" -q --timeout=1800
 
-      # TODO(wave-f): soak-marked cases are not checked in yet; marker is registered in
-      # pyproject.toml so --strict-markers collection succeeds. Until soak tests exist this
-      # step exits pytest code 5 (no tests collected) when the release/Sunday branch runs.
-      - name: 1M-entry replay/resource probe (release profile, and designated weekly cadence)
+      - name: Run checked-in soak replay/resource probes when present
         if: inputs.profile == 'release' || github.event.schedule == '37 4 * * 0'
         run: |
+          set +e
           uv run --locked pytest tests/integration/storage \
-            -k "replay or resource or scale" \
-            -m "soak" -q --timeout=5400
+            -k "replay or resource or scale" -m "soak" \
+            --collect-only -q > "${RUNNER_TEMP}/soak-collection.txt"
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            uv run --locked pytest tests/integration/storage \
+              -k "replay or resource or scale" -m "soak" -q --timeout=5400
+            echo "SOAK_COVERAGE=present-and-passed" >> "$GITHUB_ENV"
+          elif [ "$status" -eq 5 ]; then
+            echo "::notice::No soak-marked replay/resource tests are checked in; no 1M-entry coverage is claimed."
+            echo "SOAK_COVERAGE=not-checked-in" >> "$GITHUB_ENV"
+          else
+            cat "${RUNNER_TEMP}/soak-collection.txt"
+            exit "$status"
+          fi
 
       - name: Latency/RSS/WAL-growth/checkpoint/backup-restore time budgets
         run: |
@@ -418,21 +429,41 @@ jobs:
             -m "not soak and not live" -q --timeout=1800
 
       - name: Redact and produce canonical replay-and-resource evidence
-        if: always()
+        env:
+          CANDIDATE_DIGEST: ${{ inputs.candidate-digest || 'source-build-not-bound' }}
+          RELEASE_PROFILE: ${{ inputs.profile || 'standard' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/evidence"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          raw_digest = os.environ["CANDIDATE_DIGEST"]
+          candidate_digest = (
+              f"sha256:{raw_digest}" if len(raw_digest) == 64 else raw_digest
+          )
+          evidence = {
+              "candidate_artifact_digest": candidate_digest,
+              "non_soak_replay_resource": "passed",
+              "profile": os.environ["RELEASE_PROFILE"],
+              "resource_budgets": "passed",
+              "soak_coverage": os.environ.get("SOAK_COVERAGE", "not-requested"),
+          }
+          path = Path(os.environ["RUNNER_TEMP"]) / "evidence" / "replay-and-resource.json"
+          path.write_text(json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n")
+          PY
           uv run --locked python scripts/scan_public_boundary.py \
             --source-tree "${RUNNER_TEMP}/evidence" \
-            --evidence-dir "${RUNNER_TEMP}/evidence-scanned" || true
+            --evidence-dir "${RUNNER_TEMP}/evidence-scanned"
 
       - name: Upload redacted evidence
-        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-replay-and-resource
           path: ${{ runner.temp }}/evidence-scanned
           retention-days: 10
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------------------------
   # nightly-evidence
@@ -466,17 +497,64 @@ jobs:
           path: ${{ runner.temp }}/evidence
           merge-multiple: false
 
-      - name: Verify completeness and candidate equality; produce nightly manifest
+      - name: Record exact job coverage and produce the nightly manifest
         id: manifest
+        env:
+          CANDIDATE_DIGEST: ${{ inputs.candidate-digest || 'source-build-not-bound' }}
+          FAULT_LINUX_RESULT: ${{ needs.fault-matrix-linux.result }}
+          FAULT_MACOS_RESULT: ${{ needs.fault-matrix-macos.result }}
+          PROFILE: ${{ inputs.profile || 'standard' }}
+          PROPERTY_RESULT: ${{ needs.property-state-machine.result }}
+          REPLAY_RESULT: ${{ needs.replay-and-resource.result }}
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/evidence" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
+          mkdir -p "${{ runner.temp }}/evidence"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "evidence"
+          downloaded = sorted(
+              path.relative_to(root).as_posix()
+              for path in root.rglob("*")
+              if path.is_file()
+          )
+          raw_digest = os.environ["CANDIDATE_DIGEST"]
+          candidate_digest = (
+              f"sha256:{raw_digest}" if len(raw_digest) == 64 else raw_digest
+          )
+          manifest = {
+              "candidate_artifact_digest": candidate_digest,
+              "downloaded_evidence_files": downloaded,
+              "jobs": {
+                  "fault-matrix-linux": os.environ["FAULT_LINUX_RESULT"],
+                  "fault-matrix-macos": os.environ["FAULT_MACOS_RESULT"],
+                  "property-state-machine": os.environ["PROPERTY_RESULT"],
+                  "replay-and-resource": os.environ["REPLAY_RESULT"],
+              },
+              "profile": os.environ["PROFILE"],
+          }
+          (root / "nightly-manifest.json").write_text(
+              json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          digest=$(sha256sum "${{ runner.temp }}/evidence/nightly-manifest.json" | cut -d' ' -f1)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           {
             echo "## Nightly Fault and Scale evidence"
             echo "profile: ${{ inputs.profile || 'standard' }}"
             echo "manifest digest: ${digest}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the canonical nightly manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-manifest
+          path: ${{ runner.temp }}/evidence/nightly-manifest.json
+          retention-days: 10
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------------------------------
   # nightly-required

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,8 +247,9 @@ jobs:
         id: digest
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/dist" -type f -name '*.whl' -o -type f -name '*.tar.gz' \
-            | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          (cd "${{ runner.temp }}/dist" && sha256sum ./*.whl ./*.tar.gz > SHA256SUMS)
+          (cd "${{ runner.temp }}/dist" && sha256sum --check SHA256SUMS)
+          digest=$(sha256sum "${{ runner.temp }}/dist/SHA256SUMS" | cut -d' ' -f1)
           uv run --locked python -c "
           import json, platform
           json.dump({
@@ -261,8 +262,6 @@ jobs:
               'python': '3.14.6',
           }, open('${{ runner.temp }}/dist/candidate.json', 'w'), indent=2)
           "
-          sha256sum "${{ runner.temp }}"/dist/*.whl "${{ runner.temp }}"/dist/*.tar.gz \
-            > "${{ runner.temp }}/dist/SHA256SUMS"
           echo "value=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance for the immutable candidate artifacts
@@ -367,7 +366,7 @@ jobs:
           set -euo pipefail
           tgz="${{ runner.temp }}/npm-dist/yoetz-${{ needs.validate-release-source.outputs.version }}.tgz"
           digest=$(sha256sum "$tgz" | cut -d' ' -f1)
-          sha256sum "$tgz" > "${{ runner.temp }}/npm-dist/NPM_SHA256SUMS"
+          (cd "${{ runner.temp }}/npm-dist" && sha256sum "$(basename "$tgz")" > NPM_SHA256SUMS)
           python3 - <<PY
           import json
           import os
@@ -428,10 +427,16 @@ jobs:
       - name: Verify candidate digest before use
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/dist" -type f -name '*.whl' -o -type f -name '*.tar.gz' \
-            | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          (cd "${{ runner.temp }}/dist" && sha256sum --check SHA256SUMS)
+          digest=$(sha256sum "${{ runner.temp }}/dist/SHA256SUMS" | cut -d' ' -f1)
           [ "$digest" = "${{ needs.build-candidate.outputs.candidate-digest }}" ] || \
             { echo "::error::downloaded candidate digest mismatch"; exit 1; }
+
+      - name: Install the enforcing Linux check sandbox backend
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap
+          bwrap --version
 
       - name: Install candidate outside checkout; assert OS/CPU/ABI/filesystem/Python/APSW/SQLite identity
         run: |
@@ -450,10 +455,7 @@ jobs:
 
       - name: version/startup, resource/schema/migration identity, strict-local six operations, MCP/CLI subprocess
         run: |
-          iso="${RUNNER_TEMP}/yoetz-home"
-          mkdir -p "$iso"
-          export HOME="$iso" XDG_DATA_HOME="$iso/.local/share" XDG_CONFIG_HOME="$iso/.config" \
-                 XDG_CACHE_HOME="$iso/.cache" YOETZ_DENY_NETWORK=1 \
+          export YOETZ_DENY_NETWORK=1 \
                  YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
@@ -507,8 +509,8 @@ jobs:
       - name: Verify candidate digest before use
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/dist" -type f -name '*.whl' -o -type f -name '*.tar.gz' \
-            | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          (cd "${{ runner.temp }}/dist" && sha256sum --check SHA256SUMS)
+          digest=$(sha256sum "${{ runner.temp }}/dist/SHA256SUMS" | cut -d' ' -f1)
           [ "$digest" = "${{ needs.build-candidate.outputs.candidate-digest }}" ] || \
             { echo "::error::downloaded candidate digest mismatch"; exit 1; }
 
@@ -529,10 +531,7 @@ jobs:
 
       - name: version/startup, resource/schema/migration identity, strict-local six operations, MCP/CLI subprocess
         run: |
-          iso="${RUNNER_TEMP}/yoetz-home"
-          mkdir -p "$iso"
-          export HOME="$iso" XDG_DATA_HOME="$iso/.local/share" XDG_CONFIG_HOME="$iso/.config" \
-                 XDG_CACHE_HOME="$iso/.cache" YOETZ_DENY_NETWORK=1 \
+          export YOETZ_DENY_NETWORK=1 \
                  YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
@@ -754,8 +753,8 @@ jobs:
       - name: Verify candidate digest before publication
         run: |
           set -euo pipefail
-          digest=$(find "${{ runner.temp }}/dist" -type f -name '*.whl' -o -type f -name '*.tar.gz' \
-            | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+          (cd "${{ runner.temp }}/dist" && sha256sum --check SHA256SUMS)
+          digest=$(sha256sum "${{ runner.temp }}/dist/SHA256SUMS" | cut -d' ' -f1)
           [ "$digest" = "${{ needs.build-candidate.outputs.candidate-digest }}" ] || \
             { echo "::error::candidate digest mismatch before publish"; exit 1; }
 

--- a/.github/workflows/security-privacy.yml
+++ b/.github/workflows/security-privacy.yml
@@ -288,14 +288,14 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build one clean candidate (PR/source/schedule mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           uv sync --locked --all-extras --group dev
           rm -rf "${{ runner.temp }}/export"
@@ -369,14 +369,14 @@ jobs:
         run: uv sync --locked --all-extras --group dev
 
       - name: Download release-supplied candidate artifact (call mode only)
-        if: github.event_name == 'workflow_call'
+        if: inputs.candidate-digest != ''
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.candidate-artifact-name }}
           path: ${{ runner.temp }}/dist
 
       - name: Build one clean candidate (PR/source/schedule mode only)
-        if: github.event_name != 'workflow_call'
+        if: inputs.candidate-digest == ''
         run: |
           rm -rf "${{ runner.temp }}/export"
           git worktree add --detach "${{ runner.temp }}/export" HEAD

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -7,6 +7,11 @@ from typing import Final
 
 _ROOT: Final = Path(__file__).resolve().parents[2]
 _WORKFLOW: Final = _ROOT / ".github" / "workflows" / "release.yml"
+_REUSABLE_WORKFLOWS: Final = (
+    _ROOT / ".github" / "workflows" / "capability.yml",
+    _ROOT / ".github" / "workflows" / "nightly-fault.yml",
+    _ROOT / ".github" / "workflows" / "security-privacy.yml",
+)
 
 
 def test_dry_run_retains_builder_backed_release_evidence_bundle() -> None:
@@ -106,3 +111,55 @@ def test_tag_workflow_rejects_missing_or_drifted_hosted_schema_bytes() -> None:
     assert "curl --fail --silent --show-error --location" in verify
     assert "cmp -s" in verify
     assert "|| true" not in verify
+
+
+def test_candidate_digest_is_path_independent_and_checksum_backed() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    build = workflow.split("  build-candidate:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # build-npm-launcher",
+        1,
+    )[0]
+
+    assert "sha256sum ./*.whl ./*.tar.gz > SHA256SUMS" in build
+    assert "sha256sum --check SHA256SUMS" in build
+    assert 'sha256sum "${{ runner.temp }}/dist/SHA256SUMS"' in build
+    assert 'find "${{ runner.temp }}/dist"' not in build
+
+
+def test_reusable_release_workflows_select_supplied_artifacts_by_input() -> None:
+    for path in _REUSABLE_WORKFLOWS:
+        workflow = path.read_text(encoding="utf-8")
+        assert "github.event_name == 'workflow_call'" not in workflow
+        assert "github.event_name != 'workflow_call'" not in workflow
+        assert "if: inputs.candidate-digest != ''" in workflow
+        assert "if: inputs.candidate-digest == ''" in workflow
+
+
+def test_workflows_do_not_declare_step_level_permissions() -> None:
+    for path in (_WORKFLOW, *_REUSABLE_WORKFLOWS):
+        assert "\n        permissions:\n" not in path.read_text(encoding="utf-8")
+
+
+def test_empty_soak_selection_is_disclosed_without_claiming_coverage() -> None:
+    workflow = (_ROOT / ".github" / "workflows" / "nightly-fault.yml").read_text(encoding="utf-8")
+
+    assert "No soak-marked replay/resource tests are checked in" in workflow
+    assert "no 1M-entry coverage is claimed" in workflow
+    assert '"soak_coverage": os.environ.get(' in workflow
+
+
+def test_platform_verifiers_preserve_short_runner_home_and_install_linux_sandbox() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    linux = workflow.split("  verify-linux-x86_64:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # verify-macos-arm64",
+        1,
+    )[0]
+    macos = workflow.split("  verify-macos-arm64:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # fault-release-profile",
+        1,
+    )[0]
+
+    assert "sudo apt-get install --yes bubblewrap" in linux
+    assert "bwrap --version" in linux
+    assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in linux
+    assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos


### PR DESCRIPTION
## Summary

Repairs the concrete failures found by the first full v0.1.0 pre-tag rehearsal ([run 32373970232](https://github.com/TheGaySupreme123/yoetz/actions/runs/32373970232)):

- make the Python candidate digest path-independent and bind it to the portable `SHA256SUMS` file
- select caller-supplied artifacts in reusable workflows by the immutable digest input (reusable workflows preserve the caller event name)
- preserve the hosted runner short home for Unix control sockets and install the enforcing Linux `bubblewrap` backend
- treat the currently absent soak-marked tests as explicitly unclaimed coverage, while retaining the passing checked-in replay/resource and budget slices
- emit canonical replay/nightly manifests even when subordinate jobs do not otherwise upload evidence files

## Verification

- 23 focused packaging/workflow tests passed
- Ruff passed repository-wide
- every workflow parsed as YAML
- a real wheel/sdist candidate checksum was verified after relocation to a different directory
- `git diff --check` passed

Relates to #366.