### PR TITLE
Repair issue 403 release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,7 +485,17 @@ jobs:
           set -euo pipefail
           if [[ "${1:-}" == "pip" && "${2:-}" == "install" ]]; then
             shift 2
-            exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"
+            has_no_index=false
+            for argument in "$@"; do
+              if [[ "$argument" == "--no-index" ]]; then
+                has_no_index=true
+                break
+              fi
+            done
+            if [[ "$has_no_index" == false ]]; then
+              set -- --no-index "$@"
+            fi
+            exec "${YOETZ_REAL_UV:?}" pip install "$@"
           fi
           exec "${YOETZ_REAL_UV:?}" "$@"
           UV_WRAPPER
@@ -595,7 +605,17 @@ jobs:
           set -euo pipefail
           if [[ "${1:-}" == "pip" && "${2:-}" == "install" ]]; then
             shift 2
-            exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"
+            has_no_index=false
+            for argument in "$@"; do
+              if [[ "$argument" == "--no-index" ]]; then
+                has_no_index=true
+                break
+              fi
+            done
+            if [[ "$has_no_index" == false ]]; then
+              set -- --no-index "$@"
+            fi
+            exec "${YOETZ_REAL_UV:?}" pip install "$@"
           fi
           exec "${YOETZ_REAL_UV:?}" "$@"
           UV_WRAPPER

--- a/tests/integration/service/test_installation_recovery_flow.py
+++ b/tests/integration/service/test_installation_recovery_flow.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -79,14 +81,27 @@ def _private_dir(path: Path) -> None:
     path.chmod(0o700)
 
 
+@pytest.fixture
+def private_test_root() -> Iterator[Path]:
+    """Keep synthetic installation state outside pytest's shared temporary root."""
+
+    with tempfile.TemporaryDirectory(
+        prefix=".yoetz-installation-recovery-",
+        dir=Path.home(),
+    ) as temporary:
+        root = Path(temporary)
+        root.chmod(0o700)
+        yield root
+
+
 @pytest.mark.anyio
 async def test_self_contained_clean_profile_restores_same_vault_authority(
-    tmp_path: Path,
+    private_test_root: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     clock = _Clock()
-    original_bundle = tmp_path / "original"
-    original_state = tmp_path / "original-state"
+    original_bundle = private_test_root / "original"
+    original_state = private_test_root / "original-state"
     _private_dir(original_bundle)
     _private_dir(original_state)
     original_throttle = UnlockThrottleStore(
@@ -201,11 +216,11 @@ async def test_self_contained_clean_profile_restores_same_vault_authority(
     metadata = sets.stage(artifact, snapshot)
     await vault.commit_installation_recovery_metadata(metadata)
     sets.activate(metadata)
-    archive = tmp_path / "installation-recovery.yirs"
+    archive = private_test_root / "installation-recovery.yirs"
     sets.export_generation(1, archive)
 
-    clean_bundle = tmp_path / "clean"
-    clean_state = tmp_path / "clean-state"
+    clean_bundle = private_test_root / "clean"
+    clean_state = private_test_root / "clean-state"
     _private_dir(clean_bundle)
     _private_dir(clean_state)
     clean_sets = InstallationRecoverySetStore(clean_bundle)

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -230,7 +230,10 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
     for verifier in (linux, macos):
         assert "uv run --locked pytest tests/packaging \\" in verifier
         assert 'tagged_uv_wrapper="${{ runner.temp }}/tagged-uv-bin"' in verifier
-        assert 'exec "${YOETZ_REAL_UV:?}" pip install --no-index "$@"' in verifier
+        assert 'if [[ "$argument" == "--no-index" ]]' in verifier
+        assert 'set -- --no-index "$@"' in verifier
+        assert 'exec "${YOETZ_REAL_UV:?}" pip install "$@"' in verifier
+        assert 'pip install --no-index "$@"' not in verifier
         assert 'PATH="$tagged_uv_wrapper:$PATH" \\' in verifier
         assert 'UV_CACHE_DIR="${{ runner.temp }}/tagged-offline-cache" \\' in verifier
         assert ".venv/bin/pytest \\" in verifier


### PR DESCRIPTION
## Issue

- Refs #403 (do not auto-close until the publication-disabled Linux and macOS rehearsal is green on merged `main`)
- I searched existing issues and PRs for duplicates before opening this PR; #403 is the acknowledged design-gated owner.
- Maintainer acknowledgement: https://github.com/TheGaySupreme123/yoetz/issues/403#issuecomment-5387643844

## Documentation

- Behavior change? `no`
- Docs updated: `n/a — no product behavior change`; this repairs portable test/release verification only.

## Verification

Commands run:

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked pytest tests/integration/service/test_installation_recovery_flow.py::test_self_contained_clean_profile_restores_same_vault_authority tests/packaging/test_release_workflow_contract.py -q
# 13 passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked pytest tests/integration/service/test_installation_recovery_flow.py tests/packaging/test_release_workflow_contract.py tests/packaging/test_offline_reinstall.py -q --timeout=900
# 24 passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked pytest tests/packaging -q --timeout=900
# 273 passed, 3 skipped, 4 xfailed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked ruff check .
# All checks passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run --locked ruff format --check .
# 604 files already formatted

npx --no-install pyright
# 0 errors, 0 warnings, 0 informations

git diff --check
# clean
```

The generated-resource fixed-point command is not applicable: this change does not alter a packaged-resource inventory or owner-controlled generated artifact.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.
- [x] Production path-safety remains unchanged; the synthetic recovery drill now uses an owner-private test root.
- [x] Offline tests retain their own explicit `--offline` / `--no-index` controls; the workflow wrapper now avoids duplicating an already-present `--no-index` argument.

## Summary

Repair the two remaining portable verification blockers recorded on #403. The Linux clean-profile recovery drill now creates its synthetic installation under an owner-private home-scoped temporary directory instead of pytest's shared `/tmp`, preserving the production `path_shared_temp` rejection. Both platform release wrappers now inject `--no-index` only when the test command does not already supply it, and the workflow contract locks that behavior.
