### PR TITLE
fix(release): isolate tagged offline test subprocesses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,8 +460,14 @@ jobs:
         run: |
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          UV_NO_INDEX=1 uv run --locked pytest tests/packaging \
+          uv run --locked pytest tests/packaging \
+            --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
+            --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
+          uv run --locked env UV_NO_INDEX=1 pytest \
+            tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
+            tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
+            -q --timeout=900
           YOETZ_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/subprocess \
@@ -548,8 +554,14 @@ jobs:
         run: |
           "${{ runner.temp }}/verify-venv/bin/yoetz" version --json
           uv sync --locked --group dev
-          UV_NO_INDEX=1 uv run --locked pytest tests/packaging \
+          uv run --locked pytest tests/packaging \
+            --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
+            --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
+          uv run --locked env UV_NO_INDEX=1 pytest \
+            tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
+            tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
+            -q --timeout=900
           YOETZ_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/subprocess \

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -192,7 +192,10 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in linux
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos
     for verifier in (linux, macos):
-        assert "UV_NO_INDEX=1 uv run --locked pytest tests/packaging \\" in verifier
+        assert "uv run --locked pytest tests/packaging \\" in verifier
+        assert "uv run --locked env UV_NO_INDEX=1 pytest \\" in verifier
+        assert verifier.count("test_corrupted_wheel_fails_exact_hash_verification") == 2
+        assert verifier.count("test_correct_hash_matching_the_real_wheel_installs_cleanly") == 2
         assert "pytest tests/subprocess \\" in verifier
         assert "pytest tests/integration \\" in verifier
         assert "export YOETZ_DENY_NETWORK" not in verifier


### PR DESCRIPTION
Continues immutable v0.1.0 recovery under #366.

`UV_NO_INDEX=1 uv run pytest` set the variable on uv itself; uv did not forward that configuration variable to pytest subprocesses, so the two tagged tests still resolved public PyPI metadata.

This runs the full packaging suite in its normal environment with those two cases deselected, then runs exactly those cases as `uv run --locked env UV_NO_INDEX=1 pytest ...`. No unrelated packaging, subprocess, integration, or dependency-sync environment changes.

Exact-tag proof:
- fresh detached `v0.1.0` worktree at `1567e43b126fa4573b5b2b20cd1cad831423218a`
- exact workflow command form: 2 passed
- release workflow contract: 10 passed
- Ruff check and format check
- release workflow YAML parse