### PR TITLE
fix: bound final alpha release evidence

### DIFF
--- a/.github/workflows/capability.yml
+++ b/.github/workflows/capability.yml
@@ -314,12 +314,6 @@ jobs:
             -m "not fault and not soak and not live and not live_provider and not live_keyring" \
             -q --timeout=900
 
-      - name: Keyring disposable test namespace probe (delete after use)
-        run: |
-          uv run --locked pytest tests/unit/adapters -k "keyring or key_backend" \
-            -m "not fault and not soak and not live and not live_provider and not live_keyring" \
-            -q --timeout=300
-
       - name: Redact and upload platform-key-matrix CapabilityEvidence
         if: always()
         run: |
@@ -530,7 +524,6 @@ jobs:
           pattern: capability-evidence-*
           path: ${{ runner.temp }}/capability-evidence
           merge-multiple: true
-          if-no-files-found: ignore
 
       - name: Run generate_capability_matrix.py against reviewed policy
         run: |
@@ -547,7 +540,7 @@ jobs:
       - name: Scan public capability-matrix.json/.md before upload
         run: |
           uv run --locked python scripts/scan_public_boundary.py \
-            --source-tree "${{ runner.temp }}/release-evidence"
+            --evidence-dir "${{ runner.temp }}/release-evidence"
 
       - name: Digest and expose the aggregated capability manifest
         id: aggregate

--- a/.github/workflows/nightly-fault.yml
+++ b/.github/workflows/nightly-fault.yml
@@ -428,7 +428,7 @@ jobs:
             -k "latency or budget or checkpoint or backup" \
             -m "not soak and not live" -q --timeout=1800
 
-      - name: Redact and produce canonical replay-and-resource evidence
+      - name: Produce and scan canonical replay-and-resource evidence
         env:
           CANDIDATE_DIGEST: ${{ inputs.candidate-digest || 'source-build-not-bound' }}
           RELEASE_PROFILE: ${{ inputs.profile || 'standard' }}
@@ -454,14 +454,13 @@ jobs:
           path.write_text(json.dumps(evidence, sort_keys=True, separators=(",", ":")) + "\n")
           PY
           uv run --locked python scripts/scan_public_boundary.py \
-            --source-tree "${RUNNER_TEMP}/evidence" \
-            --evidence-dir "${RUNNER_TEMP}/evidence-scanned"
+            --evidence-dir "${RUNNER_TEMP}/evidence"
 
-      - name: Upload redacted evidence
+      - name: Upload scanned evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nightly-replay-and-resource
-          path: ${{ runner.temp }}/evidence-scanned
+          path: ${{ runner.temp }}/evidence
           retention-days: 10
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,12 +432,6 @@ jobs:
           [ "$digest" = "${{ needs.build-candidate.outputs.candidate-digest }}" ] || \
             { echo "::error::downloaded candidate digest mismatch"; exit 1; }
 
-      - name: Install the enforcing Linux check sandbox backend
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes bubblewrap
-          bwrap --version
-
       - name: Install candidate outside checkout; assert OS/CPU/ABI/filesystem/Python/APSW/SQLite identity
         run: |
           uv venv "${{ runner.temp }}/verify-venv"
@@ -459,7 +453,14 @@ jobs:
                  YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          uv run --locked pytest tests/packaging tests/subprocess tests/integration \
+          uv run --locked pytest tests/packaging \
+            -m "not fault and not soak and not live" -q --timeout=900
+          uv run --locked pytest tests/subprocess \
+            -m "not fault and not soak and not live" -q --timeout=900
+          # Linux approved-command execution remains a documented fail-closed alpha limitation.
+          uv run --locked pytest tests/integration \
+            --deselect tests/integration/observation/test_acceptance_scenarios.py::test_approved_check_stale_when_digest_changes \
+            --deselect tests/integration/observation/test_production_composition.py::test_approved_true_check_succeeds_in_sandbox \
             -m "not fault and not soak and not live" -q --timeout=900
 
       - name: Clean install/upgrade/rollback/uninstall/data-retention/offline reinstall, backup/restore, key backend states
@@ -471,7 +472,10 @@ jobs:
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
 
       - name: Installed-artifact boundary scan
-        run: uv run --locked python scripts/scan_public_boundary.py --source-tree "${{ runner.temp }}/verify-venv"
+        run: |
+          installed_root=$("${{ runner.temp }}/verify-venv/bin/python" -c \
+            'import pathlib, yoetz; print(pathlib.Path(yoetz.__file__).parent)')
+          uv run --locked python scripts/scan_public_boundary.py --runtime-tree "$installed_root"
 
   # ---------------------------------------------------------------------------------------------
   # verify-macos-arm64
@@ -535,7 +539,11 @@ jobs:
                  YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          uv run --locked pytest tests/packaging tests/subprocess tests/integration \
+          uv run --locked pytest tests/packaging \
+            -m "not fault and not soak and not live" -q --timeout=900
+          uv run --locked pytest tests/subprocess \
+            -m "not fault and not soak and not live" -q --timeout=900
+          uv run --locked pytest tests/integration \
             -m "not fault and not soak and not live" -q --timeout=900
 
       - name: Clean install/upgrade/rollback/uninstall/data-retention/offline reinstall, backup/restore, key backend states
@@ -546,7 +554,10 @@ jobs:
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
 
       - name: Installed-artifact boundary scan
-        run: uv run --locked python scripts/scan_public_boundary.py --source-tree "${{ runner.temp }}/verify-venv"
+        run: |
+          installed_root=$("${{ runner.temp }}/verify-venv/bin/python" -c \
+            'import pathlib, yoetz; print(pathlib.Path(yoetz.__file__).parent)')
+          uv run --locked python scripts/scan_public_boundary.py --runtime-tree "$installed_root"
 
   # ---------------------------------------------------------------------------------------------
   # fault-release-profile — invokes nightly-fault.yml release profile at the exact candidate digest.
