### PR TITLE
fix(release): keep tagged packaging tests offline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,7 @@ jobs:
         run: |
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          uv run --locked pytest tests/packaging \
+          UV_NO_INDEX=1 uv run --locked pytest tests/packaging \
             -m "not fault and not soak and not live" -q --timeout=900
           YOETZ_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
@@ -548,7 +548,7 @@ jobs:
         run: |
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          uv run --locked pytest tests/packaging \
+          UV_NO_INDEX=1 uv run --locked pytest tests/packaging \
             -m "not fault and not soak and not live" -q --timeout=900
           YOETZ_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -192,7 +192,7 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in linux
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos
     for verifier in (linux, macos):
-        assert "pytest tests/packaging \\" in verifier
+        assert "UV_NO_INDEX=1 uv run --locked pytest tests/packaging \\" in verifier
         assert "pytest tests/subprocess \\" in verifier
         assert "pytest tests/integration \\" in verifier
         assert "export YOETZ_DENY_NETWORK" not in verifier


### PR DESCRIPTION
Continues the immutable v0.1.0 recovery tracked by #366.

After PyPI 0.1.0 became public, the exact tagged packaging tests began resolving registry metadata ahead of their local `--find-links` wheelhouses. Current main fixes those tests with `--no-index`, but recovery correctly cannot modify tagged source.

This scopes `UV_NO_INDEX=1` to the packaging pytest invocation in both platform verifiers. Dependency synchronization still runs normally before the suite, and subprocess/integration verification remains unchanged.

Exact-tag proof:
- detached `v0.1.0` worktree at `1567e43b126fa4573b5b2b20cd1cad831423218a`
- the two affected tagged tests: 2 passed
- release workflow contract: 10 passed
- Ruff check and format check
- release workflow YAML parse