### PR TITLE
fix(landing): align hero GitHub control

### DIFF
--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -184,17 +184,18 @@ img { max-width: 100%; }
   display: flex; align-items: center; justify-content: flex-start;
   gap: 18px; flex-wrap: wrap; margin-bottom: 36px;
 }
-.hero-brand-logo { display: flex; }
-.hero-brand-logo img { height: 64px; width: auto; display: block; }
+.hero-brand-logo { display: flex; align-items: center; height: 64px; }
+.hero-brand-logo img { height: 72px; width: auto; display: block; }
 .hero-under-term { display: flex; justify-content: center; margin-top: 24px; }
 .hero-star {
   display: inline-flex; align-items: center; gap: 6px;
-  height: 30px; padding: 0 12px; border-radius: 9999px;
+  height: 64px; padding: 0 20px; border-radius: 14px;
   background: #fff; border: 1px solid var(--slate-200);
-  font-size: 12.5px; font-weight: 600; color: var(--slate-700);
-  box-shadow: var(--shadow-xs); transition: all 200ms;
+  font-size: 14px; font-weight: 600; color: var(--slate-700);
+  box-shadow: var(--shadow-sm); transition: all 200ms;
+  transform: translateY(9px);
 }
-.hero-star svg { color: var(--slate-900); }
+.hero-star svg { width: 20px; height: 20px; color: var(--slate-900); }
 .hero-star:hover { background: var(--slate-50); border-color: var(--slate-300); color: var(--slate-950); }
 
 /* ---------- Status (alpha) section ---------- */


### PR DESCRIPTION
Closes #382.\n\n## Summary\n- match the GitHub control's visual scale to the official Yoetz lockup\n- compensate for transparent padding in the logo asset\n- lower the control by the user-approved 10px optical offset\n\n## Verification\n- 
> yoetz-landing@0.1.0 build
> astro build

17:56:40 [types] Generated 52ms
17:56:40 [build] output: "static"
17:56:40 [build] mode: "static"
17:56:40 [build] directory: /Users/shayb/yoetz-core/landing/dist/
17:56:40 [build] Collecting build info...
17:56:40 [build] ✓ Completed in 74ms.
17:56:40 [build] Building static entrypoints...
17:56:40 [vite] ✓ built in 119ms
17:56:40 [vite] ✓ built in 14ms
17:56:40 [build] Rearranging server assets...

 generating static routes 
17:56:40   ├─ /index.html (+5ms) 
17:56:40 ✓ Completed in 14ms.

17:56:40 [build] ✓ Completed in 161ms.
17:56:40 [build] 1 page(s) built in 238ms
17:56:40 [build] Complete!\n- 877x714 browser check with zero console errors