### PR TITLE
fix: repair Codex activation lifecycle for host-rendered plugins

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2770,7 +2770,12 @@ digest refuses the whole apply before a file is written. Setup separately report
 `project_skill_installation`, structural plugin-source installation, `plugin_activation`, MCP
 registration, hooks/consent, service routing, and semantic readiness; none of those fields implies
 another. `plugin_activation` uses the closed state
-`active|installed_not_activated|not_installed|foreign`. Its preview/inspection/application bind the
+`active|installed_not_activated|not_installed|foreign`. When an explicitly supplied Codex home is
+bound, the registration and readiness `plugin_activation` blocks echo that home and its config
+path even when the activation preview or inspection fails, and they carry the actual failure
+reason; `codex_home_required` appears only when no home was provided. Readiness facts that were
+not observed (`marketplace_registered`, `plugin_enabled`) are reported as null, never asserted
+`false`. Its preview/inspection/application bind the
 exact selected executable path and SHA-256, an owner-supplied existing absolute non-symlink home,
 the parsed result of exact `--version`, repository marketplace and selected-home config
 preimages/proposals, installed managed source-tree digest, cache root
@@ -2782,15 +2787,25 @@ home variables to the approved home, re-probes under its lock, and CAS-fences ea
 failure preserves approved partial marketplace/config/cache state for retry and performs no
 pathname rollback that could race a concurrent replacement.
 `active` additionally requires canonical inventory to report the expected repository plugin
-installed and enabled and its installed-version cache tree to match the managed source bytes;
-marketplace/config presence alone remains `installed_not_activated`. This is standing trust for
-future sessions, not proof that a session loaded a hook or delivered observation evidence.
-The managed hook tree is selected from the exact activation probe version. Pure-ingress command
+installed and enabled and its installed-version cache tree to match the host-specific render of
+the managed source; marketplace/config presence alone remains `installed_not_activated`. This is
+standing trust for future sessions, not proof that a session loaded a hook or delivered
+observation evidence.
+The managed project-tree source is always the canonical async-free render; the exact activation
+probe version selects only the cache-layer render. Pure-ingress command
 hooks use `"async": true` only from Codex `0.148.0-alpha.6`; older, missing, malformed, or
 oversized versions use the bounded synchronous form because affected Codex hosts otherwise discard