@@ -687,7 +698,7 @@ jobs:
       - name: Public-boundary scan the assembled evidence
         run: |
           uv run --locked python scripts/scan_public_boundary.py \
-            --source-tree "${{ runner.temp }}/release-evidence"
+            --evidence-dir "${{ runner.temp }}/release-evidence"
 
       - name: Digest the release evidence bundle
         id: evidence

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -53,6 +53,9 @@ it delegates unchanged arguments and terminal I/O to `uvx yoetz==0.1.0`.
 - It publishes no verified Codex-version, hook-observation, provider-endpoint, keyring/platform, or
   structural subject-capture support cell where release-bound evidence is absent.
 - It makes no support-mailbox availability or response-time promise.
+- On Linux, approved external-command checks fail closed in v0.1.0 because the bubblewrap launch
+  profile is not release-certified. Built-in deterministic checks and the ledger remain available;
+  Yoetz does not claim that an external command ran when its sandbox boundary is unavailable.
 - It does not claim bit-for-bit reproducible Python archives, package signing, or broad platform
   support beyond the exact release jobs and artifacts that passed.
 - Semantic output is advisory. Yoetz records challenges and provenance; it does not replace code,

--- a/release/known-limitations.json
+++ b/release/known-limitations.json
@@ -14,6 +14,10 @@
       "description": "Startup safety validation and 'yoetz version --json' are available; the public 'yoetz doctor' command is deferred to v0.2."
     },
     {
+      "code": "linux_approved_command_sandbox_unavailable",
+      "description": "On Linux v0.1, approved external-command checks fail closed because the bubblewrap launch profile is not release-certified. Ledger operations and Yoetz's built-in deterministic checks remain available; no external command is reported as checked when the sandbox cannot enforce its boundary."
+    },
+    {
       "code": "open_questions_ledger_not_automatically_enforced",
       "description": "The E-001 through E-016 and R-001/R-002 decision ledger remains an owner-reviewed release record; this evidence bundle does not claim that every ledger item is automatically represented or enforced."
     }

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -148,7 +148,7 @@ def test_empty_soak_selection_is_disclosed_without_claiming_coverage() -> None:
     assert '"soak_coverage": os.environ.get(' in workflow
 
 
-def test_platform_verifiers_preserve_short_runner_home_and_install_linux_sandbox() -> None:
+def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     linux = workflow.split("  verify-linux-x86_64:\n", 1)[1].split(
         "  # ---------------------------------------------------------------------------------------------\n  # verify-macos-arm64",
@@ -159,7 +159,35 @@ def test_platform_verifiers_preserve_short_runner_home_and_install_linux_sandbox
         1,
     )[0]
 
-    assert "sudo apt-get install --yes bubblewrap" in linux
-    assert "bwrap --version" in linux
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in linux
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos
+    for verifier in (linux, macos):
+        assert "pytest tests/packaging \\" in verifier
+        assert "pytest tests/subprocess \\" in verifier
+        assert "pytest tests/integration \\" in verifier
+        assert '--runtime-tree "$installed_root"' in verifier
+    assert "test_approved_check_stale_when_digest_changes" in linux
+    assert "test_approved_true_check_succeeds_in_sandbox" in linux
+    assert "test_approved_check_stale_when_digest_changes" not in macos
+
+    limitations = (_ROOT / "release" / "known-limitations.json").read_text(encoding="utf-8")
+    release_notes = (_ROOT / "docs" / "releases" / "v0.1.0.md").read_text(encoding="utf-8")
+    assert "linux_approved_command_sandbox_unavailable" in limitations
+    assert "approved external-command checks fail closed" in release_notes
+
+
+def test_generated_evidence_uses_evidence_scanner_mode() -> None:
+    release = _WORKFLOW.read_text(encoding="utf-8")
+    capability = (_ROOT / ".github" / "workflows" / "capability.yml").read_text(encoding="utf-8")
+    fault = (_ROOT / ".github" / "workflows" / "nightly-fault.yml").read_text(encoding="utf-8")
+
+    assert '--evidence-dir "${{ runner.temp }}/release-evidence"' in release
+    assert '--evidence-dir "${{ runner.temp }}/release-evidence"' in capability
+    assert '--evidence-dir "${RUNNER_TEMP}/evidence"' in fault
+    assert "evidence-scanned" not in fault.split("  replay-and-resource:\n", 1)[1]
+
+    download = capability.split(
+        "      - name: Download CapabilityEvidence records (exclude candidate artifact JSON)\n",
+        1,
+    )[1].split("\n      - name:", 1)[0]
+    assert "if-no-files-found" not in download


### PR DESCRIPTION
## Summary

Repairs the remaining concrete harness failures from the second v0.1.0 rehearsal ([run 32375486419](https://github.com/TheGaySupreme123/yoetz/actions/runs/32375486419)) without inflating release claims:

- split packaging, subprocess, and integration collections so imports from unrelated suites cannot contaminate clean-install service tests
- keep the two uncertified Linux approved-command sandbox cases out of the release verifier and publish the fail-closed limitation in both release notes and the machine-readable limitations bundle
- remove a keyring selector that collected zero tests; the preceding platform/key-backend slice remains
- scan generated evidence with `--evidence-dir` and installed package bytes with `--runtime-tree`
- remove an unsupported `download-artifact` input

## Verification

- 29 focused workflow/release-evidence tests passed
- the two clean-install foreground-service tests pass when run as their isolated packaging slice
- Ruff format and lint pass repository-wide
- every workflow parses as YAML
- evidence and installed-runtime scanner modes pass real local probes
- `git diff --check` passes

Relates to #366.