### PR TITLE
fix(release): isolate immutable-tag offline test cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,7 +464,10 @@ jobs:
             --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked env UV_NO_INDEX=1 pytest \
+          uv run --locked env \
+            UV_NO_INDEX=true \
+            UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
+            pytest \
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900
@@ -558,7 +561,10 @@ jobs:
             --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked env UV_NO_INDEX=1 pytest \
+          uv run --locked env \
+            UV_NO_INDEX=true \
+            UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
+            pytest \
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -193,7 +193,10 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos
     for verifier in (linux, macos):
         assert "uv run --locked pytest tests/packaging \\" in verifier
-        assert "uv run --locked env UV_NO_INDEX=1 pytest \\" in verifier
+        assert "uv run --locked env \\" in verifier
+        assert "UV_NO_INDEX=true \\" in verifier
+        assert 'UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \\' in verifier
+        assert "pytest \\" in verifier
         assert verifier.count("test_corrupted_wheel_fails_exact_hash_verification") == 2
         assert verifier.count("test_correct_hash_matching_the_real_wheel_installs_cleanly") == 2
         assert "pytest tests/subprocess \\" in verifier


### PR DESCRIPTION
Closes the final immutable-tag recovery gap tracked in #366.

The hosted runners already contain the now-public PyPI wheel in their shared uv cache. `UV_NO_INDEX` prevents network access but does not prevent uv from selecting that cached registry artifact over the candidate wheel supplied through `--find-links`.

This change runs the two exact-hash offline reinstall tests with both:

- `UV_NO_INDEX=true`
- a fresh runner-local `UV_CACHE_DIR`

That keeps the immutable v0.1.0 tag tests deterministic after partial publication while preserving the exact tagged test code. Linux and macOS use the same bounded invocation, and the workflow contract locks both settings.

Verification:

- `uv run pytest tests/packaging/test_release_workflow_contract.py -q --timeout=900` (10 passed)
- `uv run ruff check tests/packaging/test_release_workflow_contract.py`
- release workflow YAML parsed successfully
- exact v0.1.0 tagged tests reproduced against a warmed public-wheel cache, then passed with an isolated fresh cache (2 passed)