### PR TITLE
fix: make evidence co-requirement hints actionable

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -102,12 +102,15 @@ unknown or hostile property names are never echoed. Closed reason tokens are:
   and the required peer are named; the authoring hint states the schema peer rule (e.g.
   `workspace_ref requires external_ref`) without echoing submitted values;
 - `conditional_field_required` — a root-level schema `if`/`then` (or equivalent closed object rule)
-  activated required alternatives, or a selected const-discriminated `oneOf` branch has a missing
-  required peer (for example `start` with `mode` `attach` without `session_id`, or
-  `evidence_recorded` with `strength` `mutable_reference` without `reference`). Named fields are
-  the safe required alternatives; the authoring hint states the activating condition when it is a
-  bounded schema const (e.g. `mode attach requires …` or `strength mutable_reference requires
-  reference`).
+  activated required alternatives, a selected const-discriminated `oneOf` branch has a missing
+  required peer or `anyOf`-of-`required` alternative (for example `start` with `mode` `attach`
+  without `session_id`, `evidence_recorded` with `strength` `mutable_reference` without `reference`,
+  or `strength` `metadata_only` with neither `description` nor `reference`), or a selected payload's
+  `allOf` `if`/`then` required pair is incomplete (for example `content_digest` without
+  `digest_binding`). Named fields are the safe required alternatives; the authoring hint states the
+  activating condition when it is a bounded schema const (e.g. `mode attach requires …`, `strength
+  mutable_reference requires reference`, or `strength metadata_only requires description or
+  reference`) and otherwise the schema peer rule (e.g. `content_digest requires digest_binding`).
 
 These object-rule tokens are projected only from checked-in schema metadata and validator kind —
 never from caller-controlled keys or free-form exception text. Unrecognized object rules degrade

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -107,10 +107,13 @@ unknown or hostile property names are never echoed. Closed reason tokens are:
   without `session_id`, `evidence_recorded` with `strength` `mutable_reference` without `reference`,
   or `strength` `metadata_only` with neither `description` nor `reference`), or a selected payload's
   `allOf` `if`/`then` required pair is incomplete (for example `content_digest` without
-  `digest_binding`). Named fields are the safe required alternatives; the authoring hint states the
-  activating condition when it is a bounded schema const (e.g. `mode attach requires …`, `strength
-  mutable_reference requires reference`, or `strength metadata_only requires description or
-  reference`) and otherwise the schema peer rule (e.g. `content_digest requires digest_binding`).
+  `digest_binding`, or `action_kind` `command` without `command`). Named fields are the safe
+  required alternatives; the authoring hint states the activating condition when it is a bounded
+  schema const (e.g. `mode attach requires …`, `strength mutable_reference requires reference`,
+  `strength metadata_only requires description or reference`, or `action_kind command requires
+  command`) and otherwise the schema peer rule (e.g. `content_digest requires digest_binding`). A
+  payload field that is required unconditionally is never this token: with no activating condition
+  to state, it falls through to the residual path token instead.
 
 These object-rule tokens are projected only from checked-in schema metadata and validator kind —
 never from caller-controlled keys or free-form exception text. Unrecognized object rules degrade

--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -427,10 +427,11 @@ def safe_validation_locations(exc: object) -> tuple[dict[str, str], ...]:
         elif reason == _CONDITIONAL_FIELD_REQUIRED_REASON:
             family = _family_from_validation_item(source)
             family_version = _family_version_from_validation_item(source)
-            condition = _conditional_requirement_from_validation_item(source)
-            if family is not None and family_version is not None and condition is not None:
+            if family is not None and family_version is not None:
                 entry["family"] = family
                 entry["family_version"] = family_version
+            condition = _conditional_requirement_from_validation_item(source)
+            if condition is not None:
                 entry["condition_field"] = condition[0]
                 entry["condition_value"] = condition[1]
         projected.append(entry)
