### PR TITLE
fix(release): let evidence generator publish atomically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,7 +688,6 @@ jobs:
 
       - name: generate_release_evidence.py --write
         run: |
-          mkdir -p "${{ runner.temp }}/release-evidence/${{ needs.validate-release-source.outputs.version }}"
           uv run --locked python scripts/generate_release_evidence.py \
             --input-manifest "${{ runner.temp }}/release-inputs.json" \
             --output-dir "${{ runner.temp }}/release-evidence/${{ needs.validate-release-source.outputs.version }}" --write

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -28,6 +28,7 @@ def test_dry_run_retains_builder_backed_release_evidence_bundle() -> None:
     assert "dry-run candidate ${candidate} is not current origin/main ${protected}" in workflow
     assert "scripts/build_release_inputs.py" in assembly
     assert "generate_release_evidence.py" in assembly
+    assert 'mkdir -p "${{ runner.temp }}/release-evidence/${{' not in assembly
     assert 'pattern: "candidate-*,nightly-*,capability-*,security-*"' not in assembly
     assert "python -c" not in assembly
     assert "--candidate-commit" in assembly


### PR DESCRIPTION
Continues the v0.1.0 release work tracked by #366.

The evidence assembly job pre-created the version output directory immediately before invoking `generate_release_evidence.py --write`. The generator intentionally treats any existing version directory as already published and verifies it byte-for-byte, so the empty directory failed closed as `output_dir_conflicts_with_published_version`.

Remove the pre-creation and let the generator create its parent, stage files, fsync, and atomically publish the version directory as designed. A workflow contract assertion prevents reintroducing this conflict.

Verification:
- release workflow contract and evidence generator tests: 11 passed
- Ruff check and format check
- release workflow YAML parse