### PR TITLE
Define portable plugin carrier and host activation contract

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2869,6 +2869,66 @@ phase/outcome, before/after state, compatibility, managed-file count, structural
 optional closed integration reason; it has no project path, content, environment, Git, task, or
 exception field.
 
+### Portable plugin carrier and host activation (design-registered, ADR-023)
+
+The names below are registered ahead of implementation (ADR-023, issue #149); no implementing
+module exists yet, and the child issues of #148 own the phased code. A portable plugin is a
+carrier, never an authority: it may carry metadata, shared skill bytes, and an optional exact MCP
+declaration, and it cannot authorize disclosure, hold credentials, unlock the vault, approve
+observation, call providers, strengthen coverage, or replace a receipt (ADR-008, ADR-023).
+
+`PortablePluginPlan` is the one canonical neutral plan every manifest/configuration is generated
+from: common metadata (name exactly `yoetz`, version, description); canonical skill/resource byte
+sources (the packaged `guidance/` mirrors, byte-identical per ADR-010); `format_profile:
+PluginFormatProfile`; `mcp_ownership: McpOwnership` with `mcp_route_profile` (`policy|strict`)
+present exactly when plugin-managed; an optional host-extension profile; schema and renderer
+versions (Agent Plugins spec pin `1.0.0` plus the plan renderer version); and the complete
+managed-file inventory with relative paths, sizes, and SHA-256 digests. Agent Plugin JSON is never
+the input for another host's manifest; projections share only the plan (ADR-023).
+
+- `PluginFormatProfile` is a closed enum; initial membership is exactly
+  `agent_plugins_1|codex_plugin_native`. A new member requires a reviewed projection design and
+  ADR-023-conformant root registration before any render targets it.
+- `McpOwnership` is exactly `external_registration|plugin_managed`. `McpOwnershipState` is the
+  closed observed-owner state `absent|external|plugin|dual|foreign|ambiguous`; `dual`, `foreign`,
+  and `ambiguous` are explicit reported states, never silently resolved or overwritten (ADR-018,
+  ADR-023). Child-issue shorthand does not add members: `owned` resolves to `external|plugin` from
+  the observed source, and `foreign_present` projects to `foreign`.
+- `HostSurface` is the closed host-product enum
+  `codex_cli|chatgpt_desktop|cursor_ide|cursor_cli|cursor_cloud|claude_code`, used only to key
+  evidence cells. It is distinct from `HarnessId` (v0.1 membership still exactly `codex`); format
+  compatibility earns no `HostSurface` support claim, first-party identity, or coverage (ADR-005,
+  ADR-023). A Cursor surface consuming the portable artifact is a *portable* cell; one consuming a
+  generated native projection is a *native* cell; Claude Code is a *native dual-target* host whose
+  project-scope and user-scope targets are separate cells.
+- `PluginOperationState` is the closed mutation status
+  `not_started|in_progress|completed|refused|outcome_unknown`. Every mutating artifact/activation
+  request carries an exact request identity; same-request replay returns the stored result or
+  reconciles through status; timeout or connection loss reports `outcome_unknown` and never implies
+  failure; retry cannot create a second stage/apply/remove; status carries no user-controlled
+  structural content (ADR-023).
+- `PluginProofFacet` is the closed independent-facet list `source`, `rendered_artifact`,
+  `installed_bytes`, `host_discovery`, `host_activation`, `skill_delivery`, `mcp_owner`,
+  `mcp_binding`, `mcp_runtime`, `model_use`, `trigger_capability`, `observation_consent`,
+  `observation_evidence`, `service_readiness`, `semantic_readiness`, `provider_dispatch`,
+  `privacy_receipt`, `workflow_receipt`. No facet implies another, and format validation proves
+  none of activation, observation, semantic dispatch, or closure (ADR-023).
+
+`PluginArtifactPort` methods are `preview_artifact`, `install_artifact`, `status_artifact`, and
+`remove_artifact`; interrupted-swap recovery is expressed through `status_artifact` reconciliation,
+never automatic repair. `HostActivationPort` methods are `observe_discovery`,
+`observe_activation`, and — only when authorized — `preview_activation` and `apply_activation`.
+Both are siblings of `IntegrationsPort`, `HarnessMcpPort`, and `ObservationPort` under the
+ADR-010/ADR-012 sibling-port rule: a host adapter may compose them but cannot collapse their state
+or authority, and no port's status field implies another's. Mutations preserve the full safe
+artifact lifecycle (exact before/after preview and accepted digest, stale-preview rejection,
+safe-root containment, no symlink members, complete digest inventory, no unmanaged/modified
+overwrite, failure-atomic replacement, installed-byte verification, no
+filesystem-presence-to-activation inference). Once implemented under #150, standalone
+install/remove/activation-apply consume the ADR-016 `review_only` single-shot trusted review; this
+design registration does not make a new mutation available. The ADR-012 setup composition remains
+its own separately authorized path (ADR-023 decision 11).
+
 ## 11. Application (`application/`)
 
 `Application` is a service-internal frozen dataclass wiring all use-case ports, `PrivacyCoordinator`,

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,6 +1,6 @@
 # Yoetz v0.1 — decision ledger and release-gate dispositions
 
-**ADRs:** ADR-001 through ADR-016 | **Related:** [`docs/INTERFACES.md`](INTERFACES.md),
+**ADRs:** ADR-001 through ADR-023 | **Related:** [`docs/INTERFACES.md`](INTERFACES.md),
 [`docs/adr/`](adr/), release-evidence generation
 
 ## Purpose
@@ -113,6 +113,7 @@ that evidence.
 | E-014 | Publication-ceremony budget and work-package grouping examples | Dogfood must measure publications per work package, model-authored event bytes, token/latency overhead, abandoned or stale-ledger rate, skipped checks, and user-visible chatter. Large inventories must compare grouped work packages with per-file publication amplification; no threshold is inferred from file count alone. | Harness-neutral capability/conformance fixtures plus bounded dogfood evidence used to freeze guidance examples and budgets. |
 | E-015 | Exact structural subject-state capture matrix | No support claim until installed-artifact tests freeze Git/object-format and OS cells, symlink/submodule/racy-worktree behavior, file/byte caps, exclusions, sanitized environment, path/content-free output, and no network or trusted-service reachability. | ADR-011 CLI/subprocess, packaging-boundary, privacy, and capability evidence. |
 | E-016 | TOML as alternate nonsecret settings surface, including official OpenAI vs owner-declared OpenAI-compatible HTTPS origin+model | **Working (ADR-014).** Config validates constrained `https_origin`, rejects secrets/free `base_url`, mutual-excludes official vs owner-declared, and writes the same fields from wizard/menu/`yoetz provider endpoint`. Owner-declared data-use defaults to `unknown` (never `assisted`). Privacy desired-state export/apply classifies widen vs tighten and never silently widens. Remaining: optional live owner-declared host probe before advertising verified interoperability beyond the protocol cell. | ADR-014, ADR-006/009 amendments, config/privacy/openai_responses specs, unit fixtures; live probe optional. |
+| E-017 | Agent Plugins portable-carrier host cells (ADR-023, issue #149) | No cell is populated. Each `HostSurface` (Codex CLI, ChatGPT desktop, Cursor IDE/CLI/cloud, Claude Code) × format (portable vs native projection) pair is its own evidence cell requiring installed-artifact proof of discovery, activation, skill delivery, and — where declared — MCP ownership and observation, per the independent ADR-023 proof facets. Format compatibility with Agent Plugins 1.0.0 earns no discovery, activation, support, or coverage claim. E-002/E-013 continue to gate Codex unchanged; non-supporting hosts' native roots are frozen per host profile with fixture evidence before any render targets them. Introduced after the v0.1.0 tag; owned by the #148 child issues. | ADR-023, per-host installed-artifact capability evidence and support-matrix cells. |
 
 ### v0.1.0 public-alpha gate dispositions — 2026-08-20
 

--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -102,6 +102,7 @@ from packaged bytes, committed mirrors regenerated exclusively by their owning s
 hand-edited, and covered by the packaging suites before any install-parity claim. The Agent
 Plugins 1.0.0 schemas must be vendored byte-pinned by #150 with the SHA-256 digests recorded in
 ADR-023 decision 3 and then treated exactly like decision 11 mirrors: the packaged copy is the
-runtime authority and upstream hosting is never an operational dependency. Marketplace publication of the
-portable artifact is deferred and requires its own separate, dated release decision like the
-2026-08-20 npm decision above; rendering an artifact locally creates no publication claim.
+runtime authority and upstream hosting is never an operational dependency. Marketplace
+publication of the portable artifact is deferred and requires its own separate, dated release
+decision like the 2026-08-20 npm decision above; rendering an artifact locally creates no
+publication claim.

--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -93,3 +93,15 @@ Every dependency update is a reviewed PR + package patch release rerunning contr
 packaging/capability matrices. E-001 refreshes these implementation pins at release lock and must
 record whether each selected identity stayed fixed or changed; a newer version alone never widens
 the support allowlist.
+
+**Amendment (ADR-023, 2026-08-21, issue #149): generated Agent Plugins artifacts and vendored
+upstream schema bytes.** Portable plugin artifacts are generated projections of the neutral
+`PortablePluginPlan` and follow the same parity rules as every packaged resource: rendered only
+from packaged bytes, committed mirrors regenerated exclusively by their owning scripts
+(`scripts/sync_resource_ripple.py` and the committed-tree regeneration it drives), never
+hand-edited, and covered by the packaging suites before any install-parity claim. The Agent
+Plugins 1.0.0 schemas must be vendored byte-pinned by #150 with the SHA-256 digests recorded in
+ADR-023 decision 3 and then treated exactly like decision 11 mirrors: the packaged copy is the
+runtime authority and upstream hosting is never an operational dependency. Marketplace publication of the
+portable artifact is deferred and requires its own separate, dated release decision like the
+2026-08-20 npm decision above; rendering an artifact locally creates no publication claim.

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -181,6 +181,19 @@ bounded the adjacent surface since #128. Per-item budgets cannot catch this clas
 item can sit inside its own bound while the total doubles. Anyone inlining a document here again
 will fail CI rather than a live session.
 
+**Amendment (ADR-023, 2026-08-21, issue #149): tier 2 gains a portable carrier; artifact and
+activation are sibling ports.** Tier 2 on-disk delivery may now be carried either by a host-native
+projection (the existing Codex layout) or by a portable Agent Plugins 1.0.0 artifact, both
+generated from the neutral `PortablePluginPlan` — never from each other. The carrier changes reach,
+not authority: tiers 0 and 1 are byte-for-byte unchanged, guidance stays owned once under
+`guidance/` with no byte variation per ADR-010 decision 1, and a host consuming the portable format
+still earns exactly the coverage its evidence cell proves. Following the `HarnessMcpPort`
+precedent above, `PluginArtifactPort` (preview/install/status/remove of a rendered artifact) and
+`HostActivationPort` (discovery/activation observation and authorized preview/apply) are sibling
+ports, never `IntegrationsPort` overloads; a host adapter may compose them but cannot collapse
+their state or authority. The fork guarantee is extended, not weakened: a standards-compliant host
+is reached by a projection plus a host profile, still with no shared-type edits.
+
 **Amendment (2026-08-14, issue #222):** Codex hook stdout is event-specific. `SessionStart`,
 `PostToolUse`, and `UserPromptSubmit` keep `hookSpecificOutput.additionalContext`. `Stop` and
 `SubagentStop` have no such field: JSON that includes `hookSpecificOutput` is marked Failed with

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -261,6 +261,26 @@ Each mutating step is previewed, digest-bound, and individually declinable; `yoe
 reports the same posture read-only at any time. The CLI support-command matrix grows by one
 (`setup`), recorded in the conformance contract test in the same change.
 
+**Amendment (ADR-023, 2026-08-21, issue #149): host-derived artifact projection behind the
+unchanged wizard.** The setup ordering and user experience above do not change: project skill,
+then structural plugin sources, then explicitly approved activation, then MCP verification, each
+previewed, digest-bound, and individually declinable. What changes is backend selection only: the
+structural plugin-source step becomes a projection of the neutral `PortablePluginPlan`, chosen
+from the detected host profile — the portable Agent Plugins artifact in the host's own client
+plugin root where the host supports it, a generated native projection in that host's distinct
+documented native root where it does not. The user never chooses a root, format, or migration
+path. Artifact preview/apply, host activation, MCP registration, and observation consent remain
+separately reported facts, and setup status additionally reports the closed `McpOwnershipState`
+(`absent|external|plugin|dual|foreign|ambiguous`): dual, foreign, and ambiguous ownership are
+explicit reported states that setup never silently resolves or overwrites. For Codex the plugin
+root stays `.agents/plugins/yoetz`; a format migration there is a whole-directory,
+marker-identified, digest-bound replacement under this ADR's existing preview/apply and activation
+ceremony, and the bespoke layout remains the shipping control until a portable projection is
+capability-proven and explicitly approved. This amendment grants no new authority: the wizard's
+narrow approval covers exactly what it covered before, and the standalone portable
+install/remove/activation-apply paths, once implemented by #150, take the ADR-016 `review_only`
+lane instead (ADR-023 decision 11).
+
 Package replacement changes binaries, not accepted trust bytes. Installed-wheel proof is still
 required before issue #139 can close: consecutive real checks must prove distinct attempt authority
 and receipts in one approved repository, and a second repository must remain blocked. Router routing

--- a/docs/adr/ADR-016-human-review-non-default-actions.md
+++ b/docs/adr/ADR-016-human-review-non-default-actions.md
@@ -2,7 +2,9 @@
 
 **Status:** Working decision; amended 2026-07-31 to require action-bound OS user presence before
 console review; amended 2026-08-09 for agent-attested current-chat authorize (issue #164); amended
-2026-08-18 for atomic concurrent review claims (issue #344).
+2026-08-18 for atomic concurrent review claims (issue #344); amended 2026-08-21 to assign portable
+plugin artifact and host-activation mutation to `review_only` (issue #149, ADR-023; implementation
+owned by #150).
 **Implemented by:** `src/yoetz/service/elevated_bootstrap.py`,
 `src/yoetz/cli/elevated.py`, `src/yoetz/cli/trusted_console.py`,
 `src/yoetz/protocol/consent.py`, `src/yoetz/protocol/chat_user_authority.py`, and
@@ -77,6 +79,21 @@ documents that Yoetz cannot independently authenticate its chat provenance.
    idle-relock weakening, and generic `privacy_policy_widen` remain catalogued but unimplemented
    until the owning mutation boundary consumes this single-shot review safely.
    `repository_privacy_grant` is the implemented exact-recipe privacy path for chat-user authorize.
+
+   **Amendment (ADR-023, 2026-08-21, issue #149):** the skill/harness-configuration slice of
+   `review_only` is the accepted owning boundary for standalone portable plugin artifact
+   install/remove and host-activation apply. #150 must implement the operation-specific catalog,
+   prepare, and consume path before any such mutation exists; this amendment does not mark the
+   current generic skill/harness operations implemented. Once implemented, the path consumes this
+   class's single-shot trusted review of the exact plan digest under all existing rules — one
+   pending request, atomic claim, verified presence before console review. An ordinary TTY
+   confirmation, `--accept`, a same-UID process, or a host marketplace prompt is not and cannot
+   silently become `UserPresencePort` authority, so
+   until a production presence adapter exists these standalone paths fail closed with
+   `human_authority_unavailable` and remain render/preview/status-only in practice. The
+   agent-attested current-chat authorize lane (decision 5) is deliberately **not** extended to
+   them. The ADR-012 setup wizard's already-authorized digest-bound composition is a separate,
+   unchanged authority and does not route through this class.
 
 ## Consequences
 

--- a/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
+++ b/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
@@ -69,6 +69,19 @@ There are now two reviewed descriptor digests and two owned Codex registration c
 either command or either descriptor set is a public-contract change and must update this ADR,
 documentation, schemas where applicable, fixtures, and conformance evidence together.
 
+**Amendment (ADR-023, 2026-08-21, issue #149): a plugin-managed `mcp.json` is a third generated
+route surface under the same ceiling.** When a portable plugin artifact carries `mcp.json`
+(`plugin_managed` ownership only), that file is generated exclusively from the
+`PortablePluginPlan`'s bound route: the exact argv and `strict|policy` profile are chosen before
+approval and bound into the preview and artifact digests, and runtime configuration, environment,
+agent input, or later privacy widening cannot change the route — the same immutability decision 1
+gives the process flag. An `external_registration` artifact omits `mcp.json` entirely; the
+existing registration commands above remain authoritative. No second native or global registration
+may own the `yoetz` server name while a plugin-managed declaration exists: dual, foreign, and
+ambiguous ownership are explicit `McpOwnershipState` values that are reported, never overwritten
+or silently chosen between. Changing the generated `mcp.json` bytes for a bound route is a
+public-contract change under the same update rule as the two registration commands.
+
 ## Alternatives considered
 
 **Infer the route from current policy for each call.** Rejected: the host would be approving a

--- a/docs/adr/ADR-023-portable-plugin-carrier-host-activation.md
+++ b/docs/adr/ADR-023-portable-plugin-carrier-host-activation.md
@@ -1,0 +1,227 @@
+# ADR-023 — Portable plugin carrier and host activation
+
+**Status:** Accepted (2026-08-21), acknowledged in
+[issue #149](https://github.com/TheGaySupreme123/yoetz/issues/149#issuecomment-5371952502).
+Issue #149 suggested the name ADR-020; that number was taken by typed evidence digest provenance
+before this document landed, so the accepted decision set lives here unchanged.
+**Implemented by:** no module yet. This ADR is design-first under #148/#149; the child issues of
+#148 own the phased implementation, and every shared name below is pre-registered in
+`docs/INTERFACES.md` before code exists.
+**Relates to:** ADR-005 (exact capability identity), ADR-007 (packaging/release), ADR-008
+(trust boundary), ADR-009 (egress/privacy — deliberately not amended), ADR-010 (harness
+integration port), ADR-012 (first-run setup wizard), ADR-016 (human review), ADR-018 (MCP route
+egress ceiling).
+
+## Context
+
+Yoetz has the right security split but no neutral package model. The current Codex renderer
+(`src/yoetz/adapters/integrations/codex_plugin.py`) directly produces `.codex-plugin/plugin.json`,
+`.mcp.json`, skills, and hooks with no owning port, and its generated `.mcp.json` hard-imports the
+policy serve command with no strict variant — a generated file claiming a route the artifact does
+not own, exactly what ADR-018 exists to prevent. Generalizing that renderer would make a Codex
+artifact the source for Cursor and Claude, merge installation with activation, and conflate format
+compatibility with tested support.
+
+The Agent Plugins specification 1.0.0 (Working Draft) standardizes a portable plugin directory: a
+`plugin.json` manifest at the plugin root, shared skills, and an optional MCP configuration. It
+intentionally does not standardize installation, trust, consent, hooks, observation, marketplaces,
+credentials, or proof, and it prescribes no install root — each client chooses. That thinness is
+useful: the portable format can carry Yoetz's shared guidance to any standards-compliant host
+without Yoetz inheriting authority claims it must then disown.
+
+This change is about platform reach, not user experience. Adopting the universal standard lets
+Yoetz reach every host that speaks it while preserving first-class support for hosts that do not.
+The user-facing install surface — the ADR-012 wizard and `yoetz integrate` commands, one
+preview/apply experience — does not change; only the backend selection of what is rendered where
+becomes host-derived.
+
+## Decisions
+
+1. **A portable plugin is a carrier, never an authority.** A portable artifact may carry common
+   metadata, shared skill/guidance bytes, and an optional exact MCP declaration. It cannot
+   authorize disclosure, store credentials, unlock the vault, approve observation, call providers
+   directly, strengthen coverage, or replace a Yoetz receipt. The trusted local service remains the
+   sole state, privacy, and provider authority (ADR-008, ADR-009); plugin and MCP clients remain
+   untrusted. Nothing a host does with the artifact — discovery, activation, marketplace listing —
+   creates authority, consent, or coverage.
+
+2. **One canonical neutral plan: `PortablePluginPlan`.** Every manifest and configuration —
+   Agent Plugins `plugin.json`, the Codex-native layout, any future Cursor or Claude Code native
+   projection, and a plugin-managed `mcp.json` — is a generated projection of one pure plan
+   carrying: common metadata; canonical skill/resource byte sources (the packaged `guidance/`
+   mirrors, byte-identical per ADR-010 decision 1); a `PluginFormatProfile`; `McpOwnership`
+   (`external_registration | plugin_managed`) with the exact `strict | policy` route profile when
+   plugin-managed; an optional host-extension profile; schema and renderer versions; and the
+   complete managed-file inventory with sizes and SHA-256 digests. Agent Plugin JSON is never the
+   input for a Claude, Cursor, or Codex native manifest; projections share only the plan.
+
+3. **The upstream revision is pinned for vendoring.** The portable projection targets Agent Plugins
+   specification 1.0.0 exactly. Its two canonical schemas are pinned for vendoring by URL and
+   digest:
+   `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`
+   (SHA-256 `0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883`) and
+   `https://agent-plugins.org/schemas/1.0.0/mcp.schema.json`
+   (SHA-256 `6539175bfcdf43085855183e86da40ea94b166547a72b47ae9a0a390516d3acb`). As with ADR-007
+   decision 11, the #150 implementation must vendor those exact bytes before any renderer or
+   validator ships; the packaged vendored copy then becomes the runtime authority and upstream
+   availability is never an operational dependency. Upstream v1 is intentionally thin and may
+   evolve; adopting a newer revision is a reviewed change to this pin, never an ambient upgrade.
+   #150 must register the vendored schema bytes and every generated/committed artifact tree under
+   the `scripts/sync_resource_ripple.py` owning fixed-point before adding them; mirrors are never
+   hand-edited. The two digests above were re-fetched and confirmed against the canonical HTTPS
+   bytes on 2026-08-21; that live comparison is design evidence, not a runtime dependency.
+
+4. **Sibling capabilities, not a catch-all port.** The skill-focused `IntegrationsPort` is not
+   broadened. Two sibling ports are registered, following the `HarnessMcpPort` precedent
+   (ADR-010/ADR-012): `PluginArtifactPort` — `preview_artifact`, `install_artifact`,
+   `status_artifact`, `remove_artifact`, with interrupted-swap recovery expressed through status
+   reconciliation, never automatic repair — and `HostActivationPort` — `observe_discovery`,
+   `observe_activation`, and, only when authorized, `preview_activation` / `apply_activation`.
+   `HarnessMcpPort` keeps external/global MCP registration; `ObservationPort` keeps consented
+   observation. A host adapter may compose these ports; it cannot collapse their state or
+   authority, and no port's status field implies another's.
+
+5. **Host product, format, and capability cell stay distinct.** Codex CLI, ChatGPT desktop, Cursor
+   IDE, Cursor CLI, Cursor cloud, and Claude Code are distinct `HostSurface` values and distinct
+   evidence cells. Each exact host profile records version/build, accepted format, skill discovery,
+   activation, MCP ownership, trigger events, observation events, observability limits, and
+   evidence fixture IDs. Speaking the Agent Plugins format earns no first-party identity, no
+   populated capability cell, and no coverage — ADR-005's rule becomes more load-bearing as format
+   compatibility gets cheaper, not less. `HarnessId` membership is unchanged (exactly `codex` in
+   v0.1). Fixed terminology: a Cursor surface consuming the portable artifact is a **portable**
+   cell and one consuming a generated native projection is a **native** cell — separate cells even
+   on the same product; Claude Code is a **native dual-target** host whose project-scope and
+   user-scope install targets are separate cells, with only project scope in initial design scope.
+
+6. **Hybrid per-host install roots, one install surface.** A host that supports the portable
+   format receives the portable artifact in that host's own client plugin root; a host that cannot
+   consume it receives a generated native projection in a distinct, per-host documented native
+   root. The user-facing installer is unchanged: setup detects the host and derives format and
+   root; the user approves exact before/after bytes and never chooses a root, format, or migration
+   path. For Codex the client plugin root is the existing `.agents/plugins/yoetz`, so migration
+   from the bespoke layout to the portable layout is a whole-directory, marker-identified,
+   digest-bound replacement at the same root under the existing ADR-012 preview/apply and
+   activation ceremony — exactly one managed tree exists there at a time, its format identified by
+   its managed marker, and the bespoke Codex fallback remains the shipping control until a portable
+   projection is capability-proven and explicitly approved. Portable and native projections must
+   have disjoint path inventories wherever both could exist; a collision is a refused preview,
+   never a merge. Native roots for non-supporting hosts (e.g. Claude Code) are frozen in that
+   host's profile registration, with fixture evidence, before any render targets them. Upgrade,
+   remove, interrupted recovery, and rollback follow the existing whole-directory swap rules; there
+   is no pathname rollback.
+
+7. **Exclusive MCP ownership.** Under `external_registration` the portable artifact omits
+   `mcp.json` and the existing `HarnessMcpPort` registration remains authoritative. Under
+   `plugin_managed` the artifact includes a generated `mcp.json` and no second native or global
+   registration may own the `yoetz` server name. Observed ownership is the closed
+   `McpOwnershipState` (`absent | external | plugin | dual | foreign | ambiguous`); dual, foreign,
+   and ambiguous are explicit reported states — never silently resolved, chosen between, or
+   overwritten. Child-issue shorthand is reconciled to this enum: `owned` is not a seventh state
+   and must resolve to `external` or `plugin` from the observed source, while `foreign_present`
+   projects to `foreign`; unknown or conflicting evidence projects to `ambiguous`, never to an
+   effective route. In plugin-managed mode the exact argv and the `strict | policy` route profile
+   are chosen before approval and bound into the preview and artifact digests; runtime
+   configuration, environment, agent input, and later privacy widening cannot change the route
+   (ADR-018).
+
+8. **Idempotent mutations with honest ambiguity.** Every mutating artifact or activation request
+   carries an exact request identity. Same-request replay returns the stored result or reconciles
+   through status; a timeout or connection loss returns `outcome_unknown` and never implies
+   failure; a retry cannot create a second stage, apply, or remove operation. Status distinguishes
+   the closed `PluginOperationState` (`not_started | in_progress | completed | refused |
+   outcome_unknown`) without user-controlled structural content.
+
+9. **The safe artifact lifecycle is preserved wholesale.** Every mutation targets one selected
+   trusted project and keeps the current protections: exact before/after preview and accepted
+   digest; stale-preview rejection; safe-root/path containment with no symlink members; complete
+   inventory, sizes, and SHA-256 digests; no portable/host-extension path collisions; no overwrite
+   or removal of unmanaged or modified content; failure-atomic replacement with conservative
+   recovery; installed-byte verification; and no inference from filesystem presence to activation.
+
+10. **Proof facets stay independent.** Public and setup status keep these facets separate, and no
+    document, status field, or summary may imply one from another: source, rendered artifact,
+    installed bytes, host discovery, host activation, skill delivery, MCP owner, MCP binding, MCP
+    runtime, model-controlled use, trigger capability, observation consent, observation evidence,
+    service readiness, semantic readiness, provider dispatch, privacy receipt, and the final
+    workflow receipt. Format validation in particular proves none of activation, observation,
+    semantic dispatch, or closure.
+
+11. **Authority: standalone mutation is assigned to ADR-016 `review_only`.** The
+    install/remove/activation-apply paths of the new ports must consume the ADR-016 `review_only`
+    single-shot trusted review of the exact plan digest (ADR-016 is amended accordingly). #150
+    owns the first implementation of that operation-specific prepare/consume boundary; this
+    design-only change does not make any new mutation available. An
+    ordinary TTY confirmation, `--accept`, a same-UID process, or a host marketplace prompt is not
+    and cannot silently become `UserPresencePort` authority; until a production presence adapter
+    exists, standalone console review fails closed with `human_authority_unavailable`, leaving
+    those standalone paths render/preview/status-only in practice. Before #150 implements the
+    boundary they do not exist at all. The ADR-012 setup wizard's
+    already-authorized digest-bound composition remains the separately authorized install path and
+    is unchanged. Agent preparation is never trusted human review (ADR-015/ADR-016).
+
+12. **Phased rollout, ADR-009 untouched.** Slice 1 is explicitly skills-only with
+    `external_registration`: the portable artifact carries metadata and shared skill bytes, omits
+    `mcp.json`, and will ship render/preview/status plus the authorized install paths of decision
+    11 only after #150 implements and tests them. The native Codex behavior in
+    `docs/runbooks/codex-integration.md` remains the control.
+    Plugin-managed MCP is a separately reviewed child issue. Every new host cell (ChatGPT desktop,
+    Cursor surfaces, Claude Code) remains evidence-gated under E-017; E-002/E-013 continue to gate
+    Codex unchanged. No consent, disclosure, or observation behavior changes, so ADR-009 is
+    deliberately not amended; if a later slice changes any of those, it must amend ADR-009 first.
+
+## Consequences
+
+Adding a standards-compliant host becomes a projection and a host profile, not a renderer fork —
+the ADR-010 property ("one `HarnessId` value plus one adapter") extends to packaging. The current
+`codex_plugin.py` renderer becomes an adapter behind `PluginArtifactPort` producing the
+Codex-native projection of the plan, and the marketplace/activation mechanics in
+`codex_marketplace.py` become a `HostActivationPort` adapter; both refactors are behavior-preserving
+and land only after the names in `docs/INTERFACES.md` and this ADR. The generated `.mcp.json` route
+hazard is closed structurally: route bytes exist only in a plugin-managed projection, generated
+from the plan's bound route profile.
+
+The cost is a third managed-artifact vocabulary to keep honest (portable format, native
+projections, and their proof facets), a vendored upstream schema pin to maintain, and a per-host
+root model that must be frozen cell by cell instead of assumed. The distinct-cells rule means
+Yoetz will frequently be *format-compatible* with a host it does not *support*; status wording must
+keep saying so.
+
+ADR-007, ADR-010, ADR-012, ADR-016, and ADR-018 are amended in the same review as this ADR.
+`docs/OPEN_QUESTIONS.md` gains gate E-017 for portable-carrier host cells. Child issue scopes under
+#148 must be reconciled against this ADR before their implementation PRs open.
+
+The reconciled execution map is explicit: #150 owns the skills-only portable renderer, schema
+vendoring, artifact lifecycle, and first `review_only` consumer; #151 alone may add
+`plugin_managed` MCP; #152 proves Codex CLI and ChatGPT desktop as separate cells while retaining
+the native fallback; #153 owns the separate Cursor portable/native cells; #154 owns the Claude
+Code native dual target and must not claim Agent Plugins consumption; and #155 consumes those
+bounded cells for cross-host evidence without repairing their implementations. All remain children
+of #148. #151 is not on the critical path for the skills-only #152 pilot, and no child may populate
+E-017 or widen a support claim from format conformance alone.
+
+## Alternatives considered
+
+**Generalize the existing Codex renderer.** Rejected: it makes a Codex artifact the source for
+other hosts, merges installation with activation, and gives a generated `mcp.json` a route it does
+not own.
+
+**Use Agent Plugin JSON as the canonical input for every manifest.** Rejected: the upstream format
+is intentionally thin; deriving native manifests from it would smuggle format limits into the plan
+and invert ownership. The neutral plan is authoritative; every format is a projection.
+
+**One standards root for every host, including non-supporting ones.** Rejected: hosts that cannot
+consume the portable format would need shims or copies inside a root they do not read, and the
+migration risk lands on exactly the hosts least able to verify it. Distinct native roots keep each
+host's cell honest.
+
+**Broaden `IntegrationsPort` into a catch-all.** Rejected: skill-install types carry
+trusted-project file semantics that artifact and activation state must not reuse; the
+`HarnessMcpPort` sibling precedent already proved the split keeps the fork guarantee intact.
+
+**Treat a host marketplace prompt or `--accept` as review authority.** Rejected: ADR-016's
+presence rule exists precisely because same-UID automation can fabricate both; a standing trust
+change needs the single-shot digest-bound review lane or the already-authorized setup ceremony.
+
+**Ship phase 1 render/preview/status-only and defer the authority question.** Rejected by
+maintainer decision: the `review_only` lane is designed now so implementation does not later
+improvise authority; the practical effect is the same until a production presence adapter exists.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ ADR wins; when an ADR and the code disagree, that is a bug in one of them and wo
 | [020](ADR-020-typed-evidence-digest-provenance.md) | Typed evidence digest provenance |
 | [021](ADR-021-recommended-defaults-advisories-and-update-check-surfacing.md) | Recommended-defaults advisories and update-check surfacing |
 | [022](ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md) | Harness observation writer identity and observation-tolerant concurrency |
+| [023](ADR-023-portable-plugin-carrier-host-activation.md) | Portable plugin carrier and host activation |
 
 Unresolved gates are centralized in [`docs/OPEN_QUESTIONS.md`](../OPEN_QUESTIONS.md), not scattered
 through individual ADRs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,3 +145,13 @@ harness by adding an adapter and a profile, without touching the core.
 
 Integration buys ergonomics, never a stronger claim. An agent publishing over MCP earns the weakest
 honest coverage, and the coverage vector says so exactly.
+
+The accepted packaging design extends this reach without moving any authority
+([ADR-023](adr/ADR-023-portable-plugin-carrier-host-activation.md), design-first — implementation
+is phased under issue #148). One neutral `PortablePluginPlan` projects into either a portable
+Agent Plugins 1.0.0 artifact, for hosts that consume the universal standard in their own client
+plugin root, or a generated host-native projection in a distinct documented root for hosts that do
+not. The artifact is a carrier, never an authority: installation, activation, MCP ownership, and
+observation stay separately owned sibling capabilities (`PluginArtifactPort`,
+`HostActivationPort`, the existing `HarnessMcpPort` and `ObservationPort`), and format
+compatibility with the standard earns no support claim, activation claim, or coverage.

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -23,6 +23,12 @@ parent-directory, fuzzy discovery, or symlink-target resolution.
 The installed files are byte-identical to the packaged wheel resource. The managed marker records
 only versions and sorted digests — never a path, username, timestamp, or repository reference.
 
+ADR-023 (issue #149) accepts a portable Agent Plugins carrier design whose Codex projection will
+eventually replace the bespoke plugin layout at the same `.agents/plugins/yoetz` root through the
+ordinary digest-bound preview/apply and activation ceremony. Until that projection is
+capability-proven and explicitly approved, the native behavior in this runbook is the control and
+nothing here changes.
+
 ## 2. Prerequisites and exact supported scope
 
 Check `yoetz version --json`, the installed resource set, and the current compatibility/capability


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #149
- I searched existing issues and PRs for duplicates before opening this PR.
- This is design-gated packaging/ADR work; the maintainer acknowledgement is recorded on #149.

## Documentation

- Behavior change? no — design registration only; implementation is owned by #150–#155.
- Docs updated: ADR-023; ADR-007, ADR-010, ADR-012, ADR-016, and ADR-018 amendments; docs/INTERFACES.md; docs/architecture.md; docs/OPEN_QUESTIONS.md; ADR index; Codex integration runbook.

## Verification

Commands run:

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/conformance/claims/test_local_service_security_doc.py tests/packaging/test_privacy_docs_and_resources.py
git diff --cached --check
```

Results: public-boundary scan passed (962 files); 19 tests passed and 2 expected xfails.

The Agent Plugins 1.0.0 plugin and MCP schema bytes were also fetched from their canonical HTTPS URLs on 2026-08-21; their SHA-256 digests matched the values pinned in ADR-023.

## Boundaries

- [x] No material from docs/architecture/ or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Define Agent Plugins 1.0.0 as a portable carrier rather than an authority, register the neutral plan and sibling artifact/activation ports, freeze exclusive MCP ownership and route binding, preserve independent proof facets, and reconcile the phased #150–#155 implementation/evidence program.

This PR deliberately adds no renderer, vendored schema, mutation, host support claim, or capability evidence.

## Follow-up issue alignment

The downstream issue contracts were synchronized with ADR-023:

- #150 now owns the first `review_only` consumer and the exact Codex whole-directory migration contract.
- #151–#155 use the canonical `McpOwnership` / `McpOwnershipState` vocabulary and conservative route-null rules.
- #152–#155 link their dependency explicitly to #149 / PR #384.
- Non-Codex render targets remain blocked until their exact host root and scope are registered with fixture evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added ADR-023 documenting a portable plugin packaging and host activation architecture.
  - Defined a canonical plugin plan, supported artifact formats, host surfaces, lifecycle states, proof requirements, and MCP ownership states.
  - Documented separate artifact delivery and host activation responsibilities, with explicit handling for unresolved or conflicting states.
  - Added packaging, setup, review, architecture, and integration guidance.
  - No user-facing plugin installation or activation behavior is introduced yet; current native behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Define ADR-023 portable plugin carrier and host activation contract
> - Adds [ADR-023](https://github.com/TheGaySupreme123/yoetz/pull/384/files#diff-1479fbd04265039bc093686894119062a89d5e590a346ed8b69b497de3fea167) defining `PortablePluginPlan` as the canonical plan, with Agent Plugins 1.0.0 as a portable carrier artifact and two sibling ports: `PluginArtifactPort` and `HostActivationPort`
> - Registers closed enums and terminology in [docs/INTERFACES.md](https://github.com/TheGaySupreme123/yoetz/pull/384/files#diff-bd84c40b183ad2c5740e5e3bc44737ede568ee2cf675fc5683f81fea434738e2) covering `PluginFormatProfile`, `McpOwnership`/`McpOwnershipState`, `HostSurface`, `PluginOperationState`, and `PluginProofFacet`
> - Amends ADRs 007, 010, 012, 016, and 018 to align packaging, harness integration, setup wizard, human-review lanes, and MCP egress routing with the new portable-carrier model
> - Assigns standalone artifact install/remove and host-activation apply to the ADR-016 `review_only` lane; these fail closed with `human_authority_unavailable` until a production presence adapter exists
> - Behavioral Change: plugin-managed `mcp.json` becomes a third generated route surface under the ADR-018 egress ceiling; existing Codex bespoke layout in [docs/runbooks/codex-integration.md](https://github.com/TheGaySupreme123/yoetz/pull/384/files#diff-879a4e754d62c2c66c8ed47cd522f1043905af25fa84b3a649280ba303a7bb43) remains the control until portable projection is capability-proven and explicitly approved
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17b3a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->