@@ -737,20 +738,17 @@ def _payload_schema(
 def _conditional_requirement_hint_parts(
     document: Mapping[str, JsonValue], locations: Sequence[Mapping[str, str]]
 ) -> list[tuple[str, tuple[str, str]]]:
-    """Render selected-oneOf repairs only after re-checking frozen schema metadata."""
+    """Render selected-oneOf, anyOf-of-required, and allOf peer repairs from frozen schema metadata."""
 
     parts: list[tuple[str, tuple[str, str]]] = []
+    seen: set[str] = set()
     for location in locations:
         if location.get("reason") != _CONDITIONAL_FIELD_REQUIRED_REASON:
             continue
         pointer = location.get("field")
-        condition_field = location.get("condition_field")
-        condition_value = location.get("condition_value")
         if (
             type(pointer) is not str
             or _EVENT_DRAFT_PAYLOAD_FIELD_POINTER.fullmatch(pointer) is None
-            or type(condition_field) is not str
-            or type(condition_value) is not str
         ):
             continue
         required = pointer.rsplit("/", 1)[-1]
@@ -762,35 +760,114 @@ def _conditional_requirement_hint_parts(
         if payload is None:
             continue
         properties = payload.get("properties")
-        options = payload.get("oneOf")
-        if (
-            not isinstance(properties, Mapping)
-            or condition_field not in properties
-            or required not in properties
-            or not isinstance(options, list)
-        ):
+        if not isinstance(properties, Mapping) or required not in properties:
             continue
-        for branch in cast(list[JsonValue], options):
-            if not isinstance(branch, Mapping):
-                continue
-            branch_properties = cast(Mapping[str, JsonValue], branch).get("properties")
-            branch_required = cast(Mapping[str, JsonValue], branch).get("required")
-            if not isinstance(branch_properties, Mapping) or not isinstance(branch_required, list):
-                continue
-            condition = cast(Mapping[str, JsonValue], branch_properties).get(condition_field)
-            if not isinstance(condition, Mapping):
-                continue
-            if (
-                cast(Mapping[str, JsonValue], condition).get("const") != condition_value
-                or required not in branch_required
-            ):
-                continue
-            text = f"{condition_field} {condition_value} requires {required}"
-            parts.append((text, (text, "")))
-            break
+        prop_names = cast(Mapping[str, JsonValue], properties)
+        text = _selected_branch_requirement_text(
+            payload,
+            prop_names,
+            location.get("condition_field"),
+            location.get("condition_value"),
+            required,
+        )
+        if text is None:
+            text = _allof_required_peer_text(payload, prop_names, required)
+        if text is None or text in seen:
+            continue
+        seen.add(text)
+        parts.append((text, (text, "")))
         if len(parts) == _MAX_HINT_FIELDS:
             break
     return parts
+
+
+def _selected_branch_requirement_text(
+    payload: Mapping[str, JsonValue],
+    prop_names: Mapping[str, JsonValue],
+    condition_field: object,
+    condition_value: object,
+    required: str,
+) -> str | None:
+    """Return the selected const-branch repair, including anyOf required alternatives."""
+
+    options = payload.get("oneOf")
+    if (
+        type(condition_field) is not str
+        or type(condition_value) is not str
+        or condition_field not in prop_names
+        or not isinstance(options, list)
+    ):
+        return None
+    for branch in cast(list[JsonValue], options):
+        if not isinstance(branch, Mapping):
+            continue
+        source = cast(Mapping[str, JsonValue], branch)
+        branch_properties = source.get("properties")
+        if not isinstance(branch_properties, Mapping):
+            continue
+        condition = cast(Mapping[str, JsonValue], branch_properties).get(condition_field)
+        if not isinstance(condition, Mapping):
+            continue
+        if cast(Mapping[str, JsonValue], condition).get("const") != condition_value:
+            continue
+        branch_required = source.get("required")
+        if isinstance(branch_required, list) and required in cast(list[object], branch_required):
+            return f"{condition_field} {condition_value} requires {required}"
+        alternatives = source.get("anyOf")
+        if not isinstance(alternatives, list):
+            continue
+        matched = False
+        names: list[str] = []
+        for alternative in cast(list[JsonValue], alternatives):
+            if not isinstance(alternative, Mapping):
+                continue
+            required_list = cast(Mapping[str, JsonValue], alternative).get("required")
+            text = _format_required_list(required_list, prop_names)
+            if not text:
+                continue
+            if text not in names:
+                names.append(text)
+            if isinstance(required_list, list) and required in cast(list[object], required_list):
+                matched = True
+        if matched and names:
+            return f"{condition_field} {condition_value} requires {' or '.join(names)}"
+    return None
+
+
+def _allof_required_peer_text(
+    payload: Mapping[str, JsonValue],
+    prop_names: Mapping[str, JsonValue],
+    missing: str,
+) -> str | None:
+    """Return a simple ``if required X then required Y`` allOf peer, or None."""
+
+    all_of = payload.get("allOf")
+    if not isinstance(all_of, list):
+        return None
+    for item in cast(list[JsonValue], all_of):
+        if not isinstance(item, Mapping):
+            continue
+        source = cast(Mapping[str, JsonValue], item)
+        if_node = source.get("if")
+        then_node = source.get("then")
+        if not isinstance(if_node, Mapping) or not isinstance(then_node, Mapping):
+            continue
+        if "properties" in if_node:
+            continue
+        if_required = cast(Mapping[str, JsonValue], if_node).get("required")
+        then_required = cast(Mapping[str, JsonValue], then_node).get("required")
+        if not isinstance(if_required, list) or len(cast(list[object], if_required)) != 1:
+            continue
+        present = _format_required_list(if_required, prop_names)
+        if (
+            not present
+            or not isinstance(then_required, list)
+            or missing not in cast(list[object], then_required)
+            or _format_required_list(then_required, prop_names) != missing
+        ):
+            continue
+        return f"{present} requires {missing}"
+    return None
 
 
 def _unknown_property_measure(count: object) -> str:

--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -839,7 +839,12 @@ def _allof_required_peer_text(
     prop_names: Mapping[str, JsonValue],
     missing: str,
 ) -> str | None:
-    """Return a simple ``if required X then required Y`` allOf peer, or None."""
+    """Return a single-condition ``if``/``then`` allOf peer for the missing field, or None.
+
+    Both frozen shapes are rendered: ``if required X then required Y`` (``content_digest requires
+    digest_binding``) and the single-property ``if properties.X const V then required Y``
+    (``action_kind command requires command``).
+    """
 
     all_of = payload.get("allOf")
     if not isinstance(all_of, list):
@@ -852,22 +857,31 @@ def _allof_required_peer_text(
         then_node = source.get("then")
         if not isinstance(if_node, Mapping) or not isinstance(then_node, Mapping):
             continue
-        if "properties" in if_node:
-            continue
-        if_required = cast(Mapping[str, JsonValue], if_node).get("required")
         then_required = cast(Mapping[str, JsonValue], then_node).get("required")
-        if not isinstance(if_required, list) or len(cast(list[object], if_required)) != 1:
-            continue
-        present = _format_required_list(if_required, prop_names)
         if (
-            not present
-            or not isinstance(then_required, list)
+            not isinstance(then_required, list)
             or missing not in cast(list[object], then_required)
             or _format_required_list(then_required, prop_names) != missing
         ):
             continue
+        present = _allof_peer_condition_text(cast(Mapping[str, JsonValue], if_node), prop_names)
+        if present is None:
+            continue
         return f"{present} requires {missing}"
     return None
+
+
+def _allof_peer_condition_text(
+    if_node: Mapping[str, JsonValue], prop_names: Mapping[str, JsonValue]
+) -> str | None:
+    """Name an allOf peer condition: a const-valued property, else a single required key."""
+
+    if isinstance(if_node.get("properties"), Mapping):
+        return _if_const_condition(if_node, prop_names)
+    if_required = if_node.get("required")
+    if not isinstance(if_required, list) or len(cast(list[object], if_required)) != 1:
+        return None
+    return _format_required_list(if_required, prop_names) or None
 
 
 def _unknown_property_measure(count: object) -> str:

--- a/src/yoetz/protocol/schemas.py
+++ b/src/yoetz/protocol/schemas.py
@@ -1110,7 +1110,17 @@ def _project_selected_one_of_required_locations_impl(
     payload_properties = _payload_property_names_from_option(option_values[selected_index])
     if payload_properties is None:
         return None
-    ordered = _missing_required_locations(selected, base_path, payload_properties)
+    # No discriminator picked this branch's contract, so only rules the schema itself marks
+    # conditional (``anyOf``/``allOf`` of ``required``) may be reported as conditional. A plain
+    # top-level ``required`` failure here is an unconditional payload field: projecting it would
+    # both mislabel the reason and strand the caller with a repair sentence no rule can render.
+    ordered = _missing_required_locations(
+        selected,
+        base_path,
+        payload_properties,
+        wrappers_only=True,
+        branch_schema_path=parent_schema_path + (selected_index,),
+    )
     if not ordered:
         return None
     identity = _selected_family_for(exc) or _family_from_option(option_values[selected_index])
@@ -1192,12 +1202,21 @@ def _missing_required_locations(
     errors: Sequence[ValidationError],
     base_path: tuple[str | int, ...],
     admitted: frozenset[str],
+    *,
+    wrappers_only: bool = False,
+    branch_schema_path: tuple[object, ...] = (),
 ) -> list[tuple[tuple[str | int, ...], str]]:
     """Collect missing schema-named required fields from one already-selected branch.
 
     Direct ``required`` errors and ``anyOf``/``allOf`` wrappers of ``required`` are in scope.
     Nested ``oneOf`` is left to the discriminator-selecting caller so sibling contracts stay
     unprojected.
+
+    ``wrappers_only`` narrows the collection to ``required`` rules that sit under an
+    ``anyOf``/``allOf`` inside ``branch_schema_path``. Every location this collection yields is
+    reported as ``conditional_field_required``, so a caller that has not proved the whole branch
+    conditional on a matched discriminator must pass it: an unconditional payload ``required``
+    would otherwise be labelled conditional and carry no repair sentence at all.
     """
 
     ordered: list[tuple[tuple[str | int, ...], str]] = []
@@ -1207,6 +1226,8 @@ def _missing_required_locations(
             return
         validator = error.validator
         if validator == "required":
+            if wrappers_only and not _is_wrapped_required(error, branch_schema_path):
+                return
             _append_missing_required(error, base_path, admitted, ordered)
             return
         if validator == "anyOf":
@@ -1222,6 +1243,26 @@ def _missing_required_locations(
         if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
             break
     return ordered
+
+
+_CONDITIONAL_SCHEMA_WRAPPERS: Final = frozenset({"anyOf", "allOf"})
+
+
+def _is_wrapped_required(error: ValidationError, branch_schema_path: tuple[object, ...]) -> bool:
+    """True when a ``required`` rule sits under an ``anyOf``/``allOf`` inside the given branch.
+
+    ``$ref``-resolved payload rules arrive flat rather than nested under a wrapper error, so the
+    schema location is what distinguishes ``allOf/0/then/required`` from the payload's own
+    unconditional ``required``.
+    """
+
+    schema_path = tuple(error.absolute_schema_path)
+    if schema_path[: len(branch_schema_path)] != branch_schema_path:
+        return False
+    return any(
+        segment in _CONDITIONAL_SCHEMA_WRAPPERS
+        for segment in schema_path[len(branch_schema_path) :]
+    )
 
 
 def _append_missing_required(

--- a/src/yoetz/protocol/schemas.py
+++ b/src/yoetz/protocol/schemas.py
@@ -997,14 +997,25 @@ def _project_root_object_rule_locations(
 
 def _project_selected_one_of_required_locations(
     exc: ValidationError,
-) -> tuple[tuple[tuple[tuple[str | int, ...], str], ...], str, str, tuple[str, str] | None] | None:
+) -> (
+    tuple[
+        tuple[tuple[tuple[str | int, ...], str], ...],
+        str | None,
+        str | None,
+        tuple[str, str] | None,
+    ]
+    | None
+):
     """Project required peers from exactly one const-discriminated ``oneOf`` branch.
 
     A failed ``oneOf`` normally has an empty instance path.  Flattening all of its branches would
     name fields from alternatives the caller did not choose, while selecting the parent error
     loses the actual missing peer.  This picks a branch only when sibling const rejections prove
-    that every other branch was ruled out by the same schema-authored property.  Projection is
-    best-effort: an unexpected error-tree shape degrades to the generic best-path rule.
+    that every other branch was ruled out by the same schema-authored property.  The selected
+    branch's own ``required`` list, ``anyOf``-of-``required`` alternatives, and sibling ``allOf``
+    ``if``/``then`` required peers are all eligible once the branch is uniquely selected.
+    Projection is best-effort: an unexpected error-tree shape degrades to the generic best-path
+    rule.
     """
 
     try:
@@ -1015,7 +1026,15 @@ def _project_selected_one_of_required_locations(
 
 def _project_selected_one_of_required_locations_impl(
     exc: ValidationError,
-) -> tuple[tuple[tuple[tuple[str | int, ...], str], ...], str, str, tuple[str, str] | None] | None:
+) -> (
+    tuple[
+        tuple[tuple[tuple[str | int, ...], str], ...],
+        str | None,
+        str | None,
+        tuple[str, str] | None,
+    ]
+    | None
+):
     if exc.validator != "oneOf" or not isinstance(exc.schema, Mapping):
         return None
     branches: dict[int, list[ValidationError]] = {}
@@ -1072,21 +1091,7 @@ def _project_selected_one_of_required_locations_impl(
         if len(survivors) != 1:
             continue
         selected_index, selected_value = survivors[0]
-        ordered: list[tuple[tuple[str | int, ...], str]] = []
-        for error in branches[selected_index]:
-            validator_value = cast(object, error.validator_value)
-            if error.validator != "required" or not isinstance(validator_value, list):
-                continue
-            instance = error.instance
-            if not isinstance(instance, Mapping):
-                continue
-            for item in cast(list[object], validator_value):
-                required = _safe_schema_field(item, root_properties)
-                if required is None or required in instance:
-                    continue
-                location = (base_path + (required,), _OBJECT_RULE_CONDITIONAL)
-                if location not in ordered:
-                    ordered.append(location)
+        ordered = _missing_required_locations(branches[selected_index], base_path, root_properties)
         if ordered:
             return (tuple(ordered), field, selected_value, _selected_family_for(exc))
     # Descend only into a branch the discriminator proved selected. Recursing into
@@ -1099,7 +1104,148 @@ def _project_selected_one_of_required_locations_impl(
         projected = _project_selected_one_of_required_locations_impl(nested)
         if projected is not None:
             return projected
-    return None
+    selected_index = _shared_branch_index(parent_schema_path, selected)
+    if selected_index is None or not 0 <= selected_index < len(option_values):
+        return None
+    payload_properties = _payload_property_names_from_option(option_values[selected_index])
+    if payload_properties is None:
+        return None
+    ordered = _missing_required_locations(selected, base_path, payload_properties)
+    if not ordered:
+        return None
+    identity = _selected_family_for(exc) or _family_from_option(option_values[selected_index])
+    return (tuple(ordered), None, None, identity)
+
+
+def _shared_branch_index(
+    parent_schema_path: tuple[object, ...], errors: Sequence[ValidationError]
+) -> int | None:
+    """Return the one child index shared by every selected error, or None if mixed."""
+
+    indices: set[int] = set()
+    for error in errors:
+        schema_path = tuple(error.absolute_schema_path)
+        if len(schema_path) <= len(parent_schema_path):
+            return None
+        index = schema_path[len(parent_schema_path)]
+        if type(index) is not int:
+            return None
+        indices.add(index)
+    return next(iter(indices)) if len(indices) == 1 else None
+
+
+def _payload_property_names_from_option(option: object) -> frozenset[str] | None:
+    """Return payload property names from one event-draft union option, resolving ``$ref``."""
+
+    if not isinstance(option, Mapping):
+        return None
+    properties = cast(Mapping[str, JsonValue], option).get("properties")
+    if not isinstance(properties, Mapping):
+        return None
+    return _schema_property_names(
+        _resolve_schema_mapping(cast(Mapping[str, JsonValue], properties).get("payload"))
+    )
+
+
+def _family_from_option(option: object) -> tuple[str, str] | None:
+    """Name the family whose payload ``$ref`` this event-draft option carries."""
+
+    payload = _resolve_schema_mapping(_option_payload_node(option))
+    if payload is None:
+        return None
+    schema_id = payload.get("$id")
+    if type(schema_id) is not str:
+        return None
+    document = _load_catalog_state().catalog.by_id.get(schema_id)
+    if document is None:
+        return None
+    family = document.schema_name.replace("-", "_")
+    version = document.schema_version
+    if family not in _load_catalog_state().catalog.event_schema_versions:
+        return None
+    return (family, version) if SCHEMA_VERSION_PATTERN.fullmatch(version) is not None else None
+
+
+def _option_payload_node(option: object) -> object:
+    if not isinstance(option, Mapping):
+        return None
+    properties = cast(Mapping[str, JsonValue], option).get("properties")
+    if not isinstance(properties, Mapping):
+        return None
+    return cast(Mapping[str, JsonValue], properties).get("payload")
+
+
+def _resolve_schema_mapping(node: object) -> Mapping[str, JsonValue] | None:
+    """Return a schema object, following a same-catalog ``$ref`` when that is the node."""
+
+    if not isinstance(node, Mapping):
+        return None
+    source = cast(Mapping[str, JsonValue], node)
+    ref = source.get("$ref")
+    if type(ref) is not str:
+        return source
+    target = _load_catalog_state().plain_by_id.get(ref)
+    return target if isinstance(target, dict) else None
+
+
+def _missing_required_locations(
+    errors: Sequence[ValidationError],
+    base_path: tuple[str | int, ...],
+    admitted: frozenset[str],
+) -> list[tuple[tuple[str | int, ...], str]]:
+    """Collect missing schema-named required fields from one already-selected branch.
+
+    Direct ``required`` errors and ``anyOf``/``allOf`` wrappers of ``required`` are in scope.
+    Nested ``oneOf`` is left to the discriminator-selecting caller so sibling contracts stay
+    unprojected.
+    """
+
+    ordered: list[tuple[tuple[str | int, ...], str]] = []
+
+    def consider(error: ValidationError) -> None:
+        if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
+            return
+        validator = error.validator
+        if validator == "required":
+            _append_missing_required(error, base_path, admitted, ordered)
+            return
+        if validator == "anyOf":
+            for nested in error.context or ():
+                consider(nested)
+            return
+        if validator == "allOf":
+            for nested in error.context or ():
+                consider(nested)
+
+    for error in errors:
+        consider(error)
+        if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
+            break
+    return ordered
+
+
+def _append_missing_required(
+    error: ValidationError,
+    base_path: tuple[str | int, ...],
+    admitted: frozenset[str],
+    ordered: list[tuple[tuple[str | int, ...], str]],
+) -> None:
+    validator_value = cast(object, error.validator_value)
+    instance = error.instance
+    if not isinstance(validator_value, list) or not isinstance(instance, Mapping):
+        return
+    object_path = _path_items_from(error)
+    if object_path is None:
+        object_path = base_path
+    for item in cast(list[object], validator_value):
+        required = _safe_schema_field(item, admitted)
+        if required is None or required in instance:
+            continue
+        location = (object_path + (required,), _OBJECT_RULE_CONDITIONAL)
+        if location not in ordered:
+            ordered.append(location)
+        if len(ordered) >= _MAX_PROJECTED_OBJECT_LOCATIONS:
+            return
 
 
 def _project_root_object_rule_locations_impl(

--- a/tests/unit/mcp/test_root_object_rule_locations.py
+++ b/tests/unit/mcp/test_root_object_rule_locations.py
@@ -156,6 +156,78 @@ def test_selected_payload_one_of_names_its_missing_co_required_field() -> None:
     assert "strength admits" not in message
 
 
+def test_selected_payload_any_of_required_names_metadata_only_alternatives() -> None:
+    """A metadata_only draft missing both description and reference must name the pair (#335)."""
+
+    base = deepcopy(cast(dict[str, object], cast(list[object], _PUBLISH_SCHEMA["examples"])[0]))
+    draft = cast(dict[str, object], cast(list[object], base["event_drafts"])[0])
+    draft["schema"] = {"name": "evidence_recorded", "version": "1.1.0"}
+    draft["payload"] = {
+        "evidence_id": "evd_00000000-0000-4000-8000-000000000001",
+        "evidence_kind": "artifact",
+        "strength": "metadata_only",
+        "observed_at": "2026-01-01T00:00:00.000Z",
+    }
+    with pytest.raises(ValidationError) as captured:
+        PublishWorkRequest.model_validate(base)
+
+    locations = safe_validation_locations(captured.value)
+    assert locations == (
+        {
+            "field": "/event_drafts/0/payload/description",
+            "reason": "conditional_field_required",
+            "family": "evidence_recorded",
+            "family_version": "1.1.0",
+            "condition_field": "strength",
+            "condition_value": "metadata_only",
+        },
+        {
+            "field": "/event_drafts/0/payload/reference",
+            "reason": "conditional_field_required",
+            "family": "evidence_recorded",
+            "family_version": "1.1.0",
+            "condition_field": "strength",
+            "condition_value": "metadata_only",
+        },
+    )
+    message = invalid_request_message("publish_work", locations)
+    assert "strength metadata_only requires description or reference" in message
+    assert "each event_drafts entry requires" not in message
+    assert "strength admits" not in message
+
+
+def test_selected_payload_all_of_requires_digest_binding_with_content_digest() -> None:
+    """A content_digest draft missing digest_binding must name the allOf peer (#335)."""
+
+    base = deepcopy(cast(dict[str, object], cast(list[object], _PUBLISH_SCHEMA["examples"])[0]))
+    draft = cast(dict[str, object], cast(list[object], base["event_drafts"])[0])
+    draft["schema"] = {"name": "evidence_recorded", "version": "1.1.0"}
+    draft["payload"] = {
+        "evidence_id": "evd_00000000-0000-4000-8000-000000000001",
+        "evidence_kind": "artifact",
+        "strength": "content_digest",
+        "content_digest": "sha256:" + ("0" * 64),
+        "observed_at": "2026-01-01T00:00:00.000Z",
+        "description": "bounded evidence description",
+    }
+    with pytest.raises(ValidationError) as captured:
+        PublishWorkRequest.model_validate(base)
+
+    locations = safe_validation_locations(captured.value)
+    assert locations == (
+        {
+            "field": "/event_drafts/0/payload/digest_binding",
+            "reason": "conditional_field_required",
+            "family": "evidence_recorded",
+            "family_version": "1.1.0",
+        },
+    )
+    message = invalid_request_message("publish_work", locations)
+    assert "content_digest requires digest_binding" in message
+    assert "each event_drafts entry requires" not in message
+    assert "strength admits" not in message
+
+
 def test_unselected_sibling_branch_contract_is_never_projected() -> None:
     """When const rejections cannot isolate one branch, no branch's contract is projected.
 

--- a/tests/unit/mcp/test_root_object_rule_locations.py
+++ b/tests/unit/mcp/test_root_object_rule_locations.py
@@ -228,6 +228,78 @@ def test_selected_payload_all_of_requires_digest_binding_with_content_digest() -
     assert "strength admits" not in message
 
 
+def _action_recorded_locations(payload: dict[str, object]) -> tuple[dict[str, str], ...]:
+    base = deepcopy(cast(dict[str, object], cast(list[object], _PUBLISH_SCHEMA["examples"])[0]))
+    draft = cast(dict[str, object], cast(list[object], base["event_drafts"])[0])
+    draft["schema"] = {"name": "action_recorded", "version": "1.0.0"}
+    draft["payload"] = payload
+    with pytest.raises(ValidationError) as captured:
+        PublishWorkRequest.model_validate(base)
+    return safe_validation_locations(captured.value)
+
+
+def test_unconditional_payload_required_is_not_reported_as_conditional() -> None:
+    """A plain missing payload field must keep an actionable envelope hint, not a bare pointer.
+
+    Without a discriminator to select the branch, a top-level ``required`` failure carries no
+    activating condition, so no repair sentence can be rendered for it. Projecting it as
+    ``conditional_field_required`` therefore both mislabelled the rule and produced an empty hint.
+    """
+
+    locations = _action_recorded_locations(
+        {"action_kind": "edit", "description": "bounded action description"}
+    )
+    assert all(item.get("reason") != "conditional_field_required" for item in locations)
+    assert locations == ({"field": "/event_drafts/0/payload", "reason": "invalid_type_or_value"},)
+
+    hint = authoring_hint(_PUBLISH_SCHEMA, locations)
+    assert "each event_drafts entry requires" in hint
+    assert "payload" in hint
+    message = invalid_request_message("publish_work", locations)
+    assert "each event_drafts entry requires" in message
+
+
+def test_selected_payload_all_of_property_const_names_its_required_peer() -> None:
+    """A command action missing ``command`` must name the const condition that activated it."""
+
+    locations = _action_recorded_locations(
+        {
+            "action_id": "act_00000000-0000-4000-8000-000000000001",
+            "action_kind": "command",
+            "description": "bounded action description",
+        }
+    )
+    assert locations == (
+        {
+            "field": "/event_drafts/0/payload/command",
+            "reason": "conditional_field_required",
+            "family": "action_recorded",
+            "family_version": "1.0.0",
+        },
+    )
+    message = invalid_request_message("publish_work", locations)
+    assert "action_kind command requires command" in message
+    assert "action_kind admits" not in message
+
+
+def test_mixed_payload_requireds_report_only_the_conditional_peer() -> None:
+    """An unconditional miss beside a conditional one must not borrow the conditional token."""
+
+    locations = _action_recorded_locations(
+        {"action_kind": "command", "description": "bounded action description"}
+    )
+    assert all(item.get("field") != "/event_drafts/0/payload/action_id" for item in locations)
+    assert locations == (
+        {
+            "field": "/event_drafts/0/payload/command",
+            "reason": "conditional_field_required",
+            "family": "action_recorded",
+            "family_version": "1.0.0",
+        },
+    )
+    assert "action_kind command requires command" in authoring_hint(_PUBLISH_SCHEMA, locations)
+
+
 def test_unselected_sibling_branch_contract_is_never_projected() -> None:
     """When const rejections cannot isolate one branch, no branch's contract is projected.
 


### PR DESCRIPTION
Closes #335

## Summary
- project selected `anyOf`-of-`required` alternatives from frozen schema metadata after the enclosing event-draft branch is uniquely selected
- project simple selected-payload `allOf` `if`/`then` required peers without exposing caller-controlled field names
- render actionable hints for `metadata_only` missing both `description`/`reference` and `content_digest` missing `digest_binding`
- document the extended `conditional_field_required` contract and add both regression rows

## Verification
- focused and adjacent schema/MCP slice: 169 passed
- Ruff check and format: passed
- Pyright: 0 errors
- GitHub required CI: green

## Dogfood
Implemented in the isolated official arm64 Cursor Testing instance with Cursor Grok 4.6 at Medium effort. Yoetz `start` succeeded before edits, and the plan and implementation evidence were published through the installed Cursor MCP integration. The isolated Cursor account intentionally had no regular GitHub credential, so the validated commit was pushed and this PR was opened from the trusted maintainer terminal.

After issue #153 head `9f9cfdd` was installed, Cursor received exact JSON MCP results, corrected the dry-run from typed `EVENT_INVALID` details, and resolved the #335 delivery obligation at frontier 23 against PR #406 head `297c1c8f386b14e221ec64888bd533c8a6d68f0d`. A fresh `semantic_required` check is honestly pending the typed repository privacy setup continuation; no provider success or final receipt is claimed yet.