### PR TITLE
fix(release): isolate platform test environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,16 +449,18 @@ jobs:
 
       - name: version/startup, resource/schema/migration identity, strict-local six operations, MCP/CLI subprocess
         run: |
-          export YOETZ_DENY_NETWORK=1 \
-                 YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
           uv run --locked pytest tests/packaging \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked pytest tests/subprocess \
+          YOETZ_DENY_NETWORK=1 \
+          YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
+            uv run --locked pytest tests/subprocess \
             -m "not fault and not soak and not live" -q --timeout=900
           # Linux approved-command execution remains a documented fail-closed alpha limitation.
-          uv run --locked pytest tests/integration \
+          YOETZ_DENY_NETWORK=1 \
+          YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
+            uv run --locked pytest tests/integration \
             --deselect tests/integration/observation/test_acceptance_scenarios.py::test_approved_check_stale_when_digest_changes \
             --deselect tests/integration/observation/test_production_composition.py::test_approved_true_check_succeeds_in_sandbox \
             -m "not fault and not soak and not live" -q --timeout=900
@@ -535,15 +537,17 @@ jobs:
 
       - name: version/startup, resource/schema/migration identity, strict-local six operations, MCP/CLI subprocess
         run: |
-          export YOETZ_DENY_NETWORK=1 \
-                 YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python"
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
           uv run --locked pytest tests/packaging \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked pytest tests/subprocess \
+          YOETZ_DENY_NETWORK=1 \
+          YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
+            uv run --locked pytest tests/subprocess \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked pytest tests/integration \
+          YOETZ_DENY_NETWORK=1 \
+          YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
+            uv run --locked pytest tests/integration \
             -m "not fault and not soak and not live" -q --timeout=900
 
       - name: Clean install/upgrade/rollback/uninstall/data-retention/offline reinstall, backup/restore, key backend states

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -165,6 +165,13 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
         assert "pytest tests/packaging \\" in verifier
         assert "pytest tests/subprocess \\" in verifier
         assert "pytest tests/integration \\" in verifier
+        assert "export YOETZ_DENY_NETWORK" not in verifier
+        assert "export YOETZ_CANDIDATE_PYTHON" not in verifier
+        assert verifier.count("YOETZ_DENY_NETWORK=1 \\") == 2
+        assert (
+            verifier.count('YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \\')
+            == 2
+        )
         assert '--runtime-tree "$installed_root"' in verifier
     assert "test_approved_check_stale_when_digest_changes" in linux
     assert "test_approved_true_check_succeeds_in_sandbox" in linux


### PR DESCRIPTION
Closes the final v0.1.0 release-rehearsal defect tracked by #366.

The platform verification step exported `YOETZ_DENY_NETWORK` and `YOETZ_CANDIDATE_PYTHON` across the entire packaging, subprocess, and integration sequence. Each variable independently changes clean-install service startup, so both Linux and macOS packaging verification failed despite the tests passing in their intended clean environment.

This scopes those release-only variables to the subprocess and integration invocations that consume them, while preserving a true clean environment for packaging verification. A workflow contract test prevents future global export leakage.

Verification:
- `uv run pytest -q tests/packaging/test_release_workflow_contract.py`
- two affected clean-install tests: 2 passed
- Ruff check and format check
- release workflow YAML parse