### PR TITLE
fix: reap approved-check process groups on timeout

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2507,7 +2507,10 @@ Independent verification support (local control, not MCP):
 
 - Approved-check runner — executes only commitment-approved argv (`shell=False`, bounded
   time/output, sanitized env, no network unless separately authorized); binds results to the
-  observed subject-state digest so later edits stale prior success.
+  observed subject-state digest so later edits stale prior success. On POSIX the child is started
+  in a dedicated session/process group; a timeout signals that group (TERM, then KILL) and reaps
+  it before the TIMEOUT result is returned. Windows keeps CREATE_NEW_PROCESS_GROUP isolation and
+  TerminateProcess on the launched process.
 - `.yoetz/checks.toml` — fixed schema `yoetz.approved-check-policy/1`; raw bytes produce the trust
   digest. Repository content proposes no authority. One trusted-local exact-digest confirmation is
   retained as an encrypted workspace-scoped record. Any byte change is untrusted.

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2509,8 +2509,11 @@ Independent verification support (local control, not MCP):
   time/output, sanitized env, no network unless separately authorized); binds results to the
   observed subject-state digest so later edits stale prior success. On POSIX the child is started
   in a dedicated session/process group; a timeout signals that group (TERM, then KILL) and reaps
-  it before the TIMEOUT result is returned. Windows keeps CREATE_NEW_PROCESS_GROUP isolation and
-  TerminateProcess on the launched process.
+  its members before the TIMEOUT result is returned, adopting orphaned descendants as a child
+  subreaper on Linux so a non-reaping PID 1 cannot strand them. A check that closes its own
+  stdout/stderr and keeps running still times out rather than escaping the runner. On Windows the
+  launched tree is terminated (`taskkill /T /F`, falling back to TerminateProcess) under
+  CREATE_NEW_PROCESS_GROUP console isolation.
 - `.yoetz/checks.toml` — fixed schema `yoetz.approved-check-policy/1`; raw bytes produce the trust
   digest. Repository content proposes no authority. One trusted-local exact-digest confirmation is
   retained as an encrypted workspace-scoped record. Any byte change is untrusted.

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2508,12 +2508,14 @@ Independent verification support (local control, not MCP):
 - Approved-check runner — executes only commitment-approved argv (`shell=False`, bounded
   time/output, sanitized env, no network unless separately authorized); binds results to the
   observed subject-state digest so later edits stale prior success. On POSIX the child is started
-  in a dedicated session/process group; a timeout signals that group (TERM, then KILL) and reaps
-  its members before the TIMEOUT result is returned, adopting orphaned descendants as a child
-  subreaper on Linux so a non-reaping PID 1 cannot strand them. A check that closes its own
-  stdout/stderr and keeps running still times out rather than escaping the runner. On Windows the
-  launched tree is terminated (`taskkill /T /F`, falling back to TerminateProcess) under
-  CREATE_NEW_PROCESS_GROUP console isolation.
+  in a dedicated session/process group, and that group is killed and reaped before any result is
+  returned -- on timeout (TERM, then KILL) and equally after a check exits on its own, so a member
+  it leaves running never outlives its result. Orphaned descendants are adopted as a child
+  subreaper on Linux so a non-reaping PID 1 cannot strand them. A descendant that calls `setsid`
+  leaves the group and is not covered; containing that needs a PID namespace. A check that closes
+  its own stdout/stderr and keeps running still times out rather than escaping the runner. On
+  Windows the launched tree is terminated (`taskkill /T /F`, falling back to TerminateProcess)
+  under CREATE_NEW_PROCESS_GROUP console isolation.
 - `.yoetz/checks.toml` — fixed schema `yoetz.approved-check-policy/1`; raw bytes produce the trust
   digest. Repository content proposes no authority. One trusted-local exact-digest confirmation is
   retained as an encrypted workspace-scoped record. Any byte change is untrusted.

--- a/src/yoetz/adapters/approved_checks.py
+++ b/src/yoetz/adapters/approved_checks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import selectors
+import signal
 import stat
 import subprocess
 import tempfile
