### PR TITLE
fix(release): repair published-wheel smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1141,16 +1141,30 @@ jobs:
           curl -sL -o "${{ runner.temp }}/hosted-manifest.json" https://schemas.yoetz.dev/0.1/manifest.json
           cmp -s "${{ runner.temp }}/hosted-manifest.json" "${{ runner.temp }}/candidate/../schemas/manifest.json" 2>/dev/null || true
 
-      - name: Install with network denied from the captured wheelhouse; run version --json and strict-local smoke
+      - name: Install the locked uv release tool
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.29"
+          enable-cache: false
+
+      - name: Capture runtime dependencies; reinstall the public wheel with the index denied; run smoke
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          export PATH="$HOME/.local/bin:$PATH"
-          uv venv "${{ runner.temp }}/published-venv"
+          set -euo pipefail
+          version="${{ needs.validate-release-source.outputs.version }}"
+          venv="${{ runner.temp }}/published-venv"
+          wheel="${{ runner.temp }}/published/yoetz-${version}-py3-none-any.whl"
+          [ -f "$wheel" ] || { echo "::error::published wheel is missing: $wheel"; exit 1; }
+          uv python install 3.14
+          uv venv --python 3.14 "$venv"
+          # Resolve the wheel's pinned runtime dependencies while the registry is available, then
+          # remove Yoetz so the actual smoke installation is forced through the captured public wheel.
+          uv pip install --python "$venv/bin/python" "$wheel"
+          uv pip uninstall --python "$venv/bin/python" yoetz
           uv pip install --python "${{ runner.temp }}/published-venv/bin/python" \
-            --no-index --find-links "${{ runner.temp }}/published" \
-            "yoetz==${{ needs.validate-release-source.outputs.version }}"
-          "${{ runner.temp }}/published-venv/bin/yoetz" version --json
-          "${{ runner.temp }}/published-venv/bin/python" -c "import yoetz"
+            --no-index --no-deps --find-links "${{ runner.temp }}/published" \
+            "yoetz==${version}"
+          "$venv/bin/yoetz" version --json
+          "$venv/bin/python" -c "import yoetz"
 
   # ---------------------------------------------------------------------------------------------
   # verify-npm-published

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -143,6 +143,22 @@ def test_tag_workflow_rejects_missing_or_drifted_hosted_schema_bytes() -> None:
     assert "|| true" not in verify
 
 
+def test_post_publication_smoke_uses_python314_and_reinstalls_the_approved_wheel_offline() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    verify = workflow.split("  verify-published:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # verify-npm-published",
+        1,
+    )[0]
+
+    assert 'version: "0.11.29"' in verify
+    assert "curl -LsSf https://astral.sh/uv/install.sh" not in verify
+    assert "uv python install 3.14" in verify
+    assert 'uv venv --python 3.14 "$venv"' in verify
+    assert 'uv pip install --python "$venv/bin/python" "$wheel"' in verify
+    assert 'uv pip uninstall --python "$venv/bin/python" yoetz' in verify
+    assert '--no-index --no-deps --find-links "${{ runner.temp }}/published"' in verify
+
+
 def test_candidate_digest_is_path_independent_and_checksum_backed() -> None:
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     build = workflow.split("  build-candidate:\n", 1)[1].split(


### PR DESCRIPTION
Finishes the v0.1.0 release recovery tracked in #366 after publication succeeded.

The public artifacts, npm tarball, schemas, and GitHub Release all matched the approved candidate. The remaining post-publication smoke failed because Ubuntu selected Python 3.12 (Yoetz requires 3.14) and the single-wheel directory intentionally did not contain transitive dependencies.

This change:

- uses the repository-locked uv 0.11.29 instead of installing latest
- explicitly provisions Python 3.14 on both runners
- loads runtime dependencies from the already byte-verified public wheel
- removes Yoetz, then reinstalls the captured public wheel with `--no-index --no-deps`
- runs `version --json` and an import smoke after that index-denied reinstall

Verification:

- official public `yoetz-0.1.0-py3-none-any.whl` completed the full corrected sequence locally on Python 3.14
- `uv run pytest tests/packaging/test_release_workflow_contract.py -q --timeout=900`: 11 passed
- `uv run ruff check tests/packaging/test_release_workflow_contract.py`: passed
- release workflow YAML parsed successfully