-the handlers. The version-specific source marker and cache bytes are included in the existing
-preview/source digests, and apply refuses a variant transition until the intended managed source
-tree is installed.
+the handlers. Apply seeds the versioned cache with the exact previewed host-rendered bytes
+(`plugin add` copies the canonical source, and apply then replaces that marker-identified copy in
+one atomic whole-directory swap) and verifies the result against the bound install digest. A cache
+tree that carries a valid `yoetz.codex-plugin-install/1` marker and byte-matches that marker's own
+inventory is a prior yoetz-managed render: preview classifies it as replaceable, binds its digest
+as the cache preimage, and apply atomically replaces the whole directory (same-version refresh).
+`destination_conflict` remains reserved for foreign, marker-inconsistent, or modified cache trees,
+and a cache that changes between preview and apply still refuses as `preview_stale`. A project
+source tree that byte-matches its own valid marker (for example a prior host-rendered or
+older-guidance render) is likewise a replaceable managed render, not a `modified_copy`; apply
+still requires a byte-exact current renderer variant at its source fences before any mutation.
 MCP server registration is a sibling port, never an `IntegrationsPort` overload (ADR-012).
 `HarnessMcpPort` methods are `status_registration`, `observe_registration`, `preview_registration`,
 and `apply_registration`, each taking a `HarnessBinary` (harness ID, redacted-repr executable path,
@@ -2814,8 +2829,15 @@ its `status` diagnostic phase — it exists because both owned serve commands cl
 diagnostics (`McpRegistrationDiagnostic`, `HarnessMcpDiagnosticSink`); every registration
 mutation is digest-bound to a freshly recomputed preview, a foreign same-name entry is
 preserved without any force path, and success is verified by re-reading state. The preview binds
-the exact command and `policy|strict` route profile. A zero-egress setup selects strict; a
-Yoetz-owned registration with the other command requires explicit digest-bound re-registration.
+the exact command and `policy|strict` route profile. The route profile is explicit input:
+`yoetz setup run` and `yoetz integrate <harness> mcp preview|install` accept
+`--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
+its observed profile — no configuration derivation (or derivation-on-exception fallback) may
+rewrite a previously chosen route — and only a fresh registration falls back to strict
+(zero-egress wizard) or the structural configuration derivation (`integrate`). A route transition
+is surfaced before mutation: the wizard preview and report carry `route_profile_before` next to
+`route_profile`, and changing an existing owned route requires the explicit input plus the
+ordinary digest-bound re-registration.
 The setup-wizard
 schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
 `yoetz.setup-status/1`, and `yoetz.mcp-registration-preview/1`; the marker lives at

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -171,6 +171,45 @@ exactly those contracts and connects the steps without weakening any existing tr
    consequently requires the ordinary digest-bound plugin refresh and activation approval. The
    committed/unprobed plugin tree is the conservative synchronous variant.
 
+   **Amended 2026-08-21 — canonical source, host-rendered cache, and managed refresh (issues
+   #387 and #388).** Live testing on an async-capable host showed the previous amendment's
+   version-threaded *source* render deadlocks activation: the committed project tree deliberately
+   carries the canonical async-free render (pinned by packaging tests), so comparing it against
+   the host-specific render fails `modified_copy` forever and `inspect_activation` reads
+   `not_installed` with everything else in place. The corrected split is: the project-tree plugin
+   source is always the canonical (`codex_version=None`) render — the wizard's project-source
+   preview/inspect/install never thread the probed version, and the committed tree stays
+   byte-stable — while host-specific rendering belongs only to the activation cache layer. The
+   probe version selects the intended cache bytes; `plugin add` copies the canonical source, and
+   apply then atomically replaces that marker-identified copy with the exact previewed
+   host-rendered bytes and verifies the bound install digest. A source tree that reads as
+   `installed` is a byte-exact canonical or host-variant render; a tree that instead byte-matches
+   its own valid `yoetz.codex-plugin-install/1` marker (a prior managed render, including the
+   async-variant or an older-guidance form) is replaceable by install without `replace_modified`,
+   while genuinely modified trees keep the `modified_copy` refusal.
+
+   The same marker rule repairs same-version cache refresh: package version `0.1.0` is stable
+   while plugin content drifts, so a previously activated home's versioned cache can differ from
+   the fresh render without being foreign. A cache tree carrying a valid install marker that
+   byte-matches its own inventory is classified replaceable — preview binds its digest as the
+   cache preimage, apply atomically swaps the whole directory, and a cache changed between preview
+   and apply still refuses as `preview_stale`. `destination_conflict` remains reserved for
+   foreign, marker-inconsistent, or modified cache trees. `active` now requires the versioned
+   cache to match the host-specific render rather than the managed source bytes.
+
+   **Amended 2026-08-21 — explicit route input and honest activation reporting (issues #389 and
+   #390).** `setup run` and `integrate <harness> mcp preview|install` accept an explicit
+   `--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
+   its observed route — the structural configuration derivation (including its fail-closed
+   exception fallback) applies only to a fresh registration, and non-interactive `--accept` alone
+   never changes an existing route. The interactive wizard still derives the route from the
+   review-mode answer, and any transition of an existing owned route is shown in the confirmed
+   preview and reported as `route_profile_before` → `route_profile`. Separately, when an explicit
+   Codex home was supplied, the registration and readiness `plugin_activation` blocks echo the
+   bound home/config path and the actual activation failure reason instead of resetting to
+   `codex_home_required`, and unobserved readiness facts are reported as null rather than asserted
+   `false`.
+
 The short `yoetz --set --fireworks --model MODEL` and `yoetz --set --grok --model MODEL` paths are
 provider-only entries into the same setup ceremonies. They derive internal provider bindings and
 always collect the API key through hidden TTY

--- a/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
+++ b/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
@@ -82,6 +82,19 @@ ambiguous ownership are explicit `McpOwnershipState` values that are reported, n
 or silently chosen between. Changing the generated `mcp.json` bytes for a bound route is a
 public-contract change under the same update rule as the two registration commands.
 
+**Amended 2026-08-21 — the route profile is explicit registration input (issue #389).** Live
+testing showed non-interactive `setup run --accept` silently re-registering an existing
+yoetz-owned *policy* route as *strict*, because the registration-time route was derived from
+structural configuration (falling back to strict on any load failure) with no route input surface.
+That violated this ADR's premise that the registered argv is a deliberately chosen, host-inspectable
+ceiling: no derivation — and especially no derivation-on-exception in a degraded environment — may
+rewrite a previously chosen route in either direction. `setup run` and
+`integrate codex mcp preview|install` now accept `--route-profile strict|policy`; without it an
+existing yoetz-owned registration keeps its observed profile, a fresh registration falls back to
+strict (wizard) or the configuration derivation (`integrate`), and any transition of an existing
+owned route is surfaced (`route_profile_before` → `route_profile`) before the ordinary
+digest-bound re-registration.
+
 **Issue #151 implementation detail.** The portable projection emits one closed stdio server named
 `yoetz`. Its executable token is exactly `yoetz`; policy args are exactly `mcp serve`, and strict
 args are exactly `mcp serve --semantic off`. It emits no `env`, headers, credential references, or

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -148,14 +148,29 @@ already-approved marketplace/config/cache partial state for an honest retry; it 
 pathname rollback that could delete or overwrite a concurrent change. `active` means all of these
 agree: managed source installed, repository marketplace and selected-home config exact, canonical
 inventory says `yoetz@yoetz` is installed and enabled from this repository, and the installed
-version cache is byte-identical to the managed source. Other closed states are `installed_not_activated`,
-`not_installed`, and `foreign`. None of them—and not even `active`—proves a later Codex process
-loaded a hook or delivered an observation.
+version cache is byte-identical to the host-specific render of the managed source. Other closed
+states are `installed_not_activated`, `not_installed`, and `foreign`. None of them—and not even
+`active`—proves a later Codex process loaded a hook or delivered an observation.
+
+The managed project source always carries the canonical async-free render; the host-specific form
+(async pure-ingress hooks from Codex `0.148.0-alpha.6`) exists only in the versioned activation
+cache, which apply seeds and verifies against the previewed install digest. Because the package
+version stays constant while plugin content drifts, a previously activated home's cache can
+legitimately differ from the fresh render: a cache tree that carries a valid
+`.yoetz-plugin-install.json` marker and byte-matches that marker's own inventory is a prior
+yoetz-managed render, previewed as a same-version refresh and replaced atomically on apply.
+`destination_conflict` is reserved for foreign, marker-inconsistent, or modified cache trees —
+those still require the owner to resolve the conflict by hand.
 
 Registration also decides *which* route the agent gets. Both owned serve commands classify as
 `yoetz_owned`, so the state alone cannot tell a strict registration from a policy one. Read the
 route from `yoetz integrate codex mcp status --json` (`route_profile`) or from
-`yoetz provider status --json` (`mcp_route.registered_profile`). Before running a session that will
+`yoetz provider status --json` (`mcp_route.registered_profile`). The route is explicit input:
+pass `--route-profile strict|policy` to `yoetz setup run` or
+`yoetz integrate codex mcp preview|install` to choose it. Without that flag an existing
+yoetz-owned registration keeps its current route (non-interactive `--accept` never changes it),
+and a route transition is shown in the preview and reported as `route_profile_before` →
+`route_profile`. Before running a session that will
 report a finding about Yoetz's semantic behaviour, walk the
 [semantic dogfood runbook](semantic-dogfood.md) — it declares up front which claim the run is
 allowed to make, and refuses to score semantic quality when no provider attempt happened. To measure
@@ -232,7 +247,9 @@ manage any MCP configuration yourself if you want it removed too.
 | Compatibility is `unsupported` | Automatic activation is unprofiled; use a supported Yoetz/Codex version pair when capability evidence is required. |
 | Write/swap interrupted | Run `status`; preserve any staged content; do not delete it yourself. |
 | Skill not discovered, or duplicate `$yoetz` names loaded | Check the exact scope, loaded skill roots, managed path, trust, version, and capability matrix; reload Codex. |
-| Setup reports `installed_not_activated` | Re-run setup/recommendation preview for the exact selected executable. Review canonical inventory and the versioned cache; marketplace/config presence alone is insufficient. |
+| Setup reports `installed_not_activated` | Re-run setup/recommendation preview for the exact selected executable. Review canonical inventory and the versioned cache; marketplace/config presence alone is insufficient. A marker-consistent stale cache is refreshed by an ordinary approved re-run. |
+| Activation reports `destination_conflict` | The versioned cache (or a config/marketplace surface) holds foreign, marker-inconsistent, or modified content. Review it by hand; setup only replaces trees that match their own Yoetz install marker. |
+| Activation failed with an explicit `--codex-home` | Read the actual `reason` in `registration.plugin_activation`/`readiness.plugin_activation`; the bound home and config path are echoed there. `codex_home_required` appears only when no home was passed. |
 | Setup reports plugin source files but no Yoetz skill appears | Check `.agents/skills/yoetz`; source installation and plugin activation do not prove project-skill discovery. |
 | MCP name already present | Preserve it and review ownership rather than running `mcp add`. |
 | `setup` skipped MCP registration | Codex not on PATH, or the entry is foreign-owned; run `yoetz integrate codex mcp status --json` for the exact state. |

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import tomllib
@@ -19,6 +20,7 @@ from yoetz import __version__
 from yoetz.adapters.integrations.codex_plugin import (
     PluginHookPresence,
     inspect_plugin,
+    plugin_tree_matches_marker,
     render_plugin_install_tree,
 )
 from yoetz.adapters.integrations.codex_session_stream import resolve_codex_home
@@ -58,7 +60,6 @@ _PLUGIN_ADD_TIMEOUT_SECONDS: Final = 30.0
 _MAX_PLUGIN_OUTPUT_BYTES: Final = 262_144
 _MAX_EXECUTABLE_BYTES: Final = 256 * 1024 * 1024
 _ACTIVATION_LOCK: Final = ".yoetz-marketplace-activation.lock"
-_ASYNC_PLUGIN_VARIANT_VERSION: Final = "0.148.0-alpha.6"
 _PLUGIN_ADD_COMMAND: Final = ("plugin", "add", _PLUGIN_ID, "--json")
 _PLUGIN_LIST_COMMAND: Final = ("plugin", "list", "--marketplace", _MARKETPLACE_NAME, "--json")
 _VERSION_RE: Final = re.compile(
@@ -445,6 +446,41 @@ def _cache_version_path(root: Path, version: str) -> Path:
     return root / version
 
 
+def _plugin_source_installed(target: IntegrationTarget, *, codex_version: str) -> bool:
+    """True when the project tree is byte-exactly one current managed renderer variant.
+
+    The committed project tree deliberately carries the canonical (async-free)
+    render (``codex_version=None``); the host-specific form belongs only to the
+    activation cache. Either byte-exact form counts as an installed source, so a
+    canonical source on an async-capable host never reads as ``not_installed``.
+    """
+
+    return any(
+        inspect_plugin(target, codex_version=variant).presence is PluginHookPresence.INSTALLED
+        for variant in (None, codex_version)
+    )
+
+
+def _read_managed_tree(root: Path) -> dict[str, bytes]:
+    """Read one owner-private managed tree, refusing symlinks and unsafe members."""
+
+    members: dict[str, bytes] = {}
+    try:
+        for candidate in root.rglob("*"):
+            if candidate.is_symlink():
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            if candidate.is_dir():
+                _owned_not_writable(candidate, directory=True)
+                continue
+            if not candidate.is_file():
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            _owned_not_writable(candidate, directory=False)
+            members[candidate.relative_to(root).as_posix()] = candidate.read_bytes()
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    return members
+
+
 def _source_cache_members(target: IntegrationTarget, *, codex_version: str) -> dict[str, bytes]:
     project = _validated_project(target)
     source = project / ".agents/plugins/yoetz"
@@ -454,18 +490,12 @@ def _source_cache_members(target: IntegrationTarget, *, codex_version: str) -> d
         return expected
     if inspection.presence is not PluginHookPresence.INSTALLED:
         # Setup previews activation before it replaces a previously managed tree.
-        # Admit only the other byte-exact renderer variant here, then bind the
-        # preview to the intended version-specific bytes. Apply still requires
-        # that intended tree at its first source fence before any mutation.
-        alternate_versions = (
-            (None, _ASYNC_PLUGIN_VARIANT_VERSION)
-            if codex_version != _ASYNC_PLUGIN_VARIANT_VERSION
-            else (None,)
-        )
-        if any(
-            inspect_plugin(target, codex_version=alternate).presence is PluginHookPresence.INSTALLED
-            for alternate in alternate_versions
-        ):
+        # Admit any byte-exact prior yoetz-managed render here (the canonical
+        # committed source, the other renderer variant, or an older marker-bound
+        # render), then bind the preview to the intended version-specific bytes.
+        # Apply still requires an exact current renderer variant at its first
+        # source fence before any mutation.
+        if plugin_tree_matches_marker(_read_managed_tree(source)):
             return expected
         raise _error(IntegrationReason.PARTIAL_INSTALL)
     actual_paths: set[str] = set()
@@ -510,31 +540,23 @@ def _members_digest(members: Mapping[str, bytes]) -> str:
 
 
 def _installed_cache_digest(path: Path, expected_members: Mapping[str, bytes]) -> str | None:
+    """Digest the installed cache tree when it is yoetz-managed, else refuse.
+
+    ``None`` means absent. A tree byte-identical to ``expected_members`` is the
+    current render. A tree that instead byte-matches its own valid install marker
+    (schema ``yoetz.codex-plugin-install/1``) is a *prior* yoetz-managed render:
+    preview binds its digest as ``cache_before`` and apply may atomically replace
+    the whole directory (#388). Foreign, marker-inconsistent, or otherwise
+    modified trees stay ``destination_conflict``.
+    """
+
     if path.is_symlink():
         raise _error(IntegrationReason.TARGET_UNSAFE)
     if not path.exists():
         return None
     _owned_not_writable(path, directory=True)
-    expected_paths = frozenset(expected_members)
-    actual_paths: set[str] = set()
-    try:
-        for candidate in path.rglob("*"):
-            if candidate.is_symlink():
-                raise _error(IntegrationReason.TARGET_UNSAFE)
-            relative = candidate.relative_to(path).as_posix()
-            if candidate.is_file():
-                _owned_not_writable(candidate, directory=False)
-                actual_paths.add(relative)
-            elif candidate.is_dir():
-                _owned_not_writable(candidate, directory=True)
-            else:
-                raise _error(IntegrationReason.TARGET_UNSAFE)
-        if actual_paths != set(expected_paths):
-            raise _error(IntegrationReason.DESTINATION_CONFLICT)
-        actual = {relative: (path / relative).read_bytes() for relative in sorted(actual_paths)}
-    except OSError as exc:
-        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-    if any(actual[name] != payload for name, payload in expected_members.items()):
+    actual = _read_managed_tree(path)
+    if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
         raise _error(IntegrationReason.DESTINATION_CONFLICT)
     return _members_digest(actual)
 
@@ -630,10 +652,10 @@ def inspect_activation(
     if codex_home is not None and _codex_root(codex_home) != binary.codex_home:
         raise _error(IntegrationReason.PREVIEW_STALE)
     project, home, marketplace_path, config_path = _paths(target, binary.codex_home)
-    installed = (
-        inspect_plugin(target, codex_version=binary.codex_version).presence
-        is PluginHookPresence.INSTALLED
-    )
+    # The committed project tree carries the canonical render; judging ``installed``
+    # against the host-specific render alone would keep an async-capable host at
+    # ``not_installed`` forever (#387).
+    installed = _plugin_source_installed(target, codex_version=binary.codex_version)
     plugin_cached = False
     cache_foreign = False
     if installed:
@@ -854,7 +876,7 @@ def _activation_plan(
         (("CODEX_HOME", str(home)), ("CODEX_TESTING_HOME", str(home))),
         _sha(b"" if marketplace_before is None else marketplace_before),
         _sha(config_bytes),
-        cache_before is None,
+        cache_before != plugin_install_digest,
     )
     config_after = _activated_config_bytes(config_bytes, config, project)
     return _ActivationPlan(
@@ -918,6 +940,47 @@ def _atomic_write(path: Path, payload: bytes) -> None:
         raise _error(IntegrationReason.WRITE_FAILED) from exc
 
 
+def _replace_cache_tree(path: Path, members: Mapping[str, bytes]) -> None:
+    """Atomically replace one managed cache directory with freshly rendered members."""
+
+    parent = path.parent
+    _safe_parent(parent)
+    stage = parent / f".yoetz-cache-stage-{os.urandom(6).hex()}"
+    rollback = parent / f".yoetz-cache-rollback-{os.urandom(6).hex()}"
+    destination_moved = False
+    try:
+        stage.mkdir(mode=0o700)
+        for relative_path, payload in members.items():
+            destination = stage / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                written = 0
+                while written < len(payload):
+                    written += os.write(descriptor, payload[written:])
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        if path.exists():
+            os.replace(path, rollback)
+            destination_moved = True
+        os.replace(stage, path)
+        if rollback.exists():
+            shutil.rmtree(rollback)
+    except OSError as exc:
+        if destination_moved and rollback.exists():
+            try:
+                if path.exists():
+                    shutil.rmtree(path)
+                os.replace(rollback, path)
+            except OSError:
+                pass
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+
+
 def _current_bytes(path: Path) -> bytes | None:
     if path.is_symlink():
         raise _error(IntegrationReason.TARGET_UNSAFE)
@@ -979,10 +1042,7 @@ def _assert_plugin_source(
 ) -> None:
     if _plugin_source_digest(codex_version=codex_version) != expected_digest:
         raise _error(IntegrationReason.PREVIEW_STALE)
-    if (
-        inspect_plugin(target, codex_version=codex_version).presence
-        is not PluginHookPresence.INSTALLED
-    ):
+    if not _plugin_source_installed(target, codex_version=codex_version):
         raise _error(IntegrationReason.PARTIAL_INSTALL)
     if _source_cache_members(target, codex_version=codex_version) != dict(expected_members):
         raise _error(IntegrationReason.PREVIEW_STALE)
@@ -1106,6 +1166,21 @@ def apply_activation(
             if inventory_installed:
                 if inventory_version != __version__ or plan.cache_before is None:
                     raise _error(IntegrationReason.DESTINATION_CONFLICT)
+                if plan.cache_before != preview.plugin_install_digest:
+                    # Same-version refresh (#388): the approved preview bound the
+                    # marker-identified prior render's digest as ``cache_before``.
+                    # Replace only those exact bytes; anything else is stale.
+                    if (
+                        _installed_cache_digest(preview.plugin_install_path, plan.cache_members)
+                        != plan.cache_before
+                    ):
+                        raise _error(IntegrationReason.PREVIEW_STALE)
+                    _replace_cache_tree(preview.plugin_install_path, plan.cache_members)
+                    if (
+                        _installed_cache_digest(preview.plugin_install_path, plan.cache_members)
+                        != preview.plugin_install_digest
+                    ):
+                        raise _error(IntegrationReason.WRITE_FAILED)
             elif plan.cache_before is not None:
                 raise _error(IntegrationReason.DESTINATION_CONFLICT)
             else:
@@ -1127,7 +1202,16 @@ def apply_activation(
                     _installed_cache_digest(cache_created, plan.cache_members)
                     != preview.plugin_install_digest
                 ):
-                    raise _error(IntegrationReason.WRITE_FAILED)
+                    # ``plugin add`` copies the canonical project source; the
+                    # host-specific render belongs to the cache layer (#387).
+                    # Seed the exact previewed install bytes over the copied
+                    # marker-identified tree.
+                    _replace_cache_tree(cache_created, plan.cache_members)
+                    if (
+                        _installed_cache_digest(cache_created, plan.cache_members)
+                        != preview.plugin_install_digest
+                    ):
+                        raise _error(IntegrationReason.WRITE_FAILED)
             _assert_snapshot(config_path, plan.config_after)
             _assert_snapshot(marketplace_path, preview.marketplace_bytes)
             _assert_plugin_source(

--- a/src/yoetz/adapters/integrations/codex_plugin.py
+++ b/src/yoetz/adapters/integrations/codex_plugin.py
@@ -44,6 +44,7 @@ __all__ = [
     "codex_supports_async_hooks",
     "inspect_plugin",
     "install_plugin",
+    "plugin_tree_matches_marker",
     "render_plugin_install_tree",
     "render_plugin_tree",
 ]
@@ -391,6 +392,73 @@ def _validated_plugin_parent(root: Path, *, create: bool) -> Path:
     return current
 
 
+def plugin_tree_matches_marker(members: Mapping[str, bytes]) -> bool:
+    """True when a file tree byte-matches its own valid Yoetz install marker.
+
+    ADR-023 treats a marker-identified, internally consistent tree as a prior
+    yoetz-managed render that whole-directory replacement may refresh. Anything
+    else — a foreign tree, a missing or inconsistent marker, or a modified
+    member — is not replaceable through this classification.
+    """
+
+    marker_raw = members.get(_MARKER_NAME)
+    if marker_raw is None or len(marker_raw) > _SOURCE_FILE_LIMIT:
+        return False
+    try:
+        parsed = strict_json_parse(marker_raw)
+    except ProtocolValueError:
+        return False
+    if not isinstance(parsed, Mapping):
+        return False
+    marker = cast(Mapping[str, object], parsed)
+    if marker.get("schema") != _MARKER_SCHEMA:
+        return False
+    body = {name: value for name, value in marker.items() if name != "marker_digest"}
+    if marker.get("marker_digest") != canonical_digest(cast(JsonValue, body)):
+        return False
+    rows = marker.get("managed_files")
+    if type(rows) is not list:
+        return False
+    inventory: dict[str, tuple[str, int]] = {}
+    for raw_row in cast(list[object], rows):
+        if not isinstance(raw_row, Mapping):
+            return False
+        row = cast(Mapping[str, object], raw_row)
+        relative_path = row.get("relative_path")
+        digest = row.get("sha256")
+        size = row.get("size")
+        if type(relative_path) is not str or type(digest) is not str or type(size) is not int:
+            return False
+        if relative_path in inventory or relative_path == _MARKER_NAME:
+            return False
+        inventory[relative_path] = (digest, size)
+    actual = {
+        path: (_sha(data), len(data)) for path, data in members.items() if path != _MARKER_NAME
+    }
+    return inventory == actual
+
+
+def _is_prior_managed_render(destination: Path) -> bool:
+    """True when the installed tree is exactly one marker-consistent prior render."""
+
+    members: dict[str, bytes] = {}
+    try:
+        for candidate in destination.rglob("*"):
+            if candidate.is_symlink():
+                return False
+            if candidate.is_dir():
+                continue
+            if not candidate.is_file():
+                return False
+            data = candidate.read_bytes()
+            if len(data) > _SOURCE_FILE_LIMIT:
+                return False
+            members[candidate.relative_to(destination).as_posix()] = data
+    except OSError:
+        return False
+    return plugin_tree_matches_marker(members)
+
+
 def _build_marker(members: Mapping[str, bytes]) -> bytes:
     managed = [
         {
@@ -463,6 +531,19 @@ def install_plugin(
     if destination.exists():
         if destination.is_symlink() or not destination.is_dir():
             raise _error(IntegrationReason.TARGET_UNSAFE)
+        # A destination that byte-matches its own valid install marker is a prior
+        # yoetz-managed render (for example the async-variant hooks form, or an
+        # older guidance render), not an owner edit: ADR-023 whole-directory
+        # replacement may refresh it without ``replace_modified``. The check is
+        # lazy so an already-exact tree never pays for it.
+        prior_render: bool | None = None
+
+        def _replaceable_prior_render() -> bool:
+            nonlocal prior_render
+            if prior_render is None:
+                prior_render = _is_prior_managed_render(destination)
+            return prior_render
+
         for relative_path, expected in members.items():
             path = destination / relative_path
             if not path.exists():
@@ -470,7 +551,7 @@ def install_plugin(
             if path.is_symlink() or not path.is_file():
                 raise _error(IntegrationReason.TARGET_UNSAFE)
             current = path.read_bytes()
-            if current != expected and not replace_modified:
+            if current != expected and not replace_modified and not _replaceable_prior_render():
                 raise _error(
                     IntegrationReason.MODIFIED_COPY,
                     {"relative_path": relative_path, "replace_modified": True},
@@ -480,6 +561,7 @@ def install_plugin(
             existing_marker.is_file()
             and existing_marker.read_bytes() != marker
             and not replace_modified
+            and not _replaceable_prior_render()
         ):
             raise _error(
                 IntegrationReason.MODIFIED_COPY,

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1146,6 +1146,22 @@ _ACCEPT = Annotated[
     bool,
     typer.Option("--accept", help="Explicitly accept the previewed registration."),
 ]
+_ROUTE_PROFILE = Annotated[
+    str | None,
+    typer.Option(
+        "--route-profile",
+        help=(
+            "Exact MCP route profile to register (strict or policy). Without it, an "
+            "existing yoetz-owned registration keeps its current route."
+        ),
+    ),
+]
+
+
+def _validated_route_profile(route_profile: str | None) -> str | None:
+    if route_profile is not None and route_profile not in {"strict", "policy"}:
+        raise typer.BadParameter("--route-profile must be 'strict' or 'policy'")
+    return route_profile
 
 
 def _setup_operation(name: str) -> Callable[..., Awaitable[int]]:
@@ -1162,9 +1178,11 @@ def _integration_mcp_command(action: str) -> Callable[..., None]:
             str | None,
             typer.Option("--preview-digest", help="Exact preview digest to bind."),
         ] = None,
+        route_profile: _ROUTE_PROFILE = None,
         json_output: _JSON = False,
     ) -> None:
         harness = cast(str, context.find_root().find_object(str) or context.obj)
+        chosen_route = _validated_route_profile(route_profile)
         operation = _setup_operation("integrate_mcp")
         _finish(
             run_async(
@@ -1175,6 +1193,7 @@ def _integration_mcp_command(action: str) -> Callable[..., None]:
                     accept=accept,
                     preview_digest=preview_digest,
                     json_output=json_output,
+                    route_profile=chosen_route,
                 )
             )
         )
@@ -1198,12 +1217,14 @@ def setup_run(
         typer.Option("--codex-home", help="Exact Codex home to bind activation to."),
     ] = None,
     accept: _ACCEPT = False,
+    route_profile: _ROUTE_PROFILE = None,
     json_output: _JSON = False,
 ) -> None:
     """Run the guided first-run setup wizard."""
 
     if (codex_path is None) != (codex_home is None):
         raise typer.BadParameter("--codex-path and --codex-home must be provided together")
+    chosen_route = _validated_route_profile(route_profile)
 
     operation = _setup_operation("run_setup_wizard")
     _finish(
@@ -1214,6 +1235,7 @@ def setup_run(
                 codex_home=codex_home,
                 accept=accept,
                 json_output=json_output,
+                route_profile=chosen_route,
             )
         )
     )

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -680,6 +680,8 @@ def _emit_registration_preview(
     skill_preview: IntegrationPreview | None = None,
     activation_preview: ActivationPreview | None = None,
     activation_target: Path | None = None,
+    *,
+    route_profile_before: str | None = None,
 ) -> None:
     typer.echo("Proposed change: complete Yoetz Codex project integration:")
     typer.echo("  1. Install discoverable guidance under .agents/skills/yoetz")
@@ -688,6 +690,15 @@ def _emit_registration_preview(
     typer.echo("  MCP server name: yoetz")
     serve_command = getattr(mcp_preview, "serve_command", ())
     typer.echo(f"  Command: {' '.join(serve_command)}")
+    route_profile = getattr(mcp_preview, "route_profile", None)
+    if type(route_profile) is str:
+        if route_profile_before is not None and route_profile_before != route_profile:
+            typer.echo(
+                f"  MCP route profile change: {route_profile_before} -> {route_profile} "
+                "(the existing yoetz-owned registration will be rewritten)"
+            )
+        else:
+            typer.echo(f"  MCP route profile: {route_profile}")
     typer.echo(f"  Codex executable: {binary.executable_path}")
     if binary.reported_version is not None:
         typer.echo(f"  Codex version: {binary.reported_version}")
@@ -871,7 +882,9 @@ def configured_mcp_route_profile() -> Literal["policy", "strict"]:
 
     A caller that has just asked the human which review posture they want passes that answer
     instead: the reply is the authority, and configuration is only the fallback for surfaces
-    (post-setup ``/connect``, ``integrate codex mcp``) that ask nothing.
+    (post-setup ``/connect``, ``integrate codex mcp``) that ask nothing. Even then it applies
+    only to a *fresh* registration: an existing yoetz-owned registration keeps its observed
+    route unless an explicit route input requests otherwise (#389 / ADR-018).
     """
 
     return _configured_mcp_route_profile()
@@ -966,27 +979,29 @@ def _readiness_layers(
 ) -> dict[str, JsonValue]:
     consent_active = consent_outcome == "granted"
     service_routing = bool(service.get("reachable"))
+    # Unobserved facts start as null (unknown), never as an asserted ``false``;
+    # they become booleans only when an inspection actually ran (#390).
     activation: dict[str, JsonValue] = {
         "codex_home": None,
         "config_path": None,
-        "marketplace_registered": False,
-        "plugin_enabled": False,
+        "marketplace_registered": None,
+        "plugin_enabled": None,
         "state": "unknown",
     }
     if binary is not None and codex_home is not None:
+        # The bound home is echoed even when inspection fails, so a failure can
+        # never read as "no home was provided" (#390).
+        activation["codex_home"] = str(codex_home)
+        activation["config_path"] = str(codex_home / "config.toml")
         try:
             inspected = inspect_activation(
                 _integration_target(workspace),
                 executable_path=binary.executable_path,
                 codex_home=codex_home,
             )
-            activation = {
-                "codex_home": str(codex_home),
-                "config_path": str(codex_home / "config.toml"),
-                "marketplace_registered": inspected.marketplace_registered,
-                "plugin_enabled": inspected.plugin_enabled,
-                "state": inspected.state.value,
-            }
+            activation["marketplace_registered"] = inspected.marketplace_registered
+            activation["plugin_enabled"] = inspected.plugin_enabled
+            activation["state"] = inspected.state.value
         except IntegrationError as error:
             activation["reason"] = error.reason.value
         except (OSError, TypeError, ValueError) as error:
@@ -1050,9 +1065,16 @@ async def _codex_integration_step(
     previews echo them back. They are a *stricter* gate than ``accept``, not a softer one: the
     step re-previews and refuses as stale if any digest moved since approval was shown,
     and only an explicitly echoed policy digest activates the policy trust.
+
+    ``route_profile=None`` means "no explicit route input": an existing yoetz-owned
+    registration keeps its observed profile, and a fresh registration defaults to
+    strict. No configuration derivation (or derivation-on-exception fallback) may
+    silently rewrite a previously chosen route (#389 / ADR-018).
     """
 
-    mcp_service = HarnessMcpService(_mcp_adapter(route_profile))
+    mcp_service = HarnessMcpService(
+        _mcp_adapter("strict" if route_profile is None else route_profile)
+    )
     plugin_service = CodexPluginService()
     project = _integration_target(workspace)
     selected_codex_home: Path | None = None
@@ -1080,6 +1102,9 @@ async def _codex_integration_step(
                     "state": None,
                     "plugin": {"outcome": "skipped", "presence": None},
                     "plugin_activation": {
+                        "codex_home": str(
+                            selected_codex_home if selected_codex_home is not None else codex_home
+                        ),
                         "outcome": "failed",
                         "reason": activation_unavailable_reason,
                         "state": "unknown",
@@ -1093,12 +1118,21 @@ async def _codex_integration_step(
     activation_state_before = (
         activation_plan.inspection.state.value if activation_plan is not None else "unknown"
     )
-    plugin_codex_version = activation_plan.codex_version if activation_plan is not None else None
+    # The wizard's project-tree plugin steps always use the canonical render
+    # (``codex_version=None``): the committed source deliberately carries the
+    # async-free fallback form, and host-specific rendering belongs only to the
+    # activation cache layer (#387).
+    bound_home = selected_codex_home if selected_codex_home is not None else codex_home
     activation_unavailable: dict[str, JsonValue] = {
         "outcome": "skipped",
         "reason": activation_unavailable_reason,
         "state": activation_state_before,
     }
+    if bound_home is not None:
+        # An explicitly bound home is echoed even when the preview failed, so the
+        # report never claims the home was missing when it was not (#390).
+        activation_unavailable["codex_home"] = str(bound_home)
+        activation_unavailable["config_path"] = str(bound_home / "config.toml")
     if activation_plan is None and approved_activation_digest is not None:
         return {
             "outcome": "failed",
@@ -1125,13 +1159,43 @@ async def _codex_integration_step(
             "observation_consent": {"outcome": "absent", "workspace_commitment": None},
         }
 
-    plugin_preview = plugin_service.preview(project, codex_version=plugin_codex_version)
+    # Only two Yoetz routes exist, so the preview's own probe already names the
+    # observed profile of an existing owned registration: ``noop`` means it
+    # matches the previewing route, ``reregister`` means it is the other one.
+    route_profile_before: Literal["policy", "strict"] | None = None
+    if mcp_preview.state_before is McpRegistrationState.YOETZ_OWNED:
+        if mcp_preview.action is McpRegistrationAction.REREGISTER:
+            route_profile_before = "policy" if mcp_preview.route_profile == "strict" else "strict"
+        else:
+            route_profile_before = mcp_preview.route_profile
+    if (
+        route_profile is None
+        and route_profile_before is not None
+        and route_profile_before != mcp_preview.route_profile
+    ):
+        # No explicit route input: preserve the observed profile of the existing
+        # yoetz-owned registration instead of rewriting it (#389).
+        mcp_service = HarnessMcpService(_mcp_adapter(route_profile_before))
+        try:
+            mcp_preview = await mcp_service.preview(binary)
+        except McpRegistrationError as error:
+            return {
+                "outcome": "failed",
+                "reason": error.reason.value,
+                "state": None,
+                "plugin": {"outcome": "skipped", "presence": None},
+                "plugin_activation": {"outcome": "skipped", "state": "unknown"},
+                "skill": {"outcome": "skipped", "presence": None},
+                "observation_consent": {"outcome": "absent", "workspace_commitment": None},
+            }
+
+    plugin_preview = plugin_service.preview(project)
     check_policy = _check_policy_preview(workspace)
     already_registered = mcp_preview.action is McpRegistrationAction.NOOP
     foreign = mcp_preview.state_before is McpRegistrationState.FOREIGN_PRESENT
 
     if foreign:
-        inspection = plugin_service.inspect(project, codex_version=plugin_codex_version)
+        inspection = plugin_service.inspect(project)
         return {
             "outcome": "skipped",
             "reason": "foreign_entry_present",
@@ -1227,6 +1291,7 @@ async def _codex_integration_step(
             skill_plan.preview,
             activation_plan,
             Path(project.project_root),
+            route_profile_before=route_profile_before,
         )
         typer.echo(
             f"  Plugin presence before apply: {plugin_preview.presence_before.value} "
@@ -1288,7 +1353,6 @@ async def _codex_integration_step(
         inspection = plugin_service.install(
             project,
             allow_untested=True,
-            codex_version=plugin_codex_version,
         )
         plugin_report = {
             "outcome": "installed",
@@ -1456,6 +1520,7 @@ async def _codex_integration_step(
         "outcome": mcp_outcome,
         "reason": None,
         "route_profile": mcp_preview.route_profile,
+        "route_profile_before": route_profile_before,
         "serve_command": list(mcp_preview.serve_command),
         "state": mcp_state.value,
         "plugin": plugin_report,
@@ -2109,8 +2174,16 @@ async def run_setup_wizard(
     codex_home: Path | None,
     accept: bool,
     json_output: bool,
+    route_profile: Literal["policy", "strict"] | None = None,
 ) -> int:
-    """Run the guided first-run setup and report each step honestly."""
+    """Run the guided first-run setup and report each step honestly.
+
+    ``route_profile`` is the explicit MCP route input (``--route-profile``). When
+    absent, an interactive run derives the route from the human's review-mode
+    answer as before, and a non-interactive run preserves the observed profile of
+    an existing yoetz-owned registration (strict only for a fresh registration) —
+    ``--accept`` alone never changes an existing route (#389).
+    """
 
     interactive = not non_interactive and _is_interactive_terminal()
 
@@ -2150,11 +2223,19 @@ async def run_setup_wizard(
     if chosen is None:
         registration = _registration_report(None, outcome="skipped", reason="codex_not_found")
     else:
+        if route_profile is not None:
+            selected_route: Literal["policy", "strict"] | None = route_profile
+        elif interactive:
+            selected_route = "policy" if review_mode == "semantic" else "strict"
+        else:
+            # No explicit input and no human answer: the step preserves an
+            # existing yoetz-owned route and registers strict only when fresh.
+            selected_route = None
         registration = await _register_step(
             chosen,
             interactive=interactive,
             accept=accept,
-            route_profile="policy" if review_mode == "semantic" else "strict",
+            route_profile=selected_route,
             codex_home=codex_home,
         )
 
@@ -2363,6 +2444,10 @@ async def run_setup_wizard(
         raw_codex_home = activation_block.get("codex_home")
         if type(raw_codex_home) is str:
             selected_codex_home = Path(raw_codex_home)
+    if selected_codex_home is None and chosen is not None and codex_home is not None:
+        # An explicitly provided home stays bound for readiness even when the
+        # registration step failed before echoing it (#390).
+        selected_codex_home = codex_home
     readiness = _readiness_layers(
         binary=chosen,
         mcp_state=cast(str | None, registration.get("state")),
@@ -2431,6 +2516,13 @@ def _emit_human_report(report: dict[str, JsonValue]) -> None:
         if reason:
             line += f" ({reason})"
         typer.echo(line)
+        route = registration.get("route_profile")
+        if type(route) is str:
+            route_line = f"  MCP route profile: {route}"
+            route_before = registration.get("route_profile_before")
+            if type(route_before) is str and route_before != route:
+                route_line += f" (changed from {route_before})"
+            typer.echo(route_line)
         plugin = registration.get("plugin")
         if isinstance(plugin, dict):
             typer.echo(
@@ -2595,8 +2687,14 @@ async def integrate_mcp(
     accept: bool,
     preview_digest: str | None,
     json_output: bool,
+    route_profile: Literal["policy", "strict"] | None = None,
 ) -> int:
-    """Client-local ``integrate <harness> mcp status|preview|install`` commands."""
+    """Client-local ``integrate <harness> mcp status|preview|install`` commands.
+
+    ``route_profile`` is the explicit route input. When absent, an existing
+    yoetz-owned registration keeps its observed profile (#389); only a fresh
+    registration falls back to the structural configuration derivation.
+    """
 
     if harness != "codex" or action not in {"status", "preview", "install"}:
         return _usage_failure("the harness or action is not supported")
@@ -2609,7 +2707,7 @@ async def integrate_mcp(
     if chosen is None:
         return _usage_failure("no codex executable was found on PATH")
 
-    service = HarnessMcpService(_mcp_adapter())
+    service = HarnessMcpService(_mcp_adapter(route_profile))
     try:
         if action == "status":
             observation = await service.observe(chosen)
@@ -2623,6 +2721,25 @@ async def integrate_mcp(
             )
             return 0
         preview = await service.preview(chosen)
+        route_profile_before: Literal["policy", "strict"] | None = None
+        if preview.state_before is McpRegistrationState.YOETZ_OWNED:
+            # Only two Yoetz routes exist, so the preview's probe names the
+            # observed profile: ``noop``/register match the previewing route,
+            # ``reregister`` means the entry carries the other one.
+            route_profile_before = (
+                ("policy" if preview.route_profile == "strict" else "strict")
+                if preview.action is McpRegistrationAction.REREGISTER
+                else preview.route_profile
+            )
+        if (
+            route_profile is None
+            and route_profile_before is not None
+            and route_profile_before != preview.route_profile
+        ):
+            # No explicit route input: preserve the existing yoetz-owned route
+            # rather than letting the configuration derivation rewrite it (#389).
+            service = HarnessMcpService(_mcp_adapter(route_profile_before))
+            preview = await service.preview(chosen)
         if action == "preview":
             _emit(
                 {
@@ -2630,6 +2747,7 @@ async def integrate_mcp(
                     "harness": harness,
                     "preview_digest": preview.preview_digest,
                     "route_profile": preview.route_profile,
+                    "route_profile_before": route_profile_before,
                     "serve_command": list(preview.serve_command),
                     "state_before": preview.state_before.value,
                     "warnings": list(preview.warnings),

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -1255,6 +1255,216 @@ def test_integrate_mcp_refuses_foreign_entry(wizard_env: dict[str, object]) -> N
     assert "foreign_entry_present" in result.stderr
 
 
+def test_non_interactive_accept_preserves_existing_policy_route(
+    wizard_env: dict[str, object],
+) -> None:
+    """#389: ``--accept`` without an explicit route never rewrites an owned registration."""
+
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),  # tentative strict preview get: owned, other route
+        _yoetz_entry("policy"),  # preserved policy re-preview get: noop
+        _yoetz_entry("policy"),  # status verify after plugin install
+    ]
+    result = _RUNNER.invoke(cli.app, ["setup", "run", "--non-interactive", "--accept", "--json"])
+    assert result.exit_code == 0, (result.output, result.exception)
+    report = json.loads(result.stdout)
+    assert report["registration"]["outcome"] == "already_registered"
+    assert report["registration"]["route_profile"] == "policy"
+    assert report["registration"]["route_profile_before"] == "policy"
+    assert report["registration"]["serve_command"] == ["yoetz", "mcp", "serve"]
+    # No mutating ``mcp add`` ever ran: the existing policy route survives.
+    for calls in cast(list[list[tuple[str, ...]]], wizard_env["calls"]):
+        assert all(call[1:3] == ("mcp", "get") for call in calls)
+
+
+def test_explicit_route_profile_flag_reregisters_and_reports_the_transition(
+    wizard_env: dict[str, object],
+) -> None:
+    """#389: only an explicit ``--route-profile`` may change an existing owned route."""
+
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),  # preview get: owned on the policy route
+        _yoetz_entry("policy"),  # adapter apply re-preview get
+        CommandOutput(0, b""),  # add
+        _yoetz_entry("strict"),  # verify get
+    ]
+    result = _RUNNER.invoke(
+        cli.app,
+        [
+            "setup",
+            "run",
+            "--non-interactive",
+            "--accept",
+            "--route-profile",
+            "strict",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, (result.output, result.exception)
+    report = json.loads(result.stdout)
+    assert report["registration"]["outcome"] == "reregistered"
+    assert report["registration"]["route_profile"] == "strict"
+    assert report["registration"]["route_profile_before"] == "policy"
+
+
+def test_route_profile_flag_rejects_unknown_values(wizard_env: dict[str, object]) -> None:
+    result = _RUNNER.invoke(
+        cli.app,
+        ["setup", "run", "--non-interactive", "--accept", "--route-profile", "open", "--json"],
+    )
+    assert result.exit_code == 2
+
+
+def test_interactive_preview_surfaces_a_route_profile_transition(
+    wizard_env: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#389: a route change must be visible in the preview the human confirms."""
+
+    import yoetz.cli.provider_binding as provider_binding
+    import yoetz.cli.setup as setup_module
+
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),  # preview get: owned on the policy route
+        _yoetz_entry("policy"),  # adapter apply re-preview get
+        CommandOutput(0, b""),  # add
+        _yoetz_entry("strict"),  # verify get
+    ]
+    monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
+    monkeypatch.setattr(
+        provider_binding, "prompt_provider_endpoint_binding", _skip_provider_binding
+    )
+
+    # Installation, home, local-only review (strict), update checks yes, confirm.
+    result = _RUNNER.invoke(
+        cli.app,
+        ["setup", "run"],
+        input=f"1\n{wizard_env['codex_home']}\n2\nY\nY\n",
+    )
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert "MCP route profile change: policy -> strict" in result.stdout
+    assert "MCP route profile: strict (changed from policy)" in result.stdout
+
+
+def test_failed_activation_preview_reports_bound_home_and_real_reason(
+    wizard_env: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """#390: an explicit ``--codex-home`` failure must not read as ``codex_home_required``."""
+
+    import yoetz.cli.setup as setup_module
+
+    codex = tmp_path / "codex-testing"
+    codex.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    codex.chmod(0o700)
+    codex_home = cast(Path, wizard_env["codex_home"])
+
+    def conflicted(*_args: object, **_kwargs: object) -> object:
+        raise IntegrationError(IntegrationReason.DESTINATION_CONFLICT, {})
+
+    monkeypatch.setattr(setup_module, "preview_activation", conflicted)
+    monkeypatch.setattr(setup_module, "inspect_activation", conflicted)
+    wizard_env["outputs"] = [
+        CommandOutput(1, b""),  # preview get: absent
+        CommandOutput(1, b""),  # apply re-preview get: absent
+        CommandOutput(0, b""),  # add
+        _yoetz_entry(),  # verify get
+    ]
+
+    result = _RUNNER.invoke(
+        cli.app,
+        [
+            "setup",
+            "run",
+            "--non-interactive",
+            "--accept",
+            "--codex-path",
+            str(codex),
+            "--codex-home",
+            str(codex_home),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    report = json.loads(result.stdout)
+    activation = report["registration"]["plugin_activation"]
+    assert activation["outcome"] == "skipped"
+    assert activation["reason"] == "destination_conflict"
+    assert activation["codex_home"] == str(codex_home)
+    assert activation["config_path"] == str(codex_home / "config.toml")
+    readiness_activation = report["readiness"]["plugin_activation"]
+    assert readiness_activation["codex_home"] == str(codex_home)
+    assert readiness_activation["config_path"] == str(codex_home / "config.toml")
+    assert readiness_activation["reason"] == "destination_conflict"
+    # Unobserved facts are reported as unknown (null), never asserted false.
+    assert readiness_activation["marketplace_registered"] is None
+    assert readiness_activation["plugin_enabled"] is None
+
+
+def test_integrate_mcp_install_without_route_input_preserves_owned_policy_route(
+    wizard_env: dict[str, object],
+) -> None:
+    """#389: the ``integrate codex mcp`` surface must not rewrite an owned route either."""
+
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),  # derived-strict preview get: owned, other route
+        _yoetz_entry("policy"),  # preserved policy re-preview get: noop
+    ]
+    result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "install", "--accept", "--json"])
+    assert result.exit_code == 0, (result.output, result.exception)
+    body = json.loads(result.stdout)
+    assert body["action"] == "noop"
+    assert body["state_after"] == "yoetz_owned"
+    for calls in cast(list[list[tuple[str, ...]]], wizard_env["calls"]):
+        assert all(call[1:3] == ("mcp", "get") for call in calls)
+
+
+def test_integrate_mcp_preview_names_the_observed_route_before(
+    wizard_env: dict[str, object],
+) -> None:
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),
+        _yoetz_entry("policy"),
+    ]
+    result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview", "--json"])
+    assert result.exit_code == 0
+    body = json.loads(result.stdout)
+    assert body["action"] == "noop"
+    assert body["route_profile"] == "policy"
+    assert body["route_profile_before"] == "policy"
+
+
+def test_integrate_mcp_explicit_route_profile_reregisters(
+    wizard_env: dict[str, object],
+) -> None:
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy"),  # preview get: owned on the policy route
+        _yoetz_entry("policy"),  # adapter apply re-preview get
+        CommandOutput(0, b""),  # add
+        _yoetz_entry("strict"),  # verify get
+    ]
+    result = _RUNNER.invoke(
+        cli.app,
+        [
+            "integrate",
+            "codex",
+            "mcp",
+            "install",
+            "--accept",
+            "--route-profile",
+            "strict",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, (result.output, result.exception)
+    body = json.loads(result.stdout)
+    assert body["action"] == "reregister"
+    assert body["state_after"] == "yoetz_owned"
+
+
 def test_setup_surfaces_no_secret_shaped_option() -> None:
     for args in (
         ["--help"],

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -45,7 +45,7 @@ def _target(tmp_path: Path) -> tuple[IntegrationTarget, Path, Path]:
     return target, project, home
 
 
-def _install(target: IntegrationTarget, *, codex_version: str = "0.148.0-alpha.6") -> None:
+def _install(target: IntegrationTarget, *, codex_version: str | None = "0.148.0-alpha.6") -> None:
     install_plugin(target, allow_untested=True, codex_version=codex_version)
 
 
@@ -260,19 +260,214 @@ def test_stable_codex_activation_serves_required_hooks_synchronously(tmp_path: P
     assert (project / ".agents/plugins/marketplace.json").is_file()
 
 
-def test_version_variant_migration_is_previewed_but_fenced_until_source_refresh(
+def test_canonical_source_activates_on_async_host_and_seeds_host_rendered_cache(
     tmp_path: Path,
 ) -> None:
+    """#387: the committed async-free source must activate on an async-capable host.
+
+    The project tree deliberately carries the canonical (``codex_version=None``)
+    render; the host-specific async hooks belong only to the activation cache.
+    Activation must succeed without rewriting the project source, and the cache
+    must end up byte-identical to the host-specific render.
+    """
+
     target, project, home = _target(tmp_path)
-    _install(target, codex_version="0.147.0")
+    _install(target, codex_version=None)
+    source_hooks = (project / ".agents/plugins/yoetz/hooks/hooks.json").read_bytes()
+    source_tree_before = {
+        path.relative_to(project).as_posix(): path.read_bytes()
+        for path in (project / ".agents/plugins/yoetz").rglob("*")
+        if path.is_file()
+    }
     runner = _FakeCodex(target, home, codex_version="0.148.0-alpha.6")
+
+    assert (
+        _inspect_activation(
+            target, executable_path=str(runner.executable), codex_home=home, _run=runner
+        ).state
+        is ActivationState.INSTALLED_NOT_ACTIVATED
+    )
     preview = _preview_activation(
         target,
         executable_path=str(runner.executable),
         codex_home=home,
         _run=runner,
     )
+    result = _apply_activation(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        approved_digest=preview.preview_digest,
+        _run=runner,
+    )
 
+    assert result.state is ActivationState.ACTIVE
+    # The committed source stays byte-stable in its canonical async-free form.
+    source_tree_after = {
+        path.relative_to(project).as_posix(): path.read_bytes()
+        for path in (project / ".agents/plugins/yoetz").rglob("*")
+        if path.is_file()
+    }
+    assert source_tree_after == source_tree_before
+    assert b'"async":true' not in source_hooks
+    # The cache carries the host-specific render: async ingress hooks present.
+    cache_hooks = json.loads(
+        (home / "plugins/cache/yoetz/yoetz/0.1.0/hooks/hooks.json").read_bytes()
+    )
+    handler = cache_hooks["hooks"]["PreToolUse"][0]["hooks"][0]
+    assert handler.get("async") is True
+
+
+def test_same_version_cache_refresh_replaces_prior_managed_render(tmp_path: Path) -> None:
+    """#388: a marker-identified prior cache render is replaceable, not a conflict."""
+
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    target, _project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    runner = _FakeCodex(target, home, codex_version="0.148.0-alpha.6")
+    first = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    _apply_activation(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        approved_digest=first.preview_digest,
+        _run=runner,
+    )
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    # Simulate content drift since the prior activation: overwrite the cache with
+    # the other renderer variant, which is exactly a prior yoetz-managed render.
+    shutil.rmtree(cache)
+    cache.mkdir(mode=0o700)
+    for relative_path, payload in render_plugin_install_tree(codex_version=None).items():
+        destination = cache / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+
+    inspection = _inspect_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    assert inspection.state is ActivationState.INSTALLED_NOT_ACTIVATED
+
+    preview = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    assert preview.cache_mutation_planned is True
+    result = _apply_activation(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        approved_digest=preview.preview_digest,
+        _run=runner,
+    )
+    assert result.state is ActivationState.ACTIVE
+    refreshed = json.loads((cache / "hooks/hooks.json").read_bytes())
+    assert refreshed["hooks"]["PreToolUse"][0]["hooks"][0].get("async") is True
+
+
+def test_cache_refresh_between_preview_and_apply_is_stale(tmp_path: Path) -> None:
+    """A cache that changes after preview must still refuse as ``preview_stale``."""
+
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    target, _project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    runner = _FakeCodex(target, home, codex_version="0.148.0-alpha.6")
+    first = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    _apply_activation(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        approved_digest=first.preview_digest,
+        _run=runner,
+    )
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    shutil.rmtree(cache)
+    cache.mkdir(mode=0o700)
+    for relative_path, payload in render_plugin_install_tree(codex_version=None).items():
+        destination = cache / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    preview = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    # The cache moves again between preview and apply: back to the host render.
+    shutil.rmtree(cache)
+    cache.mkdir(mode=0o700)
+    for relative_path, payload in render_plugin_install_tree(
+        codex_version="0.148.0-alpha.6"
+    ).items():
+        destination = cache / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_activation(
+            target,
+            executable_path=str(runner.executable),
+            codex_home=home,
+            approved_digest=preview.preview_digest,
+            _run=runner,
+        )
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+
+
+def test_modified_or_foreign_cache_stays_destination_conflict(tmp_path: Path) -> None:
+    """#388 keeps ``destination_conflict`` for marker-inconsistent or foreign trees."""
+
+    target, _project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    runner = _FakeCodex(target, home, codex_version="0.148.0-alpha.6")
+    first = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
+    _apply_activation(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        approved_digest=first.preview_digest,
+        _run=runner,
+    )
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    hooks = cache / "hooks/hooks.json"
+    hooks.write_bytes(hooks.read_bytes() + b"# modified\n")
+
+    with pytest.raises(IntegrationError) as caught:
+        _preview_activation(
+            target, executable_path=str(runner.executable), codex_home=home, _run=runner
+        )
+    assert caught.value.reason is IntegrationReason.DESTINATION_CONFLICT
+
+
+def test_stale_managed_source_render_is_previewed_but_fenced_until_source_refresh(
+    tmp_path: Path,
+) -> None:
+    """An older marker-consistent source render previews, but apply requires a refresh."""
+
+    from yoetz.adapters.integrations.codex_plugin import (
+        _build_marker,  # pyright: ignore[reportPrivateUsage]
+        render_plugin_tree,
+    )
+
+    target, project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    source = project / ".agents/plugins/yoetz"
+    # Rebuild the source as an older-guidance managed render: one member changes
+    # and the marker is regenerated so the tree stays marker-consistent.
+    members = dict(render_plugin_tree(codex_version=None))
+    members["skills/yoetz/SKILL.md"] = b"# an older guidance render\n"
+    for relative_path, payload in members.items():
+        (source / relative_path).write_bytes(payload)
+    (source / ".yoetz-plugin-install.json").write_bytes(_build_marker(members))
+
+    runner = _FakeCodex(target, home, codex_version="0.148.0-alpha.6")
+    preview = _preview_activation(
+        target, executable_path=str(runner.executable), codex_home=home, _run=runner
+    )
     with pytest.raises(IntegrationError) as caught:
         _apply_activation(
             target,
@@ -285,12 +480,7 @@ def test_version_variant_migration_is_previewed_but_fenced_until_source_refresh(
     assert not (project / ".agents/plugins/marketplace.json").exists()
     assert not (home / "config.toml").exists()
 
-    install_plugin(
-        target,
-        replace_modified=True,
-        allow_untested=True,
-        codex_version=runner.codex_version,
-    )
+    install_plugin(target, allow_untested=True, codex_version=None)
     result = _apply_activation(
         target,
         executable_path=str(runner.executable),

--- a/tests/unit/adapters/test_codex_plugin.py
+++ b/tests/unit/adapters/test_codex_plugin.py
@@ -336,6 +336,58 @@ def test_install_refuses_locally_modified_file(
     }
 
 
+def test_install_replaces_prior_managed_variant_render_without_replace_modified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#387: a marker-consistent prior render (e.g. async-variant hooks) is not an owner edit.
+
+    A wizard that previously wrote the host-rendered async form must be able to
+    return the tree to the canonical render without the ``modified_copy`` refusal
+    reserved for genuinely modified files.
+    """
+
+    tmp_path.chmod(0o700)
+    resources = _resources()
+    _enable_supported_profile(monkeypatch, resources)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path))
+    install_plugin(target, resource_source=resources, codex_version="0.148.0-alpha.6")
+    hooks_path = tmp_path / ".agents/plugins/yoetz/hooks/hooks.json"
+    assert b'"async":true' in hooks_path.read_bytes()
+
+    inspection = install_plugin(target, resource_source=resources, codex_version=None)
+
+    assert inspection.presence is PluginHookPresence.INSTALLED
+    assert b'"async":true' not in hooks_path.read_bytes()
+
+
+def test_plugin_tree_matches_marker_accepts_only_marker_consistent_trees() -> None:
+    from yoetz.adapters.integrations.codex_plugin import (
+        plugin_tree_matches_marker,
+        render_plugin_install_tree,
+    )
+
+    tree = render_plugin_install_tree(resource_source=_resources())
+    assert plugin_tree_matches_marker(tree) is True
+
+    modified = dict(tree)
+    modified["hooks/hooks.json"] = modified["hooks/hooks.json"] + b"# modified\n"
+    assert plugin_tree_matches_marker(modified) is False
+
+    extra = dict(tree)
+    extra["credential123"] = b"not managed"
+    assert plugin_tree_matches_marker(extra) is False
+
+    missing = dict(tree)
+    del missing[".yoetz-plugin-install.json"]
+    assert plugin_tree_matches_marker(missing) is False
+
+    tampered = dict(tree)
+    tampered[".yoetz-plugin-install.json"] = tampered[".yoetz-plugin-install.json"].replace(
+        b"yoetz.codex-plugin-install/1", b"yoetz.codex-plugin-install/9"
+    )
+    assert plugin_tree_matches_marker(tampered) is False
+
+
 def test_install_refuses_symlinked_plugin_ancestor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Repairs the four defects found on 2026-08-21 while live-testing the #149–#151 merges on an isolated Codex host (`codex-testing` 0.148.0, `CODEX_HOME=~/.codex-testing`), as groundwork for #152. This PR was directed by the maintainer, which satisfies #152's "do not open a PR until this issue receives maintainer acknowledgement" gate; it advances #152's isolated-Codex-CLI slice (it does **not** close #152).

## What / why per issue

### #387 — activation deadlock on async-capable hosts (P0)
The wizard threaded the probed host `codex_version` into the *project-tree* plugin steps, so the committed `.agents/plugins/yoetz` tree — which deliberately carries the async-free fallback `hooks/hooks.json` (pinned by `tests/packaging/test_committed_plugin_tree.py`) — could never match the host-specific render: `install_plugin` refused with `modified_copy` and `inspect_activation` read `not_installed` forever.

Fix: the project-tree source is the canonical render (`codex_version=None`) everywhere. The wizard's project-source preview/inspect/install no longer thread the probed version (`src/yoetz/cli/setup.py`), `inspect_activation` judges `installed` against the canonical/host-variant renders (`_plugin_source_installed`), and `apply_activation` seeds the versioned cache with the exact previewed host-rendered bytes after `codex plugin add` copies the canonical source (atomic whole-directory swap of the marker-identified copy, verified against the bound install digest). The committed tree stays byte-stable; `integrate` and apply fences stay coherent (`_assert_plugin_source` accepts either byte-exact renderer variant, and still refuses arbitrary/modified trees).

### #388 — same-version cache refresh impossible
`_installed_cache_digest` raised `destination_conflict` whenever the existing `<codex_home>/plugins/cache/yoetz/yoetz/0.1.0` differed from the fresh render — but plugin content drifts while the package version stays `0.1.0`, so every previously activated host hit a hard conflict.

Fix: a cache tree that carries a valid `.yoetz-plugin-install.json` marker (schema `yoetz.codex-plugin-install/1`) **and** byte-matches that marker's own inventory is a *prior yoetz-managed render*: preview classifies it as a refresh, binds its digest as `cache_before` into the `yoetz.codex-marketplace-activation/2` digest body, and apply atomically replaces the whole directory. `destination_conflict` stays reserved for foreign/marker-inconsistent/modified trees, and a cache that changes between preview and apply still refuses as `preview_stale`. The same marker rule lets `install_plugin` replace a prior managed *source* render (async-variant or older-guidance) without `replace_modified`, while genuinely modified files keep the `modified_copy` refusal.

### #389 — silent route rewrite
Non-interactive `setup run --accept` re-registered an existing yoetz-owned **policy** MCP route as **strict**, because `_configured_mcp_route_profile()` derived strict (including on any `load_config` exception) and no route input existed — a silent change to the ADR-018 egress-ceiling argv.

Fix: `setup run` and `integrate codex mcp preview|install` accept an explicit `--route-profile [strict|policy]`. Without it, an existing yoetz-owned registration keeps its observed profile (the preview's own probe identifies it; a preserved route previews as `noop`, so `--accept` performs no `mcp add` at all); the derivation applies only to fresh registrations and can never rewrite an existing one. Transitions are surfaced before mutation (`MCP route profile change: policy -> strict` in the interactive preview) and reported as `route_profile_before` next to `route_profile`. The interactive wizard still derives the route from the human's review-mode answer, as today.

### #390 — readiness masks the real failure
When the activation preview raised, `readiness.plugin_activation` reset to `{codex_home: null, ..., reason: "codex_home_required", marketplace_registered: false}` even with an explicit `--codex-home`, asserting unobserved facts as `false` and misdirecting diagnosis.

Fix: the bound home/config path is echoed in the registration and readiness blocks even on failure, the actual `IntegrationError` reason is carried through, `codex_home_required` appears only when no home was provided, and unobserved facts (`marketplace_registered`, `plugin_enabled`) report as `null`, never `false`. (`yoetz.setup-wizard-report/1` is a schema token, not a hand-authored JSON schema, so no manifest-digest ripple applies.)

## Live evidence (from the issues)

- #387: "verified live: registration outcome `failed`, plugin `{outcome: failed, presence: installed_untrusted_unknown, reason: modified_copy}`" and "`ActivationState.NOT_INSTALLED` with `marketplace_registered=True`, `plugin_enabled=True`" — the committed tree "matches `render_plugin_tree(codex_version=None)` byte-for-byte; only `hooks/hooks.json` differs from `render_plugin_tree(codex_version='0.148.0')`".
- #388: "`plugin_activation: {outcome: skipped, reason: destination_conflict, state: unknown}` ... traceback confirmed at `codex_marketplace.py:538` via `:795`. Only after manually moving the cache directory aside does the preview proceed (into #387)."
- #389: "config diff shows `args = [\"mcp\", \"serve\"]` -> `args = [\"mcp\", \"serve\", \"--semantic\", \"off\"]`, report shows `registration.outcome: reregistered`, `route_profile: strict`" while the pre-run status had observed `registered_route_profile: policy`, and "during the same run the service was unreachable" — a degraded environment downgraded a human-chosen route.
- #390: "`{codex_home: null, config_path: null, marketplace_registered: false, plugin_enabled: false, reason: \"codex_home_required\", state: \"unknown\"}` — even though an explicit `--codex-home` was passed and the actual failure was `destination_conflict`."

## Tests

- `tests/unit/adapters/test_codex_marketplace.py`: canonical source activates on an async host with a byte-stable project tree and an async-hooked cache; same-version refresh replaces a prior managed render; preview-to-apply cache drift is `preview_stale`; modified/foreign caches stay `destination_conflict`; an older marker-consistent source render previews but is fenced until refresh.
- `tests/unit/adapters/test_codex_plugin.py`: `install_plugin` replaces a prior managed variant render without `replace_modified`; `plugin_tree_matches_marker` accepts only marker-consistent trees (modified/extra/missing/tampered all refused).
- `tests/subprocess/test_setup_wizard_cli.py`: non-interactive `--accept` preserves an existing policy route with zero `mcp add` calls; explicit `--route-profile strict` reregisters and reports the transition; the interactive preview surfaces the transition; invalid `--route-profile` values are refused; `integrate codex mcp` preserves/reports/reregisters equivalently; a failed activation preview reports the bound home, `destination_conflict`, and null (not false) unobserved facts.

Checks run: `uv run ruff format --check .`, `uv run ruff check`, full `pyright` (0 errors), and pytest over `tests/unit/adapters`, `tests/unit/cli`, `tests/unit/application`, `tests/unit/tui`, `tests/unit/version`, `tests/conformance`, `tests/subprocess` (setup/MCP), and `tests/packaging` — all green except two `tests/packaging/test_service_boundary_imports.py` failures that reproduce at the base commit in this git-worktree environment (`state capture` refuses the worktree's `unsafe_root`), i.e. pre-existing and unrelated.

## Not proven here (remaining #152 acceptance items)

- No live proof of portable-artifact discovery on the isolated Codex CLI (exact bundle digest, host discovery of portable skill bytes, raw-vs-model-visible inventory capture, fresh-session correlated `start`/`status` call).
- No negative fixture where raw inventory is healthy but the model lacks tools.
- Nothing on ChatGPT desktop — its entire evidence chain remains untested.
- No semantic/receipt/rollback evidence chain (strict-route negative control, policy-route provenance, digest-bound restore of pre-test host state).
- This PR makes the native install/refresh/activation path actually work on an async-capable isolated host so those proofs can be gathered; it claims nothing beyond that.

Fixes #387
Fixes #388
Fixes #389
Fixes #390
Advances #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
