### PR TITLE
fix(release): force no-index in immutable-tag hash tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,10 +464,23 @@ jobs:
             --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked env \
-            UV_NO_INDEX=true \
-            UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
-            pytest \
+          real_uv="$(command -v uv)"
+          tagged_uv_wrapper="${{ runner.temp }}/tagged-uv-bin"
+          mkdir -p "$tagged_uv_wrapper"
+          cat > "$tagged_uv_wrapper/uv" <<'UV_WRAPPER'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [[ "${1:-}" == "pip" && "${2:-}" == "install" ]]; then
+            shift 2
+            exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"
+          fi
+          exec "${YOETZ_REAL_UV:?}" "$@"
+          UV_WRAPPER
+          chmod +x "$tagged_uv_wrapper/uv"
+          YOETZ_REAL_UV="$real_uv" \
+          PATH="$tagged_uv_wrapper:$PATH" \
+          UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
+            .venv/bin/pytest \
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900
@@ -561,10 +574,23 @@ jobs:
             --deselect tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             --deselect tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -m "not fault and not soak and not live" -q --timeout=900
-          uv run --locked env \
-            UV_NO_INDEX=true \
-            UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
-            pytest \
+          real_uv="$(command -v uv)"
+          tagged_uv_wrapper="${{ runner.temp }}/tagged-uv-bin"
+          mkdir -p "$tagged_uv_wrapper"
+          cat > "$tagged_uv_wrapper/uv" <<'UV_WRAPPER'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [[ "${1:-}" == "pip" && "${2:-}" == "install" ]]; then
+            shift 2
+            exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"
+          fi
+          exec "${YOETZ_REAL_UV:?}" "$@"
+          UV_WRAPPER
+          chmod +x "$tagged_uv_wrapper/uv"
+          YOETZ_REAL_UV="$real_uv" \
+          PATH="$tagged_uv_wrapper:$PATH" \
+          UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \
+            .venv/bin/pytest \
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -193,10 +193,11 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     assert 'export HOME="${RUNNER_TEMP}/yoetz-home"' not in macos
     for verifier in (linux, macos):
         assert "uv run --locked pytest tests/packaging \\" in verifier
-        assert "uv run --locked env \\" in verifier
-        assert "UV_NO_INDEX=true \\" in verifier
+        assert 'tagged_uv_wrapper="${{ runner.temp }}/tagged-uv-bin"' in verifier
+        assert 'exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"' in verifier
+        assert 'PATH="$tagged_uv_wrapper:$PATH" \\' in verifier
         assert 'UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \\' in verifier
-        assert "pytest \\" in verifier
+        assert ".venv/bin/pytest \\" in verifier
         assert verifier.count("test_corrupted_wheel_fails_exact_hash_verification") == 2
         assert verifier.count("test_correct_hash_matching_the_real_wheel_installs_cleanly") == 2
         assert "pytest tests/subprocess \\" in verifier


### PR DESCRIPTION
Continues the v0.1.0 release recovery tracked in #366.

The previous recovery fix isolated the tagged tests in a fresh uv cache, but the v0.1.0 test fixture launches nested `uv pip install` processes. `UV_NO_INDEX` is not the nested CLI control, so the fixture repopulated that fresh cache from the now-public PyPI release before the exact-hash assertions ran.

This change gives only those two immutable-tag tests a narrow `uv` wrapper. The wrapper forwards every command unchanged except `uv pip install`, where it injects the supported `--no-index` flag. The checkout and release tag are untouched; the candidate is still built from `v0.1.0` at `1567e43`.

Verification:

- exact immutable `v0.1.0` checkout with fresh cache and wrapper: 2 passed
- `uv run pytest tests/packaging/test_release_workflow_contract.py -q --timeout=900`: 10 passed
- `uv run ruff check tests/packaging/test_release_workflow_contract.py`: passed
- release workflow YAML parsed successfully