@@ -258,6 +259,89 @@ def _bounded_communicate(
     return stdout, truncated
 
 
+def _wait_process(process: subprocess.Popen[bytes], timeout_seconds: float) -> bool:
+    try:
+        process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return False
+    return True
+
+
+def _posix_process_group_id(process: subprocess.Popen[bytes]) -> int | None:
+    get_group = getattr(os, "getpgid", None)
+    get_self_group = getattr(os, "getpgrp", None)
+    if not callable(get_group) or not callable(get_self_group):
+        return None
+    try:
+        group_id = get_group(process.pid)
+        self_group = get_self_group()
+    except OSError, ProcessLookupError:
+        return None
+    if type(group_id) is not int or type(self_group) is not int:
+        return None
+    if group_id <= 1 or group_id == self_group:
+        return None
+    return group_id
+
+
+def _signal_posix_group(group_id: int, sig: int) -> bool:
+    kill_group = getattr(os, "killpg", None)
+    if not callable(kill_group):
+        return False
+    try:
+        kill_group(group_id, sig)
+    except OSError, ProcessLookupError:
+        return False
+    return True
+
+
+def _posix_group_exists(group_id: int) -> bool:
+    return _signal_posix_group(group_id, 0)
+
+
+def _reap_approved_check_process(
+    process: subprocess.Popen[bytes],
+    *,
+    process_group_id: int | None = None,
+) -> None:
+    """Terminate the isolated check tree, then wait until the leader is reaped."""
+
+    if os.name == "nt":
+        if process.poll() is None:
+            process.kill()
+        _wait_process(process, 5.0)
+        if process.poll() is None:
+            process.kill()
+            _wait_process(process, 5.0)
+        return
+
+    group_id = (
+        process_group_id if process_group_id is not None else _posix_process_group_id(process)
+    )
+    if group_id is None:
+        if process.poll() is None:
+            process.kill()
+        _wait_process(process, 5.0)
+        return
+
+    _signal_posix_group(group_id, signal.SIGTERM)
+    if not _wait_process(process, 0.5) or _posix_group_exists(group_id):
+        _signal_posix_group(group_id, signal.SIGKILL)
+        _wait_process(process, 5.0)
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _posix_group_exists(group_id):
+        _signal_posix_group(group_id, signal.SIGKILL)
+        if _wait_process(process, 0.05):
+            time.sleep(0.01)
+            continue
+        time.sleep(0.01)
+
+    if process.poll() is None:
+        process.kill()
+        _wait_process(process, 1.0)
+
+
 class ApprovedCheckRunner:
     """Execute only commitment-approved argv under a consented workspace root."""
 
@@ -332,6 +416,7 @@ class ApprovedCheckRunner:
         home, tmpdir, temp_root = _owner_private_temp_dirs()
         started = time.monotonic()
         process: subprocess.Popen[bytes] | None = None
+        process_group_id: int | None = None
         try:
             env = _sanitized_env(home=home, tmpdir=tmpdir)
             launch = self._sandbox.prepare(
@@ -352,16 +437,35 @@ class ApprovedCheckRunner:
                     approval.approval_commitment,
                     int((time.monotonic() - started) * 1000),
                 )
-            process = subprocess.Popen(
-                list(launch.argv),
-                cwd=launch.cwd,
-                env=dict(launch.env),
-                shell=False,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                close_fds=True,
-            )
+            if os.name == "nt":
+                process = subprocess.Popen(
+                    list(launch.argv),
+                    cwd=launch.cwd,
+                    env=dict(launch.env),
+                    shell=False,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                    creationflags=int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)),
+                )
+            else:
+                process = subprocess.Popen(
+                    list(launch.argv),
+                    cwd=launch.cwd,
+                    env=dict(launch.env),
+                    shell=False,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                    start_new_session=True,
+                )
+                # ``start_new_session`` makes the child's PID the new session and process-group
+                # ID.  Capture that identity without a post-launch ``getpgid`` lookup: the group
+                # can remain alive after a short-lived leader exits, and losing the leader must
+                # not make its descendants unaddressable at timeout.
+                process_group_id = process.pid
             stdout, truncated = _bounded_communicate(
                 process,
                 stdout_limit=_MAX_OUTPUT_BYTES,
@@ -399,8 +503,7 @@ class ApprovedCheckRunner:
             )
         except TimeoutError:
             if process is not None:
-                process.kill()
-                process.wait(timeout=5)
+                _reap_approved_check_process(process, process_group_id=process_group_id)
             return self._result(
                 ApprovedCheckStatus.TIMEOUT,
                 ApprovedCheckOutcome.TIMEOUT,

--- a/src/yoetz/adapters/approved_checks.py
+++ b/src/yoetz/adapters/approved_checks.py
@@ -50,6 +50,9 @@ _REAP_DEADLINE_SECONDS: Final = 5.0
 # still disappear is an external reaper (init/launchd). Give that a short grace window instead
 # of burning the whole deadline against zombies we are structurally unable to reap.
 _REAP_NO_PROGRESS_SECONDS: Final = 0.5
+# Teardown bound for a check that returned on its own: the tree is normally already gone,
+# so this only pays for stragglers the check left behind.
+_COMPLETED_DRAIN_SECONDS: Final = 1.0
 _PR_SET_CHILD_SUBREAPER: Final = 36
 
 
@@ -376,7 +379,7 @@ def _taskkill_tree(pid: int) -> bool:
     """Kill a Windows process *tree*; ``TerminateProcess`` alone spares grandchildren."""
 
     try:
-        subprocess.run(  # noqa: S603 - fixed argv, no shell, output discarded
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell, output discarded
             ["taskkill", "/PID", str(pid), "/T", "/F"],
             capture_output=True,
             check=False,
@@ -384,7 +387,9 @@ def _taskkill_tree(pid: int) -> bool:
         )
     except OSError, subprocess.SubprocessError:
         return False
-    return True
+    # A nonzero code (access denied, no such pid) means the tree is still standing: report the
+    # failure so the caller falls back to ``kill`` now instead of after a five-second wait.
+    return completed.returncode == 0
 
 
 def _reap_windows_process_tree(process: subprocess.Popen[bytes]) -> None:
@@ -394,6 +399,55 @@ def _reap_windows_process_tree(process: subprocess.Popen[bytes]) -> None:
     if process.poll() is None:
         process.kill()
         _wait_process(process, 5.0)
+
+
+def _drain_posix_group(
+    process: subprocess.Popen[bytes],
+    group_id: int,
+    *,
+    deadline_seconds: float,
+) -> None:
+    """Kill and reap every member of the check's process group until empty or the bound expires.
+
+    Known limitation: a descendant that calls ``setsid`` leaves the group and is not covered
+    here; containing that needs a PID namespace (follow-up: bwrap ``--unshare-pid``).
+    """
+
+    deadline = time.monotonic() + deadline_seconds
+    last_progress = time.monotonic()
+    while time.monotonic() < deadline:
+        if not _posix_group_exists(group_id):
+            break
+        _signal_posix_group(group_id, signal.SIGKILL)
+        reaped, waitable = _reap_posix_group_members(group_id)
+        leader_reaped = process.poll() is not None or _wait_process(process, 0.05)
+        if reaped:
+            last_progress = time.monotonic()
+            continue
+        if (
+            leader_reaped
+            and not waitable
+            and time.monotonic() - last_progress >= _REAP_NO_PROGRESS_SECONDS
+        ):
+            # Signals are delivered and nothing left in the group belongs to us: the remainder
+            # are zombies owned by a parent that may never reap them. Stop instead of spending
+            # the full deadline on every timed-out check.
+            break
+        time.sleep(0.01)
+
+
+def _drain_completed_check_group(process: subprocess.Popen[bytes], group_id: int | None) -> None:
+    """Tear the group down after a check returns on its own, not only after a timeout.
+
+    A member the check leaves running would otherwise outlive its result -- and because this
+    process is a child subreaper, such an orphan reparents here when its parent exits and stays
+    ``<defunct>`` for the lifetime of a long-lived service. ``group_id`` is ``None`` on Windows
+    and wherever the launch could not claim a group, where there is nothing to drain.
+    """
+
+    if group_id is None:
+        return
+    _drain_posix_group(process, group_id, deadline_seconds=_COMPLETED_DRAIN_SECONDS)
 
 
 def _reap_approved_check_process(
@@ -421,27 +475,7 @@ def _reap_approved_check_process(
         _signal_posix_group(group_id, signal.SIGKILL)
         _wait_process(process, 5.0)
 
-    deadline = time.monotonic() + _REAP_DEADLINE_SECONDS
-    last_progress = time.monotonic()
-    while time.monotonic() < deadline:
-        if not _posix_group_exists(group_id):
-            break
-        _signal_posix_group(group_id, signal.SIGKILL)
-        reaped, waitable = _reap_posix_group_members(group_id)
-        leader_reaped = process.poll() is not None or _wait_process(process, 0.05)
-        if reaped:
-            last_progress = time.monotonic()
-            continue
-        if (
-            leader_reaped
-            and not waitable
-            and time.monotonic() - last_progress >= _REAP_NO_PROGRESS_SECONDS
-        ):
-            # Signals are delivered and nothing left in the group belongs to us: the remainder
-            # are zombies owned by a parent that may never reap them. Stop instead of spending
-            # the full deadline on every timed-out check.
-            break
-        time.sleep(0.01)
+    _drain_posix_group(process, group_id, deadline_seconds=_REAP_DEADLINE_SECONDS)
 
     if process.poll() is None:
         process.kill()
@@ -582,6 +616,7 @@ class ApprovedCheckRunner:
                 stdout_limit=_MAX_OUTPUT_BYTES,
                 timeout_seconds=approval.timeout_seconds,
             )
+            _drain_completed_check_group(process, process_group_id)
             duration_ms = int((time.monotonic() - started) * 1000)
             exit_status = int(process.returncode or 0)
             safe_output, _redacted = redact_sensitive_content(bytes(stdout))

--- a/src/yoetz/adapters/approved_checks.py
+++ b/src/yoetz/adapters/approved_checks.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import ctypes
+import functools
 import hashlib
 import os
 import selectors
 import signal
 import stat
 import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
@@ -42,6 +45,12 @@ _MAX_ARG_BYTES: Final = 512
 _TOKEN_CHARS: Final = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._/+-="
 )
+_REAP_DEADLINE_SECONDS: Final = 5.0
+# Once the leader is reaped and no group member is waitable by us, the only way the group can
+# still disappear is an external reaper (init/launchd). Give that a short grace window instead
+# of burning the whole deadline against zombies we are structurally unable to reap.
+_REAP_NO_PROGRESS_SECONDS: Final = 0.5
+_PR_SET_CHILD_SUBREAPER: Final = 36
 
 
 class ApprovedCheckStatus(str, Enum):  # noqa: UP042 - exact wire enum
@@ -253,7 +262,14 @@ def _bounded_communicate(
                     else:
                         stdout.extend(chunk)
                 # stderr is discarded after consumption; never retained for advice/status.
-        process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        try:
+            process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            # End-of-file on both pipes is not exit: a check may close its own stdout/stderr
+            # and keep running. ``TimeoutExpired`` is a ``SubprocessError``, so letting it
+            # escape would skip the runner's timeout result *and* its group reaping, leaking
+            # the whole tree. Translate it into the timeout contract the runner handles.
+            raise TimeoutError from None
     finally:
         selector.close()
     return stdout, truncated
@@ -275,7 +291,7 @@ def _posix_process_group_id(process: subprocess.Popen[bytes]) -> int | None:
     try:
         group_id = get_group(process.pid)
         self_group = get_self_group()
-    except OSError, ProcessLookupError:
+    except OSError:
         return None
     if type(group_id) is not int or type(self_group) is not int:
         return None
@@ -290,7 +306,7 @@ def _signal_posix_group(group_id: int, sig: int) -> bool:
         return False
     try:
         kill_group(group_id, sig)
-    except OSError, ProcessLookupError:
+    except OSError:
         return False
     return True
 
@@ -299,20 +315,96 @@ def _posix_group_exists(group_id: int) -> bool:
     return _signal_posix_group(group_id, 0)
 
 
+@functools.cache
+def _enable_child_subreaper() -> bool:
+    """Best-effort ``PR_SET_CHILD_SUBREAPER`` so orphaned check descendants stay waitable.
+
+    Under a container PID 1 that never calls ``wait()``, a killed grandchild that outlived its
+    parent reparents to PID 1 and stays ``<defunct>`` forever: the process group keeps existing,
+    ``killpg(group, 0)`` keeps succeeding, and the reaper below would spin against zombies it
+    cannot reap while PIDs leak. As a subreaper this process inherits those orphans instead, so
+    ``waitpid(-group, ...)`` can actually clear them. Linux-only; ignored everywhere else.
+    """
+
+    if sys.platform != "linux":
+        return False
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        prctl = libc.prctl
+        prctl.argtypes = [
+            ctypes.c_int,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+            ctypes.c_ulong,
+        ]
+        prctl.restype = ctypes.c_int
+        return prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == 0
+    except OSError, AttributeError, ValueError:
+        # Best effort only: a missing libc symbol or a seccomp-blocked prctl must never fail
+        # the check run; the reap loop below degrades to its bounded no-progress exit.
+        return False
+
+
+def _reap_posix_group_members(group_id: int) -> tuple[int, bool]:
+    """Reap every waitable member of ``group_id``; return (reaped_count, waitable_remaining).
+
+    ``waitpid(-group_id, WNOHANG)`` is scoped to the isolated check's own process group, so it
+    can never steal an unrelated child of this runner. It may reap the leader out from under its
+    ``Popen``; that is harmless because ``Popen`` treats ``ChildProcessError`` as "already
+    exited" and the timeout result never reports an exit status.
+    """
+
+    if os.name == "nt" or not hasattr(os, "waitpid"):
+        return 0, False
+    reaped = 0
+    while True:
+        try:
+            pid, _status = os.waitpid(-group_id, os.WNOHANG)
+        except ChildProcessError:
+            # No member of the group is a child of ours: nothing here is waitable.
+            return reaped, False
+        except OSError:
+            return reaped, reaped > 0
+        if pid == 0:
+            # Live children remain but none has exited yet.
+            return reaped, True
+        reaped += 1
+
+
+def _taskkill_tree(pid: int) -> bool:
+    """Kill a Windows process *tree*; ``TerminateProcess`` alone spares grandchildren."""
+
+    try:
+        subprocess.run(  # noqa: S603 - fixed argv, no shell, output discarded
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+            timeout=5.0,
+        )
+    except OSError, subprocess.SubprocessError:
+        return False
+    return True
+
+
+def _reap_windows_process_tree(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None and not _taskkill_tree(process.pid):
+        process.kill()
+    _wait_process(process, 5.0)
+    if process.poll() is None:
+        process.kill()
+        _wait_process(process, 5.0)
+
+
 def _reap_approved_check_process(
     process: subprocess.Popen[bytes],
     *,
     process_group_id: int | None = None,
 ) -> None:
-    """Terminate the isolated check tree, then wait until the leader is reaped."""
+    """Terminate the isolated check tree, then wait until its members are reaped."""
 
     if os.name == "nt":
-        if process.poll() is None:
-            process.kill()
-        _wait_process(process, 5.0)
-        if process.poll() is None:
-            process.kill()
-            _wait_process(process, 5.0)
+        _reap_windows_process_tree(process)
         return
 
     group_id = (
@@ -329,12 +421,26 @@ def _reap_approved_check_process(
         _signal_posix_group(group_id, signal.SIGKILL)
         _wait_process(process, 5.0)
 
-    deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline and _posix_group_exists(group_id):
+    deadline = time.monotonic() + _REAP_DEADLINE_SECONDS
+    last_progress = time.monotonic()
+    while time.monotonic() < deadline:
+        if not _posix_group_exists(group_id):
+            break
         _signal_posix_group(group_id, signal.SIGKILL)
-        if _wait_process(process, 0.05):
-            time.sleep(0.01)
+        reaped, waitable = _reap_posix_group_members(group_id)
+        leader_reaped = process.poll() is not None or _wait_process(process, 0.05)
+        if reaped:
+            last_progress = time.monotonic()
             continue
+        if (
+            leader_reaped
+            and not waitable
+            and time.monotonic() - last_progress >= _REAP_NO_PROGRESS_SECONDS
+        ):
+            # Signals are delivered and nothing left in the group belongs to us: the remainder
+            # are zombies owned by a parent that may never reap them. Stop instead of spending
+            # the full deadline on every timed-out check.
+            break
         time.sleep(0.01)
 
     if process.poll() is None:
@@ -447,9 +553,14 @@ class ApprovedCheckRunner:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     close_fds=True,
+                    # Console-signal isolation, the Windows counterpart of ``start_new_session``:
+                    # a Ctrl-C on our console must not race the reaper for this tree. Killing the
+                    # tree does not go through the group (see ``_reap_windows_process_tree``).
                     creationflags=int(getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)),
                 )
             else:
+                # Adopt orphaned descendants (Linux) so the reaper can actually clear them.
+                _enable_child_subreaper()
                 process = subprocess.Popen(
                     list(launch.argv),
                     cwd=launch.cwd,

--- a/tests/unit/adapters/test_approved_checks.py
+++ b/tests/unit/adapters/test_approved_checks.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import shutil
+import sys
+import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+
+import pytest
 
 from yoetz.adapters.approved_checks import (
     ApprovedCheckApproval,
@@ -40,13 +45,13 @@ class _ReadyCheckSandbox:
         )
 
 
-def _approval(argv: tuple[str, ...]) -> ApprovedCheckApproval:
+def _approval(argv: tuple[str, ...], *, timeout_seconds: float = 10.0) -> ApprovedCheckApproval:
     commitment = approval_commitment("pytest-unit", argv, allow_network=False)
     return ApprovedCheckApproval(
         approval_id="pytest-unit",
         argv=argv,
         allow_network=False,
-        timeout_seconds=10.0,
+        timeout_seconds=timeout_seconds,
         approval_commitment=commitment,
     )
 
@@ -118,3 +123,81 @@ def test_output_never_retained_as_secret_text(tmp_path: Path) -> None:
     assert result.output_digest is not None
     assert "secret-token-value" not in repr(result)
     assert "SECRET" not in repr(result)
+
+
+def test_nonforking_timeout_is_deterministic(tmp_path: Path) -> None:
+    handle = open_inspect_workspace(tmp_path)
+    sleep = shutil.which("sleep") or "/bin/sleep"
+    approval = _approval((sleep, "8"), timeout_seconds=0.3)
+    runner = ApprovedCheckRunner(
+        {approval.approval_commitment: approval},
+        sandbox=_ReadyCheckSandbox(),
+    )
+    started = time.monotonic()
+    result = runner.run(
+        ApprovedCheckCommand(
+            workspace=handle,
+            approval=approval,
+            subject_state_digest="sha256:" + "e" * 64,
+        )
+    )
+    elapsed = time.monotonic() - started
+    assert result.status is ApprovedCheckStatus.TIMEOUT
+    assert result.outcome is ApprovedCheckOutcome.TIMEOUT
+    assert result.exit_status is None
+    assert result.output_digest is None
+    assert result.output_bytes == 0
+    assert elapsed < 4.0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_timeout_reaps_forked_descendant_before_result(tmp_path: Path) -> None:
+    handle = open_inspect_workspace(tmp_path)
+    pid_path = tmp_path / "desc.pid"
+    stop_path = tmp_path / "stop.flag"
+    leak_path = tmp_path / "leaked.txt"
+    script_path = tmp_path / "fork-check.sh"
+    script_path.write_text(
+        "#!/bin/sh\n"
+        "pid_file=$1\n"
+        "stop_file=$2\n"
+        "leak_file=$3\n"
+        "(\n"
+        "  trap '' TERM\n"
+        '  while [ ! -f "$stop_file" ]; do\n'
+        "    sleep 0.05\n"
+        "  done\n"
+        '  echo leaked > "$leak_file"\n'
+        ") &\n"
+        'echo $! > "$pid_file"\n'
+        # Exit the direct child while its descendant keeps the inherited output pipes open. This
+        # proves the runner retains the launch-time group identity instead of relying on a later
+        # lookup through a leader that may already be gone.
+        "exit 0\n",
+        encoding="ascii",
+    )
+    os.chmod(script_path, 0o700)
+    approval = _approval(
+        ("/bin/sh", str(script_path), str(pid_path), str(stop_path), str(leak_path)),
+        timeout_seconds=0.5,
+    )
+    runner = ApprovedCheckRunner(
+        {approval.approval_commitment: approval},
+        sandbox=_ReadyCheckSandbox(),
+    )
+    result = runner.run(
+        ApprovedCheckCommand(
+            workspace=handle,
+            approval=approval,
+            subject_state_digest="sha256:" + "f" * 64,
+        )
+    )
+    assert result.status is ApprovedCheckStatus.TIMEOUT
+    assert result.outcome is ApprovedCheckOutcome.TIMEOUT
+    assert pid_path.is_file()
+    descendant_pid = int(pid_path.read_text(encoding="ascii").strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(descendant_pid, 0)
+    stop_path.write_text("stop", encoding="ascii")
+    time.sleep(0.3)
+    assert not leak_path.exists()

--- a/tests/unit/adapters/test_approved_checks.py
+++ b/tests/unit/adapters/test_approved_checks.py
@@ -4,19 +4,25 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
+import subprocess
 import sys
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import cast
 
 import pytest
 
+from yoetz.adapters import approved_checks
 from yoetz.adapters.approved_checks import (
     ApprovedCheckApproval,
     ApprovedCheckCommand,
     ApprovedCheckOutcome,
     ApprovedCheckRunner,
     ApprovedCheckStatus,
+    _reap_approved_check_process,  # pyright: ignore[reportPrivateUsage]
+    _reap_posix_group_members,  # pyright: ignore[reportPrivateUsage]
     approval_commitment,
 )
 from yoetz.adapters.workspace_inspect import open_inspect_workspace
@@ -201,3 +207,182 @@ def test_timeout_reaps_forked_descendant_before_result(tmp_path: Path) -> None:
     stop_path.write_text("stop", encoding="ascii")
     time.sleep(0.3)
     assert not leak_path.exists()
+
+
+class _FakeLeader:
+    """Stand-in for the leader ``Popen`` in reaper unit tests."""
+
+    def __init__(self, *, pid: int = 424_242, running: bool = False) -> None:
+        self.pid = pid
+        self.running = running
+        self.kill_calls = 0
+
+    def poll(self) -> int | None:
+        return None if self.running else 0
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.running = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.running:
+            raise subprocess.TimeoutExpired(cmd="fake-check", timeout=timeout or 0.0)
+        return 0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_closed_output_pipes_still_time_out_and_reap_group(tmp_path: Path) -> None:
+    handle = open_inspect_workspace(tmp_path)
+    leader_path = tmp_path / "leader.pid"
+    child_path = tmp_path / "child.pid"
+    script_path = tmp_path / "closed-fds-check.sh"
+    script_path.write_text(
+        "#!/bin/sh\n"
+        'echo $$ > "$1"\n'
+        # Closing both output pipes hands the runner EOF while the tree keeps running, so the
+        # selector loop finishes early and only the final wait can observe the overrun. That
+        # wait must not escape as ``subprocess.TimeoutExpired``: it would skip both the timeout
+        # result and the group reaping, leaking the whole tree.
+        "exec 1>&- 2>&-\n"
+        "sleep 30 &\n"
+        'echo $! > "$2"\n'
+        "wait\n",
+        encoding="ascii",
+    )
+    os.chmod(script_path, 0o700)
+    approval = _approval(
+        ("/bin/sh", str(script_path), str(leader_path), str(child_path)),
+        timeout_seconds=0.5,
+    )
+    runner = ApprovedCheckRunner(
+        {approval.approval_commitment: approval},
+        sandbox=_ReadyCheckSandbox(),
+    )
+    started = time.monotonic()
+    result = runner.run(
+        ApprovedCheckCommand(
+            workspace=handle,
+            approval=approval,
+            subject_state_digest="sha256:" + "1" * 64,
+        )
+    )
+    elapsed = time.monotonic() - started
+    assert result.status is ApprovedCheckStatus.TIMEOUT
+    assert result.outcome is ApprovedCheckOutcome.TIMEOUT
+    assert result.exit_status is None
+    assert elapsed < 4.0
+    group_id = int(leader_path.read_text(encoding="ascii").strip())
+    descendant_pid = int(child_path.read_text(encoding="ascii").strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(descendant_pid, 0)
+    with pytest.raises(ProcessLookupError):
+        os.killpg(group_id, 0)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_group_reaper_drains_exited_members() -> None:
+    sleep = shutil.which("sleep") or "/bin/sleep"
+    process = subprocess.Popen(
+        [sleep, "30"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    group_id = process.pid
+    try:
+        os.killpg(group_id, signal.SIGKILL)
+        reaped = 0
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and reaped == 0:
+            reaped, _waitable = _reap_posix_group_members(group_id)
+            if reaped == 0:
+                time.sleep(0.01)
+        assert reaped == 1
+        # Drained: no member of the group is waitable by us any more.
+        assert _reap_posix_group_members(group_id) == (0, False)
+    finally:
+        process.wait(timeout=5.0)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_reaper_waits_on_the_group_and_returns_when_it_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    leader = _FakeLeader()
+    alive = [True]
+    waitpid_calls: list[tuple[int, int]] = []
+
+    def _fake_signal(group_id: int, sig: int) -> bool:
+        assert group_id == 7_777
+        return alive[0]
+
+    def _fake_waitpid(pid: int, options: int) -> tuple[int, int]:
+        waitpid_calls.append((pid, options))
+        if len(waitpid_calls) == 1:
+            return (8_888, 0)
+        alive[0] = False
+        raise ChildProcessError
+
+    monkeypatch.setattr(approved_checks, "_signal_posix_group", _fake_signal)
+    monkeypatch.setattr(approved_checks.os, "waitpid", _fake_waitpid)
+    started = time.monotonic()
+    _reap_approved_check_process(cast("subprocess.Popen[bytes]", leader), process_group_id=7_777)
+    elapsed = time.monotonic() - started
+    assert waitpid_calls[0] == (-7_777, os.WNOHANG)
+    assert elapsed < 1.0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_reaper_stops_early_when_group_members_are_unreapable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    leader = _FakeLeader()
+    signals: list[int] = []
+
+    def _fake_signal(group_id: int, sig: int) -> bool:
+        assert group_id == 9_999
+        signals.append(sig)
+        # A non-reaping PID 1 keeps the killed members ``<defunct>``: the group never goes away.
+        return True
+
+    def _fake_waitpid(pid: int, options: int) -> tuple[int, int]:
+        raise ChildProcessError
+
+    monkeypatch.setattr(approved_checks, "_signal_posix_group", _fake_signal)
+    monkeypatch.setattr(approved_checks.os, "waitpid", _fake_waitpid)
+    started = time.monotonic()
+    _reap_approved_check_process(cast("subprocess.Popen[bytes]", leader), process_group_id=9_999)
+    elapsed = time.monotonic() - started
+    assert signal.SIGKILL in signals
+    # Bounded no-progress exit, not the full reap deadline burned on every timed-out check.
+    assert elapsed < 2.0
+
+
+def test_windows_reaper_kills_the_process_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    leader = _FakeLeader(pid=4_321, running=True)
+    killed: list[int] = []
+
+    def _fake_taskkill(pid: int) -> bool:
+        killed.append(pid)
+        leader.running = False
+        return True
+
+    monkeypatch.setattr(approved_checks.os, "name", "nt")
+    monkeypatch.setattr(approved_checks, "_taskkill_tree", _fake_taskkill)
+    _reap_approved_check_process(cast("subprocess.Popen[bytes]", leader))
+    # ``TerminateProcess`` on the direct child alone would spare its grandchildren.
+    assert killed == [4_321]
+    assert leader.kill_calls == 0
+
+
+def test_windows_reaper_falls_back_to_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    leader = _FakeLeader(pid=4_321, running=True)
+
+    def _fake_taskkill(pid: int) -> bool:
+        return False
+
+    monkeypatch.setattr(approved_checks.os, "name", "nt")
+    monkeypatch.setattr(approved_checks, "_taskkill_tree", _fake_taskkill)
+    _reap_approved_check_process(cast("subprocess.Popen[bytes]", leader))
+    assert leader.kill_calls == 1

--- a/tests/unit/adapters/test_approved_checks.py
+++ b/tests/unit/adapters/test_approved_checks.py
@@ -23,6 +23,7 @@ from yoetz.adapters.approved_checks import (
     ApprovedCheckStatus,
     _reap_approved_check_process,  # pyright: ignore[reportPrivateUsage]
     _reap_posix_group_members,  # pyright: ignore[reportPrivateUsage]
+    _taskkill_tree,  # pyright: ignore[reportPrivateUsage]
     approval_commitment,
 )
 from yoetz.adapters.workspace_inspect import open_inspect_workspace
@@ -216,15 +217,18 @@ class _FakeLeader:
         self.pid = pid
         self.running = running
         self.kill_calls = 0
+        self.events: list[str] = []
 
     def poll(self) -> int | None:
         return None if self.running else 0
 
     def kill(self) -> None:
         self.kill_calls += 1
+        self.events.append("kill")
         self.running = False
 
     def wait(self, timeout: float | None = None) -> int:
+        self.events.append(f"wait:{timeout}")
         if self.running:
             raise subprocess.TimeoutExpired(cmd="fake-check", timeout=timeout or 0.0)
         return 0
@@ -376,13 +380,81 @@ def test_windows_reaper_kills_the_process_tree(monkeypatch: pytest.MonkeyPatch) 
     assert leader.kill_calls == 0
 
 
-def test_windows_reaper_falls_back_to_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_windows_reaper_falls_back_to_kill_on_taskkill_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     leader = _FakeLeader(pid=4_321, running=True)
+    commands: list[list[str]] = []
 
-    def _fake_taskkill(pid: int) -> bool:
-        return False
+    def _fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        commands.append(argv)
+        # taskkill reports access denied rather than raising; the tree is still standing.
+        return subprocess.CompletedProcess(argv, 1, b"", b"ERROR: Access is denied.")
 
     monkeypatch.setattr(approved_checks.os, "name", "nt")
-    monkeypatch.setattr(approved_checks, "_taskkill_tree", _fake_taskkill)
+    monkeypatch.setattr(approved_checks.subprocess, "run", _fake_run)
     _reap_approved_check_process(cast("subprocess.Popen[bytes]", leader))
+    assert commands == [["taskkill", "/PID", "4321", "/T", "/F"]]
+    # The nonzero code must fall back immediately: kill before any wait, not five seconds later.
+    assert leader.events[0] == "kill"
     assert leader.kill_calls == 1
+
+
+def test_taskkill_tree_reports_the_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    codes = [0, 1]
+
+    def _fake_run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(argv, codes.pop(0), b"", b"")
+
+    monkeypatch.setattr(approved_checks.subprocess, "run", _fake_run)
+    assert _taskkill_tree(4_321) is True
+    assert _taskkill_tree(4_321) is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group reaping")
+def test_completed_check_tears_down_leftover_group_members(tmp_path: Path) -> None:
+    handle = open_inspect_workspace(tmp_path)
+    leader_path = tmp_path / "leader.pid"
+    child_path = tmp_path / "child.pid"
+    script_path = tmp_path / "orphan-check.sh"
+    script_path.write_text(
+        "#!/bin/sh\n"
+        'echo $$ > "$1"\n'
+        # The background member drops the inherited pipes so the check can return normally,
+        # then outlives its parent. Without an unconditional teardown it survives the PASSED
+        # result -- and where this process is a child subreaper it later reparents here and
+        # becomes an unreapable zombie for the lifetime of a long-lived service.
+        "sleep 30 >/dev/null 2>&1 &\n"
+        'echo $! > "$2"\n'
+        "exit 0\n",
+        encoding="ascii",
+    )
+    os.chmod(script_path, 0o700)
+    approval = _approval(
+        ("/bin/sh", str(script_path), str(leader_path), str(child_path)),
+        timeout_seconds=5.0,
+    )
+    runner = ApprovedCheckRunner(
+        {approval.approval_commitment: approval},
+        sandbox=_ReadyCheckSandbox(),
+    )
+    started = time.monotonic()
+    result = runner.run(
+        ApprovedCheckCommand(
+            workspace=handle,
+            approval=approval,
+            subject_state_digest="sha256:" + "2" * 64,
+        )
+    )
+    elapsed = time.monotonic() - started
+    # The outcome contract is unchanged: the check itself succeeded.
+    assert result.status is ApprovedCheckStatus.PASSED
+    assert result.outcome is ApprovedCheckOutcome.SUCCESS
+    assert result.exit_status == 0
+    assert elapsed < 4.0
+    group_id = int(leader_path.read_text(encoding="ascii").strip())
+    descendant_pid = int(child_path.read_text(encoding="ascii").strip())
+    with pytest.raises(ProcessLookupError):
+        os.kill(descendant_pid, 0)
+    with pytest.raises(ProcessLookupError):
+        os.killpg(group_id, 0)


### PR DESCRIPTION
Closes #399

## Summary

- launch POSIX approved checks in a dedicated session/process group and Windows checks in a new process group
- retain the launch-time POSIX group identity even when the direct child exits before timeout
- terminate with TERM, escalate to KILL, and wait for the isolated group before returning the terminal timeout result
- document the timeout/reaping contract without changing output, redaction, or result wire shapes
- add regressions for deterministic nonforking timeout, real forked-descendant termination, and no post-result workspace mutation

## Verification

- `uv run pytest tests/unit/adapters/test_approved_checks.py tests/unit/adapters/test_check_sandbox.py -q --tb=short` — 9 passed
- `uv run ruff check src/yoetz/adapters/approved_checks.py tests/unit/adapters/test_approved_checks.py` — passed
- `uv run ruff format --check src/yoetz/adapters/approved_checks.py tests/unit/adapters/test_approved_checks.py` — passed
- `npx --no-install pyright src/yoetz/adapters/approved_checks.py tests/unit/adapters/test_approved_checks.py` — 0 errors

## Dogfood

Implemented in the isolated official ARM64 Cursor Testing instance with Cursor Grok 4.6 at Medium effort. The final regression was independently hardened to record the actual background child PID and cover a leader that exits before timeout while its descendant holds inherited pipes open.