### PR TITLE
fix(release): attach scanned CycloneDX SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,6 +715,12 @@ jobs:
           name: capability-matrix
           path: ${{ runner.temp }}/inputs/capability-matrix
 
+      - name: Download the generated and public-boundary-scanned CycloneDX SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: security-dependency-evidence
+          path: ${{ runner.temp }}/inputs/security-dependency-evidence
+
       - name: Build the release-inputs manifest for the evidence generator
         run: |
           uv run --locked python scripts/build_release_inputs.py \
@@ -750,6 +756,14 @@ jobs:
           uv run --locked python scripts/generate_release_evidence.py \
             --input-manifest "${{ runner.temp }}/release-inputs.json" \
             --output-dir "${{ runner.temp }}/release-evidence/${{ needs.validate-release-source.outputs.version }}" --check
+
+      - name: Add the exact scanned CycloneDX SBOM to the public release evidence
+        run: |
+          set -euo pipefail
+          source="${{ runner.temp }}/inputs/security-dependency-evidence/sbom.cdx.json"
+          destination="${{ runner.temp }}/release-evidence/${{ needs.validate-release-source.outputs.version }}/yoetz-${{ needs.validate-release-source.outputs.version }}.sbom.cdx.json"
+          [ -f "$source" ] || { echo "::error::security workflow SBOM artifact is missing"; exit 1; }
+          cp -- "$source" "$destination"
 
       - name: Public-boundary scan the assembled evidence
         run: |

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -171,7 +171,9 @@ def test_release_bundle_carries_the_scanned_cyclonedx_sbom_into_github_assets() 
     )[0]
 
     assert "name: security-dependency-evidence" in assemble
-    assert 'source="${{ runner.temp }}/inputs/security-dependency-evidence/sbom.cdx.json"' in assemble
+    assert (
+        'source="${{ runner.temp }}/inputs/security-dependency-evidence/sbom.cdx.json"' in assemble
+    )
     assert "yoetz-${{ needs.validate-release-source.outputs.version }}.sbom.cdx.json" in assemble
     assert "Public-boundary scan the assembled evidence" in assemble
     assert "${{ runner.temp }}/release-assets/**/*.json" in publish

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -159,6 +159,24 @@ def test_post_publication_smoke_uses_python314_and_reinstalls_the_approved_wheel
     assert '--no-index --no-deps --find-links "${{ runner.temp }}/published"' in verify
 
 
+def test_release_bundle_carries_the_scanned_cyclonedx_sbom_into_github_assets() -> None:
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+    assemble = workflow.split("  assemble-release-evidence:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # approve-publication",
+        1,
+    )[0]
+    publish = workflow.split("  publish-github-release:\n", 1)[1].split(
+        "  # ---------------------------------------------------------------------------------------------\n  # verify-schema-site",
+        1,
+    )[0]
+
+    assert "name: security-dependency-evidence" in assemble
+    assert 'source="${{ runner.temp }}/inputs/security-dependency-evidence/sbom.cdx.json"' in assemble
+    assert "yoetz-${{ needs.validate-release-source.outputs.version }}.sbom.cdx.json" in assemble
+    assert "Public-boundary scan the assembled evidence" in assemble
+    assert "${{ runner.temp }}/release-assets/**/*.json" in publish
+
+
 def test_candidate_digest_is_path_independent_and_checksum_backed() -> None:
     workflow = _WORKFLOW.read_text(encoding="utf-8")
     build = workflow.split("  build-candidate:\n", 1)[1].split(


### PR DESCRIPTION
Completes the GitHub asset inventory for the official v0.1.0 release tracked in #366.

The security workflow already generates `sbom.cdx.json`, scans it through the public-boundary gate, and includes its digest in security evidence. The release evidence assembler did not download that artifact, so the release notes accurately described SBOM generation but the actual SBOM file was missing from the public GitHub assets.

This change downloads the exact scanned security artifact after the security workflow succeeds, copies it into the versioned release-evidence bundle as `yoetz-0.1.0.sbom.cdx.json`, scans the complete assembled bundle again, includes it in the evidence digest, and lets the existing JSON asset glob attach it to the GitHub Release. Registry bytes and the immutable tag do not change.

Verification:

- `uv run pytest tests/packaging/test_release_workflow_contract.py -q --timeout=900`: 12 passed
- `uv run ruff check tests/packaging/test_release_workflow_contract.py`: passed
- release workflow YAML parsed successfully