### PR TITLE
feat(codex): add consent-gated plugin and MCP uninstall

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2896,9 +2896,11 @@ is surfaced before mutation: the wizard preview and report carry `route_profile_
 ordinary digest-bound re-registration.
 The setup-wizard
 schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
-`yoetz.setup-status/1`, and `yoetz.mcp-registration-preview/1`; the marker lives at
-`state_dir()/setup-wizard.json` via `config.paths.setup_marker_path`. The CLI surfaces are
-`yoetz setup run|status` and `yoetz integrate <harness> mcp status|preview|install|remove` (ADR-012).
+`yoetz.setup-status/1`, `yoetz.mcp-registration-preview/1`, and
+`yoetz.mcp-unregistration-preview/1`; the marker lives at `state_dir()/setup-wizard.json` via
+`config.paths.setup_marker_path`. The CLI surfaces are
+`yoetz setup run|status` and
+`yoetz integrate <harness> mcp status|preview|preview-remove|install|remove` (ADR-012).
 Standalone `yoetz provider endpoint` retains its explicit credential next command. When endpoint
 binding is embedded in the composed setup wizard, that standalone handoff is suppressed because
 the wizard still owns privacy consent and confidential ingress. Every visible yes/no prompt near

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3035,7 +3035,18 @@ conflicting marketplace, config, inventory, or cache surfaces with `remove_refus
 `conflict` token (`personal_marketplace|repository_marketplace|config_marketplace|config_plugin|
 inventory|cache`). Cache purge is default-off. The removal digest binds the exact trusted project
 root as well as the selected executable, Codex home, configuration/cache preimages, planned host
-commands, and cache-purge choice. After a successful removal, `codex plugin list
+commands, and cache-purge choice. Cache preview and apply share descriptor-relative no-follow
+total-entry, recursion-depth, relative-path, file-count, per-member, and aggregate-byte bounds.
+Apply retains the validated version descriptor through quarantine rename, binds deletion to the
+exact approved member names and bytes, refuses
+observable additions/changes before unlink, restores the exact version name when drift occurs
+before the first unlink, preserves the remainder after deletion starts, and never sweeps an
+unapproved name into deletion.
+Pre-mutation drift is `preview_stale`; once any accepted host/config/filesystem mutation has
+started, a later conflict is `write_failed` because partial state is possible. The adapter does not
+claim an atomic compare-and-unlink primitive for a non-cooperating same-UID writer's final POSIX
+content window, so the operator must quiesce such writers. After a successful removal,
+`codex plugin list
 --marketplace yoetz --json` is empty and `config.toml` has no yoetz tables;
 `inspect_activation` / observe status reports `installed_not_activated` when the managed plugin
 source at `.agents/plugins/yoetz` remains (issue #387) and `not_installed` only when that source

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3043,7 +3043,9 @@ observable additions/changes before unlink, restores the exact version name when
 before the first unlink, preserves the remainder after deletion starts, and never sweeps an
 unapproved name into deletion.
 Pre-mutation drift is `preview_stale`; once any accepted host/config/filesystem mutation has
-started, a later conflict is `write_failed` because partial state is possible. The adapter does not
+started, a later conflict is `write_failed` because partial state is possible. A successful
+cache-only deletion sets the same operation-wide fence before final inventory/config/activation/
+skill verification. The adapter does not
 claim an atomic compare-and-unlink primitive for a non-cooperating same-UID writer's final POSIX
 content window, so the operator must quiesce such writers. After a successful removal,
 `codex plugin list

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3042,8 +3042,11 @@ exact approved member names and bytes, refuses
 observable additions/changes before unlink, restores the exact version name when drift occurs
 before the first unlink, preserves the remainder after deletion starts, and never sweeps an
 unapproved name into deletion.
+Repository `marketplace.json` and any host-created empty `config.toml` cleanup use the same
+descriptor/inode/byte-bound private-quarantine rule rather than pathname-only unlink.
 Pre-mutation drift is `preview_stale`; once any accepted host/config/filesystem mutation has
-started, a later conflict is `write_failed` because partial state is possible. A successful
+started, including a zero-exit mutating host command whose JSON result is malformed, a later
+conflict is `write_failed` because partial state is possible. A successful
 cache-only deletion sets the same operation-wide fence before final inventory/config/activation/
 skill verification. The adapter does not
 claim an atomic compare-and-unlink primitive for a non-cooperating same-UID writer's final POSIX

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2859,13 +2859,14 @@ older-guidance render) is likewise a replaceable managed render, not a `modified
 still requires a byte-exact current renderer variant at its source fences before any mutation.
 MCP server registration is a sibling port, never an `IntegrationsPort` overload (ADR-012).
 `HarnessMcpPort` methods are `status_registration`, `observe_registration`, `preview_registration`,
-and `apply_registration`, each taking a `HarnessBinary` (harness ID, redacted-repr executable path,
+`apply_registration`, `preview_unregistration`, and `apply_unregistration`, each taking a
+`HarnessBinary` (harness ID, redacted-repr executable path,
 optional reported version, `supported|untested` compatibility). Shared names are
 `MCP_SERVER_NAME` (exactly `yoetz`), `MCP_SERVE_COMMAND` (exactly `("yoetz", "mcp", "serve")`),
 `MCP_STRICT_SERVE_COMMAND` (exactly
 `("yoetz", "mcp", "serve", "--semantic", "off")`),
 `McpRegistrationState` (`absent|yoetz_owned|foreign_present`), `McpRegistrationAction`
-(`register|reregister|noop`), `McpRegistrationReason` (`confirmation_required|preview_stale|
+(`register|reregister|unregister|noop`), `McpRegistrationReason` (`confirmation_required|preview_stale|
 harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_present`),
 `McpRegistrationPreview`, `McpRegistrationObservation`, `McpRegistrationCommand`,
 `McpRegistrationResult`, and
@@ -2879,7 +2880,11 @@ its `status` diagnostic phase — it exists because both owned serve commands cl
 (`McpRegistrationConfirmation` with channel exactly `interactive|noninteractive_flag`) and
 diagnostics (`McpRegistrationDiagnostic`, `HarnessMcpDiagnosticSink`); every registration
 mutation is digest-bound to a freshly recomputed preview, a foreign same-name entry is
-preserved without any force path, and success is verified by re-reading state. The preview binds
+preserved without any force path, and success is verified by re-reading state. Unregistration is
+the same digest-bound lifecycle for an owned external registration: `preview_unregistration` /
+`apply_unregistration` run `codex mcp remove yoetz` only when the registered argv is an exact
+Yoetz serve command, refuse a foreign same-name entry, and treat an already-absent entry as
+`noop`. The preview binds
 the exact command and `policy|strict` route profile. The route profile is explicit input:
 `yoetz setup run` and `yoetz integrate <harness> mcp preview|install` accept
 `--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
@@ -2893,7 +2898,7 @@ The setup-wizard
 schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
 `yoetz.setup-status/1`, and `yoetz.mcp-registration-preview/1`; the marker lives at
 `state_dir()/setup-wizard.json` via `config.paths.setup_marker_path`. The CLI surfaces are
-`yoetz setup run|status` and `yoetz integrate <harness> mcp status|preview|install` (ADR-012).
+`yoetz setup run|status` and `yoetz integrate <harness> mcp status|preview|install|remove` (ADR-012).
 Standalone `yoetz provider endpoint` retains its explicit credential next command. When endpoint
 binding is embedded in the composed setup wizard, that standalone handoff is suppressed because
 the wizard still owns privacy consent and confidential ingress. Every visible yes/no prompt near
@@ -2994,7 +2999,8 @@ the input for another host's manifest; projections share only the plan (ADR-023)
 `PluginArtifactPort` methods are `preview_artifact`, `install_artifact`, `status_artifact`, and
 `remove_artifact`; interrupted-swap recovery is expressed through `status_artifact` reconciliation,
 never automatic repair. `HostActivationPort` methods are `observe_discovery`,
-`observe_activation`, and — only when authorized — `preview_activation` and `apply_activation`.
+`observe_activation`, and — only when authorized — `preview_activation`, `apply_activation`,
+`preview_removal`, and `apply_removal`.
 Both are siblings of `IntegrationsPort`, `HarnessMcpPort`, and `ObservationPort` under the
 ADR-010/ADR-012 sibling-port rule: a host adapter may compose them but cannot collapse their state
 or authority, and no port's status field implies another's. Mutations preserve the full safe
@@ -3002,9 +3008,22 @@ artifact lifecycle (exact before/after preview and accepted digest, stale-previe
 safe-root containment, no symlink members, complete digest inventory, no unmanaged/modified
 overwrite, failure-atomic replacement, installed-byte verification, no
 filesystem-presence-to-activation inference). The #150 standalone artifact install/remove path
-consumes the ADR-016 `review_only` single-shot trusted review; activation apply remains owned by a
-later child and unavailable. The ADR-012 setup composition remains its own separately authorized
-path (ADR-023 decision 11).
+consumes the ADR-016 `review_only` single-shot trusted review. Codex marketplace activation and
+removal use the ADR-012 digest-bound `--accept` composition already used by MCP
+preview/install/remove; they do not consume `plugin_artifact_apply`, which remains the macOS
+Cursor portable-artifact presence cell and would fail closed on this host (issue #419). Cursor
+standalone activation apply remains owned by a later child and unavailable without the #409
+presence cell. The ADR-012 setup composition remains its own separately authorized path
+(ADR-023 decision 11).
+Codex `preview_removal` / `apply_removal` refuse foreign, modified, dual, or otherwise
+conflicting marketplace, config, inventory, or cache surfaces with `remove_refused` and a closed
+`conflict` token (`personal_marketplace|repository_marketplace|config_marketplace|config_plugin|
+inventory|cache`). Cache purge is default-off. After a successful removal, `codex plugin list
+--marketplace yoetz --json` is empty and `config.toml` has no yoetz tables;
+`inspect_activation` / observe status reports `installed_not_activated` when the managed plugin
+source at `.agents/plugins/yoetz` remains (issue #387) and `not_installed` only when that source
+is also absent. A second removal is `already_absent`. The skill tree, consent records, and
+observation store are intentionally left in place.
 
 The implemented artifact operation is exactly `plugin_artifact_apply`. Its prepare target is the
 portable preview digest, which already binds target identity, current-state digest, action,

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2882,9 +2882,12 @@ diagnostics (`McpRegistrationDiagnostic`, `HarnessMcpDiagnosticSink`); every reg
 mutation is digest-bound to a freshly recomputed preview, a foreign same-name entry is
 preserved without any force path, and success is verified by re-reading state. Unregistration is
 the same digest-bound lifecycle for an owned external registration: `preview_unregistration` /
-`apply_unregistration` run `codex mcp remove yoetz` only when the registered argv is an exact
-Yoetz serve command, refuse a foreign same-name entry, and treat an already-absent entry as
-`noop`. The preview binds
+`apply_unregistration` re-read the current entry immediately before the name-based
+`codex mcp remove yoetz`, run it only when the observed argv is still the exact previewed Yoetz
+serve command, refuse an observed foreign replacement, and treat an already-absent entry as
+`noop`. Because Codex 0.149.x exposes no compare-and-remove token, an owned-entry preview carries
+`host_remove_not_compare_and_swap`; callers must quiesce concurrent host configuration writers,
+and the port does not claim atomic exclusion inside the final host subprocess window. The preview binds
 the exact command and `policy|strict` route profile. The route profile is explicit input:
 `yoetz setup run` and `yoetz integrate <harness> mcp preview|install` accept
 `--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
@@ -3020,7 +3023,9 @@ presence cell. The ADR-012 setup composition remains its own separately authoriz
 Codex `preview_removal` / `apply_removal` refuse foreign, modified, dual, or otherwise
 conflicting marketplace, config, inventory, or cache surfaces with `remove_refused` and a closed
 `conflict` token (`personal_marketplace|repository_marketplace|config_marketplace|config_plugin|
-inventory|cache`). Cache purge is default-off. After a successful removal, `codex plugin list
+inventory|cache`). Cache purge is default-off. The removal digest binds the exact trusted project
+root as well as the selected executable, Codex home, configuration/cache preimages, planned host
+commands, and cache-purge choice. After a successful removal, `codex plugin list
 --marketplace yoetz --json` is empty and `config.toml` has no yoetz tables;
 `inspect_activation` / observe status reports `installed_not_activated` when the managed plugin
 source at `.agents/plugins/yoetz` remains (issue #387) and `not_installed` only when that source

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2874,7 +2874,14 @@ harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_prese
 `route_profile` (`policy|strict|null`); `route_profile` is non-null only when the state is
 `yoetz_owned`, because a foreign or absent entry has no Yoetz route to describe.
 `observe_registration` reads exactly what `status_registration` reads, mutates nothing, and shares
-its `status` diagnostic phase — it exists because both owned serve commands classify as
+its `status` diagnostic phase. Each observation starts with `codex mcp get yoetz --json`; because a
+nonzero named lookup is not positive absence, it falls back to bounded `codex mcp list --json`.
+Only a successful list with no matching name classifies as `absent`; a failed/malformed list or
+duplicate matching names raises a typed error, while one matching entry is classified normally.
+The bounded parser also rejects duplicate JSON keys, nonstandard constants, and truncated output.
+Codex exposes no compare-and-add token, so the port cannot claim atomic exclusion of a
+non-cooperating configuration writer inside the final accepted-add subprocess window.
+The observation exists because both owned serve commands classify as
 `yoetz_owned`, so state alone cannot distinguish a strict registration from a policy one.
 `HarnessMcpService` owns confirmation
 (`McpRegistrationConfirmation` with channel exactly `interactive|noninteractive_flag`) and
@@ -2887,8 +2894,11 @@ the same digest-bound lifecycle for an owned external registration: `preview_unr
 serve command, refuse an observed foreign replacement, and treat an already-absent entry as
 `noop`. Because Codex 0.149.x exposes no compare-and-remove token, an owned-entry preview carries
 `host_remove_not_compare_and_swap`; callers must quiesce concurrent host configuration writers,
-and the port does not claim atomic exclusion inside the final host subprocess window. The preview binds
-the exact command and `policy|strict` route profile. The route profile is explicit input:
+and the port does not claim atomic exclusion inside the final host subprocess window. The same
+positive-absence fallback is required after removal, so a generic failed named lookup never proves
+success. The interactive approval surface prints the exact command, route, warnings, and preview
+digest. The preview binds the exact command and `policy|strict` route profile. The route profile is
+explicit input:
 `yoetz setup run` and `yoetz integrate <harness> mcp preview|install` accept
 `--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
 its observed profile — no configuration derivation (or derivation-on-exception fallback) may

--- a/docs/adr/ADR-005-codex-capability-identity.md
+++ b/docs/adr/ADR-005-codex-capability-identity.md
@@ -12,9 +12,14 @@ skill files under `skills/codex/`, and `tests/capability/`.
    capability run (candidate `0.139.0` as observed local fixture); anything newer than
    maximum-tested is "untested", not "supported". The release manifest records min/max/denied.
 2. **Integration posture:** Codex is the MCP client; Yoetz is a local stdio server registered via
-   `codex mcp add yoetz -- yoetz mcp serve`, default `required = false`, only after
-   `codex mcp get yoetz --json` confirms the global name is absent. A same-name entry is never
-   overwritten unless a separately reviewed flow proves it is the exact Yoetz-owned entry. Skill
+   `codex mcp add yoetz -- yoetz mcp serve`, default `required = false`. Yoetz first runs `codex mcp
+   get yoetz --json`; because a nonzero named lookup is ambiguous, only a successful strict parse
+   of `codex mcp list --json` with no matching name confirms absence. Duplicate keys/names,
+   nonstandard constants, truncation, malformed output, and failed listing all fail closed. A
+   same-name entry is never intentionally overwritten unless a separately reviewed flow proves it
+   is the exact Yoetz-owned entry. Codex exposes no compare-and-add token, so this check cannot
+   atomically exclude a non-cooperating global configuration writer inside the final subprocess
+   window; operators must quiesce such writers during an accepted apply. Skill
    installed explicitly to `.agents/skills/yoetz/` with preview/consent. Codex-readable
    `SKILL.md` frontmatter is limited to `name`, `description`, and optional
    `metadata.short-description`; Yoetz protocol/version compatibility remains in its private

--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -61,6 +61,10 @@ manifests, the packaging/capability suites, and the release workflows under `.gi
    keyring entries. Amended by ADR-012: the `codex mcp get`/`codex mcp add` sequence is also
    available as the preview-gated `yoetz integrate <harness> mcp` commands and the `yoetz setup`
    wizard; the manual commands remain valid and the runbook's preservation rules are unchanged.
+   Amended by issue #419: `yoetz integrate <harness> mcp remove` and
+   `yoetz integrate codex plugin remove` are the digest-bound inverses for the MCP entry and the
+   marketplace/`config.toml`/cache surfaces setup writes; uninstall still never deletes
+   bundles/vault/keyring entries, consent records, or the observation store.
 10. **Diagnostics:** `yoetz version --json` emits the full `VersionManifest`; startup safety
     validation is mandatory but the public `doctor` command stays v0.2.
 11. **Public schema hosting without runtime coupling:** the checked-in `schemas/` tree is mounted

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -217,7 +217,7 @@ not authority: tiers 0 and 1 are byte-for-byte unchanged, guidance stays owned o
 `guidance/` with no byte variation per ADR-010 decision 1, and a host consuming the portable format
 still earns exactly the coverage its evidence cell proves. Following the `HarnessMcpPort`
 precedent above, `PluginArtifactPort` (preview/install/status/remove of a rendered artifact) and
-`HostActivationPort` (discovery/activation observation and authorized preview/apply) are sibling
+`HostActivationPort` (discovery/activation observation and authorized preview/apply/remove) are sibling
 ports, never `IntegrationsPort` overloads; a host adapter may compose them but cannot collapse
 their state or authority. The fork guarantee is extended, not weakened: a standards-compliant host
 is reached by a projection plus a host profile, still with no shared-type edits.

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -219,12 +219,18 @@ exactly those contracts and connects the steps without weakening any existing tr
    repository `.agents/plugins/marketplace.json` only when that file byte-matches, and it deletes
    only digest-matched versioned cache trees. `--purge-cache` is required to delete other
    yoetz-managed version directories; it is default-off. Foreign, modified, dual, or otherwise
-   conflicting entries refuse with `remove_refused` and name the conflicting surface. A second
+   conflicting entries refuse with `remove_refused` and name the conflicting surface. The removal
+   preview binds the exact trusted project root as well as the selected executable, Codex
+   home, configuration/cache preimages, planned host commands, and cache-purge choice. A second
    removal is `already_absent`. The skill tree, consent records, and observation store are
    intentionally left in place. `yoetz integrate <harness> mcp preview-remove` exposes the exact
    unregistration digest; noninteractive `remove` requires that digest plus `--accept` before it
-   unregisters an owned external `yoetz` MCP entry with `codex mcp remove yoetz`. It refuses a
-   foreign same-name entry and treats an already-absent entry as `noop`. After activation removal,
+   unregisters an owned external `yoetz` MCP entry with `codex mcp remove yoetz`. Apply immediately
+   re-reads the entry and refuses a foreign replacement or changed owned route observed before the
+   name-based remove. Codex exposes no compare-and-remove token, so the preview warns
+   `host_remove_not_compare_and_swap`; the owner must quiesce concurrent MCP config writers and no
+   atomic exclusion is claimed inside the final subprocess window. An already-absent entry is
+   `noop`. After activation removal,
    observe/inspect reports
    `installed_not_activated` when the managed plugin source remains (issue #387) and
    `not_installed` only when that source is also absent.

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -230,7 +230,18 @@ exactly those contracts and connects the steps without weakening any existing tr
    conflicting entries refuse with `remove_refused` and name the conflicting surface. The removal
    preview binds the exact trusted project root as well as the selected executable, Codex
    home, configuration/cache preimages, planned host commands, and cache-purge choice. A second
-   removal is `already_absent`. The skill tree, consent records, and observation store are
+   removal is `already_absent`. Preview and apply read cache trees through the same no-follow,
+   descriptor-relative total-entry/depth/path/file-count/per-member/aggregate-byte bounds. Apply
+   retains the validated version descriptor across quarantine rename, revalidates the exact
+   approved member set and bytes before and during unlink, and never blanket-deletes newly observed
+   names. It restores the exact version name when an observable content race invalidates the
+   quarantine snapshot before the first unlink but still reports the crossed mutation boundary as
+   `write_failed`, and preserves the remainder after deletion starts.
+   A mismatch after any host/config/filesystem mutation is reported as `write_failed`, not the
+   pre-mutation retry signal `preview_stale`. Ordinary POSIX
+   files still expose a final non-CAS write/unlink window to a non-cooperating same-UID writer, so
+   owners must quiesce concurrent cache writers during accepted removal and no atomic content
+   exclusion is claimed. The skill tree, consent records, and observation store are
    intentionally left in place. `yoetz integrate <harness> mcp preview-remove` exposes the exact
    unregistration digest; noninteractive `remove` requires that digest plus `--accept` before it
    unregisters an owned external `yoetz` MCP entry with `codex mcp remove yoetz`. Apply immediately

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -238,7 +238,8 @@ exactly those contracts and connects the steps without weakening any existing tr
    quarantine snapshot before the first unlink but still reports the crossed mutation boundary as
    `write_failed`, and preserves the remainder after deletion starts.
    A mismatch after any host/config/filesystem mutation is reported as `write_failed`, not the
-   pre-mutation retry signal `preview_stale`. Ordinary POSIX
+   pre-mutation retry signal `preview_stale`; successful cache-only deletion carries that mutation
+   fence into every final inventory/config/activation/skill verifier. Ordinary POSIX
    files still expose a final non-CAS write/unlink window to a non-cooperating same-UID writer, so
    owners must quiesce concurrent cache writers during accepted removal and no atomic content
    exclusion is claimed. The skill tree, consent records, and observation store are

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -97,9 +97,17 @@ exactly those contracts and connects the steps without weakening any existing tr
 
 3. **MCP registration becomes a first-class preview-gated operation** (`yoetz integrate <harness>
    mcp status|preview|preview-remove|install|remove`), automating the exact two-command sequence the
-   Codex runbook already mandates: `codex mcp get yoetz --json` first. It runs the exact
-   `codex mcp add yoetz -- yoetz mcp serve` command only when no entry exists; a foreign same-name
-   entry is preserved and refused with `foreign_entry_present` — there is no force path. Success is
+   Codex runbook already mandates: `codex mcp get yoetz --json` first. A nonzero named lookup is
+   not absence by itself: the adapter runs a bounded `codex mcp list --json` fallback and accepts
+   absence only when that successful structural listing contains no `yoetz` name. A failed or
+   malformed listing fails closed; a single matching entry is classified normally; duplicate
+   matching names are ambiguous and fail closed. It runs the exact `codex mcp add yoetz -- yoetz
+   mcp serve` command only after that positive absence observation; a foreign same-name entry is
+   preserved and refused with `foreign_entry_present` — there is no force path. The structural
+   JSON parser rejects duplicate keys, nonstandard constants, and truncated output. Codex exposes
+   no compare-and-add token, so operators must quiesce non-cooperating MCP configuration writers
+   during the accepted apply; no atomic exclusion is claimed inside the final subprocess window.
+   Success is
    verified by re-reading state, not by trusting the add exit code. Registration remains a fact
    separate from skill installation and from Codex capability support (E-002/E-013 are untouched);
    "registered" never implies "Codex will successfully connect".
@@ -230,7 +238,10 @@ exactly those contracts and connects the steps without weakening any existing tr
    name-based remove. Codex exposes no compare-and-remove token, so the preview warns
    `host_remove_not_compare_and_swap`; the owner must quiesce concurrent MCP config writers and no
    atomic exclusion is claimed inside the final subprocess window. An already-absent entry is
-   `noop`. After activation removal,
+   `noop`. The same positive-absence fallback applies to every pre/post removal read, so a generic
+   failed `get` cannot become a false no-op or successful unregistration. Interactive removal
+   shows the command, route, all warning tokens, and exact preview digest before confirmation.
+   After activation removal,
    observe/inspect reports
    `installed_not_activated` when the managed plugin source remains (issue #387) and
    `not_installed` only when that source is also absent.

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -224,7 +224,8 @@ exactly those contracts and connects the steps without weakening any existing tr
    preview|status|remove` classifies ownership with `inspect_activation`, then runs
    `codex plugin remove yoetz@yoetz --json` and, when the `[marketplaces.yoetz]` table
    byte-matches the yoetz render, `codex plugin marketplace remove yoetz --json`. It deletes
-   repository `.agents/plugins/marketplace.json` only when that file byte-matches, and it deletes
+   repository `.agents/plugins/marketplace.json` only when a retained no-follow descriptor still
+   byte- and inode-matches through a private quarantine rename, and it deletes
    only digest-matched versioned cache trees. `--purge-cache` is required to delete other
    yoetz-managed version directories; it is default-off. Foreign, modified, dual, or otherwise
    conflicting entries refuse with `remove_refused` and name the conflicting surface. The removal
@@ -237,11 +238,12 @@ exactly those contracts and connects the steps without weakening any existing tr
    names. It restores the exact version name when an observable content race invalidates the
    quarantine snapshot before the first unlink but still reports the crossed mutation boundary as
    `write_failed`, and preserves the remainder after deletion starts.
-   A mismatch after any host/config/filesystem mutation is reported as `write_failed`, not the
+   Malformed output after a mutating host command is outcome-unknown `write_failed`, never a
+   pre-mutation source error. A mismatch after any host/config/filesystem mutation is reported as `write_failed`, not the
    pre-mutation retry signal `preview_stale`; successful cache-only deletion carries that mutation
    fence into every final inventory/config/activation/skill verifier. Ordinary POSIX
    files still expose a final non-CAS write/unlink window to a non-cooperating same-UID writer, so
-   owners must quiesce concurrent cache writers during accepted removal and no atomic content
+   owners must quiesce concurrent cache/config/marketplace writers during accepted removal and no atomic content
    exclusion is claimed. The skill tree, consent records, and observation store are
    intentionally left in place. `yoetz integrate <harness> mcp preview-remove` exposes the exact
    unregistration digest; noninteractive `remove` requires that digest plus `--accept` before it

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -96,7 +96,7 @@ exactly those contracts and connects the steps without weakening any existing tr
    `yoetz setup run`. An unsafe or unreadable state directory never triggers the wizard.
 
 3. **MCP registration becomes a first-class preview-gated operation** (`yoetz integrate <harness>
-   mcp status|preview|install`), automating the exact two-command sequence the Codex runbook
+   mcp status|preview|install|remove`), automating the exact two-command sequence the Codex runbook
    already mandates: `codex mcp get yoetz --json` first; `codex mcp add yoetz -- yoetz mcp serve`
    only when no entry exists; a foreign same-name entry is preserved and refused with
    `foreign_entry_present` — there is no force path. Success is verified by re-reading state, not
@@ -209,6 +209,23 @@ exactly those contracts and connects the steps without weakening any existing tr
    bound home/config path and the actual activation failure reason instead of resetting to
    `codex_home_required`, and unobserved readiness facts are reported as null rather than asserted
    `false`.
+
+   **Amended 2026-08-25 — consent-gated Codex marketplace and MCP removal (issue #419).** Setup
+   writes remain reversible through the same digest-bound `--accept` lane as activation and MCP
+   install, not through `plugin_artifact_apply`. `yoetz integrate codex plugin
+   preview|status|remove` classifies ownership with `inspect_activation`, then runs
+   `codex plugin remove yoetz@yoetz --json` and, when the `[marketplaces.yoetz]` table
+   byte-matches the yoetz render, `codex plugin marketplace remove yoetz --json`. It deletes
+   repository `.agents/plugins/marketplace.json` only when that file byte-matches, and it deletes
+   only digest-matched versioned cache trees. `--purge-cache` is required to delete other
+   yoetz-managed version directories; it is default-off. Foreign, modified, dual, or otherwise
+   conflicting entries refuse with `remove_refused` and name the conflicting surface. A second
+   removal is `already_absent`. The skill tree, consent records, and observation store are
+   intentionally left in place. `yoetz integrate <harness> mcp remove` unregisters an owned
+   external `yoetz` MCP entry with `codex mcp remove yoetz`, refuses a foreign same-name entry,
+   and treats an already-absent entry as `noop`. After activation removal, observe/inspect reports
+   `installed_not_activated` when the managed plugin source remains (issue #387) and
+   `not_installed` only when that source is also absent.
 
 The short `yoetz --set --fireworks --model MODEL` and `yoetz --set --grok --model MODEL` paths are
 provider-only entries into the same setup ceremonies. They derive internal provider bindings and

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -96,13 +96,13 @@ exactly those contracts and connects the steps without weakening any existing tr
    `yoetz setup run`. An unsafe or unreadable state directory never triggers the wizard.
 
 3. **MCP registration becomes a first-class preview-gated operation** (`yoetz integrate <harness>
-   mcp status|preview|install|remove`), automating the exact two-command sequence the Codex runbook
-   already mandates: `codex mcp get yoetz --json` first; `codex mcp add yoetz -- yoetz mcp serve`
-   only when no entry exists; a foreign same-name entry is preserved and refused with
-   `foreign_entry_present` — there is no force path. Success is verified by re-reading state, not
-   by trusting the add exit code. Registration remains a fact separate from skill installation and
-   from Codex capability support (E-002/E-013 are untouched); "registered" never implies "Codex
-   will successfully connect".
+   mcp status|preview|preview-remove|install|remove`), automating the exact two-command sequence the
+   Codex runbook already mandates: `codex mcp get yoetz --json` first. It runs the exact
+   `codex mcp add yoetz -- yoetz mcp serve` command only when no entry exists; a foreign same-name
+   entry is preserved and refused with `foreign_entry_present` — there is no force path. Success is
+   verified by re-reading state, not by trusting the add exit code. Registration remains a fact
+   separate from skill installation and from Codex capability support (E-002/E-013 are untouched);
+   "registered" never implies "Codex will successfully connect".
 
    **Founder-authorized Codex activation repair (2026-08-03).** An accepted setup now also installs
    the packaged project skill at `.agents/skills/yoetz` before it installs the structural plugin
@@ -221,9 +221,11 @@ exactly those contracts and connects the steps without weakening any existing tr
    yoetz-managed version directories; it is default-off. Foreign, modified, dual, or otherwise
    conflicting entries refuse with `remove_refused` and name the conflicting surface. A second
    removal is `already_absent`. The skill tree, consent records, and observation store are
-   intentionally left in place. `yoetz integrate <harness> mcp remove` unregisters an owned
-   external `yoetz` MCP entry with `codex mcp remove yoetz`, refuses a foreign same-name entry,
-   and treats an already-absent entry as `noop`. After activation removal, observe/inspect reports
+   intentionally left in place. `yoetz integrate <harness> mcp preview-remove` exposes the exact
+   unregistration digest; noninteractive `remove` requires that digest plus `--accept` before it
+   unregisters an owned external `yoetz` MCP entry with `codex mcp remove yoetz`. It refuses a
+   foreign same-name entry and treats an already-absent entry as `noop`. After activation removal,
+   observe/inspect reports
    `installed_not_activated` when the managed plugin source remains (issue #387) and
    `not_installed` only when that source is also absent.
 

--- a/docs/adr/ADR-015-elevated-bootstrap-consent.md
+++ b/docs/adr/ADR-015-elevated-bootstrap-consent.md
@@ -1,11 +1,12 @@
 # ADR-015 — OS-presence-gated elevated bootstrap consent
 
 **Status:** Amended 2026-07-31; amended 2026-08-09 for agent-attested chat authorize
-(issue #164); amended 2026-08-18 for atomic concurrent review claims (issue #344). Superseded in
-scope by ADR-016 for the general non-default consent catalog. Console `yoetz consent review`
-remains fail-closed until a verified OS-presence adapter is installed; allowlisted first-party
-agents may use `yoetz consent authorize` for exact prepared operations that advertise delegated
-chat authority.
+(issue #164); amended 2026-08-18 for atomic concurrent review claims (issue #344); amended
+2026-08-25 to name Codex marketplace/MCP removal as outside this OS-presence lane (issue #419).
+Superseded in scope by ADR-016 for the general non-default consent catalog. Console `yoetz consent
+review` remains fail-closed until a verified OS-presence adapter is installed; allowlisted
+first-party agents may use `yoetz consent authorize` for exact prepared operations that advertise
+delegated chat authority.
 **Implemented by:** `src/yoetz/service/elevated_bootstrap.py`,
 `src/yoetz/cli/elevated.py`, `src/yoetz/cli/trusted_console.py`,
 `src/yoetz/protocol/consent.py`, and `src/yoetz/protocol/chat_user_authority.py`.
@@ -26,6 +27,14 @@ still must not accept an agent-selected passphrase.
 1. **Implemented bootstrap operations.** `vault_initialize`, `provider_credential_set`,
    `provider_credential_rotate`, and `repository_privacy_grant` use this lane. It is not a
    vault-unlock API, recovery API, or standing elevation mode.
+
+   **Amendment (2026-08-25, issue #419).** Codex marketplace/plugin removal
+   (`yoetz integrate codex plugin remove`) and external MCP unregistration
+   (`yoetz integrate codex mcp remove`) are not ADR-015 OS-presence operations. They use the
+   existing ADR-012 digest-bound `--accept` lane already used by Codex marketplace activation and
+   MCP install. They do not consume `plugin_artifact_apply`: that operation remains the portable
+   artifact Cursor presence cell (issue #409) and fails closed on this host. Agent-chat authorize
+   is not extended to either removal command.
 
 2. **Agent-safe preparation.** `yoetz consent prepare` creates one owner-only
    `yoetz.elevated-bootstrap.pending/2` record. Its agent projection is

--- a/docs/adr/ADR-016-human-review-non-default-actions.md
+++ b/docs/adr/ADR-016-human-review-non-default-actions.md
@@ -4,7 +4,8 @@
 console review; amended 2026-08-09 for agent-attested current-chat authorize (issue #164); amended
 2026-08-18 for atomic concurrent review claims (issue #344); amended 2026-08-21 to assign portable
 plugin artifact and host-activation mutation to `review_only` (issue #149, ADR-023; implementation
-owned by #150).
+owned by #150); amended 2026-08-25 to keep Codex marketplace/MCP removal on the ADR-012
+digest-bound `--accept` lane rather than `plugin_artifact_apply` (issue #419).
 **Implemented by:** `src/yoetz/service/elevated_bootstrap.py`,
 `src/yoetz/cli/elevated.py`, `src/yoetz/cli/trusted_console.py`,
 `src/yoetz/protocol/consent.py`, `src/yoetz/protocol/chat_user_authority.py`, and
@@ -104,8 +105,19 @@ documents that Yoetz cannot independently authenticate its chat provenance.
    `review_only`, and agent-chat authorization is disabled. Preparation and single-shot
    consumption exist. Issue #409 wires the scoped macOS LocalAuthentication adapter into the
    standalone Cursor CLI; it does not create a service-wide `UserPresencePort`, authorize another
-   operation, or make generic portable-plugin mutation available. Generic `skill_install`, host
-   activation apply, and harness MCP registration remain catalogued but unimplemented.
+   operation, or make generic portable-plugin mutation available. Generic `skill_install`, Cursor
+   host-activation apply, and catalogued-but-unimplemented harness MCP registration remain
+   unimplemented as `review_only` consumers.
+
+   **Amendment (2026-08-25, issue #419).** Codex marketplace activation already ships as the
+   ADR-012 digest-bound `--accept` composition, not as `plugin_artifact_apply`. Codex marketplace
+   removal (`preview_removal` / `apply_removal`) and external MCP unregistration
+   (`preview_unregistration` / `apply_unregistration`) use that same lane: exact preview digest
+   plus explicit `--accept` or the interactive confirmation already used by
+   `yoetz integrate codex mcp install`. They do not prepare or consume `plugin_artifact_apply`,
+   because that cell is the macOS Cursor portable-artifact presence path and would fail closed
+   here. Cache purge is default-off (`--purge-cache`). Agent-chat authorize is not extended to
+   these commands. Cursor standalone activation apply is unchanged.
 
 ## Consequences
 

--- a/docs/adr/ADR-023-portable-plugin-carrier-host-activation.md
+++ b/docs/adr/ADR-023-portable-plugin-carrier-host-activation.md
@@ -77,7 +77,8 @@ becomes host-derived.
    (ADR-010/ADR-012): `PluginArtifactPort` — `preview_artifact`, `install_artifact`,
    `status_artifact`, `remove_artifact`, with interrupted-swap recovery expressed through status
    reconciliation, never automatic repair — and `HostActivationPort` — `observe_discovery`,
-   `observe_activation`, and, only when authorized, `preview_activation` / `apply_activation`.
+   `observe_activation`, and, only when authorized, `preview_activation` / `apply_activation`
+   and `preview_removal` / `apply_removal`.
    `HarnessMcpPort` keeps external/global MCP registration; `ObservationPort` keeps consented
    observation. A host adapter may compose these ports; it cannot collapse their state or
    authority, and no port's status field implies another's.
@@ -164,6 +165,16 @@ becomes host-derived.
     boundary they do not exist at all. The ADR-012 setup wizard's
     already-authorized digest-bound composition remains the separately authorized install path and
     is unchanged. Agent preparation is never trusted human review (ADR-015/ADR-016).
+
+    **Amendment (2026-08-25, issue #419).** Codex marketplace removal is authorized the same way
+    Codex marketplace activation already is: the ADR-012 digest-bound `--accept` composition on
+    `yoetz integrate codex plugin remove` and `yoetz integrate codex mcp remove`. That path does
+    not consume `plugin_artifact_apply`. Using the Cursor OS-presence cell here would fail closed
+    on this host and would mis-name the authority Codex activation already uses. Cache purge is
+    default-off. Removal never deletes the skill tree, consent records, or the observation store.
+    After a successful activation removal, `inspect_activation` follows the #347/#387 closed
+    states: `installed_not_activated` when the managed plugin source at `.agents/plugins/yoetz`
+    remains, and `not_installed` only when that source is also absent.
 
 12. **Phased rollout, ADR-009 untouched.** Slice 1 is explicitly skills-only with
     `external_registration`: the portable artifact carries metadata and shared skill bytes, omits

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -106,10 +106,16 @@ codex mcp get yoetz --json
 codex mcp add yoetz -- yoetz mcp serve
 ```
 
-Run `codex mcp get yoetz --json` first. Continue with `mcp add` only when no entry exists — if an
-entry already exists, preserve it and stop unless a separately reviewed operation proves it is the
-exact Yoetz-owned registration being intentionally replaced. Current Codex `mcp add` behavior
-replaces a same-name global entry, so this preflight check matters.
+Run `codex mcp get yoetz --json` first. A nonzero result does not prove absence: Yoetz follows it
+with `codex mcp list --json` and continues only when that command succeeds with no `yoetz` entry.
+A failed/malformed list or duplicate matching names fails closed; a single matching entry is
+classified by its exact command. Strict parsing also rejects duplicate JSON keys, nonstandard
+constants, and truncated output. If an entry already exists, preserve it and stop unless a
+separately reviewed operation proves it is the exact Yoetz-owned registration being intentionally
+replaced. Current Codex `mcp add` behavior replaces a same-name global entry, so this positive
+absence check matters. Codex exposes no compare-and-add token: keep other MCP configuration writers
+quiescent during an accepted apply, because Yoetz cannot atomically exclude a non-cooperating write
+inside the final subprocess window.
 
 The registration check-then-add flow is available as
 `yoetz integrate codex mcp status|preview|install` and is what `yoetz setup run` performs after
@@ -296,14 +302,16 @@ The first command exposes the exact unregistration digest and current owned rout
 mutation. Noninteractive removal requires that digest plus `--accept`; `--accept` alone fails
 closed. Apply re-reads the current entry immediately before it runs `codex mcp remove yoetz` and
 refuses a foreign replacement or changed Yoetz route observed at that boundary. An
-already-absent entry is a no-op.
+already-absent entry is a no-op only after the same successful `mcp list --json` absence check.
+Interactive removal shows the exact command, route profile, warning tokens, and preview digest
+before requesting confirmation.
 
 Codex 0.149.x exposes a name-based remove command, not a compare-and-remove token. The owned-entry
 preview therefore includes `host_remove_not_compare_and_swap`: the owner must keep concurrent
 Codex MCP configuration writers quiescent during the accepted apply. The immediate pre-remove
 recheck narrows the host limitation, but cannot atomically exclude a non-cooperating replacement
 inside the final subprocess scheduling window. Post-apply verification still fails closed if the
-entry is not absent.
+entry is not positively observed absent; a generic failed named lookup is not success.
 Plugin-managed MCP is not this command: it goes away with the plugin artifact, not with `codex mcp
 remove`.
 

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -111,12 +111,13 @@ entry already exists, preserve it and stop unless a separately reviewed operatio
 exact Yoetz-owned registration being intentionally replaced. Current Codex `mcp add` behavior
 replaces a same-name global entry, so this preflight check matters.
 
-This check-then-add sequence is also available as
-`yoetz integrate codex mcp status|preview|preview-remove|install|remove` and is what `yoetz setup
-run` performs after Codex discovery (ADR-012). Automating it changes no rule above — it is the
-same two commands, gated by an explicit digest-bound confirmation, run by Yoetz instead of by
-hand; an existing foreign entry is still preserved and refused, success is verified by re-reading
-the entry, and "registered" still never implies Codex will successfully connect at runtime.
+The registration check-then-add flow is available as
+`yoetz integrate codex mcp status|preview|install` and is what `yoetz setup run` performs after
+Codex discovery (ADR-012). The separate removal check-then-remove flow is
+`yoetz integrate codex mcp preview-remove|remove`. Both flows are gated by an explicit
+digest-bound confirmation, preserve entries already observed as foreign, and verify the final
+state by re-reading it. A "registered" result still never implies Codex will successfully connect
+at runtime.
 
 The accepted setup path composes four separately reported layers in order: it installs the project
 skill at `.agents/skills/yoetz`, installs managed structural plugin/hook sources at
@@ -132,8 +133,8 @@ selected executable path and SHA-256 and obtains its version by running only `--
 create scratch even for that command, so the temporary home is removed afterward. No selected-home
 inventory command runs before approval.
 
-The preview digest also binds the repository marketplace and selected-home config
-preimages/proposals, managed source-tree digest, cache root
+The preview digest also binds the trusted project root, repository marketplace, and selected-home
+config preimages/proposals, managed source-tree digest, cache root
 `<selected-home>/plugins/cache/yoetz/yoetz`, cache preimage/intended install-tree digest, the
 temporary-private-home probe environment, the forced selected-home environment for mutation, and
 the exact post-consent commands `plugin list --marketplace yoetz --json` and
@@ -293,8 +294,16 @@ yoetz integrate codex mcp remove --accept --preview-digest <digest> --json
 
 The first command exposes the exact unregistration digest and current owned route without
 mutation. Noninteractive removal requires that digest plus `--accept`; `--accept` alone fails
-closed. Apply runs `codex mcp remove yoetz` only when the registered argv is an exact Yoetz serve
-command. A foreign same-name entry is preserved and refused. An already-absent entry is a no-op.
+closed. Apply re-reads the current entry immediately before it runs `codex mcp remove yoetz` and
+refuses a foreign replacement or changed Yoetz route observed at that boundary. An
+already-absent entry is a no-op.
+
+Codex 0.149.x exposes a name-based remove command, not a compare-and-remove token. The owned-entry
+preview therefore includes `host_remove_not_compare_and_swap`: the owner must keep concurrent
+Codex MCP configuration writers quiescent during the accepted apply. The immediate pre-remove
+recheck narrows the host limitation, but cannot atomically exclude a non-cooperating replacement
+inside the final subprocess scheduling window. Post-apply verification still fails closed if the
+entry is not absent.
 Plugin-managed MCP is not this command: it goes away with the plugin artifact, not with `codex mcp
 remove`.
 

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -274,15 +274,30 @@ portable-artifact authority and would fail closed on this host. Cache purge is d
 `--purge-cache` additionally deletes other version directories under
 `<codex-home>/plugins/cache/yoetz/yoetz/<ver>` whose trees byte-match a yoetz render or their own
 valid `yoetz.codex-plugin-install/1` marker. Foreign or modified cache directories are refused
-(`remove_refused`, conflict `cache`) and left untouched.
+(`remove_refused`, conflict `cache`) and left untouched. Preview and apply use the same no-follow,
+descriptor-relative 256-total-entry, 16-level, 4-KiB-relative-path, 64-file,
+256-KiB-per-member, and 4-MiB-aggregate bounds, so directory-only, deep, sparse, and oversized
+trees fail closed before unbounded allocation or recursion. Apply retains the validated version
+descriptor through quarantine rename and rechecks the exact approved names and bytes immediately
+before and during unlink; newly observed names are never swept into deletion. Observable drift
+before the first unlink restores the retained inode to its exact version name; later drift
+preserves the remaining quarantine. Both report `write_failed` because quarantine rename already
+crossed the mutation boundary. Keep same-UID cache writers
+quiescent during removal because ordinary POSIX files provide no atomic compare-and-unlink token
+for the last content-write window.
 
 Apply runs `codex plugin remove yoetz@yoetz --json`, then `codex plugin marketplace remove yoetz
 --json` when `[marketplaces.yoetz]` byte-matches the yoetz render, then deletes
 `<repo>/.agents/plugins/marketplace.json` only when that file byte-matches the yoetz render, then
 deletes the bound current-version cache. Whole-table TOML edits are verified by re-parse. A second
 removal is a no-op (`already_absent`). Foreign, modified, dual, or otherwise conflicting entries
-refuse with `remove_refused` and name the conflicting surface (`repository_marketplace`,
-`personal_marketplace`, `config_marketplace`, `config_plugin`, `inventory`, or `cache`).
+refuse with `remove_refused` and name the conflicting surface (`personal_marketplace`,
+`repository_marketplace`, `config_marketplace`, `config_plugin`, `inventory`, or `cache`). Before
+mutation, changed preview-bound bytes report `preview_stale`.
+After a host command, config write, marketplace unlink, quarantine rename, or member unlink has
+started, any newly observed conflict reports `write_failed` (with the bounded conflict token when
+available) because the outcome may be partial; it is never mislabeled as a safe stale-preview
+retry.
 
 After a successful removal, `codex plugin list --marketplace yoetz --json` is empty and
 `config.toml` has no yoetz tables. `yoetz observe status` reports the existing activation

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -112,7 +112,7 @@ exact Yoetz-owned registration being intentionally replaced. Current Codex `mcp 
 replaces a same-name global entry, so this preflight check matters.
 
 This check-then-add sequence is also available as
-`yoetz integrate codex mcp status|preview|install` and is what `yoetz setup run` performs after
+`yoetz integrate codex mcp status|preview|install|remove` and is what `yoetz setup run` performs after
 Codex discovery (ADR-012). Automating it changes no rule above — it is the same two commands,
 gated by an explicit digest-bound confirmation, run by Yoetz instead of by hand; an existing
 foreign entry is still preserved and refused, success is verified by re-reading the entry, and
@@ -237,6 +237,12 @@ evidence boundary explicitly.
 
 ## 8. Remove
 
+Skill removal and activation/MCP removal are separate, consent-gated operations. Skill removal
+never deletes marketplace, `config.toml`, cache, or MCP entries. Activation removal never deletes
+the skill tree.
+
+### Skill tree
+
 ```text
 yoetz integrate codex skill preview --json
 yoetz integrate codex skill remove --json
@@ -245,8 +251,49 @@ yoetz integrate codex skill remove --json
 Confirm the exact preview digest. Removal deletes only a valid managed marker plus its byte-exact
 file inventory. Modified, partial, or unmanaged content is refused and preserved — there is no
 force-remove in v0.1. Removal never uninstalls the Yoetz package, deletes MCP configuration, deletes
-ledger/key data, or touches other skills. Verify `status` shows `absent` afterward, and separately
-manage any MCP configuration yourself if you want it removed too.
+ledger/key data, or touches other skills. Verify `status` shows `absent` afterward.
+
+### Plugin, marketplace, and `config.toml`
+
+```text
+yoetz integrate codex plugin preview --codex-home <home> --json
+yoetz integrate codex plugin remove --codex-home <home> --accept --preview-digest <digest> --json
+```
+
+The Codex plugin command uses the same preview → explicit accept → apply shape as Codex
+activation and MCP install: the mutation is bound to the exact preview digest. It does **not**
+consume the Cursor `plugin_artifact_apply` OS-presence cell; that cell remains the standalone
+portable-artifact authority and would fail closed on this host. Cache purge is default-off.
+`--purge-cache` additionally deletes other version directories under
+`<codex-home>/plugins/cache/yoetz/yoetz/<ver>` whose trees byte-match a yoetz render or their own
+valid `yoetz.codex-plugin-install/1` marker. Foreign or modified cache directories are refused
+(`remove_refused`, conflict `cache`) and left untouched.
+
+Apply runs `codex plugin remove yoetz@yoetz --json`, then `codex plugin marketplace remove yoetz
+--json` when `[marketplaces.yoetz]` byte-matches the yoetz render, then deletes
+`<repo>/.agents/plugins/marketplace.json` only when that file byte-matches the yoetz render, then
+deletes the bound current-version cache. Whole-table TOML edits are verified by re-parse. A second
+removal is a no-op (`already_absent`). Foreign, modified, dual, or otherwise conflicting entries
+refuse with `remove_refused` and name the conflicting surface (`repository_marketplace`,
+`personal_marketplace`, `config_marketplace`, `config_plugin`, `inventory`, or `cache`).
+
+After a successful removal, `codex plugin list --marketplace yoetz --json` is empty and
+`config.toml` has no yoetz tables. `yoetz observe status` reports the existing activation
+classification: `installed_not_activated` when the managed plugin source at
+`.agents/plugins/yoetz` remains (issue #387), or `not_installed` when that source is also absent.
+The command reports whether the skill tree remains; it does not remove it. Consent records and the
+observation store are intentionally left in place.
+
+### External MCP registration
+
+```text
+yoetz integrate codex mcp remove --accept --preview-digest <digest> --json
+```
+
+This removes an `external_registration` Codex MCP entry by running `codex mcp remove yoetz` only
+when the registered argv is an exact Yoetz serve command. A foreign same-name entry is preserved
+and refused. An already-absent entry is a no-op. Plugin-managed MCP is not this command: it goes
+away with the plugin artifact, not with `codex mcp remove`.
 
 ## 9. Troubleshooting and recovery
 

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -288,13 +288,15 @@ for the last content-write window.
 
 Apply runs `codex plugin remove yoetz@yoetz --json`, then `codex plugin marketplace remove yoetz
 --json` when `[marketplaces.yoetz]` byte-matches the yoetz render, then deletes
-`<repo>/.agents/plugins/marketplace.json` only when that file byte-matches the yoetz render, then
+`<repo>/.agents/plugins/marketplace.json` only when a retained no-follow descriptor still byte- and
+inode-matches through a private quarantine rename, then
 deletes the bound current-version cache. Whole-table TOML edits are verified by re-parse. A second
 removal is a no-op (`already_absent`). Foreign, modified, dual, or otherwise conflicting entries
 refuse with `remove_refused` and name the conflicting surface (`personal_marketplace`,
 `repository_marketplace`, `config_marketplace`, `config_plugin`, `inventory`, or `cache`). Before
 mutation, changed preview-bound bytes report `preview_stale`.
-After a host command, config write, marketplace unlink, quarantine rename, or member unlink has
+After a mutating host command starts (including a zero-exit command with malformed JSON), config
+write, marketplace quarantine/unlink, cache quarantine rename, or member unlink has
 started, any newly observed conflict reports `write_failed` (with the bounded conflict token when
 available) because the outcome may be partial; it is never mislabeled as a safe stale-preview
 retry.

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -112,11 +112,11 @@ exact Yoetz-owned registration being intentionally replaced. Current Codex `mcp 
 replaces a same-name global entry, so this preflight check matters.
 
 This check-then-add sequence is also available as
-`yoetz integrate codex mcp status|preview|install|remove` and is what `yoetz setup run` performs after
-Codex discovery (ADR-012). Automating it changes no rule above — it is the same two commands,
-gated by an explicit digest-bound confirmation, run by Yoetz instead of by hand; an existing
-foreign entry is still preserved and refused, success is verified by re-reading the entry, and
-"registered" still never implies Codex will successfully connect at runtime.
+`yoetz integrate codex mcp status|preview|preview-remove|install|remove` and is what `yoetz setup
+run` performs after Codex discovery (ADR-012). Automating it changes no rule above — it is the
+same two commands, gated by an explicit digest-bound confirmation, run by Yoetz instead of by
+hand; an existing foreign entry is still preserved and refused, success is verified by re-reading
+the entry, and "registered" still never implies Codex will successfully connect at runtime.
 
 The accepted setup path composes four separately reported layers in order: it installs the project
 skill at `.agents/skills/yoetz`, installs managed structural plugin/hook sources at
@@ -287,13 +287,16 @@ observation store are intentionally left in place.
 ### External MCP registration
 
 ```text
+yoetz integrate codex mcp preview-remove --json
 yoetz integrate codex mcp remove --accept --preview-digest <digest> --json
 ```
 
-This removes an `external_registration` Codex MCP entry by running `codex mcp remove yoetz` only
-when the registered argv is an exact Yoetz serve command. A foreign same-name entry is preserved
-and refused. An already-absent entry is a no-op. Plugin-managed MCP is not this command: it goes
-away with the plugin artifact, not with `codex mcp remove`.
+The first command exposes the exact unregistration digest and current owned route without
+mutation. Noninteractive removal requires that digest plus `--accept`; `--accept` alone fails
+closed. Apply runs `codex mcp remove yoetz` only when the registered argv is an exact Yoetz serve
+command. A foreign same-name entry is preserved and refused. An already-absent entry is a no-op.
+Plugin-managed MCP is not this command: it goes away with the plugin artifact, not with `codex mcp
+remove`.
 
 ## 9. Troubleshooting and recovery
 

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -135,7 +135,9 @@ standalone Codex CLI and does not fabricate an app installation that OpenAI does
 Re-run any time with `yoetz setup run` (the prompt-driven wizard, unchanged) or `/connect` in the
 interface. Change privacy any time with `yoetz --privacy`. Inspect posture read-only with
 `yoetz setup status`. Manage registration directly with `yoetz integrate codex mcp
-status|preview|install`.
+status|preview|install|remove`. Reverse marketplace activation with
+`yoetz integrate codex plugin preview|remove` (cache purge is default-off). See the
+[Codex integration runbook](../runbooks/codex-integration.md) removal section.
 
 ## Re-run or repair a ceremony
 

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -135,7 +135,7 @@ standalone Codex CLI and does not fabricate an app installation that OpenAI does
 Re-run any time with `yoetz setup run` (the prompt-driven wizard, unchanged) or `/connect` in the
 interface. Change privacy any time with `yoetz --privacy`. Inspect posture read-only with
 `yoetz setup status`. Manage registration directly with `yoetz integrate codex mcp
-status|preview|install|remove`. Reverse marketplace activation with
+status|preview|preview-remove|install|remove`. Reverse marketplace activation with
 `yoetz integrate codex plugin preview|remove` (cache purge is default-off). See the
 [Codex integration runbook](../runbooks/codex-integration.md) removal section.
 

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -621,6 +621,8 @@ def _paths(
     project = _validated_project(target)
     _validate_descendant_ancestors(project, Path(".agents/plugins"))
     home = _codex_root(codex_home)
+    _validate_descendant_ancestors(home, Path("plugins/cache/yoetz/yoetz"))
+    _validate_descendant_ancestors(home, Path(".agents/plugins"))
     return (
         project,
         home,
@@ -1833,6 +1835,51 @@ def _directory_open_flags() -> int:
     )
 
 
+def _open_anchored_directory(
+    anchor_root: Path,
+    relative_directory: Path,
+    *,
+    missing_reason: IntegrationReason = IntegrationReason.TARGET_UNSAFE,
+) -> int:
+    """Open one descendant directory without following any path component.
+
+    The returned descriptor is derived from the selected project/home descriptor,
+    so swapping an intermediate pathname cannot redirect a later mutation outside
+    that authority root.
+    """
+
+    if relative_directory.is_absolute() or any(
+        part in {"", ".."} for part in relative_directory.parts
+    ):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    try:
+        current_fd = os.open(anchor_root, _directory_open_flags())
+    except FileNotFoundError as exc:
+        raise _error(missing_reason) from exc
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    try:
+        _owned_stat_not_writable(os.fstat(current_fd), directory=True)
+        for part in relative_directory.parts:
+            try:
+                child_fd = os.open(part, _directory_open_flags(), dir_fd=current_fd)
+            except FileNotFoundError as exc:
+                raise _error(missing_reason) from exc
+            except OSError as exc:
+                raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+            try:
+                _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+            except BaseException:
+                os.close(child_fd)
+                raise
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
 def _require_safe_cache_removal_primitives() -> None:
     required = (os.open, os.rename, os.stat)
     if (
@@ -2047,16 +2094,24 @@ def _remove_exact_managed_file(
     expected: bytes,
     *,
     mismatch_reason: IntegrationReason,
+    anchor_root: Path | None = None,
 ) -> None:
     """Quarantine and unlink only the exact descriptor-bound approved file inode."""
 
     if path.name in {"", ".", ".."} or "/" in path.name:
         raise _error(IntegrationReason.TARGET_UNSAFE)
     _require_safe_file_removal_primitives()
-    try:
-        parent_fd = os.open(path.parent, _directory_open_flags())
-    except OSError as exc:
-        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    if anchor_root is None:
+        try:
+            parent_fd = os.open(path.parent, _directory_open_flags())
+        except OSError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    else:
+        try:
+            relative_parent = path.parent.relative_to(anchor_root)
+        except ValueError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        parent_fd = _open_anchored_directory(anchor_root, relative_parent)
     descriptor: int | None = None
     try:
         _owned_stat_not_writable(os.fstat(parent_fd), directory=True)
@@ -2263,7 +2318,7 @@ def _remove_validated_directory(
     except IntegrationError as exc:
         # Recursive deletion may already have unlinked an earlier approved member. Once that
         # phase begins, an observable race is a partial write failure, not a stale preimage.
-        if exc.reason is IntegrationReason.PREVIEW_STALE and mutation_state[0]:
+        if mutation_state[0] and exc.reason is not IntegrationReason.WRITE_FAILED:
             raise _error(IntegrationReason.WRITE_FAILED) from exc
         raise
     try:
@@ -2282,14 +2337,29 @@ def _delete_managed_cache_versions(
     root: Path,
     cache_digests: tuple[tuple[str, str], ...],
     expected_members: Mapping[str, bytes],
+    *,
+    anchor_root: Path | None = None,
 ) -> bool:
-    if not cache_digests or not root.exists():
+    if not cache_digests:
         return False
     _require_safe_cache_removal_primitives()
-    try:
-        root_fd = os.open(root, _directory_open_flags())
-    except OSError as exc:
-        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    if anchor_root is None:
+        try:
+            root_fd = os.open(root, _directory_open_flags())
+        except FileNotFoundError as exc:
+            raise _error(IntegrationReason.PREVIEW_STALE) from exc
+        except OSError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    else:
+        try:
+            relative_root = root.relative_to(anchor_root)
+        except ValueError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        root_fd = _open_anchored_directory(
+            anchor_root,
+            relative_root,
+            missing_reason=IntegrationReason.PREVIEW_STALE,
+        )
     try:
         _owned_stat_not_writable(os.fstat(root_fd), directory=True)
         cache_mutation_started = False
@@ -2336,7 +2406,9 @@ def _delete_managed_cache_versions(
                     )
                 except IntegrationError as exc:
                     if exc.reason is not IntegrationReason.PREVIEW_STALE:
-                        raise
+                        if exc.reason is IntegrationReason.WRITE_FAILED:
+                            raise
+                        raise _error(IntegrationReason.WRITE_FAILED) from exc
                     # No member was deleted: restore the exact retained inode when the original
                     # version name is still absent. A failed restore is an outcome-unknown write.
                     try:
@@ -2497,6 +2569,7 @@ def apply_removal(
                                 if mutation_started
                                 else IntegrationReason.PREVIEW_STALE
                             ),
+                            anchor_root=home,
                         )
                     except IntegrationError as exc:
                         if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:
@@ -2516,6 +2589,7 @@ def apply_removal(
                         if mutation_started
                         else IntegrationReason.PREVIEW_STALE
                     ),
+                    anchor_root=project,
                 )
             except IntegrationError as exc:
                 if mutation_started or exc.reason is IntegrationReason.WRITE_FAILED:
@@ -2530,9 +2604,10 @@ def apply_removal(
                 _cache_root(home),
                 plan.cache_digests,
                 plan.cache_members,
+                anchor_root=home,
             )
         except IntegrationError as exc:
-            if mutation_started and exc.reason is IntegrationReason.PREVIEW_STALE:
+            if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:
                 raise _error(IntegrationReason.WRITE_FAILED, {"conflict": "cache"}) from exc
             raise
         mutation_started = mutation_started or cache_mutated

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -23,6 +23,10 @@ from yoetz.adapters.integrations.codex_plugin import (
     plugin_tree_matches_marker,
     render_plugin_install_tree,
 )
+from yoetz.adapters.integrations.codex_skill import (
+    inspect_destination,
+    load_packaged_skill_source,
+)
 from yoetz.adapters.integrations.codex_session_stream import resolve_codex_home
 from yoetz.ports.integrations import (
     IntegrationError,
@@ -42,9 +46,14 @@ __all__ = [
     "ActivationInspection",
     "ActivationPreview",
     "ActivationState",
+    "RemovalOutcome",
+    "RemovalPreview",
+    "RemovalResult",
     "apply_activation",
+    "apply_removal",
     "inspect_activation",
     "preview_activation",
+    "preview_removal",
     "resolve_codex_home_for_binary",
 ]
 
@@ -62,6 +71,15 @@ _MAX_EXECUTABLE_BYTES: Final = 256 * 1024 * 1024
 _ACTIVATION_LOCK: Final = ".yoetz-marketplace-activation.lock"
 _PLUGIN_ADD_COMMAND: Final = ("plugin", "add", _PLUGIN_ID, "--json")
 _PLUGIN_LIST_COMMAND: Final = ("plugin", "list", "--marketplace", _MARKETPLACE_NAME, "--json")
+_PLUGIN_REMOVE_COMMAND: Final = ("plugin", "remove", _PLUGIN_ID, "--json")
+_MARKETPLACE_REMOVE_COMMAND: Final = (
+    "plugin",
+    "marketplace",
+    "remove",
+    _MARKETPLACE_NAME,
+    "--json",
+)
+_PLUGIN_TABLE: Final = '[plugins."yoetz@yoetz"]\nenabled = true\n'
 _VERSION_RE: Final = re.compile(
     r"\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b", re.ASCII
 )
@@ -110,6 +128,49 @@ class ActivationPreview:
     cache_mutation_planned: bool
 
 
+class RemovalOutcome(str, Enum):  # noqa: UP042 - exact structural enum
+    REMOVE = "remove"
+    ALREADY_ABSENT = "already_absent"
+
+
+@dataclass(frozen=True, slots=True)
+class RemovalPreview:
+    """Exact removal bytes shown before the owner approves mutation."""
+
+    preview_digest: str
+    inspection: ActivationInspection
+    outcome: RemovalOutcome
+    purge_cache: bool
+    plugin_remove_planned: bool
+    marketplace_remove_planned: bool
+    marketplace_json_planned: bool
+    cache_versions: tuple[str, ...]
+    skill_tree_state: str
+    executable_path: Path
+    executable_digest: str
+    codex_version: str
+    codex_home: Path
+    probe_command: tuple[str, ...]
+    inventory_command: tuple[str, ...]
+    plugin_remove_command: tuple[str, ...]
+    marketplace_remove_command: tuple[str, ...]
+    probe_environment: str
+    activation_environment: tuple[tuple[str, str], ...]
+    marketplace_preimage_digest: str
+    config_preimage_digest: str
+    config_toml_block: str
+
+
+@dataclass(frozen=True, slots=True)
+class RemovalResult:
+    """Verified post-removal classification for one approved preview."""
+
+    outcome: RemovalOutcome
+    inspection: ActivationInspection
+    skill_tree_state: str
+    purge_cache: bool
+
+
 @dataclass(frozen=True, slots=True)
 class _ActivationPlan:
     preview: ActivationPreview
@@ -129,8 +190,11 @@ class _CodexBinaryProbe:
     codex_home: Path
 
 
-def _error(reason: IntegrationReason) -> IntegrationError:
-    return IntegrationError(reason, {})
+def _error(
+    reason: IntegrationReason,
+    details: Mapping[str, JsonValue] | None = None,
+) -> IntegrationError:
+    return IntegrationError(reason, {} if details is None else dict(details))
 
 
 def _sha_file(path: Path) -> str:
@@ -1233,3 +1297,467 @@ def apply_activation(
         if inspection.state is not ActivationState.ACTIVE:
             raise _error(IntegrationReason.WRITE_FAILED)
     return inspection
+
+
+@dataclass(frozen=True, slots=True)
+class _RemovalPlan:
+    preview: RemovalPreview
+    marketplace_before: bytes | None
+    config_before: bytes | None
+    config_after: bytes
+    cache_members: Mapping[str, bytes]
+    binary: _CodexBinaryProbe
+
+
+def _refuse_conflict(candidate: str) -> None:
+    raise _error(IntegrationReason.REMOVE_REFUSED, {"conflict": candidate})
+
+
+def _expected_marketplace_table(project: Path) -> str:
+    return (
+        f'[marketplaces.yoetz]\n'
+        f'source_type = "local"\n'
+        f'source = {_toml_string(str(project))}\n'
+    )
+
+
+def _canonical_marketplace_bytes() -> bytes:
+    return canonical_encode(cast(JsonValue, _marketplace_document())) + b"\n"
+
+
+def _skill_tree_state(target: IntegrationTarget) -> str:
+    return inspect_destination(target, load_packaged_skill_source()).state.value
+
+
+def _exact_table_present(raw: bytes, table: str) -> bool:
+    return table.encode("utf-8") in raw
+
+
+def _strip_exact_block(raw: bytes, block: str) -> bytes:
+    needle = block.encode("utf-8")
+    index = raw.find(needle)
+    if index < 0:
+        return raw
+    before = raw[:index]
+    after = raw[index + len(needle) :]
+    if before.endswith(b"\n") and after.startswith(b"\n"):
+        after = after[1:]
+    merged = before + after
+    while b"\n\n\n" in merged:
+        merged = merged.replace(b"\n\n\n", b"\n\n")
+    if merged in {b"", b"\n"}:
+        return b""
+    if not merged.endswith(b"\n"):
+        merged += b"\n"
+    return merged
+
+
+def _config_table_plan(
+    raw: bytes, config: Mapping[str, object], project: Path
+) -> tuple[bool, bool, bytes]:
+    """Return ``(plugin_table_owned, marketplace_table_owned, config_after)``.
+
+    A same-named table that is not byte-identical to the yoetz render is a
+    conflict, never a candidate for whole-table removal.
+    """
+
+    configured, _enabled, foreign = _config_state(config, project)
+    if foreign:
+        marketplaces = _table(config, "marketplaces")
+        marketplace = None if marketplaces is None else marketplaces.get(_MARKETPLACE_NAME)
+        if marketplace is not None:
+            _refuse_conflict("config_marketplace")
+        _refuse_conflict("config_plugin")
+    plugins = _table(config, "plugins")
+    plugin_present = plugins is not None and _PLUGIN_ID in plugins
+    plugin_owned = plugin_present and _exact_table_present(raw, _PLUGIN_TABLE)
+    if plugin_present and not plugin_owned:
+        _refuse_conflict("config_plugin")
+    marketplace_table = _expected_marketplace_table(project)
+    marketplace_owned = configured and _exact_table_present(raw, marketplace_table)
+    if configured and not marketplace_owned:
+        _refuse_conflict("config_marketplace")
+    after = raw
+    if plugin_owned:
+        after = _strip_exact_block(after, _PLUGIN_TABLE)
+    if marketplace_owned:
+        after = _strip_exact_block(after, marketplace_table)
+    if after != raw:
+        try:
+            parsed = tomllib.loads(after.decode("utf-8") if after else "")
+        except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        remaining_configured, remaining_enabled, remaining_foreign = _config_state(
+            cast(Mapping[str, object], parsed), project
+        )
+        if remaining_configured or remaining_enabled or remaining_foreign:
+            raise _error(IntegrationReason.WRITE_FAILED)
+    return plugin_owned, marketplace_owned, after
+
+
+def _marketplace_json_owned(path: Path) -> bool:
+    snapshot = _load_marketplace(path)
+    if snapshot is None:
+        return False
+    raw, document = snapshot
+    registered, foreign = _classify_manifest(document)
+    if foreign or (registered and raw != _canonical_marketplace_bytes()):
+        _refuse_conflict("repository_marketplace")
+    return raw == _canonical_marketplace_bytes()
+
+
+def _managed_cache_versions(
+    root: Path, expected: Mapping[str, bytes], *, include_all_managed: bool
+) -> tuple[str, ...]:
+    """List yoetz-managed version dirs that this removal may delete.
+
+    Foreign or unexpected members refuse. Other-version managed trees require
+    ``--purge-cache`` so default removal cannot delete extra version dirs.
+    """
+
+    if not root.exists():
+        return ()
+    if root.is_symlink() or not root.is_dir():
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    versions: list[str] = []
+    try:
+        children = sorted(root.iterdir(), key=lambda path: path.name.encode("utf-8"))
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    if not children:
+        return ()
+    for child in children:
+        if child.is_symlink():
+            raise _error(IntegrationReason.TARGET_UNSAFE)
+        if not child.is_dir() or _VERSION_RE.fullmatch(child.name) is None:
+            _refuse_conflict("cache")
+        try:
+            digest = _installed_cache_digest(child, expected)
+        except IntegrationError as exc:
+            if exc.reason is IntegrationReason.DESTINATION_CONFLICT:
+                _refuse_conflict("cache")
+            raise
+        if digest is None:
+            _refuse_conflict("cache")
+        if child.name == __version__ or include_all_managed:
+            versions.append(child.name)
+        else:
+            _refuse_conflict("cache")
+    return tuple(versions)
+
+
+def _inventory_owned(
+    binary: _CodexBinaryProbe,
+    project: Path,
+    *,
+    _run: Callable[..., subprocess.CompletedProcess[bytes]],
+) -> bool:
+    try:
+        installed, _version = _plugin_inventory(binary, project, _run=_run)
+    except IntegrationError as exc:
+        if exc.reason is IntegrationReason.DESTINATION_CONFLICT:
+            _refuse_conflict("inventory")
+        raise
+    return installed
+
+
+def _removed_tables_block(plugin_owned: bool, marketplace_owned: bool, project: Path) -> str:
+    blocks: list[str] = []
+    if marketplace_owned:
+        blocks.append(_expected_marketplace_table(project))
+    if plugin_owned:
+        blocks.append(_PLUGIN_TABLE)
+    return "\n".join(blocks)
+
+
+def _removal_plan(
+    target: IntegrationTarget,
+    *,
+    executable_path: str,
+    codex_home: Path | str | None = None,
+    purge_cache: bool = False,
+    _run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> _RemovalPlan:
+    binary = _probe_codex_binary(executable_path, codex_home=codex_home, _run=_run)
+    if codex_home is not None and _codex_root(codex_home) != binary.codex_home:
+        raise _error(IntegrationReason.PREVIEW_STALE)
+    project, home, marketplace_path, config_path = _paths(target, binary.codex_home)
+    personal_path = home / _MARKETPLACE_RELATIVE_PATH
+    if personal_path != marketplace_path:
+        personal_snapshot = _load_marketplace(personal_path)
+        personal_document = None if personal_snapshot is None else personal_snapshot[1]
+        if _personal_manifest_conflicts(personal_document):
+            _refuse_conflict("personal_marketplace")
+    marketplace_json_planned = _marketplace_json_owned(marketplace_path)
+    marketplace_snapshot = _load_marketplace(marketplace_path)
+    marketplace_before = None if marketplace_snapshot is None else marketplace_snapshot[0]
+    config_bytes, config = _load_config(config_path)
+    config_before = config_bytes if config_path.exists() else None
+    plugin_table_owned, marketplace_table_owned, config_after = _config_table_plan(
+        config_bytes, config, project
+    )
+    cache_members = render_plugin_install_tree(codex_version=binary.codex_version)
+    cache_root = _cache_root(home)
+    cache_versions = _managed_cache_versions(
+        cache_root, cache_members, include_all_managed=purge_cache
+    )
+    cache_root_planned = cache_root.exists()
+    inventory_owned = _inventory_owned(binary, project, _run=_run)
+    inspection = inspect_activation(
+        target,
+        executable_path=executable_path,
+        codex_home=home,
+        _run=_run,
+    )
+    planned = (
+        inventory_owned
+        or plugin_table_owned
+        or marketplace_table_owned
+        or marketplace_json_planned
+        or bool(cache_versions)
+        or cache_root_planned
+    )
+    outcome = RemovalOutcome.REMOVE if planned else RemovalOutcome.ALREADY_ABSENT
+    digest_body = (
+        b"yoetz.codex-marketplace-removal/1\0"
+        + str(home).encode("utf-8")
+        + b"\0"
+        + (b"1" if purge_cache else b"0")
+        + b"\0"
+        + _sha(b"" if marketplace_before is None else marketplace_before).encode()
+        + b"\0"
+        + (b"present:" if config_before is not None else b"absent:")
+        + _sha(config_bytes).encode()
+        + b"\0"
+        + (b"1" if inventory_owned else b"0")
+        + b"\0"
+        + (b"1" if plugin_table_owned else b"0")
+        + b"\0"
+        + (b"1" if marketplace_table_owned else b"0")
+        + b"\0"
+        + (b"1" if marketplace_json_planned else b"0")
+        + b"\0"
+        + canonical_encode(list(cache_versions))
+        + b"\0"
+        + (b"1" if cache_root_planned else b"0")
+        + b"\0"
+        + str(binary.executable_path).encode("utf-8")
+        + b"\0"
+        + binary.executable_digest.encode("ascii")
+        + b"\0"
+        + binary.codex_version.encode("ascii")
+        + b"\0"
+        + canonical_encode(["--version"])
+        + b"\0"
+        + b"temporary_owner_private_home"
+        + b"\0"
+        + canonical_encode(
+            {
+                "CODEX_HOME": str(home),
+                "CODEX_TESTING_HOME": str(home),
+            }
+        )
+        + b"\0"
+        + canonical_encode(list(_PLUGIN_LIST_COMMAND))
+        + b"\0"
+        + canonical_encode(list(_PLUGIN_REMOVE_COMMAND))
+        + b"\0"
+        + canonical_encode(list(_MARKETPLACE_REMOVE_COMMAND))
+    )
+    preview = RemovalPreview(
+        _sha(digest_body),
+        inspection,
+        outcome,
+        purge_cache,
+        inventory_owned,
+        marketplace_table_owned,
+        marketplace_json_planned,
+        cache_versions,
+        _skill_tree_state(target),
+        binary.executable_path,
+        binary.executable_digest,
+        binary.codex_version,
+        home,
+        ("--version",),
+        _PLUGIN_LIST_COMMAND,
+        _PLUGIN_REMOVE_COMMAND,
+        _MARKETPLACE_REMOVE_COMMAND,
+        "temporary_owner_private_home",
+        (("CODEX_HOME", str(home)), ("CODEX_TESTING_HOME", str(home))),
+        _sha(b"" if marketplace_before is None else marketplace_before),
+        _sha(config_bytes),
+        _removed_tables_block(plugin_table_owned, marketplace_table_owned, project),
+    )
+    return _RemovalPlan(
+        preview,
+        marketplace_before,
+        config_before,
+        config_after if planned else config_bytes,
+        cache_members,
+        binary,
+    )
+
+
+def preview_removal(
+    target: IntegrationTarget,
+    *,
+    executable_path: str,
+    codex_home: Path | str | None = None,
+    purge_cache: bool = False,
+    _run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> RemovalPreview:
+    """Return the exact proposed removal plan and stale-safe digest."""
+
+    return _removal_plan(
+        target,
+        executable_path=executable_path,
+        codex_home=codex_home,
+        purge_cache=purge_cache,
+        _run=_run,
+    ).preview
+
+
+def _delete_managed_cache_versions(root: Path, versions: tuple[str, ...]) -> None:
+    for version in versions:
+        path = _cache_version_path(root, version)
+        if not path.exists():
+            continue
+        if path.is_symlink() or not path.is_dir():
+            raise _error(IntegrationReason.TARGET_UNSAFE)
+        try:
+            shutil.rmtree(path)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+    if root.exists():
+        try:
+            remaining = list(root.iterdir())
+        except OSError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        if remaining:
+            raise _error(IntegrationReason.WRITE_FAILED)
+        try:
+            shutil.rmtree(root)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+
+
+def _assert_yoetz_tables_absent(config_path: Path, project: Path) -> None:
+    raw, config = _load_config(config_path)
+    configured, enabled, foreign = _config_state(config, project)
+    if configured or enabled or foreign:
+        raise _error(IntegrationReason.WRITE_FAILED)
+    del raw
+
+
+def apply_removal(
+    target: IntegrationTarget,
+    *,
+    approved_digest: str,
+    executable_path: str,
+    codex_home: Path | str | None = None,
+    purge_cache: bool = False,
+    _run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> RemovalResult:
+    """Apply one exact approved removal preview, refusing stale or foreign state."""
+
+    binary = _probe_codex_binary(executable_path, codex_home=codex_home, _run=_run)
+    if codex_home is not None and _codex_root(codex_home) != binary.codex_home:
+        raise _error(IntegrationReason.PREVIEW_STALE)
+    with _ActivationLock(target, binary.codex_home):
+        plan = _removal_plan(
+            target,
+            executable_path=executable_path,
+            codex_home=codex_home,
+            purge_cache=purge_cache,
+            _run=_run,
+        )
+        preview = plan.preview
+        if approved_digest != preview.preview_digest:
+            raise _error(IntegrationReason.PREVIEW_STALE)
+        project, home, marketplace_path, config_path = _paths(target, binary.codex_home)
+        if preview.outcome is RemovalOutcome.ALREADY_ABSENT:
+            inspection = inspect_activation(
+                target,
+                executable_path=executable_path,
+                codex_home=home,
+                _run=_run,
+            )
+            if inspection.state is ActivationState.ACTIVE:
+                raise _error(IntegrationReason.WRITE_FAILED)
+            if inspection.state is ActivationState.FOREIGN:
+                _refuse_conflict("cache")
+            return RemovalResult(
+                RemovalOutcome.ALREADY_ABSENT,
+                inspection,
+                preview.skill_tree_state,
+                purge_cache,
+            )
+        _assert_snapshot(marketplace_path, plan.marketplace_before)
+        _assert_snapshot(config_path, plan.config_before)
+        _assert_binary_probe(plan.binary, _run=_run)
+        if preview.plugin_remove_planned:
+            _run_json_command(
+                plan.binary,
+                preview.plugin_remove_command,
+                _run=_run,
+                timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
+            )
+        if preview.marketplace_remove_planned:
+            _run_json_command(
+                plan.binary,
+                preview.marketplace_remove_command,
+                _run=_run,
+                timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
+            )
+        current_config = _current_bytes(config_path)
+        if current_config is None:
+            current_config = b""
+        try:
+            parsed_config = tomllib.loads(
+                current_config.decode("utf-8") if current_config else ""
+            )
+        except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+            raise _error(IntegrationReason.SOURCE_INVALID) from exc
+        _, _, stripped = _config_table_plan(
+            current_config,
+            cast(Mapping[str, object], parsed_config),
+            project,
+        )
+        if stripped != current_config:
+            if plan.config_before is None and not stripped:
+                if config_path.exists():
+                    try:
+                        config_path.unlink()
+                    except OSError as exc:
+                        raise _error(IntegrationReason.WRITE_FAILED) from exc
+            else:
+                _atomic_write(config_path, stripped)
+        if preview.marketplace_json_planned:
+            current_marketplace = _current_bytes(marketplace_path)
+            if current_marketplace != _canonical_marketplace_bytes():
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            try:
+                marketplace_path.unlink()
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+        _delete_managed_cache_versions(_cache_root(home), preview.cache_versions)
+        installed, _version = _plugin_inventory(plan.binary, project, _run=_run)
+        if installed:
+            raise _error(IntegrationReason.WRITE_FAILED)
+        _assert_yoetz_tables_absent(config_path, project)
+        if preview.marketplace_json_planned and marketplace_path.exists():
+            raise _error(IntegrationReason.WRITE_FAILED)
+        inspection = inspect_activation(
+            target,
+            executable_path=executable_path,
+            codex_home=home,
+            _run=_run,
+        )
+        if inspection.state is ActivationState.ACTIVE:
+            raise _error(IntegrationReason.WRITE_FAILED)
+        if inspection.state is ActivationState.FOREIGN:
+            raise _error(IntegrationReason.WRITE_FAILED)
+        skill_state = _skill_tree_state(target)
+        if skill_state != preview.skill_tree_state:
+            raise _error(IntegrationReason.WRITE_FAILED)
+    return RemovalResult(RemovalOutcome.REMOVE, inspection, skill_state, purge_cache)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -70,6 +70,9 @@ _VERSION_TIMEOUT_SECONDS: Final = 5.0
 _PLUGIN_ADD_TIMEOUT_SECONDS: Final = 30.0
 _MAX_PLUGIN_OUTPUT_BYTES: Final = 262_144
 _MAX_EXECUTABLE_BYTES: Final = 256 * 1024 * 1024
+_MAX_MANAGED_CACHE_FILES: Final = 64
+_MAX_MANAGED_CACHE_MEMBER_BYTES: Final = 262_144
+_MAX_MANAGED_CACHE_TREE_BYTES: Final = 4 * 1024 * 1024
 _ACTIVATION_LOCK: Final = ".yoetz-marketplace-activation.lock"
 _PLUGIN_ADD_COMMAND: Final = ("plugin", "add", _PLUGIN_ID, "--json")
 _PLUGIN_LIST_COMMAND: Final = ("plugin", "list", "--marketplace", _MARKETPLACE_NAME, "--json")
@@ -1715,8 +1718,11 @@ def _require_safe_cache_removal_primitives() -> None:
 
 def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
+    file_count = 0
+    total_bytes = 0
 
     def walk(directory_fd: int, prefix: str) -> None:
+        nonlocal file_count, total_bytes
         try:
             names = sorted(os.listdir(directory_fd), key=lambda name: os.fsencode(name))
         except OSError as exc:
@@ -1742,16 +1748,38 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
                     os.close(child_fd)
                 continue
             _owned_stat_not_writable(facts, directory=False)
+            file_count += 1
+            if file_count > _MAX_MANAGED_CACHE_FILES:
+                raise _error(IntegrationReason.PREVIEW_STALE)
             flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
             try:
                 descriptor = os.open(name, flags, dir_fd=directory_fd)
             except OSError as exc:
                 raise _error(IntegrationReason.TARGET_UNSAFE) from exc
             try:
-                _owned_stat_not_writable(os.fstat(descriptor), directory=False)
+                opened_facts = os.fstat(descriptor)
+                _owned_stat_not_writable(opened_facts, directory=False)
+                if (
+                    opened_facts.st_size < 0
+                    or opened_facts.st_size > _MAX_MANAGED_CACHE_MEMBER_BYTES
+                    or total_bytes + opened_facts.st_size > _MAX_MANAGED_CACHE_TREE_BYTES
+                ):
+                    raise _error(IntegrationReason.PREVIEW_STALE)
                 chunks: list[bytes] = []
-                while chunk := os.read(descriptor, 1024 * 1024):
+                file_bytes = 0
+                while chunk := os.read(descriptor, 64 * 1024):
+                    file_bytes += len(chunk)
+                    if (
+                        file_bytes > _MAX_MANAGED_CACHE_MEMBER_BYTES
+                        or total_bytes + file_bytes > _MAX_MANAGED_CACHE_TREE_BYTES
+                    ):
+                        raise _error(IntegrationReason.PREVIEW_STALE)
                     chunks.append(chunk)
+                final_facts = os.fstat(descriptor)
+                _owned_stat_not_writable(final_facts, directory=False)
+                if final_facts.st_size != file_bytes:
+                    raise _error(IntegrationReason.PREVIEW_STALE)
+                total_bytes += file_bytes
                 members[relative] = b"".join(chunks)
             except OSError as exc:
                 raise _error(IntegrationReason.TARGET_UNSAFE) from exc

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -1793,6 +1793,19 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
 def _managed_cache_digest_at(
     root_fd: int, name: str, expected_members: Mapping[str, bytes]
 ) -> str | None:
+    opened = _open_managed_cache_digest_at(root_fd, name, expected_members)
+    if opened is None:
+        return None
+    descriptor, digest = opened
+    os.close(descriptor)
+    return digest
+
+
+def _open_managed_cache_digest_at(
+    root_fd: int, name: str, expected_members: Mapping[str, bytes]
+) -> tuple[int, str] | None:
+    """Open and validate one managed cache tree, retaining its exact directory inode."""
+
     try:
         descriptor = os.open(name, _directory_open_flags(), dir_fd=root_fd)
     except FileNotFoundError:
@@ -1802,11 +1815,89 @@ def _managed_cache_digest_at(
     try:
         _owned_stat_not_writable(os.fstat(descriptor), directory=True)
         actual = _read_managed_tree_fd(descriptor)
-    finally:
+        if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
+            raise _error(IntegrationReason.PREVIEW_STALE)
+        return descriptor, _members_digest(actual)
+    except BaseException:
         os.close(descriptor)
-    if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
+        raise
+
+
+def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _remove_managed_tree_contents_fd(directory_fd: int) -> None:
+    """Delete contents relative to one already-open validated directory inode."""
+
+    try:
+        names = sorted(os.listdir(directory_fd), key=lambda name: os.fsencode(name))
+    except OSError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+    for name in names:
+        if type(name) is not str or name in {"", ".", ".."} or "/" in name:
+            raise _error(IntegrationReason.TARGET_UNSAFE)
+        try:
+            before = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise _error(IntegrationReason.PREVIEW_STALE) from exc
+        if stat.S_ISDIR(before.st_mode):
+            _owned_stat_not_writable(before, directory=True)
+            try:
+                child_fd = os.open(name, _directory_open_flags(), dir_fd=directory_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.PREVIEW_STALE) from exc
+            try:
+                opened = os.fstat(child_fd)
+                _owned_stat_not_writable(opened, directory=True)
+                if not _same_inode(before, opened):
+                    raise _error(IntegrationReason.PREVIEW_STALE)
+                _remove_managed_tree_contents_fd(child_fd)
+                current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+                if not _same_inode(opened, current):
+                    raise _error(IntegrationReason.PREVIEW_STALE)
+                os.rmdir(name, dir_fd=directory_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            finally:
+                os.close(child_fd)
+            continue
+        _owned_stat_not_writable(before, directory=False)
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            member_fd = os.open(name, flags, dir_fd=directory_fd)
+        except OSError as exc:
+            raise _error(IntegrationReason.PREVIEW_STALE) from exc
+        try:
+            opened = os.fstat(member_fd)
+            _owned_stat_not_writable(opened, directory=False)
+            if not _same_inode(before, opened):
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            if not _same_inode(opened, current):
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            os.unlink(name, dir_fd=directory_fd)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        finally:
+            os.close(member_fd)
+
+
+def _remove_validated_directory(root_fd: int, name: str, descriptor: int) -> None:
+    """Remove a tree through its retained descriptor, never by reopening its pathname."""
+
+    validated = os.fstat(descriptor)
+    _remove_managed_tree_contents_fd(descriptor)
+    try:
+        current = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise _error(IntegrationReason.PREVIEW_STALE) from exc
+    if not _same_inode(validated, current):
         raise _error(IntegrationReason.PREVIEW_STALE)
-    return _members_digest(actual)
+    try:
+        os.rmdir(name, dir_fd=root_fd)
+    except OSError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
 
 
 def _delete_managed_cache_versions(
@@ -1839,8 +1930,15 @@ def _delete_managed_cache_versions(
                 )
             except OSError as exc:
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
-            if _managed_cache_digest_at(root_fd, quarantine, expected_members) != expected_digest:
+            opened = _open_managed_cache_digest_at(root_fd, quarantine, expected_members)
+            if opened is None:
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            quarantine_fd, quarantine_digest = opened
+            if quarantine_digest != expected_digest:
                 try:
+                    current = os.stat(quarantine, dir_fd=root_fd, follow_symlinks=False)
+                    if not _same_inode(os.fstat(quarantine_fd), current):
+                        raise _error(IntegrationReason.PREVIEW_STALE)
                     os.rename(
                         quarantine,
                         version,
@@ -1849,11 +1947,13 @@ def _delete_managed_cache_versions(
                     )
                 except OSError as exc:
                     raise _error(IntegrationReason.WRITE_FAILED) from exc
+                finally:
+                    os.close(quarantine_fd)
                 raise _error(IntegrationReason.PREVIEW_STALE)
             try:
-                shutil.rmtree(quarantine, dir_fd=root_fd)
-            except OSError as exc:
-                raise _error(IntegrationReason.WRITE_FAILED) from exc
+                _remove_validated_directory(root_fd, quarantine, quarantine_fd)
+            finally:
+                os.close(quarantine_fd)
         if os.listdir(root_fd):
             raise _error(IntegrationReason.WRITE_FAILED)
     finally:

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -2706,12 +2706,13 @@ def _delete_managed_cache_versions(
                         approved_members,
                     )
                 except IntegrationError as exc:
-                    if exc.reason is not IntegrationReason.PREVIEW_STALE:
-                        if exc.reason is IntegrationReason.WRITE_FAILED:
-                            raise
-                        raise _error(IntegrationReason.WRITE_FAILED) from exc
+                    if exc.reason is IntegrationReason.WRITE_FAILED:
+                        raise
                     # No member was deleted: restore the exact retained inode when the original
-                    # version name is still absent. A failed restore is an outcome-unknown write.
+                    # version name is still absent. `_remove_validated_directory` converts every
+                    # error after its first unlink to WRITE_FAILED, so every other reason is an
+                    # initial-validation failure eligible for this recovery. A failed restore is
+                    # itself an outcome-unknown write.
                     try:
                         quarantine_current = os.stat(
                             quarantine,

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 import tomllib
@@ -14,7 +15,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Final, cast
+from typing import Final, Never, cast
 
 from yoetz import __version__
 from yoetz.adapters.integrations.codex_plugin import (
@@ -145,6 +146,7 @@ class RemovalPreview:
     marketplace_remove_planned: bool
     marketplace_json_planned: bool
     cache_versions: tuple[str, ...]
+    cache_digests: tuple[tuple[str, str], ...]
     skill_tree_state: str
     executable_path: Path
     executable_digest: str
@@ -504,6 +506,17 @@ def _cache_root(home: Path) -> Path:
     return home / "plugins" / "cache" / _MARKETPLACE_NAME / "yoetz"
 
 
+def _cache_root_has_entries(home: Path) -> bool:
+    root = _cache_root(home)
+    if not root.exists() and not root.is_symlink():
+        return False
+    _validate_descendant_ancestors(home, Path("plugins/cache/yoetz/yoetz"))
+    try:
+        return next(root.iterdir(), None) is not None
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+
+
 def _cache_version_path(root: Path, version: str) -> Path:
     if _VERSION_RE.fullmatch(version) is None:
         raise _error(IntegrationReason.SOURCE_INVALID)
@@ -736,12 +749,12 @@ def inspect_activation(
                         _cache_version_path(_cache_root(home), version),
                         cache_members,
                     ) == _members_digest(cache_members)
-                elif _cache_root(home).exists():
+                elif _cache_root_has_entries(home):
                     cache_foreign = True
             elif local_digest is not None:
                 # Preview is mutation-free: a canonical inventory command is reserved for apply.
                 plugin_cached = False
-            elif _cache_root(home).exists():
+            elif _cache_root_has_entries(home):
                 cache_foreign = True
         except IntegrationError as exc:
             if exc.reason in {
@@ -1306,19 +1319,16 @@ class _RemovalPlan:
     config_before: bytes | None
     config_after: bytes
     cache_members: Mapping[str, bytes]
+    cache_digests: tuple[tuple[str, str], ...]
     binary: _CodexBinaryProbe
 
 
-def _refuse_conflict(candidate: str) -> None:
+def _refuse_conflict(candidate: str) -> Never:
     raise _error(IntegrationReason.REMOVE_REFUSED, {"conflict": candidate})
 
 
 def _expected_marketplace_table(project: Path) -> str:
-    return (
-        f'[marketplaces.yoetz]\n'
-        f'source_type = "local"\n'
-        f'source = {_toml_string(str(project))}\n'
-    )
+    return f'[marketplaces.yoetz]\nsource_type = "local"\nsource = {_toml_string(str(project))}\n'
 
 
 def _canonical_marketplace_bytes() -> bytes:
@@ -1329,17 +1339,52 @@ def _skill_tree_state(target: IntegrationTarget) -> str:
     return inspect_destination(target, load_packaged_skill_source()).state.value
 
 
-def _exact_table_present(raw: bytes, table: str) -> bool:
-    return table.encode("utf-8") in raw
+_TOML_TABLE_HEADER_RE: Final = re.compile(rb"[ \t]*\[\[?[^\r\n\]]+\]\]?[ \t]*(?:#[^\r\n]*)?")
 
 
-def _strip_exact_block(raw: bytes, block: str) -> bytes:
-    needle = block.encode("utf-8")
-    index = raw.find(needle)
-    if index < 0:
+def _exact_table_span(raw: bytes, table: str) -> tuple[int, int] | None:
+    """Return the whole byte span only when one TOML table is exact.
+
+    Matching a generated prefix is insufficient: an owner-added key would then
+    survive removal at the parent scope. Blank separator lines are outside the
+    table identity, but comments and fields before the next header are not.
+    """
+
+    expected = table.encode("utf-8")
+    header = expected.splitlines(keepends=True)[0]
+    lines = raw.splitlines(keepends=True)
+    offsets: list[int] = []
+    offset = 0
+    for line in lines:
+        if line == header:
+            offsets.append(offset)
+        offset += len(line)
+    if len(offsets) != 1:
+        return None
+    start = offsets[0]
+    end = len(raw)
+    offset = 0
+    seen = False
+    for line in lines:
+        if offset == start:
+            seen = True
+        elif seen and _TOML_TABLE_HEADER_RE.fullmatch(line.rstrip(b"\r\n")):
+            end = offset
+            break
+        offset += len(line)
+    candidate = raw[start:end].rstrip(b"\r\n") + b"\n"
+    if candidate != expected:
+        return None
+    return start, end
+
+
+def _strip_exact_table(raw: bytes, table: str) -> bytes:
+    span = _exact_table_span(raw, table)
+    if span is None:
         return raw
-    before = raw[:index]
-    after = raw[index + len(needle) :]
+    start, end = span
+    before = raw[:start]
+    after = raw[end:]
     if before.endswith(b"\n") and after.startswith(b"\n"):
         after = after[1:]
     merged = before + after
@@ -1361,7 +1406,7 @@ def _config_table_plan(
     conflict, never a candidate for whole-table removal.
     """
 
-    configured, _enabled, foreign = _config_state(config, project)
+    _configured, _enabled, foreign = _config_state(config, project)
     if foreign:
         marketplaces = _table(config, "marketplaces")
         marketplace = None if marketplaces is None else marketplaces.get(_MARKETPLACE_NAME)
@@ -1369,19 +1414,32 @@ def _config_table_plan(
             _refuse_conflict("config_marketplace")
         _refuse_conflict("config_plugin")
     plugins = _table(config, "plugins")
-    plugin_present = plugins is not None and _PLUGIN_ID in plugins
-    plugin_owned = plugin_present and _exact_table_present(raw, _PLUGIN_TABLE)
+    plugin = None if plugins is None else plugins.get(_PLUGIN_ID)
+    plugin_present = plugin is not None
+    plugin_owned = (
+        isinstance(plugin, Mapping)
+        and dict(cast(Mapping[str, object], plugin)) == {"enabled": True}
+        and _exact_table_span(raw, _PLUGIN_TABLE) is not None
+    )
     if plugin_present and not plugin_owned:
         _refuse_conflict("config_plugin")
     marketplace_table = _expected_marketplace_table(project)
-    marketplace_owned = configured and _exact_table_present(raw, marketplace_table)
-    if configured and not marketplace_owned:
+    marketplaces = _table(config, "marketplaces")
+    marketplace = None if marketplaces is None else marketplaces.get(_MARKETPLACE_NAME)
+    marketplace_present = marketplace is not None
+    marketplace_owned = (
+        isinstance(marketplace, Mapping)
+        and dict(cast(Mapping[str, object], marketplace))
+        == {"source_type": "local", "source": str(project)}
+        and _exact_table_span(raw, marketplace_table) is not None
+    )
+    if marketplace_present and not marketplace_owned:
         _refuse_conflict("config_marketplace")
     after = raw
     if plugin_owned:
-        after = _strip_exact_block(after, _PLUGIN_TABLE)
+        after = _strip_exact_table(after, _PLUGIN_TABLE)
     if marketplace_owned:
-        after = _strip_exact_block(after, marketplace_table)
+        after = _strip_exact_table(after, marketplace_table)
     if after != raw:
         try:
             parsed = tomllib.loads(after.decode("utf-8") if after else "")
@@ -1408,7 +1466,7 @@ def _marketplace_json_owned(path: Path) -> bool:
 
 def _managed_cache_versions(
     root: Path, expected: Mapping[str, bytes], *, include_all_managed: bool
-) -> tuple[str, ...]:
+) -> tuple[tuple[str, str], ...]:
     """List yoetz-managed version dirs that this removal may delete.
 
     Foreign or unexpected members refuse. Other-version managed trees require
@@ -1419,7 +1477,7 @@ def _managed_cache_versions(
         return ()
     if root.is_symlink() or not root.is_dir():
         raise _error(IntegrationReason.TARGET_UNSAFE)
-    versions: list[str] = []
+    versions: list[tuple[str, str]] = []
     try:
         children = sorted(root.iterdir(), key=lambda path: path.name.encode("utf-8"))
     except OSError as exc:
@@ -1440,7 +1498,7 @@ def _managed_cache_versions(
         if digest is None:
             _refuse_conflict("cache")
         if child.name == __version__ or include_all_managed:
-            versions.append(child.name)
+            versions.append((child.name, digest))
         else:
             _refuse_conflict("cache")
     return tuple(versions)
@@ -1498,10 +1556,13 @@ def _removal_plan(
     )
     cache_members = render_plugin_install_tree(codex_version=binary.codex_version)
     cache_root = _cache_root(home)
-    cache_versions = _managed_cache_versions(
+    _validate_descendant_ancestors(home, Path("plugins/cache/yoetz/yoetz"))
+    cache_digests = _managed_cache_versions(
         cache_root, cache_members, include_all_managed=purge_cache
     )
-    cache_root_planned = cache_root.exists()
+    if cache_digests:
+        _require_safe_cache_removal_primitives()
+    cache_versions = tuple(version for version, _digest in cache_digests)
     inventory_owned = _inventory_owned(binary, project, _run=_run)
     inspection = inspect_activation(
         target,
@@ -1515,7 +1576,6 @@ def _removal_plan(
         or marketplace_table_owned
         or marketplace_json_planned
         or bool(cache_versions)
-        or cache_root_planned
     )
     outcome = RemovalOutcome.REMOVE if planned else RemovalOutcome.ALREADY_ABSENT
     digest_body = (
@@ -1537,9 +1597,9 @@ def _removal_plan(
         + b"\0"
         + (b"1" if marketplace_json_planned else b"0")
         + b"\0"
-        + canonical_encode(list(cache_versions))
-        + b"\0"
-        + (b"1" if cache_root_planned else b"0")
+        + canonical_encode(
+            [{"version": version, "digest": digest} for version, digest in cache_digests]
+        )
         + b"\0"
         + str(binary.executable_path).encode("utf-8")
         + b"\0"
@@ -1573,6 +1633,7 @@ def _removal_plan(
         marketplace_table_owned,
         marketplace_json_planned,
         cache_versions,
+        cache_digests,
         _skill_tree_state(target),
         binary.executable_path,
         binary.executable_digest,
@@ -1594,6 +1655,7 @@ def _removal_plan(
         config_before,
         config_after if planned else config_bytes,
         cache_members,
+        cache_digests,
         binary,
     )
 
@@ -1617,28 +1679,152 @@ def preview_removal(
     ).preview
 
 
-def _delete_managed_cache_versions(root: Path, versions: tuple[str, ...]) -> None:
-    for version in versions:
-        path = _cache_version_path(root, version)
-        if not path.exists():
-            continue
-        if path.is_symlink() or not path.is_dir():
-            raise _error(IntegrationReason.TARGET_UNSAFE)
+def _owned_stat_not_writable(facts: os.stat_result, *, directory: bool) -> None:
+    expected = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected(facts.st_mode):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    if hasattr(os, "geteuid") and facts.st_uid != os.geteuid():
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    if facts.st_mode & 0o022:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+
+
+def _directory_open_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def _require_safe_cache_removal_primitives() -> None:
+    required = (os.open, os.rename, os.stat)
+    if (
+        not getattr(os, "O_NOFOLLOW", 0)
+        or any(function not in os.supports_dir_fd for function in required)
+        or not getattr(shutil.rmtree, "avoids_symlink_attacks", False)
+    ):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+
+
+def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
+    members: dict[str, bytes] = {}
+
+    def walk(directory_fd: int, prefix: str) -> None:
         try:
-            shutil.rmtree(path)
-        except OSError as exc:
-            raise _error(IntegrationReason.WRITE_FAILED) from exc
-    if root.exists():
-        try:
-            remaining = list(root.iterdir())
+            names = sorted(os.listdir(directory_fd), key=lambda name: os.fsencode(name))
         except OSError as exc:
             raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-        if remaining:
+        for name in names:
+            if type(name) is not str or name in {"", ".", ".."} or "/" in name:
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            relative = name if not prefix else f"{prefix}/{name}"
+            try:
+                facts = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            except OSError as exc:
+                raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+            if stat.S_ISDIR(facts.st_mode):
+                _owned_stat_not_writable(facts, directory=True)
+                try:
+                    child_fd = os.open(name, _directory_open_flags(), dir_fd=directory_fd)
+                except OSError as exc:
+                    raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+                try:
+                    _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+                    walk(child_fd, relative)
+                finally:
+                    os.close(child_fd)
+                continue
+            _owned_stat_not_writable(facts, directory=False)
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                descriptor = os.open(name, flags, dir_fd=directory_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+            try:
+                _owned_stat_not_writable(os.fstat(descriptor), directory=False)
+                chunks: list[bytes] = []
+                while chunk := os.read(descriptor, 1024 * 1024):
+                    chunks.append(chunk)
+                members[relative] = b"".join(chunks)
+            except OSError as exc:
+                raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+            finally:
+                os.close(descriptor)
+
+    walk(root_fd, "")
+    return members
+
+
+def _managed_cache_digest_at(
+    root_fd: int, name: str, expected_members: Mapping[str, bytes]
+) -> str | None:
+    try:
+        descriptor = os.open(name, _directory_open_flags(), dir_fd=root_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    try:
+        _owned_stat_not_writable(os.fstat(descriptor), directory=True)
+        actual = _read_managed_tree_fd(descriptor)
+    finally:
+        os.close(descriptor)
+    if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
+        raise _error(IntegrationReason.PREVIEW_STALE)
+    return _members_digest(actual)
+
+
+def _delete_managed_cache_versions(
+    root: Path,
+    cache_digests: tuple[tuple[str, str], ...],
+    expected_members: Mapping[str, bytes],
+) -> None:
+    if not cache_digests or not root.exists():
+        return
+    _require_safe_cache_removal_primitives()
+    try:
+        root_fd = os.open(root, _directory_open_flags())
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    try:
+        _owned_stat_not_writable(os.fstat(root_fd), directory=True)
+        for version, expected_digest in cache_digests:
+            current_digest = _managed_cache_digest_at(root_fd, version, expected_members)
+            if current_digest is None:
+                continue
+            if current_digest != expected_digest:
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            quarantine = f".yoetz-cache-remove-{os.urandom(8).hex()}"
+            try:
+                os.rename(
+                    version,
+                    quarantine,
+                    src_dir_fd=root_fd,
+                    dst_dir_fd=root_fd,
+                )
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            if _managed_cache_digest_at(root_fd, quarantine, expected_members) != expected_digest:
+                try:
+                    os.rename(
+                        quarantine,
+                        version,
+                        src_dir_fd=root_fd,
+                        dst_dir_fd=root_fd,
+                    )
+                except OSError as exc:
+                    raise _error(IntegrationReason.WRITE_FAILED) from exc
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            try:
+                shutil.rmtree(quarantine, dir_fd=root_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+        if os.listdir(root_fd):
             raise _error(IntegrationReason.WRITE_FAILED)
-        try:
-            shutil.rmtree(root)
-        except OSError as exc:
-            raise _error(IntegrationReason.WRITE_FAILED) from exc
+    finally:
+        os.close(root_fd)
 
 
 def _assert_yoetz_tables_absent(config_path: Path, project: Path) -> None:
@@ -1713,9 +1899,7 @@ def apply_removal(
         if current_config is None:
             current_config = b""
         try:
-            parsed_config = tomllib.loads(
-                current_config.decode("utf-8") if current_config else ""
-            )
+            parsed_config = tomllib.loads(current_config.decode("utf-8") if current_config else "")
         except (UnicodeError, tomllib.TOMLDecodeError) as exc:
             raise _error(IntegrationReason.SOURCE_INVALID) from exc
         _, _, stripped = _config_table_plan(
@@ -1740,7 +1924,7 @@ def apply_removal(
                 marketplace_path.unlink()
             except OSError as exc:
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
-        _delete_managed_cache_versions(_cache_root(home), preview.cache_versions)
+        _delete_managed_cache_versions(_cache_root(home), plan.cache_digests, plan.cache_members)
         installed, _version = _plugin_inventory(plan.binary, project, _run=_run)
         if installed:
             raise _error(IntegrationReason.WRITE_FAILED)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -56,6 +56,7 @@ __all__ = [
     "preview_activation",
     "preview_removal",
     "resolve_codex_home_for_binary",
+    "skill_tree_state",
 ]
 
 _MARKETPLACE_NAME: Final = "yoetz"
@@ -80,7 +81,7 @@ _MARKETPLACE_REMOVE_COMMAND: Final = (
     _MARKETPLACE_NAME,
     "--json",
 )
-_PLUGIN_TABLE: Final = '[plugins."yoetz@yoetz"]\nenabled = true\n'
+_PLUGIN_TABLE: Final = f'[plugins."{_PLUGIN_ID}"]\nenabled = true\n'
 _VERSION_RE: Final = re.compile(
     r"\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b", re.ASCII
 )
@@ -1335,7 +1336,9 @@ def _canonical_marketplace_bytes() -> bytes:
     return canonical_encode(cast(JsonValue, _marketplace_document())) + b"\n"
 
 
-def _skill_tree_state(target: IntegrationTarget) -> str:
+def skill_tree_state(target: IntegrationTarget) -> str:
+    """Return the packaged skill destination state used by preview, apply, and CLI status."""
+
     return inspect_destination(target, load_packaged_skill_source()).state.value
 
 
@@ -1580,6 +1583,8 @@ def _removal_plan(
     outcome = RemovalOutcome.REMOVE if planned else RemovalOutcome.ALREADY_ABSENT
     digest_body = (
         b"yoetz.codex-marketplace-removal/1\0"
+        + str(project).encode("utf-8")
+        + b"\0"
         + str(home).encode("utf-8")
         + b"\0"
         + (b"1" if purge_cache else b"0")
@@ -1634,7 +1639,7 @@ def _removal_plan(
         marketplace_json_planned,
         cache_versions,
         cache_digests,
-        _skill_tree_state(target),
+        skill_tree_state(target),
         binary.executable_path,
         binary.executable_digest,
         binary.codex_version,
@@ -1902,11 +1907,20 @@ def apply_removal(
             parsed_config = tomllib.loads(current_config.decode("utf-8") if current_config else "")
         except (UnicodeError, tomllib.TOMLDecodeError) as exc:
             raise _error(IntegrationReason.SOURCE_INVALID) from exc
-        _, _, stripped = _config_table_plan(
-            current_config,
-            cast(Mapping[str, object], parsed_config),
-            project,
-        )
+        try:
+            _, _, stripped = _config_table_plan(
+                current_config,
+                cast(Mapping[str, object], parsed_config),
+                project,
+            )
+        except IntegrationError as exc:
+            if exc.reason is IntegrationReason.REMOVE_REFUSED:
+                # A conflict discovered after the host removal subprocesses have already
+                # mutated state is a partial-apply failure, not a pre-mutation refusal.
+                conflict = exc.safe_details.get("conflict")
+                details = {"conflict": conflict} if type(conflict) is str else None
+                raise _error(IntegrationReason.WRITE_FAILED, details) from exc
+            raise
         if stripped != current_config:
             if plan.config_before is None and not stripped:
                 if config_path.exists():
@@ -1941,7 +1955,7 @@ def apply_removal(
             raise _error(IntegrationReason.WRITE_FAILED)
         if inspection.state is ActivationState.FOREIGN:
             raise _error(IntegrationReason.WRITE_FAILED)
-        skill_state = _skill_tree_state(target)
+        skill_state = skill_tree_state(target)
         if skill_state != preview.skill_tree_state:
             raise _error(IntegrationReason.WRITE_FAILED)
     return RemovalResult(RemovalOutcome.REMOVE, inspection, skill_state, purge_cache)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -71,6 +71,9 @@ _PLUGIN_ADD_TIMEOUT_SECONDS: Final = 30.0
 _MAX_PLUGIN_OUTPUT_BYTES: Final = 262_144
 _MAX_EXECUTABLE_BYTES: Final = 256 * 1024 * 1024
 _MAX_MANAGED_CACHE_FILES: Final = 64
+_MAX_MANAGED_CACHE_ENTRIES: Final = 256
+_MAX_MANAGED_CACHE_DEPTH: Final = 16
+_MAX_MANAGED_CACHE_RELATIVE_PATH_BYTES: Final = 4_096
 _MAX_MANAGED_CACHE_MEMBER_BYTES: Final = 262_144
 _MAX_MANAGED_CACHE_TREE_BYTES: Final = 4 * 1024 * 1024
 _ACTIVATION_LOCK: Final = ".yoetz-marketplace-activation.lock"
@@ -543,23 +546,19 @@ def _plugin_source_installed(target: IntegrationTarget, *, codex_version: str) -
 
 
 def _read_managed_tree(root: Path) -> dict[str, bytes]:
-    """Read one owner-private managed tree, refusing symlinks and unsafe members."""
+    """Read one managed tree through the shared bounded, no-follow descriptor walker."""
 
-    members: dict[str, bytes] = {}
+    if root.is_symlink():
+        raise _error(IntegrationReason.TARGET_UNSAFE)
     try:
-        for candidate in root.rglob("*"):
-            if candidate.is_symlink():
-                raise _error(IntegrationReason.TARGET_UNSAFE)
-            if candidate.is_dir():
-                _owned_not_writable(candidate, directory=True)
-                continue
-            if not candidate.is_file():
-                raise _error(IntegrationReason.TARGET_UNSAFE)
-            _owned_not_writable(candidate, directory=False)
-            members[candidate.relative_to(root).as_posix()] = candidate.read_bytes()
+        descriptor = os.open(root, _directory_open_flags())
     except OSError as exc:
         raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-    return members
+    try:
+        _owned_stat_not_writable(os.fstat(descriptor), directory=True)
+        return _read_managed_tree_fd(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _source_cache_members(target: IntegrationTarget, *, codex_version: str) -> dict[str, bytes]:
@@ -1484,10 +1483,18 @@ def _managed_cache_versions(
     if root.is_symlink() or not root.is_dir():
         raise _error(IntegrationReason.TARGET_UNSAFE)
     versions: list[tuple[str, str]] = []
+    children: list[Path] = []
     try:
-        children = sorted(root.iterdir(), key=lambda path: path.name.encode("utf-8"))
+        with os.scandir(root) as entries:
+            for entry in entries:
+                if type(entry.name) is not str or entry.name in {"", ".", ".."}:
+                    raise _error(IntegrationReason.TARGET_UNSAFE)
+                children.append(root / entry.name)
+                if len(children) > _MAX_MANAGED_CACHE_ENTRIES:
+                    raise _error(IntegrationReason.PREVIEW_STALE)
     except OSError as exc:
         raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    children.sort(key=lambda path: os.fsencode(path.name))
     if not children:
         return ()
     for child in children:
@@ -1716,21 +1723,39 @@ def _require_safe_cache_removal_primitives() -> None:
         raise _error(IntegrationReason.TARGET_UNSAFE)
 
 
+def _bounded_directory_names(directory_fd: int) -> list[str]:
+    names: list[str] = []
+    try:
+        with os.scandir(directory_fd) as entries:
+            for entry in entries:
+                name = entry.name
+                if type(name) is not str or name in {"", ".", ".."} or "/" in name:
+                    raise _error(IntegrationReason.TARGET_UNSAFE)
+                names.append(name)
+                if len(names) > _MAX_MANAGED_CACHE_ENTRIES:
+                    raise _error(IntegrationReason.PREVIEW_STALE)
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    return sorted(names, key=lambda name: os.fsencode(name))
+
+
 def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
     members: dict[str, bytes] = {}
     file_count = 0
+    entry_count = 0
     total_bytes = 0
 
-    def walk(directory_fd: int, prefix: str) -> None:
-        nonlocal file_count, total_bytes
-        try:
-            names = sorted(os.listdir(directory_fd), key=lambda name: os.fsencode(name))
-        except OSError as exc:
-            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-        for name in names:
-            if type(name) is not str or name in {"", ".", ".."} or "/" in name:
-                raise _error(IntegrationReason.TARGET_UNSAFE)
+    def walk(directory_fd: int, prefix: str, depth: int) -> None:
+        nonlocal entry_count, file_count, total_bytes
+        if depth > _MAX_MANAGED_CACHE_DEPTH:
+            raise _error(IntegrationReason.PREVIEW_STALE)
+        for name in _bounded_directory_names(directory_fd):
+            entry_count += 1
+            if entry_count > _MAX_MANAGED_CACHE_ENTRIES:
+                raise _error(IntegrationReason.PREVIEW_STALE)
             relative = name if not prefix else f"{prefix}/{name}"
+            if len(os.fsencode(relative)) > _MAX_MANAGED_CACHE_RELATIVE_PATH_BYTES:
+                raise _error(IntegrationReason.PREVIEW_STALE)
             try:
                 facts = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
             except OSError as exc:
@@ -1743,7 +1768,7 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
                     raise _error(IntegrationReason.TARGET_UNSAFE) from exc
                 try:
                     _owned_stat_not_writable(os.fstat(child_fd), directory=True)
-                    walk(child_fd, relative)
+                    walk(child_fd, relative, depth + 1)
                 finally:
                     os.close(child_fd)
                 continue
@@ -1786,24 +1811,13 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
             finally:
                 os.close(descriptor)
 
-    walk(root_fd, "")
+    walk(root_fd, "", 1)
     return members
-
-
-def _managed_cache_digest_at(
-    root_fd: int, name: str, expected_members: Mapping[str, bytes]
-) -> str | None:
-    opened = _open_managed_cache_digest_at(root_fd, name, expected_members)
-    if opened is None:
-        return None
-    descriptor, digest = opened
-    os.close(descriptor)
-    return digest
 
 
 def _open_managed_cache_digest_at(
     root_fd: int, name: str, expected_members: Mapping[str, bytes]
-) -> tuple[int, str] | None:
+) -> tuple[int, str, Mapping[str, bytes]] | None:
     """Open and validate one managed cache tree, retaining its exact directory inode."""
 
     try:
@@ -1817,7 +1831,7 @@ def _open_managed_cache_digest_at(
         actual = _read_managed_tree_fd(descriptor)
         if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
             raise _error(IntegrationReason.PREVIEW_STALE)
-        return descriptor, _members_digest(actual)
+        return descriptor, _members_digest(actual), actual
     except BaseException:
         os.close(descriptor)
         raise
@@ -1827,13 +1841,50 @@ def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
     return left.st_dev == right.st_dev and left.st_ino == right.st_ino
 
 
-def _remove_managed_tree_contents_fd(directory_fd: int) -> None:
-    """Delete contents relative to one already-open validated directory inode."""
+def _expected_child_names(approved_members: Mapping[str, bytes], prefix: str) -> set[str]:
+    stem = "" if not prefix else f"{prefix}/"
+    children: set[str] = set()
+    for relative in approved_members:
+        if not relative.startswith(stem):
+            continue
+        suffix = relative[len(stem) :]
+        if suffix:
+            children.add(suffix.split("/", maxsplit=1)[0])
+    return children
 
+
+def _read_exact_member(
+    descriptor: int,
+    expected: bytes,
+    *,
+    mismatch_reason: IntegrationReason = IntegrationReason.PREVIEW_STALE,
+) -> bytes:
     try:
-        names = sorted(os.listdir(directory_fd), key=lambda name: os.fsencode(name))
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        chunks: list[bytes] = []
+        total = 0
+        while chunk := os.read(descriptor, min(64 * 1024, len(expected) + 1 - total)):
+            total += len(chunk)
+            if total > len(expected):
+                raise _error(mismatch_reason)
+            chunks.append(chunk)
+        return b"".join(chunks)
     except OSError as exc:
         raise _error(IntegrationReason.WRITE_FAILED) from exc
+
+
+def _remove_managed_tree_contents_fd(
+    directory_fd: int,
+    approved_members: Mapping[str, bytes],
+    *,
+    prefix: str = "",
+    mutation_state: list[bool],
+) -> None:
+    """Delete only names and bytes from the exact approved descriptor-bound snapshot."""
+
+    names = _bounded_directory_names(directory_fd)
+    if set(names) != _expected_child_names(approved_members, prefix):
+        raise _error(IntegrationReason.PREVIEW_STALE)
     for name in names:
         if type(name) is not str or name in {"", ".", ".."} or "/" in name:
             raise _error(IntegrationReason.TARGET_UNSAFE)
@@ -1841,7 +1892,12 @@ def _remove_managed_tree_contents_fd(directory_fd: int) -> None:
             before = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
         except OSError as exc:
             raise _error(IntegrationReason.PREVIEW_STALE) from exc
+        relative = name if not prefix else f"{prefix}/{name}"
+        expected_payload = approved_members.get(relative)
+        has_descendants = any(path.startswith(f"{relative}/") for path in approved_members)
         if stat.S_ISDIR(before.st_mode):
+            if expected_payload is not None or not has_descendants:
+                raise _error(IntegrationReason.PREVIEW_STALE)
             _owned_stat_not_writable(before, directory=True)
             try:
                 child_fd = os.open(name, _directory_open_flags(), dir_fd=directory_fd)
@@ -1852,16 +1908,24 @@ def _remove_managed_tree_contents_fd(directory_fd: int) -> None:
                 _owned_stat_not_writable(opened, directory=True)
                 if not _same_inode(before, opened):
                     raise _error(IntegrationReason.PREVIEW_STALE)
-                _remove_managed_tree_contents_fd(child_fd)
+                _remove_managed_tree_contents_fd(
+                    child_fd,
+                    approved_members,
+                    prefix=relative,
+                    mutation_state=mutation_state,
+                )
                 current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
                 if not _same_inode(opened, current):
                     raise _error(IntegrationReason.PREVIEW_STALE)
                 os.rmdir(name, dir_fd=directory_fd)
+                mutation_state[0] = True
             except OSError as exc:
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
             finally:
                 os.close(child_fd)
             continue
+        if expected_payload is None or has_descendants:
+            raise _error(IntegrationReason.PREVIEW_STALE)
         _owned_stat_not_writable(before, directory=False)
         flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         try:
@@ -1873,27 +1937,71 @@ def _remove_managed_tree_contents_fd(directory_fd: int) -> None:
             _owned_stat_not_writable(opened, directory=False)
             if not _same_inode(before, opened):
                 raise _error(IntegrationReason.PREVIEW_STALE)
+            if opened.st_size != len(expected_payload):
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            if _read_exact_member(member_fd, expected_payload) != expected_payload:
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            final_before_unlink = os.fstat(member_fd)
+            if final_before_unlink.st_size != len(expected_payload):
+                raise _error(IntegrationReason.PREVIEW_STALE)
             current = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
-            if not _same_inode(opened, current):
+            if not _same_inode(final_before_unlink, current):
                 raise _error(IntegrationReason.PREVIEW_STALE)
             os.unlink(name, dir_fd=directory_fd)
+            mutation_state[0] = True
+            # The unlink has committed. Detect a last-window write through another retained
+            # descriptor and report partial mutation instead of claiming a stale preimage.
+            if (
+                _read_exact_member(
+                    member_fd,
+                    expected_payload,
+                    mismatch_reason=IntegrationReason.WRITE_FAILED,
+                )
+                != expected_payload
+            ):
+                raise _error(IntegrationReason.WRITE_FAILED)
         except OSError as exc:
             raise _error(IntegrationReason.WRITE_FAILED) from exc
         finally:
             os.close(member_fd)
 
 
-def _remove_validated_directory(root_fd: int, name: str, descriptor: int) -> None:
-    """Remove a tree through its retained descriptor, never by reopening its pathname."""
+def _remove_validated_directory(
+    root_fd: int,
+    name: str,
+    descriptor: int,
+    approved_members: Mapping[str, bytes],
+) -> None:
+    """Remove only the approved tree through its retained descriptor and exact member snapshot."""
 
     validated = os.fstat(descriptor)
-    _remove_managed_tree_contents_fd(descriptor)
+    try:
+        current_before = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise _error(IntegrationReason.PREVIEW_STALE) from exc
+    if not _same_inode(validated, current_before):
+        raise _error(IntegrationReason.PREVIEW_STALE)
+    if _read_managed_tree_fd(descriptor) != dict(approved_members):
+        raise _error(IntegrationReason.PREVIEW_STALE)
+    mutation_state = [False]
+    try:
+        _remove_managed_tree_contents_fd(
+            descriptor,
+            approved_members,
+            mutation_state=mutation_state,
+        )
+    except IntegrationError as exc:
+        # Recursive deletion may already have unlinked an earlier approved member. Once that
+        # phase begins, an observable race is a partial write failure, not a stale preimage.
+        if exc.reason is IntegrationReason.PREVIEW_STALE and mutation_state[0]:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        raise
     try:
         current = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
     except OSError as exc:
-        raise _error(IntegrationReason.PREVIEW_STALE) from exc
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
     if not _same_inode(validated, current):
-        raise _error(IntegrationReason.PREVIEW_STALE)
+        raise _error(IntegrationReason.WRITE_FAILED)
     try:
         os.rmdir(name, dir_fd=root_fd)
     except OSError as exc:
@@ -1914,11 +2022,21 @@ def _delete_managed_cache_versions(
         raise _error(IntegrationReason.TARGET_UNSAFE) from exc
     try:
         _owned_stat_not_writable(os.fstat(root_fd), directory=True)
+        cache_mutation_started = False
         for version, expected_digest in cache_digests:
-            current_digest = _managed_cache_digest_at(root_fd, version, expected_members)
-            if current_digest is None:
+            try:
+                opened = _open_managed_cache_digest_at(root_fd, version, expected_members)
+            except IntegrationError as exc:
+                if cache_mutation_started:
+                    raise _error(IntegrationReason.WRITE_FAILED) from exc
+                raise
+            if opened is None:
                 continue
+            version_fd, current_digest, approved_members = opened
             if current_digest != expected_digest:
+                os.close(version_fd)
+                if cache_mutation_started:
+                    raise _error(IntegrationReason.WRITE_FAILED)
                 raise _error(IntegrationReason.PREVIEW_STALE)
             quarantine = f".yoetz-cache-remove-{os.urandom(8).hex()}"
             try:
@@ -1929,32 +2047,64 @@ def _delete_managed_cache_versions(
                     dst_dir_fd=root_fd,
                 )
             except OSError as exc:
+                os.close(version_fd)
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
-            opened = _open_managed_cache_digest_at(root_fd, quarantine, expected_members)
-            if opened is None:
-                raise _error(IntegrationReason.PREVIEW_STALE)
-            quarantine_fd, quarantine_digest = opened
-            if quarantine_digest != expected_digest:
+            cache_mutation_started = True
+            try:
                 try:
                     current = os.stat(quarantine, dir_fd=root_fd, follow_symlinks=False)
-                    if not _same_inode(os.fstat(quarantine_fd), current):
-                        raise _error(IntegrationReason.PREVIEW_STALE)
-                    os.rename(
-                        quarantine,
-                        version,
-                        src_dir_fd=root_fd,
-                        dst_dir_fd=root_fd,
-                    )
                 except OSError as exc:
                     raise _error(IntegrationReason.WRITE_FAILED) from exc
-                finally:
-                    os.close(quarantine_fd)
-                raise _error(IntegrationReason.PREVIEW_STALE)
-            try:
-                _remove_validated_directory(root_fd, quarantine, quarantine_fd)
+                if not _same_inode(os.fstat(version_fd), current):
+                    raise _error(IntegrationReason.WRITE_FAILED)
+                try:
+                    _remove_validated_directory(
+                        root_fd,
+                        quarantine,
+                        version_fd,
+                        approved_members,
+                    )
+                except IntegrationError as exc:
+                    if exc.reason is not IntegrationReason.PREVIEW_STALE:
+                        raise
+                    # No member was deleted: restore the exact retained inode when the original
+                    # version name is still absent. A failed restore is an outcome-unknown write.
+                    try:
+                        quarantine_current = os.stat(
+                            quarantine,
+                            dir_fd=root_fd,
+                            follow_symlinks=False,
+                        )
+                    except OSError as stat_exc:
+                        raise _error(IntegrationReason.WRITE_FAILED) from stat_exc
+                    if not _same_inode(os.fstat(version_fd), quarantine_current):
+                        raise _error(IntegrationReason.WRITE_FAILED) from exc
+                    try:
+                        os.stat(version, dir_fd=root_fd, follow_symlinks=False)
+                    except FileNotFoundError:
+                        try:
+                            os.rename(
+                                quarantine,
+                                version,
+                                src_dir_fd=root_fd,
+                                dst_dir_fd=root_fd,
+                            )
+                        except OSError as restore_exc:
+                            raise _error(IntegrationReason.WRITE_FAILED) from restore_exc
+                    except OSError as restore_exc:
+                        raise _error(IntegrationReason.WRITE_FAILED) from restore_exc
+                    else:
+                        raise _error(IntegrationReason.WRITE_FAILED) from exc
+                    raise _error(IntegrationReason.WRITE_FAILED) from exc
             finally:
-                os.close(quarantine_fd)
-        if os.listdir(root_fd):
+                os.close(version_fd)
+        try:
+            remaining = _bounded_directory_names(root_fd)
+        except IntegrationError as exc:
+            if cache_mutation_started:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            raise
+        if remaining:
             raise _error(IntegrationReason.WRITE_FAILED)
     finally:
         os.close(root_fd)
@@ -2014,6 +2164,7 @@ def apply_removal(
         _assert_snapshot(marketplace_path, plan.marketplace_before)
         _assert_snapshot(config_path, plan.config_before)
         _assert_binary_probe(plan.binary, _run=_run)
+        mutation_started = False
         if preview.plugin_remove_planned:
             _run_json_command(
                 plan.binary,
@@ -2021,6 +2172,7 @@ def apply_removal(
                 _run=_run,
                 timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
             )
+            mutation_started = True
         if preview.marketplace_remove_planned:
             _run_json_command(
                 plan.binary,
@@ -2028,12 +2180,15 @@ def apply_removal(
                 _run=_run,
                 timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
             )
+            mutation_started = True
         current_config = _current_bytes(config_path)
         if current_config is None:
             current_config = b""
         try:
             parsed_config = tomllib.loads(current_config.decode("utf-8") if current_config else "")
         except (UnicodeError, tomllib.TOMLDecodeError) as exc:
+            if mutation_started:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
             raise _error(IntegrationReason.SOURCE_INVALID) from exc
         try:
             _, _, stripped = _config_table_plan(
@@ -2042,9 +2197,9 @@ def apply_removal(
                 project,
             )
         except IntegrationError as exc:
-            if exc.reason is IntegrationReason.REMOVE_REFUSED:
+            if mutation_started:
                 # A conflict discovered after the host removal subprocesses have already
-                # mutated state is a partial-apply failure, not a pre-mutation refusal.
+                # mutated state is a partial-apply failure, not a pre-mutation refusal/staleness.
                 conflict = exc.safe_details.get("conflict")
                 details = {"conflict": conflict} if type(conflict) is str else None
                 raise _error(IntegrationReason.WRITE_FAILED, details) from exc
@@ -2056,17 +2211,34 @@ def apply_removal(
                         config_path.unlink()
                     except OSError as exc:
                         raise _error(IntegrationReason.WRITE_FAILED) from exc
+                    mutation_started = True
             else:
                 _atomic_write(config_path, stripped)
+                mutation_started = True
         if preview.marketplace_json_planned:
             current_marketplace = _current_bytes(marketplace_path)
             if current_marketplace != _canonical_marketplace_bytes():
-                raise _error(IntegrationReason.PREVIEW_STALE)
+                if not mutation_started:
+                    raise _error(IntegrationReason.PREVIEW_STALE)
+                raise _error(
+                    IntegrationReason.WRITE_FAILED,
+                    {"conflict": "repository_marketplace"},
+                )
             try:
                 marketplace_path.unlink()
             except OSError as exc:
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
-        _delete_managed_cache_versions(_cache_root(home), plan.cache_digests, plan.cache_members)
+            mutation_started = True
+        try:
+            _delete_managed_cache_versions(
+                _cache_root(home),
+                plan.cache_digests,
+                plan.cache_members,
+            )
+        except IntegrationError as exc:
+            if mutation_started and exc.reason is IntegrationReason.PREVIEW_STALE:
+                raise _error(IntegrationReason.WRITE_FAILED, {"conflict": "cache"}) from exc
+            raise
         installed, _version = _plugin_inventory(plan.binary, project, _run=_run)
         if installed:
             raise _error(IntegrationReason.WRITE_FAILED)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -6,10 +6,12 @@ import hashlib
 import json
 import os
 import re
+import selectors
 import shutil
 import stat
 import subprocess
 import tempfile
+import time
 import tomllib
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -199,6 +201,16 @@ class _CodexBinaryProbe:
     codex_home: Path
 
 
+@dataclass(frozen=True, slots=True)
+class _BoundedCommandOutput:
+    returncode: int
+    stdout: bytes
+
+
+class _CommandOutputLimit(Exception):
+    pass
+
+
 def _error(
     reason: IntegrationReason,
     details: Mapping[str, str] | None = None,
@@ -219,6 +231,116 @@ def _sha_file(path: Path) -> str:
     except OSError as exc:
         raise _error(IntegrationReason.TARGET_UNSAFE) from exc
     return f"sha256:{digest.hexdigest()}"
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=1.0)
+
+
+def _run_bounded_command(
+    argv: tuple[str, ...],
+    *,
+    env: Mapping[str, str],
+    timeout: float,
+    stdout_limit: int,
+) -> _BoundedCommandOutput:
+    """Run fixed argv while enforcing the stdout bound during capture.
+
+    Stderr is drained but never retained. This prevents a selected host binary
+    from turning the post-parse size check into unbounded process memory.
+    """
+
+    process: subprocess.Popen[bytes] | None = None
+    selector = selectors.DefaultSelector()
+    stdout = bytearray()
+    try:
+        process = subprocess.Popen(  # noqa: S603 - exact selected executable, no shell
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+            env=dict(env),
+            close_fds=True,
+        )
+        if process.stdout is None or process.stderr is None:
+            raise OSError("missing_subprocess_pipe")
+        for stream in (process.stdout, process.stderr):
+            os.set_blocking(stream.fileno(), False)
+            selector.register(stream, selectors.EVENT_READ)
+        deadline = time.monotonic() + timeout
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                raise subprocess.TimeoutExpired(argv, timeout)
+            events = selector.select(remaining)
+            if not events:
+                raise subprocess.TimeoutExpired(argv, timeout)
+            for key, _mask in events:
+                try:
+                    chunk = os.read(key.fd, 64 * 1024)
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                if key.fileobj is process.stdout:
+                    if len(stdout) + len(chunk) > stdout_limit:
+                        raise _CommandOutputLimit
+                    stdout.extend(chunk)
+        try:
+            process.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            raise subprocess.TimeoutExpired(argv, timeout) from None
+        return _BoundedCommandOutput(process.returncode, bytes(stdout))
+    except BaseException:
+        if process is not None:
+            _terminate_process(process)
+        raise
+    finally:
+        selector.close()
+        if process is not None:
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
+
+
+def _command_output(
+    argv: tuple[str, ...],
+    *,
+    env: Mapping[str, str],
+    timeout: float,
+    stdout_limit: int,
+    _run: Callable[..., subprocess.CompletedProcess[bytes]],
+) -> _BoundedCommandOutput:
+    if _run is subprocess.run:
+        return _run_bounded_command(
+            argv,
+            env=env,
+            timeout=timeout,
+            stdout_limit=stdout_limit,
+        )
+    completed = _run(
+        argv,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+        shell=False,
+        env=dict(env),
+    )
+    raw = completed.stdout[: stdout_limit + 1]
+    if len(raw) > stdout_limit:
+        raise _CommandOutputLimit
+    return _BoundedCommandOutput(completed.returncode, raw)
 
 
 def _probe_codex_binary(
@@ -249,19 +371,17 @@ def _probe_codex_binary(
         with tempfile.TemporaryDirectory(prefix="yoetz-codex-version-") as temporary:
             probe_home = Path(temporary)
             probe_home.chmod(0o700)
-            completed = _run(
+            completed = _command_output(
                 (str(executable), "--version"),
-                stdin=subprocess.DEVNULL,
-                capture_output=True,
-                timeout=_VERSION_TIMEOUT_SECONDS,
-                check=False,
-                shell=False,
                 env=_codex_environment(probe_home),
+                timeout=_VERSION_TIMEOUT_SECONDS,
+                stdout_limit=_MAX_VERSION_BYTES,
+                _run=_run,
             )
-    except (OSError, subprocess.SubprocessError) as exc:
+    except (OSError, subprocess.SubprocessError, _CommandOutputLimit) as exc:
         raise _error(IntegrationReason.SOURCE_INVALID) from exc
-    raw = completed.stdout[: _MAX_VERSION_BYTES + 1]
-    if completed.returncode != 0 or not raw or len(raw) > _MAX_VERSION_BYTES:
+    raw = completed.stdout
+    if completed.returncode != 0 or not raw:
         raise _error(IntegrationReason.SOURCE_INVALID)
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -649,19 +769,17 @@ def _run_json_command(
     timeout: float,
 ) -> Mapping[str, object]:
     try:
-        completed = _run(
+        completed = _command_output(
             (str(binary.executable_path), *command),
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-            shell=False,
             env=_codex_environment(binary.codex_home),
+            timeout=timeout,
+            stdout_limit=_MAX_PLUGIN_OUTPUT_BYTES,
+            _run=_run,
         )
-    except (OSError, subprocess.SubprocessError) as exc:
+    except (OSError, subprocess.SubprocessError, _CommandOutputLimit) as exc:
         raise _error(IntegrationReason.WRITE_FAILED) from exc
-    raw = completed.stdout[: _MAX_PLUGIN_OUTPUT_BYTES + 1]
-    if completed.returncode != 0 or not raw or len(raw) > _MAX_PLUGIN_OUTPUT_BYTES:
+    raw = completed.stdout
+    if completed.returncode != 0 or not raw:
         raise _error(IntegrationReason.WRITE_FAILED)
     try:
         parsed = strict_json_parse(raw)
@@ -1387,14 +1505,16 @@ def _strip_exact_table(raw: bytes, table: str) -> bytes:
     span = _exact_table_span(raw, table)
     if span is None:
         return raw
-    start, end = span
+    start, _end = span
+    table_bytes = table.encode("utf-8")
     before = raw[:start]
-    after = raw[end:]
-    if before.endswith(b"\n") and after.startswith(b"\n"):
-        after = after[1:]
+    after = raw[start + len(table_bytes) :]
+    # Activation inserts exactly one separator newline before its first block
+    # and between generated blocks. Remove only that adjacent byte; never
+    # normalize blank lines elsewhere in owner-authored TOML.
+    if before.endswith(b"\n\n"):
+        before = before[:-1]
     merged = before + after
-    while b"\n\n\n" in merged:
-        merged = merged.replace(b"\n\n\n", b"\n\n")
     if merged in {b"", b"\n"}:
         return b""
     if not merged.endswith(b"\n"):
@@ -1755,7 +1875,12 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
         nonlocal entry_count, file_count, total_bytes
         if depth > _MAX_MANAGED_CACHE_DEPTH:
             raise _error(IntegrationReason.PREVIEW_STALE)
-        for name in _bounded_directory_names(directory_fd):
+        names = _bounded_directory_names(directory_fd)
+        if prefix and not names:
+            # The marker/member digest models files, so an empty directory is
+            # otherwise invisible at preview but appears during exact deletion.
+            raise _error(IntegrationReason.DESTINATION_CONFLICT)
+        for name in names:
             entry_count += 1
             if entry_count > _MAX_MANAGED_CACHE_ENTRIES:
                 raise _error(IntegrationReason.PREVIEW_STALE)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -1140,8 +1140,75 @@ def _atomic_write(path: Path, payload: bytes) -> None:
         raise _error(IntegrationReason.WRITE_FAILED) from exc
 
 
-def _replace_cache_tree(path: Path, members: Mapping[str, bytes]) -> None:
+def _open_or_create_private_directory(root_fd: int, relative: Path) -> int:
+    current_fd = os.dup(root_fd)
+    try:
+        for part in relative.parts:
+            if part in {"", ".", ".."}:
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            try:
+                os.mkdir(part, mode=0o700, dir_fd=current_fd)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            try:
+                child_fd = os.open(part, _directory_open_flags(), dir_fd=current_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            try:
+                _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+            except BaseException:
+                os.close(child_fd)
+                raise
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _remove_private_tree_contents_fd(directory_fd: int, *, depth: int = 0) -> None:
+    """Remove a freshly created private staging tree without following links."""
+
+    if depth > _MAX_MANAGED_CACHE_DEPTH:
+        raise _error(IntegrationReason.WRITE_FAILED)
+    try:
+        names = _bounded_directory_names(directory_fd)
+    except IntegrationError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+    for name in names:
+        try:
+            facts = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            if stat.S_ISDIR(facts.st_mode):
+                child_fd = os.open(name, _directory_open_flags(), dir_fd=directory_fd)
+                try:
+                    _remove_private_tree_contents_fd(child_fd, depth=depth + 1)
+                finally:
+                    os.close(child_fd)
+                os.rmdir(name, dir_fd=directory_fd)
+            elif stat.S_ISREG(facts.st_mode):
+                os.unlink(name, dir_fd=directory_fd)
+            else:
+                raise _error(IntegrationReason.WRITE_FAILED)
+        except IntegrationError:
+            raise
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+
+
+def _replace_cache_tree(
+    path: Path,
+    members: Mapping[str, bytes],
+    *,
+    anchor_root: Path | None = None,
+) -> None:
     """Atomically replace one managed cache directory with freshly rendered members."""
+
+    if anchor_root is not None:
+        _replace_cache_tree_anchored(path, members, anchor_root=anchor_root)
+        return
 
     parent = path.parent
     _safe_parent(parent)
@@ -1179,6 +1246,124 @@ def _replace_cache_tree(path: Path, members: Mapping[str, bytes]) -> None:
     finally:
         if stage.exists():
             shutil.rmtree(stage, ignore_errors=True)
+
+
+def _replace_cache_tree_anchored(
+    path: Path,
+    members: Mapping[str, bytes],
+    *,
+    anchor_root: Path,
+) -> None:
+    """Replace a managed cache tree through a no-follow selected-home descriptor."""
+
+    if path.name in {"", ".", ".."} or "/" in path.name:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    try:
+        relative_parent = path.parent.relative_to(anchor_root)
+    except ValueError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    parent_fd = _open_anchored_directory(anchor_root, relative_parent)
+    stage = f".yoetz-cache-stage-{os.urandom(6).hex()}"
+    rollback = f".yoetz-cache-rollback-{os.urandom(6).hex()}"
+    stage_fd: int | None = None
+    old_fd: int | None = None
+    old_members: dict[str, bytes] | None = None
+    stage_present = False
+    rollback_present = False
+    destination_installed = False
+    failure: Exception | None = None
+    try:
+        try:
+            os.mkdir(stage, mode=0o700, dir_fd=parent_fd)
+            stage_present = True
+            stage_fd = os.open(stage, _directory_open_flags(), dir_fd=parent_fd)
+            _owned_stat_not_writable(os.fstat(stage_fd), directory=True)
+            for relative_path, payload in sorted(members.items()):
+                relative = Path(relative_path)
+                if relative.is_absolute() or any(
+                    part in {"", ".", ".."} for part in relative.parts
+                ):
+                    raise _error(IntegrationReason.SOURCE_INVALID)
+                directory_fd = _open_or_create_private_directory(stage_fd, relative.parent)
+                try:
+                    descriptor = os.open(
+                        relative.name,
+                        os.O_WRONLY
+                        | os.O_CREAT
+                        | os.O_EXCL
+                        | getattr(os, "O_CLOEXEC", 0)
+                        | getattr(os, "O_NOFOLLOW", 0),
+                        0o600,
+                        dir_fd=directory_fd,
+                    )
+                    try:
+                        written = 0
+                        while written < len(payload):
+                            written += os.write(descriptor, payload[written:])
+                        os.fsync(descriptor)
+                    finally:
+                        os.close(descriptor)
+                finally:
+                    os.close(directory_fd)
+
+            try:
+                before = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                before = None
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            if before is not None:
+                _owned_stat_not_writable(before, directory=True)
+                old_fd = os.open(path.name, _directory_open_flags(), dir_fd=parent_fd)
+                _owned_stat_not_writable(os.fstat(old_fd), directory=True)
+                old_members = _read_managed_tree_fd(old_fd)
+                os.rename(
+                    path.name,
+                    rollback,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                rollback_present = True
+            os.rename(stage, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            stage_present = False
+            destination_installed = True
+            if rollback_present:
+                assert old_fd is not None and old_members is not None
+                _remove_validated_directory(parent_fd, rollback, old_fd, old_members)
+                rollback_present = False
+        except IntegrationError:
+            raise
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+    except Exception as exc:
+        failure = exc
+        if rollback_present and not destination_installed:
+            try:
+                os.rename(
+                    rollback,
+                    path.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                rollback_present = False
+            except OSError:
+                failure = _error(IntegrationReason.WRITE_FAILED)
+    finally:
+        if stage_present and stage_fd is not None:
+            try:
+                _remove_private_tree_contents_fd(stage_fd)
+                os.rmdir(stage, dir_fd=parent_fd)
+            except IntegrationError as exc:
+                failure = exc
+        if old_fd is not None:
+            os.close(old_fd)
+        if stage_fd is not None:
+            os.close(stage_fd)
+        os.close(parent_fd)
+    if failure is not None:
+        if isinstance(failure, IntegrationError):
+            raise failure
+        raise _error(IntegrationReason.WRITE_FAILED) from failure
 
 
 def _current_bytes(path: Path) -> bytes | None:
@@ -1375,7 +1560,11 @@ def apply_activation(
                         != plan.cache_before
                     ):
                         raise _error(IntegrationReason.PREVIEW_STALE)
-                    _replace_cache_tree(preview.plugin_install_path, plan.cache_members)
+                    _replace_cache_tree(
+                        preview.plugin_install_path,
+                        plan.cache_members,
+                        anchor_root=binary.codex_home,
+                    )
                     if (
                         _installed_cache_digest(preview.plugin_install_path, plan.cache_members)
                         != preview.plugin_install_digest
@@ -1406,7 +1595,11 @@ def apply_activation(
                     # host-specific render belongs to the cache layer (#387).
                     # Seed the exact previewed install bytes over the copied
                     # marker-identified tree.
-                    _replace_cache_tree(cache_created, plan.cache_members)
+                    _replace_cache_tree(
+                        cache_created,
+                        plan.cache_members,
+                        anchor_root=binary.codex_home,
+                    )
                     if (
                         _installed_cache_digest(cache_created, plan.cache_members)
                         != preview.plugin_install_digest
@@ -2339,6 +2532,7 @@ def _delete_managed_cache_versions(
     expected_members: Mapping[str, bytes],
     *,
     anchor_root: Path | None = None,
+    missing_ok_after_prior_mutation: bool = False,
 ) -> bool:
     if not cache_digests:
         return False
@@ -2355,11 +2549,16 @@ def _delete_managed_cache_versions(
             relative_root = root.relative_to(anchor_root)
         except ValueError as exc:
             raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-        root_fd = _open_anchored_directory(
-            anchor_root,
-            relative_root,
-            missing_reason=IntegrationReason.PREVIEW_STALE,
-        )
+        try:
+            root_fd = _open_anchored_directory(
+                anchor_root,
+                relative_root,
+                missing_reason=IntegrationReason.PREVIEW_STALE,
+            )
+        except IntegrationError as exc:
+            if missing_ok_after_prior_mutation and exc.reason is IntegrationReason.PREVIEW_STALE:
+                return True
+            raise
     try:
         _owned_stat_not_writable(os.fstat(root_fd), directory=True)
         cache_mutation_started = False
@@ -2605,6 +2804,7 @@ def apply_removal(
                 plan.cache_digests,
                 plan.cache_members,
                 anchor_root=home,
+                missing_ok_after_prior_mutation=mutation_started,
             )
         except IntegrationError as exc:
             if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -23,11 +23,11 @@ from yoetz.adapters.integrations.codex_plugin import (
     plugin_tree_matches_marker,
     render_plugin_install_tree,
 )
+from yoetz.adapters.integrations.codex_session_stream import resolve_codex_home
 from yoetz.adapters.integrations.codex_skill import (
     inspect_destination,
     load_packaged_skill_source,
 )
-from yoetz.adapters.integrations.codex_session_stream import resolve_codex_home
 from yoetz.ports.integrations import (
     IntegrationError,
     IntegrationReason,
@@ -192,7 +192,7 @@ class _CodexBinaryProbe:
 
 def _error(
     reason: IntegrationReason,
-    details: Mapping[str, JsonValue] | None = None,
+    details: Mapping[str, str] | None = None,
 ) -> IntegrationError:
     return IntegrationError(reason, {} if details is None else dict(details))
 

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -636,14 +636,21 @@ def _cache_root(home: Path) -> Path:
 
 
 def _cache_root_has_entries(home: Path) -> bool:
-    root = _cache_root(home)
-    if not root.exists() and not root.is_symlink():
-        return False
-    _validate_descendant_ancestors(home, Path("plugins/cache/yoetz/yoetz"))
+    relative_root = Path("plugins/cache/yoetz/yoetz")
     try:
-        return next(root.iterdir(), None) is not None
-    except OSError as exc:
-        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        root_fd = _open_anchored_directory(
+            home,
+            relative_root,
+            missing_reason=IntegrationReason.PREVIEW_STALE,
+        )
+    except IntegrationError as exc:
+        if exc.reason is IntegrationReason.PREVIEW_STALE:
+            return False
+        raise
+    try:
+        return bool(_bounded_directory_names(root_fd))
+    finally:
+        os.close(root_fd)
 
 
 def _cache_version_path(root: Path, version: str) -> Path:
@@ -763,6 +770,41 @@ def _installed_cache_digest(path: Path, expected_members: Mapping[str, bytes]) -
     return _members_digest(actual)
 
 
+def _installed_cache_digest_anchored(
+    home: Path,
+    version: str,
+    expected_members: Mapping[str, bytes],
+) -> str | None:
+    """Digest one cache version without following a replaced home ancestor."""
+
+    if _VERSION_RE.fullmatch(version) is None:
+        raise _error(IntegrationReason.SOURCE_INVALID)
+    try:
+        root_fd = _open_anchored_directory(
+            home,
+            Path("plugins/cache/yoetz/yoetz"),
+            missing_reason=IntegrationReason.PREVIEW_STALE,
+        )
+    except IntegrationError as exc:
+        if exc.reason is IntegrationReason.PREVIEW_STALE:
+            return None
+        raise
+    try:
+        opened = _open_managed_cache_digest_at(
+            root_fd,
+            version,
+            expected_members,
+            mismatch_reason=IntegrationReason.DESTINATION_CONFLICT,
+        )
+        if opened is None:
+            return None
+        descriptor, digest, _approved_members = opened
+        os.close(descriptor)
+        return digest
+    finally:
+        os.close(root_fd)
+
+
 def _run_json_command(
     binary: _CodexBinaryProbe,
     command: tuple[str, ...],
@@ -861,16 +903,13 @@ def inspect_activation(
     if installed:
         try:
             cache_members = _source_cache_members(target, codex_version=binary.codex_version)
-            local_digest = _installed_cache_digest(
-                _cache_version_path(_cache_root(home), __version__), cache_members
-            )
+            local_digest = _installed_cache_digest_anchored(home, __version__, cache_members)
             if _canonical_inventory:
                 inventory_installed, version = _plugin_inventory(binary, project, _run=_run)
                 if inventory_installed:
                     assert version is not None
-                    plugin_cached = _installed_cache_digest(
-                        _cache_version_path(_cache_root(home), version),
-                        cache_members,
+                    plugin_cached = _installed_cache_digest_anchored(
+                        home, version, cache_members
                     ) == _members_digest(cache_members)
                 elif _cache_root_has_entries(home):
                     cache_foreign = True
@@ -1014,7 +1053,7 @@ def _activation_plan(
     plugin_install_digest = _members_digest(cache_members)
     plugin_cache_root = _cache_root(home)
     plugin_install_path = _cache_version_path(plugin_cache_root, __version__)
-    cache_before = _installed_cache_digest(plugin_install_path, cache_members)
+    cache_before = _installed_cache_digest_anchored(home, __version__, cache_members)
     digest_body = (
         b"yoetz.codex-marketplace-activation/2\0"
         + str(home).encode("utf-8")
@@ -1556,7 +1595,9 @@ def apply_activation(
                     # marker-identified prior render's digest as ``cache_before``.
                     # Replace only those exact bytes; anything else is stale.
                     if (
-                        _installed_cache_digest(preview.plugin_install_path, plan.cache_members)
+                        _installed_cache_digest_anchored(
+                            binary.codex_home, __version__, plan.cache_members
+                        )
                         != plan.cache_before
                     ):
                         raise _error(IntegrationReason.PREVIEW_STALE)
@@ -1566,7 +1607,9 @@ def apply_activation(
                         anchor_root=binary.codex_home,
                     )
                     if (
-                        _installed_cache_digest(preview.plugin_install_path, plan.cache_members)
+                        _installed_cache_digest_anchored(
+                            binary.codex_home, __version__, plan.cache_members
+                        )
                         != preview.plugin_install_digest
                     ):
                         raise _error(IntegrationReason.WRITE_FAILED)
@@ -1588,7 +1631,9 @@ def apply_activation(
                 )
                 cache_created = _validate_add_result(add_result, preview)
                 if (
-                    _installed_cache_digest(cache_created, plan.cache_members)
+                    _installed_cache_digest_anchored(
+                        binary.codex_home, __version__, plan.cache_members
+                    )
                     != preview.plugin_install_digest
                 ):
                     # ``plugin add`` copies the canonical project source; the
@@ -1601,7 +1646,9 @@ def apply_activation(
                         anchor_root=binary.codex_home,
                     )
                     if (
-                        _installed_cache_digest(cache_created, plan.cache_members)
+                        _installed_cache_digest_anchored(
+                            binary.codex_home, __version__, plan.cache_members
+                        )
                         != preview.plugin_install_digest
                     ):
                         raise _error(IntegrationReason.WRITE_FAILED)
@@ -1785,13 +1832,61 @@ def _marketplace_json_owned(path: Path) -> bool:
 
 
 def _managed_cache_versions(
-    root: Path, expected: Mapping[str, bytes], *, include_all_managed: bool
+    root: Path,
+    expected: Mapping[str, bytes],
+    *,
+    include_all_managed: bool,
+    anchor_root: Path | None = None,
 ) -> tuple[tuple[str, str], ...]:
     """List yoetz-managed version dirs that this removal may delete.
 
     Foreign or unexpected members refuse. Other-version managed trees require
     ``--purge-cache`` so default removal cannot delete extra version dirs.
     """
+
+    if anchor_root is not None:
+        try:
+            relative_root = root.relative_to(anchor_root)
+        except ValueError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        try:
+            root_fd = _open_anchored_directory(
+                anchor_root,
+                relative_root,
+                missing_reason=IntegrationReason.PREVIEW_STALE,
+            )
+        except IntegrationError as exc:
+            if exc.reason is IntegrationReason.PREVIEW_STALE:
+                return ()
+            raise
+        try:
+            names = _bounded_directory_names(root_fd)
+            versions: list[tuple[str, str]] = []
+            for name in names:
+                if _VERSION_RE.fullmatch(name) is None:
+                    _refuse_conflict("cache")
+                try:
+                    opened = _open_managed_cache_digest_at(
+                        root_fd,
+                        name,
+                        expected,
+                        mismatch_reason=IntegrationReason.DESTINATION_CONFLICT,
+                    )
+                except IntegrationError as exc:
+                    if exc.reason is IntegrationReason.DESTINATION_CONFLICT:
+                        _refuse_conflict("cache")
+                    raise
+                if opened is None:
+                    _refuse_conflict("cache")
+                descriptor, digest, _approved_members = opened
+                os.close(descriptor)
+                if name == __version__ or include_all_managed:
+                    versions.append((name, digest))
+                else:
+                    _refuse_conflict("cache")
+            return tuple(versions)
+        finally:
+            os.close(root_fd)
 
     if not root.exists():
         return ()
@@ -1886,7 +1981,10 @@ def _removal_plan(
     cache_root = _cache_root(home)
     _validate_descendant_ancestors(home, Path("plugins/cache/yoetz/yoetz"))
     cache_digests = _managed_cache_versions(
-        cache_root, cache_members, include_all_managed=purge_cache
+        cache_root,
+        cache_members,
+        include_all_managed=purge_cache,
+        anchor_root=home,
     )
     if cache_digests:
         _require_safe_cache_removal_primitives()
@@ -2187,7 +2285,11 @@ def _read_managed_tree_fd(root_fd: int) -> dict[str, bytes]:
 
 
 def _open_managed_cache_digest_at(
-    root_fd: int, name: str, expected_members: Mapping[str, bytes]
+    root_fd: int,
+    name: str,
+    expected_members: Mapping[str, bytes],
+    *,
+    mismatch_reason: IntegrationReason = IntegrationReason.PREVIEW_STALE,
 ) -> tuple[int, str, Mapping[str, bytes]] | None:
     """Open and validate one managed cache tree, retaining its exact directory inode."""
 
@@ -2201,7 +2303,7 @@ def _open_managed_cache_digest_at(
         _owned_stat_not_writable(os.fstat(descriptor), directory=True)
         actual = _read_managed_tree_fd(descriptor)
         if actual != dict(expected_members) and not plugin_tree_matches_marker(actual):
-            raise _error(IntegrationReason.PREVIEW_STALE)
+            raise _error(mismatch_reason)
         return descriptor, _members_digest(actual), actual
     except BaseException:
         os.close(descriptor)
@@ -2716,8 +2818,11 @@ def apply_removal(
                     _run=_run,
                     timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
                 )
-            except IntegrationError as exc:
-                if exc.reason is IntegrationReason.WRITE_FAILED:
+            except Exception as exc:
+                if (
+                    isinstance(exc, IntegrationError)
+                    and exc.reason is IntegrationReason.WRITE_FAILED
+                ):
                     raise
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
         if preview.marketplace_remove_planned:
@@ -2729,11 +2834,19 @@ def apply_removal(
                     _run=_run,
                     timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
                 )
-            except IntegrationError as exc:
-                if exc.reason is IntegrationReason.WRITE_FAILED:
+            except Exception as exc:
+                if (
+                    isinstance(exc, IntegrationError)
+                    and exc.reason is IntegrationReason.WRITE_FAILED
+                ):
                     raise
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
-        current_config = _current_bytes(config_path)
+        try:
+            current_config = _current_bytes(config_path)
+        except IntegrationError as exc:
+            if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            raise
         if current_config is None:
             current_config = b""
         try:

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -2012,9 +2012,9 @@ def _delete_managed_cache_versions(
     root: Path,
     cache_digests: tuple[tuple[str, str], ...],
     expected_members: Mapping[str, bytes],
-) -> None:
+) -> bool:
     if not cache_digests or not root.exists():
-        return
+        return False
     _require_safe_cache_removal_primitives()
     try:
         root_fd = os.open(root, _directory_open_flags())
@@ -2106,6 +2106,7 @@ def _delete_managed_cache_versions(
             raise
         if remaining:
             raise _error(IntegrationReason.WRITE_FAILED)
+        return cache_mutation_started
     finally:
         os.close(root_fd)
 
@@ -2230,7 +2231,7 @@ def apply_removal(
                 raise _error(IntegrationReason.WRITE_FAILED) from exc
             mutation_started = True
         try:
-            _delete_managed_cache_versions(
+            cache_mutated = _delete_managed_cache_versions(
                 _cache_root(home),
                 plan.cache_digests,
                 plan.cache_members,
@@ -2239,23 +2240,31 @@ def apply_removal(
             if mutation_started and exc.reason is IntegrationReason.PREVIEW_STALE:
                 raise _error(IntegrationReason.WRITE_FAILED, {"conflict": "cache"}) from exc
             raise
-        installed, _version = _plugin_inventory(plan.binary, project, _run=_run)
-        if installed:
-            raise _error(IntegrationReason.WRITE_FAILED)
-        _assert_yoetz_tables_absent(config_path, project)
-        if preview.marketplace_json_planned and marketplace_path.exists():
-            raise _error(IntegrationReason.WRITE_FAILED)
-        inspection = inspect_activation(
-            target,
-            executable_path=executable_path,
-            codex_home=home,
-            _run=_run,
-        )
-        if inspection.state is ActivationState.ACTIVE:
-            raise _error(IntegrationReason.WRITE_FAILED)
-        if inspection.state is ActivationState.FOREIGN:
-            raise _error(IntegrationReason.WRITE_FAILED)
-        skill_state = skill_tree_state(target)
-        if skill_state != preview.skill_tree_state:
-            raise _error(IntegrationReason.WRITE_FAILED)
+        mutation_started = mutation_started or cache_mutated
+        try:
+            installed, _version = _plugin_inventory(plan.binary, project, _run=_run)
+            if installed:
+                raise _error(IntegrationReason.WRITE_FAILED)
+            _assert_yoetz_tables_absent(config_path, project)
+            if preview.marketplace_json_planned and marketplace_path.exists():
+                raise _error(IntegrationReason.WRITE_FAILED)
+            inspection = inspect_activation(
+                target,
+                executable_path=executable_path,
+                codex_home=home,
+                _run=_run,
+            )
+            if inspection.state is ActivationState.ACTIVE:
+                raise _error(IntegrationReason.WRITE_FAILED)
+            if inspection.state is ActivationState.FOREIGN:
+                raise _error(IntegrationReason.WRITE_FAILED)
+            skill_state = skill_tree_state(target)
+            if skill_state != preview.skill_tree_state:
+                raise _error(IntegrationReason.WRITE_FAILED)
+        except IntegrationError as exc:
+            if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:
+                conflict = exc.safe_details.get("conflict")
+                details = {"conflict": conflict} if type(conflict) is str else None
+                raise _error(IntegrationReason.WRITE_FAILED, details) from exc
+            raise
     return RemovalResult(RemovalOutcome.REMOVE, inspection, skill_state, purge_cache)

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -1723,6 +1723,12 @@ def _require_safe_cache_removal_primitives() -> None:
         raise _error(IntegrationReason.TARGET_UNSAFE)
 
 
+def _require_safe_file_removal_primitives() -> None:
+    _require_safe_cache_removal_primitives()
+    if os.link not in os.supports_dir_fd or os.link not in os.supports_follow_symlinks:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+
+
 def _bounded_directory_names(directory_fd: int) -> list[str]:
     names: list[str] = []
     try:
@@ -1871,6 +1877,145 @@ def _read_exact_member(
         return b"".join(chunks)
     except OSError as exc:
         raise _error(IntegrationReason.WRITE_FAILED) from exc
+
+
+def _restore_quarantined_file(
+    parent_fd: int,
+    name: str,
+    quarantine: str,
+    quarantined_facts: os.stat_result,
+) -> None:
+    """Restore one preserved quarantine inode when the approved name is still absent."""
+
+    try:
+        current = os.stat(quarantine, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+    if not _same_inode(quarantined_facts, current):
+        raise _error(IntegrationReason.WRITE_FAILED)
+    # ``link`` is the portable no-clobber primitive here: it fails with EEXIST instead of
+    # overwriting a foreign file that appears while restoration is in progress.
+    try:
+        os.link(
+            quarantine,
+            name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+        restored = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+    if not _same_inode(quarantined_facts, restored):
+        raise _error(IntegrationReason.WRITE_FAILED)
+    try:
+        current = os.stat(quarantine, dir_fd=parent_fd, follow_symlinks=False)
+        if not _same_inode(quarantined_facts, current):
+            raise _error(IntegrationReason.WRITE_FAILED)
+        os.unlink(quarantine, dir_fd=parent_fd)
+    except OSError as exc:
+        raise _error(IntegrationReason.WRITE_FAILED) from exc
+
+
+def _remove_exact_managed_file(
+    path: Path,
+    expected: bytes,
+    *,
+    mismatch_reason: IntegrationReason,
+) -> None:
+    """Quarantine and unlink only the exact descriptor-bound approved file inode."""
+
+    if path.name in {"", ".", ".."} or "/" in path.name:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    _require_safe_file_removal_primitives()
+    try:
+        parent_fd = os.open(path.parent, _directory_open_flags())
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    descriptor: int | None = None
+    try:
+        _owned_stat_not_writable(os.fstat(parent_fd), directory=True)
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        except FileNotFoundError as exc:
+            raise _error(mismatch_reason) from exc
+        except OSError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        opened = os.fstat(descriptor)
+        _owned_stat_not_writable(opened, directory=False)
+        if (
+            opened.st_size != len(expected)
+            or _read_exact_member(
+                descriptor,
+                expected,
+                mismatch_reason=mismatch_reason,
+            )
+            != expected
+        ):
+            raise _error(mismatch_reason)
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise _error(mismatch_reason) from exc
+        if not _same_inode(opened, current):
+            raise _error(mismatch_reason)
+
+        quarantine = f".yoetz-file-remove-{os.urandom(8).hex()}"
+        try:
+            os.stat(quarantine, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        else:
+            raise _error(IntegrationReason.WRITE_FAILED)
+        try:
+            os.rename(
+                path.name,
+                quarantine,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            quarantined = os.stat(quarantine, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        if not _same_inode(opened, quarantined):
+            _restore_quarantined_file(parent_fd, path.name, quarantine, quarantined)
+            raise _error(IntegrationReason.WRITE_FAILED)
+        if (
+            _read_exact_member(
+                descriptor,
+                expected,
+                mismatch_reason=IntegrationReason.WRITE_FAILED,
+            )
+            != expected
+        ):
+            _restore_quarantined_file(parent_fd, path.name, quarantine, quarantined)
+            raise _error(IntegrationReason.WRITE_FAILED)
+        try:
+            final = os.stat(quarantine, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        if not _same_inode(opened, final):
+            raise _error(IntegrationReason.WRITE_FAILED)
+        try:
+            os.unlink(quarantine, dir_fd=parent_fd)
+        except OSError as exc:
+            raise _error(IntegrationReason.WRITE_FAILED) from exc
+        if (
+            _read_exact_member(
+                descriptor,
+                expected,
+                mismatch_reason=IntegrationReason.WRITE_FAILED,
+            )
+            != expected
+        ):
+            raise _error(IntegrationReason.WRITE_FAILED)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
 
 
 def _remove_managed_tree_contents_fd(
@@ -2167,21 +2312,31 @@ def apply_removal(
         _assert_binary_probe(plan.binary, _run=_run)
         mutation_started = False
         if preview.plugin_remove_planned:
-            _run_json_command(
-                plan.binary,
-                preview.plugin_remove_command,
-                _run=_run,
-                timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
-            )
             mutation_started = True
+            try:
+                _run_json_command(
+                    plan.binary,
+                    preview.plugin_remove_command,
+                    _run=_run,
+                    timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
+                )
+            except IntegrationError as exc:
+                if exc.reason is IntegrationReason.WRITE_FAILED:
+                    raise
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
         if preview.marketplace_remove_planned:
-            _run_json_command(
-                plan.binary,
-                preview.marketplace_remove_command,
-                _run=_run,
-                timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
-            )
             mutation_started = True
+            try:
+                _run_json_command(
+                    plan.binary,
+                    preview.marketplace_remove_command,
+                    _run=_run,
+                    timeout=_PLUGIN_ADD_TIMEOUT_SECONDS,
+                )
+            except IntegrationError as exc:
+                if exc.reason is IntegrationReason.WRITE_FAILED:
+                    raise
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
         current_config = _current_bytes(config_path)
         if current_config is None:
             current_config = b""
@@ -2209,26 +2364,41 @@ def apply_removal(
             if plan.config_before is None and not stripped:
                 if config_path.exists():
                     try:
-                        config_path.unlink()
-                    except OSError as exc:
-                        raise _error(IntegrationReason.WRITE_FAILED) from exc
+                        _remove_exact_managed_file(
+                            config_path,
+                            current_config,
+                            mismatch_reason=(
+                                IntegrationReason.WRITE_FAILED
+                                if mutation_started
+                                else IntegrationReason.PREVIEW_STALE
+                            ),
+                        )
+                    except IntegrationError as exc:
+                        if mutation_started and exc.reason is not IntegrationReason.WRITE_FAILED:
+                            raise _error(IntegrationReason.WRITE_FAILED) from exc
+                        raise
                     mutation_started = True
             else:
                 _atomic_write(config_path, stripped)
                 mutation_started = True
         if preview.marketplace_json_planned:
-            current_marketplace = _current_bytes(marketplace_path)
-            if current_marketplace != _canonical_marketplace_bytes():
-                if not mutation_started:
-                    raise _error(IntegrationReason.PREVIEW_STALE)
-                raise _error(
-                    IntegrationReason.WRITE_FAILED,
-                    {"conflict": "repository_marketplace"},
-                )
             try:
-                marketplace_path.unlink()
-            except OSError as exc:
-                raise _error(IntegrationReason.WRITE_FAILED) from exc
+                _remove_exact_managed_file(
+                    marketplace_path,
+                    _canonical_marketplace_bytes(),
+                    mismatch_reason=(
+                        IntegrationReason.WRITE_FAILED
+                        if mutation_started
+                        else IntegrationReason.PREVIEW_STALE
+                    ),
+                )
+            except IntegrationError as exc:
+                if mutation_started or exc.reason is IntegrationReason.WRITE_FAILED:
+                    raise _error(
+                        IntegrationReason.WRITE_FAILED,
+                        {"conflict": "repository_marketplace"},
+                    ) from exc
+                raise
             mutation_started = True
         try:
             cache_mutated = _delete_managed_cache_versions(

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -273,6 +273,11 @@ class CodexMcpAdapter:
         warnings: tuple[str, ...] = ()
         if state is McpRegistrationState.FOREIGN_PRESENT:
             warnings = ("foreign_entry_present",)
+        elif state is McpRegistrationState.YOETZ_OWNED:
+            # Codex 0.149.x exposes a name-based remove command, not a compare-and-remove token.
+            # Apply narrows that host limitation with an immediate ownership recheck below and
+            # the preview must surface the remaining non-atomic boundary to the operator.
+            warnings = ("host_remove_not_compare_and_swap",)
         if (
             state is McpRegistrationState.YOETZ_OWNED
             and current_command is not None
@@ -336,6 +341,16 @@ class CodexMcpAdapter:
                 preview.state_before,
                 preview.preview_digest,
             )
+        state_before_remove, command_before_remove = self._classify_get(
+            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
+        )
+        if state_before_remove is McpRegistrationState.FOREIGN_PRESENT:
+            raise McpRegistrationError(McpRegistrationReason.FOREIGN_ENTRY_PRESENT, {})
+        if (
+            state_before_remove is not McpRegistrationState.YOETZ_OWNED
+            or command_before_remove != preview.serve_command
+        ):
+            raise McpRegistrationError(McpRegistrationReason.PREVIEW_STALE, {})
         remove_output = self._run((binary.executable_path, "mcp", "remove", MCP_SERVER_NAME))
         if remove_output.exit_code != 0:
             raise McpRegistrationError(

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -419,7 +419,13 @@ class CodexMcpAdapter:
             or command_before_remove != preview.serve_command
         ):
             raise McpRegistrationError(McpRegistrationReason.PREVIEW_STALE, {})
-        remove_output = self._run((binary.executable_path, "mcp", "remove", MCP_SERVER_NAME))
+        try:
+            remove_output = self._run((binary.executable_path, "mcp", "remove", MCP_SERVER_NAME))
+        except Exception as exc:
+            # The name-based command may have mutated registration before a timeout or
+            # harness failure surfaced. Its outcome is therefore unknown, never a
+            # pre-mutation observation error.
+            raise McpRegistrationError(McpRegistrationReason.REGISTRATION_FAILED, {}) from exc
         if remove_output.exit_code != 0:
             raise McpRegistrationError(
                 McpRegistrationReason.REGISTRATION_FAILED,

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -425,7 +425,13 @@ class CodexMcpAdapter:
                 McpRegistrationReason.REGISTRATION_FAILED,
                 {"exit_code_class": "nonzero"},
             )
-        state_after, _command_after = self._observe_registration_state(binary)
+        try:
+            state_after, _command_after = self._observe_registration_state(binary)
+        except McpRegistrationError as exc:
+            # The name-based remove command already succeeded. Any unreadable or
+            # malformed verification is therefore an outcome-unknown mutation,
+            # not the pre-mutation observation reason.
+            raise McpRegistrationError(McpRegistrationReason.REGISTRATION_FAILED, {}) from exc
         if state_after is not McpRegistrationState.ABSENT:
             raise McpRegistrationError(
                 McpRegistrationReason.REGISTRATION_FAILED,

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -1,14 +1,16 @@
 """Codex adapter for the harness MCP registration port.
 
 Automates exactly the runbook's manual check-then-add sequence:
-``codex mcp get yoetz --json`` first, ``codex mcp add yoetz -- yoetz mcp serve``
-only when no entry exists, and never replacing a foreign same-name entry.
+``codex mcp get yoetz --json`` first, a bounded ``codex mcp list --json``
+fallback when ``get`` fails, and ``codex mcp add yoetz -- yoetz mcp serve`` only
+after absence is positively observed. A foreign same-name entry is never replaced.
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
+import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -50,6 +52,7 @@ class CommandOutput:
 
     exit_code: int
     stdout: bytes
+    stdout_truncated: bool = False
 
 
 type CommandRunner = Callable[[tuple[str, ...]], CommandOutput]
@@ -57,19 +60,53 @@ type CommandRunner = Callable[[tuple[str, ...]], CommandOutput]
 
 def _default_runner(argv: tuple[str, ...]) -> CommandOutput:
     try:
-        completed = subprocess.run(
-            argv,
-            stdin=subprocess.DEVNULL,
-            capture_output=True,
-            timeout=_COMMAND_TIMEOUT_SECONDS,
-            check=False,
-            shell=False,
-        )
+        # Stream host output to a private unnamed file so a noisy or compromised executable
+        # cannot force an unbounded in-memory capture before the structural size check.
+        with tempfile.TemporaryFile() as stdout_file:
+            completed = subprocess.run(
+                argv,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_file,
+                stderr=subprocess.DEVNULL,
+                timeout=_COMMAND_TIMEOUT_SECONDS,
+                check=False,
+                shell=False,
+            )
+            stdout_size = stdout_file.tell()
+            stdout_file.seek(0)
+            stdout = stdout_file.read(_OUTPUT_LIMIT_BYTES)
     except subprocess.TimeoutExpired as exc:
         raise McpRegistrationError(McpRegistrationReason.TIMEOUT, {}) from exc
     except (OSError, subprocess.SubprocessError) as exc:
         raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {}) from exc
-    return CommandOutput(completed.returncode, completed.stdout[:_OUTPUT_LIMIT_BYTES])
+    return CommandOutput(
+        completed.returncode,
+        stdout,
+        stdout_size > _OUTPUT_LIMIT_BYTES,
+    )
+
+
+def _reject_json_constant(_value: str) -> object:
+    raise ValueError("nonstandard_json_constant")
+
+
+def _reject_duplicate_object_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    parsed: dict[str, object] = {}
+    for key, value in pairs:
+        if key in parsed:
+            raise ValueError("duplicate_json_key")
+        parsed[key] = value
+    return parsed
+
+
+def _strict_json_loads(output: CommandOutput) -> object:
+    if output.stdout_truncated:
+        raise ValueError("truncated_json_output")
+    return json.loads(
+        output.stdout.decode("utf-8", errors="strict"),
+        object_pairs_hook=_reject_duplicate_object_keys,
+        parse_constant=_reject_json_constant,
+    )
 
 
 def _entry_command_tokens(entry: Mapping[str, object]) -> tuple[str, ...] | None:
@@ -121,18 +158,10 @@ class CodexMcpAdapter:
     def _run(self, argv: tuple[str, ...]) -> CommandOutput:
         return self._runner(argv)
 
-    def _classify_get(
-        self, output: CommandOutput
+    @staticmethod
+    def _classify_entry(
+        entry: Mapping[str, object],
     ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
-        if output.exit_code != 0:
-            return McpRegistrationState.ABSENT, None
-        try:
-            parsed = json.loads(output.stdout.decode("utf-8", errors="strict"))
-        except (UnicodeDecodeError, ValueError) as exc:
-            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {}) from exc
-        if not isinstance(parsed, Mapping):
-            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
-        entry = cast(Mapping[str, object], parsed)
         tokens = _entry_command_tokens(entry)
         for command in (MCP_STRICT_SERVE_COMMAND, MCP_SERVE_COMMAND):
             if tokens == command:
@@ -142,17 +171,64 @@ class CodexMcpAdapter:
         # An unreadable or different command is preserved, never replaced.
         return McpRegistrationState.FOREIGN_PRESENT, None
 
+    def _classify_get(
+        self, output: CommandOutput
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+        if output.exit_code != 0:
+            raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
+        try:
+            parsed = _strict_json_loads(output)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {}) from exc
+        if not isinstance(parsed, Mapping):
+            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
+        return self._classify_entry(cast(Mapping[str, object], parsed))
+
+    def _classify_list(
+        self, output: CommandOutput
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+        if output.exit_code != 0:
+            raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
+        try:
+            parsed = _strict_json_loads(output)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {}) from exc
+        if not isinstance(parsed, list):
+            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
+        matches: list[Mapping[str, object]] = []
+        for item in cast(list[object], parsed):
+            if not isinstance(item, Mapping):
+                raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
+            entry = cast(Mapping[str, object], item)
+            name = entry.get("name")
+            if not isinstance(name, str):
+                raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
+            if name == MCP_SERVER_NAME:
+                matches.append(entry)
+        if not matches:
+            return McpRegistrationState.ABSENT, None
+        if len(matches) != 1:
+            # A same-name duplicate is not a trustworthy absence or ownership observation.
+            raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
+        return self._classify_entry(matches[0])
+
+    def _observe_registration_state(
+        self, binary: HarnessBinary
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+        output = self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
+        if output.exit_code == 0:
+            return self._classify_get(output)
+        # Codex reports both a missing name and host/config read failures as a nonzero ``get``.
+        # Only a successful structural list may therefore establish positive absence.
+        return self._classify_list(self._run((binary.executable_path, "mcp", "list", "--json")))
+
     async def status_registration(self, binary: HarnessBinary) -> McpRegistrationState:
         self._require_codex(binary)
-        return self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )[0]
+        return self._observe_registration_state(binary)[0]
 
     async def observe_registration(self, binary: HarnessBinary) -> McpRegistrationObservation:
         self._require_codex(binary)
-        state, command = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state, command = self._observe_registration_state(binary)
         route_profile = None if command is None else _ROUTE_PROFILE_BY_COMMAND.get(command)
         return McpRegistrationObservation(binary.harness_id, state, route_profile)
 
@@ -203,9 +279,7 @@ class CodexMcpAdapter:
 
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         self._require_codex(binary)
-        state, current_command = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state, current_command = self._observe_registration_state(binary)
         return self._preview_for(binary, state, current_command)
 
     async def apply_registration(
@@ -240,9 +314,7 @@ class CodexMcpAdapter:
                 {"exit_code_class": "nonzero"},
             )
         # Verify by re-reading state rather than trusting the add exit code alone.
-        state_after, command_after = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state_after, command_after = self._observe_registration_state(binary)
         if (
             state_after is not McpRegistrationState.YOETZ_OWNED
             or command_after != self._serve_command
@@ -313,9 +385,7 @@ class CodexMcpAdapter:
 
     async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         self._require_codex(binary)
-        state, current_command = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state, current_command = self._observe_registration_state(binary)
         return self._unregistration_preview_for(binary, state, current_command)
 
     async def apply_unregistration(
@@ -341,9 +411,7 @@ class CodexMcpAdapter:
                 preview.state_before,
                 preview.preview_digest,
             )
-        state_before_remove, command_before_remove = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state_before_remove, command_before_remove = self._observe_registration_state(binary)
         if state_before_remove is McpRegistrationState.FOREIGN_PRESENT:
             raise McpRegistrationError(McpRegistrationReason.FOREIGN_ENTRY_PRESENT, {})
         if (
@@ -357,9 +425,7 @@ class CodexMcpAdapter:
                 McpRegistrationReason.REGISTRATION_FAILED,
                 {"exit_code_class": "nonzero"},
             )
-        state_after, _command_after = self._classify_get(
-            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
-        )
+        state_after, _command_after = self._observe_registration_state(binary)
         if state_after is not McpRegistrationState.ABSENT:
             raise McpRegistrationError(
                 McpRegistrationReason.REGISTRATION_FAILED,

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -258,3 +258,104 @@ class CodexMcpAdapter:
             state_after,
             preview.preview_digest,
         )
+
+    def _unregistration_preview_for(
+        self,
+        binary: HarnessBinary,
+        state: McpRegistrationState,
+        current_command: tuple[str, ...] | None,
+    ) -> McpRegistrationPreview:
+        action = (
+            McpRegistrationAction.NOOP
+            if state is McpRegistrationState.ABSENT
+            else McpRegistrationAction.UNREGISTER
+        )
+        warnings: tuple[str, ...] = ()
+        if state is McpRegistrationState.FOREIGN_PRESENT:
+            warnings = ("foreign_entry_present",)
+        if (
+            state is McpRegistrationState.YOETZ_OWNED
+            and current_command is not None
+            and current_command in _ROUTE_PROFILE_BY_COMMAND
+        ):
+            serve_command = current_command
+            route_profile = _ROUTE_PROFILE_BY_COMMAND[current_command]
+        else:
+            # Never copy a foreign argv into the preview shape. The digest still
+            # binds ``state_before``, so apply refuses the same-name entry.
+            serve_command = self._serve_command
+            route_profile = self._route_profile
+        digest = canonical_digest(
+            {
+                "action": action.value,
+                "executable_path": binary.executable_path,
+                "harness": binary.harness_id.value,
+                "schema": "yoetz.mcp-unregistration-preview/1",
+                "serve_command": list(serve_command),
+                "server_name": MCP_SERVER_NAME,
+                "state_before": state.value,
+            }
+        )
+        return McpRegistrationPreview(
+            binary.harness_id,
+            action,
+            state,
+            warnings,
+            digest,
+            serve_command,
+            route_profile,
+        )
+
+    async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview:
+        self._require_codex(binary)
+        state, current_command = self._classify_get(
+            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
+        )
+        return self._unregistration_preview_for(binary, state, current_command)
+
+    async def apply_unregistration(
+        self,
+        binary: HarnessBinary,
+        command: McpRegistrationCommand,
+    ) -> McpRegistrationResult:
+        self._require_codex(binary)
+        if type(command) is not McpRegistrationCommand:
+            raise McpRegistrationError(McpRegistrationReason.CONFIRMATION_REQUIRED, {})
+        if not command.explicitly_accepted:
+            raise McpRegistrationError(McpRegistrationReason.CONFIRMATION_REQUIRED, {})
+        preview = await self.preview_unregistration(binary)
+        if command.preview_digest != preview.preview_digest:
+            raise McpRegistrationError(McpRegistrationReason.PREVIEW_STALE, {})
+        if preview.state_before is McpRegistrationState.FOREIGN_PRESENT:
+            raise McpRegistrationError(McpRegistrationReason.FOREIGN_ENTRY_PRESENT, {})
+        if preview.action is McpRegistrationAction.NOOP:
+            return McpRegistrationResult(
+                binary.harness_id,
+                McpRegistrationAction.NOOP,
+                preview.state_before,
+                preview.state_before,
+                preview.preview_digest,
+            )
+        remove_output = self._run(
+            (binary.executable_path, "mcp", "remove", MCP_SERVER_NAME)
+        )
+        if remove_output.exit_code != 0:
+            raise McpRegistrationError(
+                McpRegistrationReason.REGISTRATION_FAILED,
+                {"exit_code_class": "nonzero"},
+            )
+        state_after, _command_after = self._classify_get(
+            self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
+        )
+        if state_after is not McpRegistrationState.ABSENT:
+            raise McpRegistrationError(
+                McpRegistrationReason.REGISTRATION_FAILED,
+                {"verified_state": state_after.value},
+            )
+        return McpRegistrationResult(
+            binary.harness_id,
+            McpRegistrationAction.UNREGISTER,
+            preview.state_before,
+            state_after,
+            preview.preview_digest,
+        )

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -336,9 +336,7 @@ class CodexMcpAdapter:
                 preview.state_before,
                 preview.preview_digest,
             )
-        remove_output = self._run(
-            (binary.executable_path, "mcp", "remove", MCP_SERVER_NAME)
-        )
+        remove_output = self._run((binary.executable_path, "mcp", "remove", MCP_SERVER_NAME))
         if remove_output.exit_code != 0:
             raise McpRegistrationError(
                 McpRegistrationReason.REGISTRATION_FAILED,

--- a/src/yoetz/application/harness_mcp.py
+++ b/src/yoetz/application/harness_mcp.py
@@ -214,3 +214,64 @@ class HarnessMcpService:
             )
         )
         return result
+
+    async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview:
+        if type(binary) is not HarnessBinary:
+            raise _invalid("integration_request_invalid")
+        try:
+            preview = await self._port.preview_unregistration(binary)
+        except McpRegistrationError as exc:
+            self._diagnostics.record_mcp_registration(
+                McpRegistrationDiagnostic(
+                    binary.harness_id, "preview", "failed", None, None, None, exc.reason
+                )
+            )
+            raise
+        self._diagnostics.record_mcp_registration(
+            McpRegistrationDiagnostic(
+                binary.harness_id,
+                "preview",
+                "success",
+                preview.state_before,
+                preview.state_before,
+                preview.preview_digest,
+                None,
+            )
+        )
+        return preview
+
+    async def unregister(
+        self,
+        binary: HarnessBinary,
+        confirmation: McpRegistrationConfirmation,
+    ) -> McpRegistrationResult:
+        if type(binary) is not HarnessBinary:
+            raise _invalid("integration_request_invalid")
+        if type(confirmation) is not McpRegistrationConfirmation:
+            raise _invalid("integration_confirmation_invalid")
+        try:
+            if not confirmation.explicitly_accepted:
+                raise McpRegistrationError(McpRegistrationReason.CONFIRMATION_REQUIRED, {})
+            result = await self._port.apply_unregistration(
+                binary,
+                McpRegistrationCommand(confirmation.preview_digest, True),
+            )
+        except McpRegistrationError as exc:
+            self._diagnostics.record_mcp_registration(
+                McpRegistrationDiagnostic(
+                    binary.harness_id, "execute", "failed", None, None, None, exc.reason
+                )
+            )
+            raise
+        self._diagnostics.record_mcp_registration(
+            McpRegistrationDiagnostic(
+                binary.harness_id,
+                "execute",
+                "success",
+                result.state_before,
+                result.state_after,
+                result.preview_digest,
+                None,
+            )
+        )
+        return result

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1264,20 +1264,20 @@ def _integration_mcp_command(action: str) -> Callable[..., None]:
     return command
 
 
-for _mcp_action in ("preview", "install", "status"):
+for _mcp_action in ("preview", "install", "status", "remove"):
     integrate_mcp_app.command(_mcp_action)(_integration_mcp_command(_mcp_action))
 
 
-def _cursor_plugin_command(command_name: str) -> Callable[..., None]:
+def _plugin_command(command_name: str) -> Callable[..., None]:
     def command(
         context: typer.Context,
         cursor_config_root: Annotated[
-            Path,
+            Path | None,
             typer.Option(
                 "--cursor-config-root",
                 help="Exact isolated Cursor ~/.cursor configuration root.",
             ),
-        ],
+        ] = None,
         project_root: Annotated[
             Path | None,
             typer.Option("--project-root", help="Exact trusted project for MCP source checks."),
@@ -1303,10 +1303,43 @@ def _cursor_plugin_command(command_name: str) -> Callable[..., None]:
             str | None,
             typer.Option("--preview-digest", help="Exact digest returned by preview."),
         ] = None,
+        codex_path: _CODEX_PATH = None,
+        codex_home: Annotated[
+            Path | None,
+            typer.Option("--codex-home", help="Exact Codex home to bind plugin removal to."),
+        ] = None,
+        purge_cache: Annotated[
+            bool,
+            typer.Option(
+                "--purge-cache",
+                help="Also delete other digest-matched yoetz cache versions.",
+            ),
+        ] = False,
         accept: _ACCEPT = False,
         json_output: _JSON = False,
     ) -> None:
         harness = cast(str, context.find_root().find_object(str) or context.obj)
+        if harness == "codex":
+            module = importlib.import_module("yoetz.cli.codex_plugin")
+            operation = cast(Callable[..., int], getattr(module, "run_codex_plugin_command"))
+            _finish(
+                operation(
+                    command_name,
+                    harness=harness,
+                    project_root=project_root,
+                    codex_path=codex_path,
+                    codex_home=codex_home,
+                    purge_cache=purge_cache,
+                    preview_digest=preview_digest,
+                    accept=accept,
+                    json_output=json_output,
+                )
+            )
+            return
+        if cursor_config_root is None:
+            sys.stderr.write("cursor_config_root_required\n")
+            _finish(2)
+            return
         module = importlib.import_module("yoetz.cli.cursor_integration")
         operation = cast(Callable[..., int], getattr(module, "run_cursor_plugin_command"))
         _finish(
@@ -1330,7 +1363,7 @@ def _cursor_plugin_command(command_name: str) -> Callable[..., None]:
 
 
 for _plugin_action in ("preview", "install", "status", "remove"):
-    integrate_plugin_app.command(_plugin_action)(_cursor_plugin_command(_plugin_action))
+    integrate_plugin_app.command(_plugin_action)(_plugin_command(_plugin_action))
 
 
 @setup_app.command("run")

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1207,7 +1207,7 @@ _CODEX_PATH = Annotated[
 ]
 _ACCEPT = Annotated[
     bool,
-    typer.Option("--accept", help="Explicitly accept the previewed MCP change."),
+    typer.Option("--accept", help="Explicitly accept the previewed change."),
 ]
 _ROUTE_PROFILE = Annotated[
     str | None,

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1207,7 +1207,7 @@ _CODEX_PATH = Annotated[
 ]
 _ACCEPT = Annotated[
     bool,
-    typer.Option("--accept", help="Explicitly accept the previewed registration."),
+    typer.Option("--accept", help="Explicitly accept the previewed MCP change."),
 ]
 _ROUTE_PROFILE = Annotated[
     str | None,
@@ -1264,7 +1264,7 @@ def _integration_mcp_command(action: str) -> Callable[..., None]:
     return command
 
 
-for _mcp_action in ("preview", "install", "status", "remove"):
+for _mcp_action in ("preview", "preview-remove", "install", "status", "remove"):
     integrate_mcp_app.command(_mcp_action)(_integration_mcp_command(_mcp_action))
 
 

--- a/src/yoetz/cli/codex_plugin.py
+++ b/src/yoetz/cli/codex_plugin.py
@@ -18,7 +18,10 @@ from yoetz.adapters.integrations.codex_skill import (
     inspect_destination,
     load_packaged_skill_source,
 )
-from yoetz.cli.setup import _UsageExit, _choose_binary
+from yoetz.cli.setup import (
+    _choose_binary,  # pyright: ignore[reportPrivateUsage]
+    _UsageExit,  # pyright: ignore[reportPrivateUsage]
+)
 from yoetz.ports.integrations import (
     IntegrationError,
     IntegrationScope,

--- a/src/yoetz/cli/codex_plugin.py
+++ b/src/yoetz/cli/codex_plugin.py
@@ -1,0 +1,155 @@
+"""Explicit local Codex plugin/marketplace removal commands."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import cast
+
+from yoetz.adapters.integrations.codex_discovery import discover_codex_binaries
+from yoetz.adapters.integrations.codex_marketplace import (
+    RemovalPreview,
+    apply_removal,
+    inspect_activation,
+    preview_removal,
+)
+from yoetz.adapters.integrations.codex_skill import (
+    inspect_destination,
+    load_packaged_skill_source,
+)
+from yoetz.cli.setup import _UsageExit, _choose_binary
+from yoetz.ports.integrations import (
+    IntegrationError,
+    IntegrationScope,
+    IntegrationTarget,
+)
+from yoetz.protocol.canonical import JsonValue, canonical_encode
+
+__all__ = ["run_codex_plugin_command"]
+
+
+def _emit(value: dict[str, object], *, json_output: bool) -> None:
+    if json_output:
+        sys.stdout.buffer.write(canonical_encode(cast(JsonValue, value)) + b"\n")
+        return
+    for key, item in value.items():
+        rendered = (
+            canonical_encode(cast(JsonValue, item)).decode("utf-8")
+            if isinstance(item, (dict, list, tuple))
+            else str(item)
+        )
+        sys.stdout.write(f"{key}: {rendered}\n")
+
+
+def _target(project_root: Path | None) -> IntegrationTarget:
+    root = Path.cwd() if project_root is None else project_root
+    return IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, os.fspath(root.resolve()))
+
+
+def _skill_tree_state(target: IntegrationTarget) -> str:
+    return inspect_destination(target, load_packaged_skill_source()).state.value
+
+
+def _preview_body(preview: RemovalPreview) -> dict[str, object]:
+    return {
+        "action": preview.outcome.value,
+        "cache_versions": list(preview.cache_versions),
+        "codex_version": preview.codex_version,
+        "config_preimage_digest": preview.config_preimage_digest,
+        "config_toml_block": preview.config_toml_block,
+        "inventory_command": list(preview.inventory_command),
+        "marketplace_json_planned": preview.marketplace_json_planned,
+        "marketplace_preimage_digest": preview.marketplace_preimage_digest,
+        "marketplace_remove_command": list(preview.marketplace_remove_command),
+        "marketplace_remove_planned": preview.marketplace_remove_planned,
+        "plugin_remove_command": list(preview.plugin_remove_command),
+        "plugin_remove_planned": preview.plugin_remove_planned,
+        "preview_digest": preview.preview_digest,
+        "purge_cache": preview.purge_cache,
+        "skill_tree": preview.skill_tree_state,
+        "state_before": preview.inspection.state.value,
+    }
+
+
+def run_codex_plugin_command(
+    command: str,
+    *,
+    harness: str,
+    project_root: Path | None,
+    codex_path: str | None,
+    codex_home: Path | None,
+    purge_cache: bool,
+    preview_digest: str | None,
+    accept: bool,
+    json_output: bool,
+) -> int:
+    """Run one path-explicit Codex marketplace removal without ambient home inference."""
+
+    if harness != "codex" or command not in {"preview", "status", "remove"}:
+        sys.stderr.write("codex_plugin_command_invalid\n")
+        return 2
+    if codex_home is None:
+        sys.stderr.write("codex_home_required\n")
+        return 2
+    binaries = discover_codex_binaries()
+    try:
+        chosen = _choose_binary(binaries, codex_path=codex_path, interactive=False)
+    except _UsageExit as failure:
+        return failure.code
+    if chosen is None:
+        sys.stderr.write("codex_executable_unresolved\n")
+        return 2
+    target = _target(project_root)
+    executable = chosen.executable_path
+    try:
+        if command == "status":
+            inspection = inspect_activation(
+                target, executable_path=executable, codex_home=codex_home
+            )
+            _emit(
+                {
+                    "skill_tree": _skill_tree_state(target),
+                    "state": inspection.state.value,
+                },
+                json_output=json_output,
+            )
+            return 0
+        preview = preview_removal(
+            target,
+            executable_path=executable,
+            codex_home=codex_home,
+            purge_cache=purge_cache,
+        )
+        if command == "preview":
+            _emit(_preview_body(preview), json_output=json_output)
+            return 0
+        if not accept or preview_digest is None:
+            sys.stderr.write("codex_plugin_exact_preview_acceptance_required\n")
+            return 3
+        result = apply_removal(
+            target,
+            approved_digest=preview_digest,
+            executable_path=executable,
+            codex_home=codex_home,
+            purge_cache=purge_cache,
+        )
+    except IntegrationError as error:
+        details = dict(error.safe_details)
+        conflict = details.get("conflict")
+        sys.stderr.write(
+            f"codex_plugin_{error.reason.value}"
+            + (f":{conflict}" if type(conflict) is str else "")
+            + "\n"
+        )
+        return 20 if error.reason.value not in {"remove_refused", "preview_stale"} else 2
+    _emit(
+        {
+            "outcome": result.outcome.value,
+            "purge_cache": result.purge_cache,
+            "skill_tree": result.skill_tree_state,
+            "state_after": result.inspection.state.value,
+        },
+        json_output=json_output,
+    )
+    return 0

--- a/src/yoetz/cli/codex_plugin.py
+++ b/src/yoetz/cli/codex_plugin.py
@@ -47,7 +47,11 @@ def _emit(value: dict[str, object], *, json_output: bool) -> None:
 
 def _target(project_root: Path | None) -> IntegrationTarget:
     root = Path.cwd() if project_root is None else project_root
-    return IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, os.fspath(root.resolve()))
+    if not root.is_absolute():
+        root = Path.cwd() / root
+    # Preserve the lexical path so the adapter can reject a symlinked project
+    # root instead of silently authorizing its resolved target.
+    return IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, os.fspath(root.absolute()))
 
 
 def _skill_tree_state(target: IntegrationTarget) -> str:
@@ -57,6 +61,9 @@ def _skill_tree_state(target: IntegrationTarget) -> str:
 def _preview_body(preview: RemovalPreview) -> dict[str, object]:
     return {
         "action": preview.outcome.value,
+        "cache_preimages": [
+            {"digest": digest, "version": version} for version, digest in preview.cache_digests
+        ],
         "cache_versions": list(preview.cache_versions),
         "codex_version": preview.codex_version,
         "config_preimage_digest": preview.config_preimage_digest,

--- a/src/yoetz/cli/codex_plugin.py
+++ b/src/yoetz/cli/codex_plugin.py
@@ -13,10 +13,7 @@ from yoetz.adapters.integrations.codex_marketplace import (
     apply_removal,
     inspect_activation,
     preview_removal,
-)
-from yoetz.adapters.integrations.codex_skill import (
-    inspect_destination,
-    load_packaged_skill_source,
+    skill_tree_state,
 )
 from yoetz.cli.setup import (
     _choose_binary,  # pyright: ignore[reportPrivateUsage]
@@ -52,10 +49,6 @@ def _target(project_root: Path | None) -> IntegrationTarget:
     # Preserve the lexical path so the adapter can reject a symlinked project
     # root instead of silently authorizing its resolved target.
     return IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, os.fspath(root.absolute()))
-
-
-def _skill_tree_state(target: IntegrationTarget) -> str:
-    return inspect_destination(target, load_packaged_skill_source()).state.value
 
 
 def _preview_body(preview: RemovalPreview) -> dict[str, object]:
@@ -119,19 +112,19 @@ def run_codex_plugin_command(
             )
             _emit(
                 {
-                    "skill_tree": _skill_tree_state(target),
+                    "skill_tree": skill_tree_state(target),
                     "state": inspection.state.value,
                 },
                 json_output=json_output,
             )
             return 0
-        preview = preview_removal(
-            target,
-            executable_path=executable,
-            codex_home=codex_home,
-            purge_cache=purge_cache,
-        )
         if command == "preview":
+            preview = preview_removal(
+                target,
+                executable_path=executable,
+                codex_home=codex_home,
+                purge_cache=purge_cache,
+            )
             _emit(_preview_body(preview), json_output=json_output)
             return 0
         if not accept or preview_digest is None:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -2689,14 +2689,14 @@ async def integrate_mcp(
     json_output: bool,
     route_profile: Literal["policy", "strict"] | None = None,
 ) -> int:
-    """Client-local ``integrate <harness> mcp status|preview|install`` commands.
+    """Client-local ``integrate <harness> mcp status|preview|install|remove`` commands.
 
     ``route_profile`` is the explicit route input. When absent, an existing
     yoetz-owned registration keeps its observed profile (#389); only a fresh
     registration falls back to the structural configuration derivation.
     """
 
-    if harness != "codex" or action not in {"status", "preview", "install"}:
+    if harness != "codex" or action not in {"status", "preview", "install", "remove"}:
         return _usage_failure("the harness or action is not supported")
     interactive = _is_interactive_terminal()
     binaries = discover_codex_binaries()
@@ -2716,6 +2716,51 @@ async def integrate_mcp(
                     "harness": harness,
                     "route_profile": observation.route_profile,
                     "state": observation.state.value,
+                },
+                json_output=json_output,
+            )
+            return 0
+        if action == "remove":
+            preview = await service.preview_unregistration(chosen)
+            if preview_digest is not None and preview_digest != preview.preview_digest:
+                return _mcp_error_exit("preview_stale")
+            if preview.state_before is McpRegistrationState.FOREIGN_PRESENT:
+                return _mcp_error_exit("foreign_entry_present")
+            accepted = accept
+            if interactive and not accepted:
+                typer.echo("Proposed change: remove the Yoetz-owned Codex MCP registration")
+                typer.echo("  MCP server name: yoetz")
+                typer.echo(f"  Action: {preview.action.value}")
+                typer.echo(f"  State before: {preview.state_before.value}")
+                typer.echo(f"  Preview digest: {preview.preview_digest}")
+                accepted = _confirm_registration()
+            if not accepted:
+                return _mcp_error_exit("confirmation_required")
+            if preview.action is McpRegistrationAction.NOOP:
+                _emit(
+                    {
+                        "action": "noop",
+                        "harness": harness,
+                        "state_after": preview.state_before.value,
+                        "state_before": preview.state_before.value,
+                    },
+                    json_output=json_output,
+                )
+                return 0
+            result = await service.unregister(
+                chosen,
+                McpRegistrationConfirmation(
+                    preview.preview_digest,
+                    True,
+                    "interactive" if interactive else "noninteractive_flag",
+                ),
+            )
+            _emit(
+                {
+                    "action": result.action.value,
+                    "harness": harness,
+                    "state_after": result.state_after.value,
+                    "state_before": result.state_before.value,
                 },
                 json_output=json_output,
             )

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -767,6 +767,23 @@ def _emit_registration_preview(
         typer.echo("  the exact digest above. Any byte change suspends execution.")
 
 
+def _emit_unregistration_preview(mcp_preview: object) -> None:
+    """Show every approval-relevant removal field before interactive consent."""
+
+    typer.echo("Proposed change: remove the Yoetz-owned Codex MCP registration")
+    typer.echo("  MCP server name: yoetz")
+    typer.echo(f"  Action: {getattr(mcp_preview, 'action').value}")
+    typer.echo(f"  State before: {getattr(mcp_preview, 'state_before').value}")
+    serve_command = getattr(mcp_preview, "serve_command", ())
+    typer.echo(f"  Command: {' '.join(serve_command)}")
+    route_profile = getattr(mcp_preview, "route_profile", None)
+    if type(route_profile) is str:
+        typer.echo(f"  MCP route profile: {route_profile}")
+    for warning in getattr(mcp_preview, "warnings", ()):
+        typer.echo(f"  Warning: {warning}")
+    typer.echo(f"  Preview digest: {getattr(mcp_preview, 'preview_digest')}")
+
+
 def _plugin_verified(presence: str | None) -> bool:
     return presence == PluginHookPresence.INSTALLED.value
 
@@ -2750,11 +2767,7 @@ async def integrate_mcp(
                 return _mcp_error_exit("confirmation_required")
             accepted = accept
             if interactive and not accepted:
-                typer.echo("Proposed change: remove the Yoetz-owned Codex MCP registration")
-                typer.echo("  MCP server name: yoetz")
-                typer.echo(f"  Action: {preview.action.value}")
-                typer.echo(f"  State before: {preview.state_before.value}")
-                typer.echo(f"  Preview digest: {preview.preview_digest}")
+                _emit_unregistration_preview(preview)
                 accepted = _confirm_registration()
             if not accepted:
                 return _mcp_error_exit("confirmation_required")

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -2689,14 +2689,20 @@ async def integrate_mcp(
     json_output: bool,
     route_profile: Literal["policy", "strict"] | None = None,
 ) -> int:
-    """Client-local ``integrate <harness> mcp status|preview|install|remove`` commands.
+    """Client-local MCP status, registration, and unregistration commands.
 
     ``route_profile`` is the explicit route input. When absent, an existing
     yoetz-owned registration keeps its observed profile (#389); only a fresh
     registration falls back to the structural configuration derivation.
     """
 
-    if harness != "codex" or action not in {"status", "preview", "install", "remove"}:
+    if harness != "codex" or action not in {
+        "status",
+        "preview",
+        "preview-remove",
+        "install",
+        "remove",
+    }:
         return _usage_failure("the harness or action is not supported")
     interactive = _is_interactive_terminal()
     binaries = discover_codex_binaries()
@@ -2720,12 +2726,28 @@ async def integrate_mcp(
                 json_output=json_output,
             )
             return 0
-        if action == "remove":
+        if action in {"preview-remove", "remove"}:
             preview = await service.preview_unregistration(chosen)
+            if action == "preview-remove":
+                _emit(
+                    {
+                        "action": preview.action.value,
+                        "harness": harness,
+                        "preview_digest": preview.preview_digest,
+                        "route_profile": preview.route_profile,
+                        "serve_command": list(preview.serve_command),
+                        "state_before": preview.state_before.value,
+                        "warnings": list(preview.warnings),
+                    },
+                    json_output=json_output,
+                )
+                return 0
             if preview_digest is not None and preview_digest != preview.preview_digest:
                 return _mcp_error_exit("preview_stale")
             if preview.state_before is McpRegistrationState.FOREIGN_PRESENT:
                 return _mcp_error_exit("foreign_entry_present")
+            if accept and preview_digest is None:
+                return _mcp_error_exit("confirmation_required")
             accepted = accept
             if interactive and not accepted:
                 typer.echo("Proposed change: remove the Yoetz-owned Codex MCP registration")

--- a/src/yoetz/ports/harness_mcp.py
+++ b/src/yoetz/ports/harness_mcp.py
@@ -56,6 +56,7 @@ class McpRegistrationState(str, Enum):  # noqa: UP042 - exact wire-valued Enum i
 class McpRegistrationAction(str, Enum):  # noqa: UP042 - exact wire-valued Enum is required
     REGISTER = "register"
     REREGISTER = "reregister"
+    UNREGISTER = "unregister"
     NOOP = "noop"
 
 
@@ -232,6 +233,14 @@ class HarnessMcpPort(Protocol):
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview: ...
 
     async def apply_registration(
+        self,
+        binary: HarnessBinary,
+        command: McpRegistrationCommand,
+    ) -> McpRegistrationResult: ...
+
+    async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview: ...
+
+    async def apply_unregistration(
         self,
         binary: HarnessBinary,
         command: McpRegistrationCommand,

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -1257,9 +1257,23 @@ def test_integrate_mcp_refuses_foreign_entry(wizard_env: dict[str, object]) -> N
 
 def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None:
     wizard_env["outputs"] = [_yoetz_entry()]
+    previewed = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview-remove", "--json"])
+    assert previewed.exit_code == 0, (previewed.output, previewed.exception)
+    preview = json.loads(previewed.stdout)
+    assert preview["action"] == "unregister"
+    assert preview["route_profile"] == "strict"
+    assert preview["serve_command"] == ["yoetz", "mcp", "serve", "--semantic", "off"]
+    assert preview["preview_digest"].startswith("sha256:")
+
+    wizard_env["outputs"] = [_yoetz_entry()]
     refused = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove", "--json"])
     assert refused.exit_code == 2
     assert "confirmation_required" in refused.stderr
+
+    wizard_env["outputs"] = [_yoetz_entry()]
+    unbound = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove", "--accept", "--json"])
+    assert unbound.exit_code == 2
+    assert "confirmation_required" in unbound.stderr
 
     wizard_env["outputs"] = [
         _yoetz_entry(),
@@ -1269,7 +1283,16 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
     ]
     result = _RUNNER.invoke(
         cli.app,
-        ["integrate", "codex", "mcp", "remove", "--accept", "--json"],
+        [
+            "integrate",
+            "codex",
+            "mcp",
+            "remove",
+            "--accept",
+            "--preview-digest",
+            preview["preview_digest"],
+            "--json",
+        ],
     )
     assert result.exit_code == 0, (result.output, result.exception)
     body = json.loads(result.stdout)
@@ -1279,9 +1302,23 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
 
 def test_integrate_mcp_remove_absent_entry_is_noop(wizard_env: dict[str, object]) -> None:
     wizard_env["outputs"] = [CommandOutput(1, b"")]
+    previewed = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview-remove", "--json"])
+    assert previewed.exit_code == 0, (previewed.output, previewed.exception)
+    preview_digest = json.loads(previewed.stdout)["preview_digest"]
+
+    wizard_env["outputs"] = [CommandOutput(1, b"")]
     result = _RUNNER.invoke(
         cli.app,
-        ["integrate", "codex", "mcp", "remove", "--accept", "--json"],
+        [
+            "integrate",
+            "codex",
+            "mcp",
+            "remove",
+            "--accept",
+            "--preview-digest",
+            preview_digest,
+            "--json",
+        ],
     )
     assert result.exit_code == 0, (result.output, result.exception)
     assert json.loads(result.stdout)["action"] == "noop"
@@ -1292,6 +1329,27 @@ def test_integrate_mcp_remove_refuses_foreign_entry(wizard_env: dict[str, object
     result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove", "--accept", "--json"])
     assert result.exit_code == 2
     assert "foreign_entry_present" in result.stderr
+
+
+def test_integrate_mcp_remove_refuses_stale_preview_digest(
+    wizard_env: dict[str, object],
+) -> None:
+    wizard_env["outputs"] = [_yoetz_entry()]
+    result = _RUNNER.invoke(
+        cli.app,
+        [
+            "integrate",
+            "codex",
+            "mcp",
+            "remove",
+            "--accept",
+            "--preview-digest",
+            "sha256:" + "0" * 64,
+            "--json",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "preview_stale" in result.stderr
 
 
 def test_non_interactive_accept_preserves_existing_policy_route(

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -1263,6 +1263,7 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
     assert preview["action"] == "unregister"
     assert preview["route_profile"] == "strict"
     assert preview["serve_command"] == ["yoetz", "mcp", "serve", "--semantic", "off"]
+    assert preview["warnings"] == ["host_remove_not_compare_and_swap"]
     assert preview["preview_digest"].startswith("sha256:")
 
     wizard_env["outputs"] = [_yoetz_entry()]
@@ -1276,6 +1277,7 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
     assert "confirmation_required" in unbound.stderr
 
     wizard_env["outputs"] = [
+        _yoetz_entry(),
         _yoetz_entry(),
         _yoetz_entry(),
         CommandOutput(0, b""),

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -81,13 +81,19 @@ def _yoetz_entry(
     return CommandOutput(0, json.dumps({"command": "yoetz", "args": args}).encode())
 
 
+def _absent_mcp() -> list[CommandOutput]:
+    """A failed named lookup plus a successful structural proof of absence."""
+
+    return [CommandOutput(1, b""), CommandOutput(0, b"[]")]
+
+
 @pytest.fixture
 def wizard_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, object]:
     """Fake discovery, adapter subprocesses, service client, and marker path."""
 
     state: dict[str, object] = {
         "binaries": (_binary(),),
-        "outputs": [CommandOutput(1, b"")],
+        "outputs": _absent_mcp(),
         "calls": [],
         "activation_apply_calls": 0,
     }
@@ -520,8 +526,8 @@ def test_non_interactive_accept_registers_and_writes_marker(
     wizard_env: dict[str, object],
 ) -> None:
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),  # preview get: absent
-        CommandOutput(1, b""),  # apply re-preview get: absent
+        *_absent_mcp(),  # preview: confirmed absent
+        *_absent_mcp(),  # apply re-preview: confirmed absent
         CommandOutput(0, b""),  # add
         _yoetz_entry(),  # verify get
     ]
@@ -555,8 +561,8 @@ def test_interactive_generic_accept_does_not_authorize_unshown_activation(
     wizard_env: dict[str, object], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),
-        CommandOutput(1, b""),
+        *_absent_mcp(),
+        *_absent_mcp(),
         CommandOutput(0, b""),
         _yoetz_entry(),
     ]
@@ -658,11 +664,11 @@ async def test_a_preview_and_apply_that_disagree_on_the_route_refuse_as_stale(
     skill_preview = await setup_module.project_skill_preview(workspace)
 
     # Exactly what the TUI does today: no route_profile, so the class default (policy) applies.
-    preview_runner = _ScriptedRunner([CommandOutput(1, b"")])
+    preview_runner = _ScriptedRunner(_absent_mcp())
     mcp_preview = await HarnessMcpService(CodexMcpAdapter(preview_runner)).preview(_binary())
 
     # And exactly what apply does today: the configured route, strict with no provider bound.
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     report = await setup_module.apply_codex_integration(
         _binary(),
         workspace=workspace,
@@ -693,14 +699,14 @@ async def test_a_preview_and_apply_on_the_same_route_register(
     workspace = cast(Path, wizard_env["marker"]).parent
     skill_preview = await setup_module.project_skill_preview(workspace)
 
-    preview_runner = _ScriptedRunner([CommandOutput(1, b"")])
+    preview_runner = _ScriptedRunner(_absent_mcp())
     mcp_preview = await HarnessMcpService(
         CodexMcpAdapter(preview_runner, route_profile="strict")
     ).preview(_binary())
 
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),  # step preview get: absent
-        CommandOutput(1, b""),  # adapter install re-preview get: absent
+        *_absent_mcp(),  # step preview: confirmed absent
+        *_absent_mcp(),  # adapter install re-preview: confirmed absent
         CommandOutput(0, b""),  # add
         _yoetz_entry("strict"),  # verify get
     ]
@@ -732,8 +738,8 @@ def test_interactive_wizard_selects_harness_then_installation_and_requires_y_or_
 ) -> None:
     wizard_env["binaries"] = (_binary("/a/codex"), _binary("/b/codex"))
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),  # preview get: absent
-        CommandOutput(1, b""),  # apply re-preview get: absent
+        *_absent_mcp(),  # preview: confirmed absent
+        *_absent_mcp(),  # apply re-preview: confirmed absent
         CommandOutput(0, b""),  # add
         _yoetz_entry(),  # verify get
     ]
@@ -807,7 +813,7 @@ def test_interactive_registration_n_declines_without_mutation(
         result.stdout
     )
     for calls in cast(list[list[tuple[str, ...]]], wizard_env["calls"]):
-        assert all(call[1:3] == ("mcp", "get") for call in calls)
+        assert all(call[1:3] in {("mcp", "get"), ("mcp", "list")} for call in calls)
 
 
 def test_semantic_first_run_suggests_and_selects_assisted_privacy_draft(
@@ -819,8 +825,8 @@ def test_semantic_first_run_suggests_and_selects_assisted_privacy_draft(
     import yoetz.cli.setup as setup_module
 
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),  # preview get: absent
-        CommandOutput(1, b""),  # apply re-preview get: absent
+        *_absent_mcp(),  # preview: confirmed absent
+        *_absent_mcp(),  # apply re-preview: confirmed absent
         CommandOutput(0, b""),  # add
         _yoetz_entry("policy"),  # verify get
     ]
@@ -965,8 +971,8 @@ def test_composed_wizard_preserves_privacy_when_hidden_credential_input_is_empty
 
     fake_credential = "sk-fake-issue-165-must-never-appear"
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),
-        CommandOutput(1, b""),
+        *_absent_mcp(),
+        *_absent_mcp(),
         CommandOutput(0, b""),
         _yoetz_entry("policy"),
     ]
@@ -1051,8 +1057,8 @@ def test_composed_wizard_reaches_semantic_readiness_after_hidden_credential_stor
     tmp_path: Path,
 ) -> None:
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),
-        CommandOutput(1, b""),
+        *_absent_mcp(),
+        *_absent_mcp(),
         CommandOutput(0, b""),
         _yoetz_entry("policy"),
     ]
@@ -1183,7 +1189,7 @@ def test_installed_hooks_use_nested_plugin_hook_path(tmp_path: Path) -> None:
 
 
 def test_integrate_mcp_status_preview_install(wizard_env: dict[str, object]) -> None:
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     status = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "status", "--json"])
     assert status.exit_code == 0
     absent_status = json.loads(status.stdout)
@@ -1191,7 +1197,7 @@ def test_integrate_mcp_status_preview_install(wizard_env: dict[str, object]) -> 
     # An absent entry has no Yoetz route to describe; the field is present and null, never guessed.
     assert absent_status["route_profile"] is None
 
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     preview = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview", "--json"])
     assert preview.exit_code == 0
     body = json.loads(preview.stdout)
@@ -1199,8 +1205,8 @@ def test_integrate_mcp_status_preview_install(wizard_env: dict[str, object]) -> 
     assert body["preview_digest"].startswith("sha256:")
 
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),
-        CommandOutput(1, b""),
+        *_absent_mcp(),
+        *_absent_mcp(),
         CommandOutput(0, b""),
         _yoetz_entry(),
     ]
@@ -1242,7 +1248,7 @@ def test_integrate_mcp_status_names_the_registered_route(
 def test_integrate_mcp_install_without_accept_fails_closed(
     wizard_env: dict[str, object],
 ) -> None:
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "install", "--json"])
     assert result.exit_code == 2
     assert "confirmation_required" in result.stderr
@@ -1282,6 +1288,7 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
         _yoetz_entry(),
         CommandOutput(0, b""),
         CommandOutput(1, b""),
+        CommandOutput(0, b"[]"),
     ]
     result = _RUNNER.invoke(
         cli.app,
@@ -1302,13 +1309,37 @@ def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None
     assert body["state_after"] == "absent"
 
 
+def test_integrate_mcp_interactive_remove_surfaces_complete_warning_bound_preview(
+    wizard_env: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yoetz.cli.setup as setup_module
+
+    wizard_env["outputs"] = [
+        _yoetz_entry(),
+        _yoetz_entry(),
+        _yoetz_entry(),
+        CommandOutput(0, b""),
+        *_absent_mcp(),
+    ]
+    monkeypatch.setattr(setup_module, "_is_interactive_terminal", lambda: True)
+    monkeypatch.setattr(setup_module, "_confirm_registration", lambda: True)
+
+    result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove"])
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert "Command: yoetz mcp serve --semantic off" in result.output
+    assert "MCP route profile: strict" in result.output
+    assert "Warning: host_remove_not_compare_and_swap" in result.output
+    assert "Preview digest: sha256:" in result.output
+
+
 def test_integrate_mcp_remove_absent_entry_is_noop(wizard_env: dict[str, object]) -> None:
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     previewed = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview-remove", "--json"])
     assert previewed.exit_code == 0, (previewed.output, previewed.exception)
     preview_digest = json.loads(previewed.stdout)["preview_digest"]
 
-    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    wizard_env["outputs"] = _absent_mcp()
     result = _RUNNER.invoke(
         cli.app,
         [
@@ -1466,8 +1497,8 @@ def test_failed_activation_preview_reports_bound_home_and_real_reason(
     monkeypatch.setattr(setup_module, "preview_activation", conflicted)
     monkeypatch.setattr(setup_module, "inspect_activation", conflicted)
     wizard_env["outputs"] = [
-        CommandOutput(1, b""),  # preview get: absent
-        CommandOutput(1, b""),  # apply re-preview get: absent
+        *_absent_mcp(),  # preview: confirmed absent
+        *_absent_mcp(),  # apply re-preview: confirmed absent
         CommandOutput(0, b""),  # add
         _yoetz_entry(),  # verify get
     ]

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -1255,6 +1255,45 @@ def test_integrate_mcp_refuses_foreign_entry(wizard_env: dict[str, object]) -> N
     assert "foreign_entry_present" in result.stderr
 
 
+def test_integrate_mcp_remove_owned_entry(wizard_env: dict[str, object]) -> None:
+    wizard_env["outputs"] = [_yoetz_entry()]
+    refused = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove", "--json"])
+    assert refused.exit_code == 2
+    assert "confirmation_required" in refused.stderr
+
+    wizard_env["outputs"] = [
+        _yoetz_entry(),
+        _yoetz_entry(),
+        CommandOutput(0, b""),
+        CommandOutput(1, b""),
+    ]
+    result = _RUNNER.invoke(
+        cli.app,
+        ["integrate", "codex", "mcp", "remove", "--accept", "--json"],
+    )
+    assert result.exit_code == 0, (result.output, result.exception)
+    body = json.loads(result.stdout)
+    assert body["action"] == "unregister"
+    assert body["state_after"] == "absent"
+
+
+def test_integrate_mcp_remove_absent_entry_is_noop(wizard_env: dict[str, object]) -> None:
+    wizard_env["outputs"] = [CommandOutput(1, b"")]
+    result = _RUNNER.invoke(
+        cli.app,
+        ["integrate", "codex", "mcp", "remove", "--accept", "--json"],
+    )
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert json.loads(result.stdout)["action"] == "noop"
+
+
+def test_integrate_mcp_remove_refuses_foreign_entry(wizard_env: dict[str, object]) -> None:
+    wizard_env["outputs"] = [CommandOutput(0, json.dumps({"command": "other"}).encode())]
+    result = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "remove", "--accept", "--json"])
+    assert result.exit_code == 2
+    assert "foreign_entry_present" in result.stderr
+
+
 def test_non_interactive_accept_preserves_existing_policy_route(
     wizard_env: dict[str, object],
 ) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tomllib
 from collections.abc import Mapping
 from pathlib import Path
@@ -1403,6 +1404,61 @@ def test_exact_empty_config_cleanup_preserves_a_replacement(
     assert config.read_bytes() == foreign
 
 
+def test_removal_preserves_unrelated_owner_blank_lines(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    owner = b'owner = "keep"\n\n\n\n[owner_table]\nvalue = true\n'
+    config = home / "config.toml"
+    config.write_bytes(owner)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+
+    removal = preview_removal(target, codex_home=home)
+    apply_removal(target, codex_home=home, approved_digest=removal.preview_digest)
+
+    assert config.read_bytes() == owner
+    assert tomllib.loads(config.read_text(encoding="utf-8")) == {
+        "owner": "keep",
+        "owner_table": {"value": True},
+    }
+
+
+def test_plugin_command_output_is_bounded_during_capture(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    executable = home / "flooding-codex"
+    pid_path = home / "flooding-codex.pid"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "import os\n"
+        "import pathlib\n"
+        "import sys\n"
+        f"pid_path = pathlib.Path({str(pid_path)!r})\n"
+        "if sys.argv[1:] == ['--version']:\n"
+        "    print('codex-cli 0.148.0-alpha.6')\n"
+        "else:\n"
+        "    pid_path.write_text(str(os.getpid()), encoding='ascii')\n"
+        "    chunk = b'x' * 65536\n"
+        "    while True:\n"
+        "        os.write(2, chunk)\n"
+        "        os.write(1, chunk)\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+
+    with pytest.raises(IntegrationError) as caught:
+        _inspect_activation(
+            target,
+            executable_path=str(executable),
+            codex_home=home,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    pid = int(pid_path.read_text(encoding="ascii"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
 def test_cache_only_removal_preserves_write_failed_for_final_verification(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1500,6 +1556,23 @@ def test_removal_preview_bounds_cache_members(tmp_path: Path, overflow: str) -> 
 
     assert caught.value.reason is IntegrationReason.PREVIEW_STALE
     assert cache.is_dir()
+
+
+def test_removal_preview_rejects_unrepresented_empty_cache_directory(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    empty = cache / "owner-empty"
+    empty.mkdir()
+
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home, purge_cache=True)
+
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details == {"conflict": "cache"}
+    assert empty.is_dir()
 
 
 def test_removal_refuses_foreign_marketplace_and_names_conflict(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -16,16 +16,25 @@ from yoetz.adapters.integrations.codex_marketplace import (
     ActivationInspection,
     ActivationPreview,
     ActivationState,
+    RemovalOutcome,
+    RemovalPreview,
+    RemovalResult,
     resolve_codex_home_for_binary,
 )
 from yoetz.adapters.integrations.codex_marketplace import (
     apply_activation as _apply_activation,
 )
 from yoetz.adapters.integrations.codex_marketplace import (
+    apply_removal as _apply_removal,
+)
+from yoetz.adapters.integrations.codex_marketplace import (
     inspect_activation as _inspect_activation,
 )
 from yoetz.adapters.integrations.codex_marketplace import (
     preview_activation as _preview_activation,
+)
+from yoetz.adapters.integrations.codex_marketplace import (
+    preview_removal as _preview_removal,
 )
 from yoetz.adapters.integrations.codex_plugin import install_plugin
 from yoetz.ports.integrations import (
@@ -123,6 +132,24 @@ class _FakeCodex:
                 "version": "0.1.0",
                 "installedPath": str(destination),
             }
+        elif args == ("plugin", "remove", "yoetz@yoetz", "--json"):
+            destination = self.home / "plugins/cache/yoetz/yoetz/0.1.0"
+            if destination.is_dir():
+                shutil.rmtree(destination)
+            body = {"pluginId": "yoetz@yoetz"}
+        elif args == ("plugin", "marketplace", "remove", "yoetz", "--json"):
+            config = self.home / "config.toml"
+            if config.exists():
+                text = config.read_text(encoding="utf-8")
+                marker = "[marketplaces.yoetz]\n"
+                start = text.find(marker)
+                if start >= 0:
+                    rest = text[start + len(marker) :]
+                    next_table = rest.find("\n[")
+                    end = start + len(marker) + (len(rest) if next_table < 0 else next_table + 1)
+                    text = text[:start] + text[end:]
+                    config.write_text(text, encoding="utf-8")
+            body = {"name": "yoetz"}
         else:
             raise AssertionError(command)
         return subprocess.CompletedProcess(
@@ -180,6 +207,42 @@ def apply_activation(
         executable_path=str(runner.executable),
         approved_digest=approved_digest,
         codex_home=home,
+        _run=runner,
+    )
+
+
+def preview_removal(
+    target: IntegrationTarget,
+    *,
+    codex_home: Path | str | None = None,
+    purge_cache: bool = False,
+) -> RemovalPreview:
+    home = _selected_home(codex_home)
+    runner = _FakeCodex(target, home)
+    return _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        purge_cache=purge_cache,
+        _run=runner,
+    )
+
+
+def apply_removal(
+    target: IntegrationTarget,
+    *,
+    approved_digest: str,
+    codex_home: Path | str | None = None,
+    purge_cache: bool = False,
+) -> RemovalResult:
+    home = _selected_home(codex_home)
+    runner = _FakeCodex(target, home)
+    return _apply_removal(
+        target,
+        executable_path=str(runner.executable),
+        approved_digest=approved_digest,
+        codex_home=home,
+        purge_cache=purge_cache,
         _run=runner,
     )
 
@@ -957,3 +1020,93 @@ def test_unreadable_cache_member_normalizes_to_integration_error(tmp_path: Path)
     finally:
         member.chmod(0o600)
     assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+
+
+def test_preview_and_apply_removal_of_managed_activation(tmp_path: Path) -> None:
+    target, project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    assert inspect_activation(target, codex_home=home).state is ActivationState.ACTIVE
+
+    preview = preview_removal(target, codex_home=home)
+    assert preview.outcome is RemovalOutcome.REMOVE
+    assert preview.plugin_remove_planned is True
+    assert preview.marketplace_remove_planned is True
+    assert preview.marketplace_json_planned is True
+    assert preview.skill_tree_state == "absent"
+    result = apply_removal(target, codex_home=home, approved_digest=preview.preview_digest)
+    assert result.outcome is RemovalOutcome.REMOVE
+    assert result.inspection.state is ActivationState.INSTALLED_NOT_ACTIVATED
+    assert not (project / ".agents/plugins/marketplace.json").exists()
+    config = home / "config.toml"
+    parsed = tomllib.loads(config.read_text(encoding="utf-8") if config.exists() else "")
+    assert "yoetz" not in parsed.get("marketplaces", {})
+    assert "yoetz@yoetz" not in parsed.get("plugins", {})
+    assert not (home / "plugins/cache/yoetz/yoetz").exists()
+    assert (
+        inspect_activation(target, codex_home=home).state
+        is ActivationState.INSTALLED_NOT_ACTIVATED
+    )
+    second = preview_removal(target, codex_home=home)
+    assert second.outcome is RemovalOutcome.ALREADY_ABSENT
+    replay = apply_removal(target, codex_home=home, approved_digest=second.preview_digest)
+    assert replay.outcome is RemovalOutcome.ALREADY_ABSENT
+
+
+def test_removal_refuses_foreign_marketplace_and_names_conflict(tmp_path: Path) -> None:
+    target, project, home = _target(tmp_path)
+    _install(target)
+    marketplace = project / ".agents/plugins/marketplace.json"
+    marketplace.parent.mkdir(parents=True, exist_ok=True)
+    marketplace.write_text(
+        '{"name":"other","plugins":[{"name":"yoetz","source":{"source":"local","path":"./"}}]}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home)
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details["conflict"] == "repository_marketplace"
+    assert marketplace.is_file()
+
+
+def test_removal_refuses_modified_plugin_table(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    config = home / "config.toml"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace("enabled = true", "enabled = false"),
+        encoding="utf-8",
+    )
+    before = config.read_bytes()
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home)
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details["conflict"] == "config_plugin"
+    assert config.read_bytes() == before
+
+
+def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    extra = home / "plugins/cache/yoetz/yoetz/0.0.1"
+    shutil.copytree(home / "plugins/cache/yoetz/yoetz/0.1.0", extra)
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home)
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details["conflict"] == "cache"
+    preview = preview_removal(target, codex_home=home, purge_cache=True)
+    assert "0.0.1" in preview.cache_versions
+    result = apply_removal(
+        target,
+        codex_home=home,
+        approved_digest=preview.preview_digest,
+        purge_cache=True,
+    )
+    assert result.outcome is RemovalOutcome.REMOVE
+    assert not extra.exists()
+    assert not (home / "plugins/cache/yoetz/yoetz").exists()

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -74,6 +74,7 @@ class _FakeCodex:
         self.calls: list[tuple[str, ...]] = []
         self.environments: list[dict[str, str]] = []
         self.fail_add_after_copy = False
+        self.conflict_after_marketplace_remove = False
         self.codex_version = codex_version
 
     def __call__(
@@ -149,6 +150,11 @@ class _FakeCodex:
                     end = start + len(marker) + (len(rest) if next_table < 0 else next_table + 1)
                     text = text[:start] + text[end:]
                     config.write_text(text, encoding="utf-8")
+            if self.conflict_after_marketplace_remove and config.exists():
+                text = config.read_text(encoding="utf-8").replace(
+                    "enabled = true\n", "enabled = true\nowner_note = true\n"
+                )
+                config.write_text(text, encoding="utf-8")
             body = {"name": "yoetz"}
         else:
             raise AssertionError(command)
@@ -1052,6 +1058,68 @@ def test_preview_and_apply_removal_of_managed_activation(tmp_path: Path) -> None
     assert second.outcome is RemovalOutcome.ALREADY_ABSENT
     replay = apply_removal(target, codex_home=home, approved_digest=second.preview_digest)
     assert replay.outcome is RemovalOutcome.ALREADY_ABSENT
+
+
+def test_removal_preview_digest_binds_the_exact_project_root(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _canonical_marketplace_bytes,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    targets: list[IntegrationTarget] = []
+    marketplace_paths: list[Path] = []
+    for name in ("project-a", "project-b"):
+        project = tmp_path / name
+        project.mkdir(mode=0o700)
+        target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(project))
+        marketplace = project / ".agents/plugins/marketplace.json"
+        marketplace.parent.mkdir(parents=True, mode=0o700)
+        marketplace.write_bytes(_canonical_marketplace_bytes())
+        targets.append(target)
+        marketplace_paths.append(marketplace)
+
+    preview_a = preview_removal(targets[0], codex_home=home)
+    preview_b = preview_removal(targets[1], codex_home=home)
+    assert preview_a.preview_digest != preview_b.preview_digest
+
+    with pytest.raises(IntegrationError) as caught:
+        apply_removal(
+            targets[1],
+            codex_home=home,
+            approved_digest=preview_a.preview_digest,
+        )
+
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert marketplace_paths[1].is_file()
+
+
+def test_post_host_mutation_config_conflict_is_write_failed(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    runner.conflict_after_marketplace_remove = True
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert caught.value.safe_details["conflict"] == "config_plugin"
+    assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
 
 
 def test_removal_refuses_foreign_marketplace_and_names_conflict(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -77,6 +77,7 @@ class _FakeCodex:
         self.fail_add_after_copy = False
         self.conflict_after_marketplace_remove = False
         self.repository_marketplace_conflict_after_remove = False
+        self.malformed_after_mutation: set[tuple[str, ...]] = set()
         self.codex_version = codex_version
 
     def __call__(
@@ -163,6 +164,8 @@ class _FakeCodex:
             body = {"name": "yoetz"}
         else:
             raise AssertionError(command)
+        if args in self.malformed_after_mutation:
+            return subprocess.CompletedProcess(command, 0, stdout=b'{"truncated":', stderr=b"")
         return subprocess.CompletedProcess(
             command,
             1
@@ -1155,6 +1158,249 @@ def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path)
     assert caught.value.safe_details["conflict"] == "repository_marketplace"
     assert marketplace.read_bytes() == b'{"name":"foreign"}\n'
     assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+
+
+@pytest.mark.parametrize("host_surface", ["plugin", "marketplace"])
+def test_mutating_host_malformed_json_is_write_failed(
+    tmp_path: Path,
+    host_surface: str,
+) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    if host_surface == "marketplace":
+        shutil.rmtree(cache)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    command = (
+        ("plugin", "remove", "yoetz@yoetz", "--json")
+        if host_surface == "plugin"
+        else ("plugin", "marketplace", "remove", "yoetz", "--json")
+    )
+    runner.malformed_after_mutation.add(command)
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    if host_surface == "plugin":
+        assert not cache.exists()
+    else:
+        config = home / "config.toml"
+        assert "marketplaces.yoetz" not in config.read_text(encoding="utf-8")
+
+
+def test_repository_marketplace_replacement_during_quarantine_is_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    target, project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    marketplace = project / ".agents/plugins/marketplace.json"
+    foreign = b'{"name":"foreign-race"}\n'
+    original_rename = os.rename
+    raced = False
+
+    def replace_before_quarantine(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        nonlocal raced
+        if source == "marketplace.json" and not raced:
+            raced = True
+            replacement = marketplace.with_name("marketplace.foreign")
+            replacement.write_bytes(foreign)
+            os.replace(replacement, marketplace)
+        original_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    # Replacing ``os.rename`` changes function identity and would make the production primitive
+    # capability probe fail before reaching the simulated supported-host race.
+    monkeypatch.setattr(module, "_require_safe_cache_removal_primitives", lambda: None)
+    monkeypatch.setattr(module, "_require_safe_file_removal_primitives", lambda: None)
+    monkeypatch.setattr(os, "rename", replace_before_quarantine)
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert raced is True
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert caught.value.safe_details["conflict"] == "repository_marketplace"
+    assert marketplace.read_bytes() == foreign
+
+
+def test_repository_marketplace_restore_never_clobbers_new_foreign_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    target, project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    marketplace = project / ".agents/plugins/marketplace.json"
+    moved_foreign = b'{"name":"moved-foreign"}\n'
+    new_foreign = b'{"name":"new-foreign"}\n'
+    original_rename = os.rename
+    original_link = os.link
+    renamed = False
+    linked = False
+
+    def replace_before_quarantine(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        nonlocal renamed
+        if source == "marketplace.json" and not renamed:
+            renamed = True
+            replacement = marketplace.with_name("marketplace.moved")
+            replacement.write_bytes(moved_foreign)
+            os.replace(replacement, marketplace)
+        original_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    def create_before_restore_link(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal linked
+        if destination == "marketplace.json" and not linked:
+            linked = True
+            marketplace.write_bytes(new_foreign)
+        original_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(module, "_require_safe_cache_removal_primitives", lambda: None)
+    monkeypatch.setattr(module, "_require_safe_file_removal_primitives", lambda: None)
+    monkeypatch.setattr(os, "rename", replace_before_quarantine)
+    monkeypatch.setattr(os, "link", create_before_restore_link)
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert renamed is True
+    assert linked is True
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert marketplace.read_bytes() == new_foreign
+    quarantines = tuple(marketplace.parent.glob(".yoetz-file-remove-*"))
+    assert len(quarantines) == 1
+    assert quarantines[0].read_bytes() == moved_foreign
+
+
+def test_exact_empty_config_cleanup_preserves_a_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    parent = tmp_path / "codex"
+    parent.mkdir(mode=0o700)
+    config = parent / "config.toml"
+    config.write_bytes(b"")
+    foreign = b'owner = "foreign"\n'
+    original_rename = os.rename
+    raced = False
+
+    def replace_before_quarantine(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        nonlocal raced
+        if source == "config.toml" and not raced:
+            raced = True
+            replacement = parent / "config.foreign"
+            replacement.write_bytes(foreign)
+            os.replace(replacement, config)
+        original_rename(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    monkeypatch.setattr(module, "_require_safe_file_removal_primitives", lambda: None)
+    monkeypatch.setattr(os, "rename", replace_before_quarantine)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._remove_exact_managed_file(  # pyright: ignore[reportPrivateUsage]
+            config,
+            b"",
+            mismatch_reason=IntegrationReason.PREVIEW_STALE,
+        )
+
+    assert raced is True
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert config.read_bytes() == foreign
 
 
 def test_cache_only_removal_preserves_write_failed_for_final_verification(

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -667,6 +667,34 @@ def test_activation_refuses_symlinked_cache_ancestor_before_host_mutation(tmp_pa
     assert list(outside.iterdir()) == []
 
 
+def test_cache_replacement_refuses_ancestor_swap_after_validation(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    home = tmp_path / "codex-home"
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache.mkdir(parents=True)
+    module._validate_descendant_ancestors(  # pyright: ignore[reportPrivateUsage]
+        home,
+        Path("plugins/cache/yoetz/yoetz"),
+    )
+    outside = tmp_path / "outside-cache"
+    (home / "plugins").rename(outside)
+    (home / "plugins").symlink_to(outside, target_is_directory=True)
+    sentinel = outside / "cache/yoetz/yoetz/0.1.0/sentinel.txt"
+    sentinel.write_bytes(b"outside")
+
+    with pytest.raises(IntegrationError) as caught:
+        module._replace_cache_tree(  # pyright: ignore[reportPrivateUsage]
+            home / "plugins/cache/yoetz/yoetz/0.1.0",
+            render_plugin_install_tree(codex_version="0.148.0-alpha.6"),
+            anchor_root=home,
+        )
+
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert sentinel.read_bytes() == b"outside"
+
+
 def test_stale_digest_refuses_without_writing(tmp_path: Path) -> None:
     target, project, home = _target(tmp_path)
     _install(target)
@@ -2091,6 +2119,25 @@ def test_cache_removal_refuses_symlinked_ancestor_beneath_selected_home(tmp_path
 
     assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
     assert (version / "hooks/hooks.json").exists()
+
+
+def test_cache_removal_accepts_host_removed_root_only_after_prior_mutation(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    root = home / "plugins/cache/yoetz/yoetz"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    assert _delete_managed_cache_versions(
+        root,
+        (("0.1.0", "sha256:" + "a" * 64),),
+        expected,
+        anchor_root=home,
+        missing_ok_after_prior_mutation=True,
+    )
 
 
 def test_file_removal_refuses_symlinked_ancestor_beneath_selected_project(

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -653,6 +653,20 @@ def test_symlinked_managed_ancestor_and_leaf_are_refused(tmp_path: Path) -> None
     assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
 
 
+def test_activation_refuses_symlinked_cache_ancestor_before_host_mutation(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    (home / "plugins").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationError) as caught:
+        preview_activation(target, codex_home=home)
+
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert list(outside.iterdir()) == []
+
+
 def test_stale_digest_refuses_without_writing(tmp_path: Path) -> None:
     target, project, home = _target(tmp_path)
     _install(target)
@@ -2044,6 +2058,109 @@ def test_cache_removal_refuses_replaced_symlink_root(tmp_path: Path) -> None:
         _delete_managed_cache_versions(root, (("0.1.0", digest),), expected)
     assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
     assert (outside / "0.1.0/hooks/hooks.json").exists()
+
+
+def test_cache_removal_refuses_symlinked_ancestor_beneath_selected_home(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+        _installed_cache_digest,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    root = outside / "cache/yoetz/yoetz"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = _installed_cache_digest(version, expected)
+    assert digest is not None
+    (home / "plugins").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationError) as caught:
+        _delete_managed_cache_versions(
+            home / "plugins/cache/yoetz/yoetz",
+            (("0.1.0", digest),),
+            expected,
+            anchor_root=home,
+        )
+
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert (version / "hooks/hooks.json").exists()
+
+
+def test_file_removal_refuses_symlinked_ancestor_beneath_selected_project(
+    tmp_path: Path,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    project = tmp_path / "project"
+    project.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    plugins = outside / "plugins"
+    plugins.mkdir(parents=True)
+    marketplace = plugins / "marketplace.json"
+    expected = b'{"name":"yoetz"}\n'
+    marketplace.write_bytes(expected)
+    (project / ".agents").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._remove_exact_managed_file(  # pyright: ignore[reportPrivateUsage]
+            project / ".agents/plugins/marketplace.json",
+            expected,
+            mismatch_reason=IntegrationReason.PREVIEW_STALE,
+            anchor_root=project,
+        )
+
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert marketplace.read_bytes() == expected
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [IntegrationReason.DESTINATION_CONFLICT, IntegrationReason.TARGET_UNSAFE],
+)
+def test_cache_removal_normalizes_every_post_quarantine_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reason: IntegrationReason,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+    assert digest is not None
+
+    def fail_after_quarantine(
+        _root_fd: int,
+        _name: str,
+        _descriptor: int,
+        _approved_members: Mapping[str, bytes],
+    ) -> None:
+        raise IntegrationError(reason, {})
+
+    monkeypatch.setattr(module, "_remove_validated_directory", fail_after_quarantine)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root,
+            (("0.1.0", digest),),
+            expected,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert any(candidate.name.startswith(".yoetz-cache-remove-") for candidate in root.iterdir())
 
 
 def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -1157,6 +1157,59 @@ def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path)
     assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
 
 
+def test_cache_only_removal_preserves_write_failed_for_final_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    target, project, home = _target(tmp_path)
+    _install(target)
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = cache / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    assert preview.cache_versions == ("0.1.0",)
+    assert preview.plugin_remove_planned is False
+    assert preview.marketplace_remove_planned is False
+    original_inventory = module._plugin_inventory  # pyright: ignore[reportPrivateUsage]
+
+    def fail_inventory_after_cache_delete(
+        binary: object,
+        selected_project: Path,
+        *,
+        _run: object,
+    ) -> tuple[bool, str | None]:
+        if not cache.exists():
+            raise IntegrationError(IntegrationReason.SOURCE_INVALID, {})
+        return original_inventory(binary, selected_project, _run=_run)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(module, "_plugin_inventory", fail_inventory_after_cache_delete)
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert not cache.exists()
+    assert project.is_dir()
+
+
 @pytest.mark.parametrize(
     "overflow",
     ["member_bytes", "file_count", "entry_count", "depth", "version_count"],

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -79,6 +79,7 @@ class _FakeCodex:
         self.conflict_after_marketplace_remove = False
         self.repository_marketplace_conflict_after_remove = False
         self.malformed_after_mutation: set[tuple[str, ...]] = set()
+        self.error_after_mutation: Exception | None = None
         self.codex_version = codex_version
 
     def __call__(
@@ -165,6 +166,11 @@ class _FakeCodex:
             body = {"name": "yoetz"}
         else:
             raise AssertionError(command)
+        if self.error_after_mutation is not None and args in {
+            ("plugin", "remove", "yoetz@yoetz", "--json"),
+            ("plugin", "marketplace", "remove", "yoetz", "--json"),
+        }:
+            raise self.error_after_mutation
         if args in self.malformed_after_mutation:
             return subprocess.CompletedProcess(command, 0, stdout=b'{"truncated":', stderr=b"")
         return subprocess.CompletedProcess(
@@ -695,6 +701,41 @@ def test_cache_replacement_refuses_ancestor_swap_after_validation(tmp_path: Path
     assert sentinel.read_bytes() == b"outside"
 
 
+def test_removal_preview_refuses_cache_ancestor_swap_after_validation(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    home = tmp_path / "codex-home"
+    cache_root = home / "plugins/cache/yoetz/yoetz"
+    cache = cache_root / "0.1.0"
+    cache.mkdir(parents=True)
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        member = cache / relative
+        member.parent.mkdir(parents=True, exist_ok=True)
+        member.write_bytes(payload)
+    module._validate_descendant_ancestors(  # pyright: ignore[reportPrivateUsage]
+        home,
+        Path("plugins/cache/yoetz/yoetz"),
+    )
+    outside = tmp_path / "outside-cache"
+    (home / "plugins").rename(outside)
+    (home / "plugins").symlink_to(outside, target_is_directory=True)
+    sentinel = outside / "cache/yoetz/yoetz/0.1.0/sentinel.txt"
+    sentinel.write_bytes(b"outside")
+
+    with pytest.raises(IntegrationError) as caught:
+        module._managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            cache_root,
+            expected,
+            include_all_managed=False,
+            anchor_root=home,
+        )
+
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert sentinel.read_bytes() == b"outside"
+
+
 def test_stale_digest_refuses_without_writing(tmp_path: Path) -> None:
     target, project, home = _target(tmp_path)
     _install(target)
@@ -1201,6 +1242,79 @@ def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path)
     assert caught.value.safe_details["conflict"] == "repository_marketplace"
     assert marketplace.read_bytes() == b'{"name":"foreign"}\n'
     assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+
+
+def test_post_host_mutation_config_read_error_is_write_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    config = home / "config.toml"
+    real_current_bytes = module._current_bytes  # pyright: ignore[reportPrivateUsage]
+
+    def fail_after_remove(path: Path) -> bytes | None:
+        if path == config and not cache.exists():
+            raise module._error(  # pyright: ignore[reportPrivateUsage]
+                IntegrationReason.TARGET_UNSAFE
+            )
+        return real_current_bytes(path)
+
+    monkeypatch.setattr(module, "_current_bytes", fail_after_remove)
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert not cache.exists()
+
+
+def test_mutating_host_runner_error_is_write_failed(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    runner.error_after_mutation = module._error(  # pyright: ignore[reportPrivateUsage]
+        IntegrationReason.TARGET_UNSAFE
+    )
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert not cache.exists()
 
 
 @pytest.mark.parametrize("host_surface", ["plugin", "marketplace"])

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import tomllib
+from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
 
@@ -75,6 +76,7 @@ class _FakeCodex:
         self.environments: list[dict[str, str]] = []
         self.fail_add_after_copy = False
         self.conflict_after_marketplace_remove = False
+        self.repository_marketplace_conflict_after_remove = False
         self.codex_version = codex_version
 
     def __call__(
@@ -155,6 +157,9 @@ class _FakeCodex:
                     "enabled = true\n", "enabled = true\nowner_note = true\n"
                 )
                 config.write_text(text, encoding="utf-8")
+            if self.repository_marketplace_conflict_after_remove:
+                marketplace = self.project / ".agents/plugins/marketplace.json"
+                marketplace.write_bytes(b'{"name":"foreign"}\n')
             body = {"name": "yoetz"}
         else:
             raise AssertionError(command)
@@ -1122,6 +1127,82 @@ def test_post_host_mutation_config_conflict_is_write_failed(tmp_path: Path) -> N
     assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
 
 
+def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path) -> None:
+    target, project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    runner = _FakeCodex(target, home)
+    preview = _preview_removal(
+        target,
+        executable_path=str(runner.executable),
+        codex_home=home,
+        _run=runner,
+    )
+    runner.repository_marketplace_conflict_after_remove = True
+
+    with pytest.raises(IntegrationError) as caught:
+        _apply_removal(
+            target,
+            executable_path=str(runner.executable),
+            approved_digest=preview.preview_digest,
+            codex_home=home,
+            _run=runner,
+        )
+
+    marketplace = project / ".agents/plugins/marketplace.json"
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert caught.value.safe_details["conflict"] == "repository_marketplace"
+    assert marketplace.read_bytes() == b'{"name":"foreign"}\n'
+    assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+
+
+@pytest.mark.parametrize(
+    "overflow",
+    ["member_bytes", "file_count", "entry_count", "depth", "version_count"],
+)
+def test_removal_preview_bounds_cache_members(tmp_path: Path, overflow: str) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _MAX_MANAGED_CACHE_DEPTH,  # pyright: ignore[reportPrivateUsage]
+        _MAX_MANAGED_CACHE_ENTRIES,  # pyright: ignore[reportPrivateUsage]
+        _MAX_MANAGED_CACHE_FILES,  # pyright: ignore[reportPrivateUsage]
+        _MAX_MANAGED_CACHE_MEMBER_BYTES,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    if overflow == "member_bytes":
+        os.truncate(cache / "hooks/hooks.json", _MAX_MANAGED_CACHE_MEMBER_BYTES + 1)
+    elif overflow == "file_count":
+        overflow_dir = cache / "overflow"
+        overflow_dir.mkdir()
+        for index in range(_MAX_MANAGED_CACHE_FILES + 1):
+            (overflow_dir / f"{index:02d}.txt").write_bytes(b"x")
+    elif overflow == "entry_count":
+        overflow_dir = cache / "overflow"
+        overflow_dir.mkdir()
+        for index in range(_MAX_MANAGED_CACHE_ENTRIES + 1):
+            (overflow_dir / f"{index:03d}").mkdir()
+    elif overflow == "depth":
+        current = cache / "overflow"
+        for index in range(_MAX_MANAGED_CACHE_DEPTH + 1):
+            current /= f"d{index:02d}"
+            current.mkdir(parents=True)
+    else:
+        cache_root = cache.parent
+        for index in range(_MAX_MANAGED_CACHE_ENTRIES + 1):
+            (cache_root / f"1.0.{index}").mkdir()
+
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home, purge_cache=True)
+
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert cache.is_dir()
+
+
 def test_removal_refuses_foreign_marketplace_and_names_conflict(tmp_path: Path) -> None:
     target, project, home = _target(tmp_path)
     _install(target)
@@ -1298,7 +1379,12 @@ def test_cache_removal_does_not_reopen_replaced_quarantine_path(
     assert digest is not None
     original_remove = module._remove_validated_directory  # pyright: ignore[reportPrivateUsage]
 
-    def replace_before_remove(root_fd: int, name: str, descriptor: int) -> None:
+    def replace_before_remove(
+        root_fd: int,
+        name: str,
+        descriptor: int,
+        approved_members: Mapping[str, bytes],
+    ) -> None:
         moved = f"{name}-moved"
         os.rename(name, moved, src_dir_fd=root_fd, dst_dir_fd=root_fd)
         os.mkdir(name, mode=0o700, dir_fd=root_fd)
@@ -1316,7 +1402,7 @@ def test_cache_removal_does_not_reopen_replaced_quarantine_path(
                 os.close(sentinel_fd)
         finally:
             os.close(replacement_fd)
-        original_remove(root_fd, name, descriptor)
+        original_remove(root_fd, name, descriptor, approved_members)
 
     monkeypatch.setattr(module, "_remove_validated_directory", replace_before_remove)
 
@@ -1325,7 +1411,7 @@ def test_cache_removal_does_not_reopen_replaced_quarantine_path(
             root, (("0.1.0", digest),), expected
         )
 
-    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
     replacements = [
         candidate
         for candidate in root.iterdir()
@@ -1334,6 +1420,232 @@ def test_cache_removal_does_not_reopen_replaced_quarantine_path(
     ]
     assert len(replacements) == 1
     assert (replacements[0] / "sentinel.txt").read_bytes() == b"foreign"
+
+
+@pytest.mark.parametrize("mutation", ["modify", "add"])
+def test_cache_removal_revalidates_exact_quarantine_contents_before_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+    assert digest is not None
+    original_remove = module._remove_validated_directory  # pyright: ignore[reportPrivateUsage]
+
+    def mutate_before_remove(
+        root_fd: int,
+        name: str,
+        descriptor: int,
+        approved_members: Mapping[str, bytes],
+    ) -> None:
+        if mutation == "modify":
+            member_fd = os.open(
+                "hooks/hooks.json",
+                os.O_WRONLY | os.O_TRUNC,
+                dir_fd=descriptor,
+            )
+            try:
+                os.write(member_fd, b"changed")
+            finally:
+                os.close(member_fd)
+        else:
+            member_fd = os.open(
+                "added.txt",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=descriptor,
+            )
+            try:
+                os.write(member_fd, b"foreign")
+            finally:
+                os.close(member_fd)
+        original_remove(root_fd, name, descriptor, approved_members)
+
+    monkeypatch.setattr(module, "_remove_validated_directory", mutate_before_remove)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root,
+            (("0.1.0", digest),),
+            expected,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert version.is_dir()
+    if mutation == "modify":
+        assert (version / "hooks/hooks.json").read_bytes() == b"changed"
+    else:
+        assert (version / "added.txt").read_bytes() == b"foreign"
+
+
+def test_cache_removal_restores_quarantine_on_race_before_first_unlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+    assert digest is not None
+    original_remove_contents = module._remove_managed_tree_contents_fd  # pyright: ignore[reportPrivateUsage]
+    mutated = False
+
+    def mutate_after_full_validation(
+        directory_fd: int,
+        approved_members: Mapping[str, bytes],
+        *,
+        prefix: str = "",
+        mutation_state: list[bool],
+    ) -> None:
+        nonlocal mutated
+        if not mutated:
+            mutated = True
+            member_fd = os.open(
+                ".codex-plugin/plugin.json",
+                os.O_WRONLY | os.O_TRUNC,
+                dir_fd=directory_fd,
+            )
+            try:
+                os.write(member_fd, b"changed-after-validation")
+            finally:
+                os.close(member_fd)
+        original_remove_contents(
+            directory_fd,
+            approved_members,
+            prefix=prefix,
+            mutation_state=mutation_state,
+        )
+
+    monkeypatch.setattr(module, "_remove_managed_tree_contents_fd", mutate_after_full_validation)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root,
+            (("0.1.0", digest),),
+            expected,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert (version / ".codex-plugin/plugin.json").read_bytes() == b"changed-after-validation"
+    assert not any(path.name.startswith(".yoetz-cache-remove-") for path in root.iterdir())
+
+
+def test_cache_removal_keeps_write_failed_across_multiple_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    digests: list[tuple[str, str]] = []
+    for version_name in ("0.1.0", "0.2.0"):
+        version = root / version_name
+        for relative, payload in expected.items():
+            destination = version / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(payload)
+        digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+        assert digest is not None
+        digests.append((version_name, digest))
+    original_open = module._open_managed_cache_digest_at  # pyright: ignore[reportPrivateUsage]
+
+    def drift_second_version(
+        root_fd: int,
+        name: str,
+        expected_members: Mapping[str, bytes],
+    ) -> tuple[int, str, Mapping[str, bytes]] | None:
+        if name == "0.2.0":
+            second_fd = os.open(name, module._directory_open_flags(), dir_fd=root_fd)  # pyright: ignore[reportPrivateUsage]
+            try:
+                member_fd = os.open(
+                    "hooks/hooks.json",
+                    os.O_WRONLY | os.O_TRUNC,
+                    dir_fd=second_fd,
+                )
+                try:
+                    os.write(member_fd, b"changed-after-first-version")
+                finally:
+                    os.close(member_fd)
+            finally:
+                os.close(second_fd)
+        return original_open(root_fd, name, expected_members)
+
+    monkeypatch.setattr(module, "_open_managed_cache_digest_at", drift_second_version)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root,
+            tuple(digests),
+            expected,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert not (root / "0.1.0").exists()
+    assert (root / "0.2.0/hooks/hooks.json").read_bytes() == b"changed-after-first-version"
+
+
+def test_cache_removal_normalizes_missing_quarantine_after_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+    assert digest is not None
+    real_rename = module.os.rename
+    moved_name: str | None = None
+
+    def disappear_quarantine_after_rename(
+        source: str,
+        destination: str,
+        **kwargs: object,
+    ) -> None:
+        nonlocal moved_name
+        real_rename(source, destination, **kwargs)  # type: ignore[arg-type]
+        if moved_name is None and destination.startswith(".yoetz-cache-remove-"):
+            moved_name = f"{destination}-moved"
+            real_rename(destination, moved_name, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(module, "_require_safe_cache_removal_primitives", lambda: None)
+    monkeypatch.setattr(module.os, "rename", disappear_quarantine_after_rename)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root,
+            (("0.1.0", digest),),
+            expected,
+        )
+
+    assert caught.value.reason is IntegrationReason.WRITE_FAILED
+    assert moved_name is not None
+    assert (root / moved_name / "hooks/hooks.json").exists()
 
 
 def test_cache_removal_refuses_replaced_symlink_root(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -1043,10 +1043,10 @@ def test_preview_and_apply_removal_of_managed_activation(tmp_path: Path) -> None
     parsed = tomllib.loads(config.read_text(encoding="utf-8") if config.exists() else "")
     assert "yoetz" not in parsed.get("marketplaces", {})
     assert "yoetz@yoetz" not in parsed.get("plugins", {})
-    assert not (home / "plugins/cache/yoetz/yoetz").exists()
+    cache_root = home / "plugins/cache/yoetz/yoetz"
+    assert not cache_root.exists() or not any(cache_root.iterdir())
     assert (
-        inspect_activation(target, codex_home=home).state
-        is ActivationState.INSTALLED_NOT_ACTIVATED
+        inspect_activation(target, codex_home=home).state is ActivationState.INSTALLED_NOT_ACTIVATED
     )
     second = preview_removal(target, codex_home=home)
     assert second.outcome is RemovalOutcome.ALREADY_ABSENT
@@ -1088,6 +1088,98 @@ def test_removal_refuses_modified_plugin_table(tmp_path: Path) -> None:
     assert config.read_bytes() == before
 
 
+def test_removal_refuses_plugin_table_with_additional_field(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    config = home / "config.toml"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace(
+            "enabled = true\n", "enabled = true\nowner_note = true\n"
+        ),
+        encoding="utf-8",
+    )
+    before = config.read_bytes()
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home)
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details["conflict"] == "config_plugin"
+    assert config.read_bytes() == before
+
+
+def test_removal_refuses_marketplace_table_with_additional_field(tmp_path: Path) -> None:
+    target, project, home = _target(tmp_path)
+    _install(target)
+    activation = preview_activation(target, codex_home=home)
+    apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
+    config = home / "config.toml"
+    expected = f'source = "{project}"\n'
+    config.write_text(
+        config.read_text(encoding="utf-8").replace(expected, f"{expected}owner_note = true\n"),
+        encoding="utf-8",
+    )
+    before = config.read_bytes()
+    with pytest.raises(IntegrationError) as caught:
+        preview_removal(target, codex_home=home)
+    assert caught.value.reason is IntegrationReason.REMOVE_REFUSED
+    assert caught.value.safe_details["conflict"] == "config_marketplace"
+    assert config.read_bytes() == before
+
+
+def test_cache_removal_revalidates_digest_immediately_before_delete(
+    tmp_path: Path,
+) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+        _installed_cache_digest,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = _installed_cache_digest(version, expected)
+    assert digest is not None
+    hooks = version / "hooks/hooks.json"
+    hooks.write_bytes(hooks.read_bytes() + b"\n")
+
+    with pytest.raises(IntegrationError) as caught:
+        _delete_managed_cache_versions(root, (("0.1.0", digest),), expected)
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert hooks.exists()
+
+
+def test_cache_removal_refuses_replaced_symlink_root(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+        _installed_cache_digest,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = _installed_cache_digest(version, expected)
+    assert digest is not None
+    outside = tmp_path / "outside"
+    root.rename(outside)
+    root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationError) as caught:
+        _delete_managed_cache_versions(root, (("0.1.0", digest),), expected)
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert (outside / "0.1.0/hooks/hooks.json").exists()
+
+
 def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:
     target, _project, home = _target(tmp_path)
     _install(target)
@@ -1109,4 +1201,5 @@ def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:
     )
     assert result.outcome is RemovalOutcome.REMOVE
     assert not extra.exists()
-    assert not (home / "plugins/cache/yoetz/yoetz").exists()
+    cache_root = home / "plugins/cache/yoetz/yoetz"
+    assert not cache_root.exists() or not any(cache_root.iterdir())

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -1950,7 +1950,7 @@ def test_cache_removal_does_not_reopen_replaced_quarantine_path(
     assert (replacements[0] / "sentinel.txt").read_bytes() == b"foreign"
 
 
-@pytest.mark.parametrize("mutation", ["modify", "add"])
+@pytest.mark.parametrize("mutation", ["modify", "add", "empty_directory"])
 def test_cache_removal_revalidates_exact_quarantine_contents_before_delete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1986,7 +1986,7 @@ def test_cache_removal_revalidates_exact_quarantine_contents_before_delete(
                 os.write(member_fd, b"changed")
             finally:
                 os.close(member_fd)
-        else:
+        elif mutation == "add":
             member_fd = os.open(
                 "added.txt",
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -1997,6 +1997,8 @@ def test_cache_removal_revalidates_exact_quarantine_contents_before_delete(
                 os.write(member_fd, b"foreign")
             finally:
                 os.close(member_fd)
+        else:
+            os.mkdir("empty", mode=0o700, dir_fd=descriptor)
         original_remove(root_fd, name, descriptor, approved_members)
 
     monkeypatch.setattr(module, "_remove_validated_directory", mutate_before_remove)
@@ -2012,8 +2014,10 @@ def test_cache_removal_revalidates_exact_quarantine_contents_before_delete(
     assert version.is_dir()
     if mutation == "modify":
         assert (version / "hooks/hooks.json").read_bytes() == b"changed"
-    else:
+    elif mutation == "add":
         assert (version / "added.txt").read_bytes() == b"foreign"
+    else:
+        assert (version / "empty").is_dir()
 
 
 def test_cache_removal_restores_quarantine_on_race_before_first_unlink(
@@ -2321,7 +2325,10 @@ def test_cache_removal_normalizes_every_post_quarantine_error(
         )
 
     assert caught.value.reason is IntegrationReason.WRITE_FAILED
-    assert any(candidate.name.startswith(".yoetz-cache-remove-") for candidate in root.iterdir())
+    assert version.is_dir()
+    assert not any(
+        candidate.name.startswith(".yoetz-cache-remove-") for candidate in root.iterdir()
+    )
 
 
 def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -1222,6 +1222,65 @@ def test_cache_removal_revalidates_digest_immediately_before_delete(
     assert hooks.exists()
 
 
+def test_cache_removal_bounds_replaced_member_before_reading_to_eof(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _MAX_MANAGED_CACHE_MEMBER_BYTES,  # pyright: ignore[reportPrivateUsage]
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+        _installed_cache_digest,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = _installed_cache_digest(version, expected)
+    assert digest is not None
+    replaced = version / "hooks/hooks.json"
+    os.truncate(replaced, _MAX_MANAGED_CACHE_MEMBER_BYTES + 1)
+
+    with pytest.raises(IntegrationError) as caught:
+        _delete_managed_cache_versions(root, (("0.1.0", digest),), expected)
+
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert replaced.stat().st_size == _MAX_MANAGED_CACHE_MEMBER_BYTES + 1
+
+
+def test_cache_removal_bounds_aggregate_revalidation_bytes(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.codex_marketplace import (
+        _MAX_MANAGED_CACHE_TREE_BYTES,  # pyright: ignore[reportPrivateUsage]
+        _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]
+        _installed_cache_digest,  # pyright: ignore[reportPrivateUsage]
+    )
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = _installed_cache_digest(version, expected)
+    assert digest is not None
+    overflow = version / "overflow"
+    overflow.mkdir()
+    member_size = _MAX_MANAGED_CACHE_TREE_BYTES // 16
+    for index in range(17):
+        member = overflow / f"{index:02d}.bin"
+        member.touch()
+        os.truncate(member, member_size)
+
+    with pytest.raises(IntegrationError) as caught:
+        _delete_managed_cache_versions(root, (("0.1.0", digest),), expected)
+
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert version.is_dir()
+
+
 def test_cache_removal_refuses_replaced_symlink_root(tmp_path: Path) -> None:
     from yoetz.adapters.integrations.codex_marketplace import (
         _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -1281,6 +1281,61 @@ def test_cache_removal_bounds_aggregate_revalidation_bytes(tmp_path: Path) -> No
     assert version.is_dir()
 
 
+def test_cache_removal_does_not_reopen_replaced_quarantine_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from yoetz.adapters.integrations import codex_marketplace as module
+    from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
+
+    root = tmp_path / "cache"
+    version = root / "0.1.0"
+    expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
+    for relative, payload in expected.items():
+        destination = version / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
+    digest = module._installed_cache_digest(version, expected)  # pyright: ignore[reportPrivateUsage]
+    assert digest is not None
+    original_remove = module._remove_validated_directory  # pyright: ignore[reportPrivateUsage]
+
+    def replace_before_remove(root_fd: int, name: str, descriptor: int) -> None:
+        moved = f"{name}-moved"
+        os.rename(name, moved, src_dir_fd=root_fd, dst_dir_fd=root_fd)
+        os.mkdir(name, mode=0o700, dir_fd=root_fd)
+        replacement_fd = os.open(name, module._directory_open_flags(), dir_fd=root_fd)  # pyright: ignore[reportPrivateUsage]
+        try:
+            sentinel_fd = os.open(
+                "sentinel.txt",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=replacement_fd,
+            )
+            try:
+                os.write(sentinel_fd, b"foreign")
+            finally:
+                os.close(sentinel_fd)
+        finally:
+            os.close(replacement_fd)
+        original_remove(root_fd, name, descriptor)
+
+    monkeypatch.setattr(module, "_remove_validated_directory", replace_before_remove)
+
+    with pytest.raises(IntegrationError) as caught:
+        module._delete_managed_cache_versions(  # pyright: ignore[reportPrivateUsage]
+            root, (("0.1.0", digest),), expected
+        )
+
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    replacements = [
+        candidate
+        for candidate in root.iterdir()
+        if candidate.name.startswith(".yoetz-cache-remove-")
+        and not candidate.name.endswith("-moved")
+    ]
+    assert len(replacements) == 1
+    assert (replacements[0] / "sentinel.txt").read_bytes() == b"foreign"
+
+
 def test_cache_removal_refuses_replaced_symlink_root(tmp_path: Path) -> None:
     from yoetz.adapters.integrations.codex_marketplace import (
         _delete_managed_cache_versions,  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -518,7 +518,31 @@ def test_apply_unregistration_does_not_claim_success_after_unreadable_verificati
                 _BINARY, McpRegistrationCommand(preview.preview_digest, True)
             )
         )
-    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+    assert caught.value.reason is McpRegistrationReason.REGISTRATION_FAILED
+    assert runner.calls[2][1:3] == ("mcp", "remove")
+
+
+def test_apply_unregistration_normalizes_malformed_post_remove_verification() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, b""),
+            CommandOutput(1, b""),
+            CommandOutput(0, b"not-json"),
+        ]
+    )
+
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+
+    assert caught.value.reason is McpRegistrationReason.REGISTRATION_FAILED
     assert runner.calls[2][1:3] == ("mcp", "remove")
 
 

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -522,6 +522,35 @@ def test_apply_unregistration_does_not_claim_success_after_unreadable_verificati
     assert runner.calls[2][1:3] == ("mcp", "remove")
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [McpRegistrationReason.TIMEOUT, McpRegistrationReason.HARNESS_UNAVAILABLE],
+)
+def test_apply_unregistration_normalizes_mutating_remove_errors(
+    reason: McpRegistrationReason,
+) -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    outputs = [CommandOutput(0, _yoetz_entry()), CommandOutput(0, _yoetz_entry())]
+    calls: list[tuple[str, ...]] = []
+
+    def fail_remove(argv: tuple[str, ...]) -> CommandOutput:
+        calls.append(argv)
+        if argv[1:3] == ("mcp", "remove"):
+            raise McpRegistrationError(reason, {})
+        return outputs.pop(0)
+
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(fail_remove).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+
+    assert caught.value.reason is McpRegistrationReason.REGISTRATION_FAILED
+    assert calls[2][1:3] == ("mcp", "remove")
+
+
 def test_apply_unregistration_normalizes_malformed_post_remove_verification() -> None:
     plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
     preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -331,3 +331,79 @@ def test_apply_noop_when_already_yoetz_owned() -> None:
     assert result.action is McpRegistrationAction.NOOP
     assert result.state_before is result.state_after is McpRegistrationState.YOETZ_OWNED
     assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
+
+
+def test_preview_unregistration_of_owned_entry() -> None:
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())])).preview_unregistration(
+            _BINARY
+        )
+    )
+    assert preview.action is McpRegistrationAction.UNREGISTER
+    assert preview.state_before is McpRegistrationState.YOETZ_OWNED
+
+
+def test_preview_unregistration_of_foreign_entry_warns_without_echoing_argv() -> None:
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(
+            _Runner([CommandOutput(0, json.dumps({"command": "other"}).encode("utf-8"))])
+        ).preview_unregistration(_BINARY)
+    )
+    assert preview.action is McpRegistrationAction.UNREGISTER
+    assert preview.state_before is McpRegistrationState.FOREIGN_PRESENT
+    assert preview.warnings == ("foreign_entry_present",)
+    assert preview.serve_command == ("yoetz", "mcp", "serve")
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).preview_unregistration(_BINARY)
+    )
+    assert preview.action is McpRegistrationAction.NOOP
+    assert preview.state_before is McpRegistrationState.ABSENT
+
+
+def test_apply_unregistration_removes_owned_entry() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, b""),
+            CommandOutput(1, b""),
+        ]
+    )
+    result = anyio.run(
+        lambda: CodexMcpAdapter(runner).apply_unregistration(
+            _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+        )
+    )
+    assert result.action is McpRegistrationAction.UNREGISTER
+    assert result.state_after is McpRegistrationState.ABSENT
+    assert runner.calls[1] == ("/opt/harness/bin/codex", "mcp", "remove", "yoetz")
+
+
+def test_apply_unregistration_refuses_foreign_entry() -> None:
+    foreign = CommandOutput(0, json.dumps({"command": "other"}).encode("utf-8"))
+    plan_adapter = CodexMcpAdapter(_Runner([foreign]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner([CommandOutput(0, json.dumps({"command": "other"}).encode("utf-8"))])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.FOREIGN_ENTRY_PRESENT
+    assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
+
+
+def test_apply_unregistration_is_noop_when_absent() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner([CommandOutput(1, b"")])
+    result = anyio.run(
+        lambda: CodexMcpAdapter(runner).apply_unregistration(
+            _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+        )
+    )
+    assert result.action is McpRegistrationAction.NOOP
+    assert result.state_after is McpRegistrationState.ABSENT
+    assert all(call[1:3] == ("mcp", "get") for call in runner.calls)

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -33,6 +33,12 @@ def _yoetz_entry(*, strict: bool = False) -> bytes:
     return json.dumps({"command": "yoetz", "args": args}).encode("utf-8")
 
 
+def _absent_outputs() -> list[CommandOutput]:
+    """A failed named lookup plus a successful structural proof of absence."""
+
+    return [CommandOutput(1, b""), CommandOutput(0, b"[]")]
+
+
 class _Runner:
     """Scripted subprocess stand-in recording every argv it was asked to run."""
 
@@ -45,12 +51,57 @@ class _Runner:
         return self.outputs.pop(0)
 
 
-def test_status_absent_on_nonzero_get() -> None:
-    runner = _Runner([CommandOutput(1, b"")])
+def test_status_absent_only_after_successful_list_confirmation() -> None:
+    runner = _Runner(_absent_outputs())
     adapter = CodexMcpAdapter(runner)
     state = anyio.run(lambda: adapter.status_registration(_BINARY))
     assert state is McpRegistrationState.ABSENT
-    assert runner.calls == [("/opt/harness/bin/codex", "mcp", "get", "yoetz", "--json")]
+    assert runner.calls == [
+        ("/opt/harness/bin/codex", "mcp", "get", "yoetz", "--json"),
+        ("/opt/harness/bin/codex", "mcp", "list", "--json"),
+    ]
+
+
+def test_status_nonzero_get_fails_closed_when_list_cannot_confirm_absence() -> None:
+    runner = _Runner([CommandOutput(1, b""), CommandOutput(1, b"")])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
+    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+
+
+def test_status_nonzero_get_recovers_owned_entry_from_list() -> None:
+    listed = json.dumps(
+        [{"name": "yoetz", "transport": {"command": "yoetz", "args": ["mcp", "serve"]}}]
+    ).encode("utf-8")
+    runner = _Runner([CommandOutput(1, b""), CommandOutput(0, listed)])
+    state = anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
+    assert state is McpRegistrationState.YOETZ_OWNED
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"not json",
+        b"{}",
+        b"[1]",
+        b'[{"transport": {}}]',
+        b'[{"name":"yoetz"},{"name":"yoetz"}]',
+        b'[{"name":"yoetz","name":"other"}]',
+        b'[{"name":"other","value":NaN}]',
+    ],
+)
+def test_status_nonzero_get_rejects_malformed_or_ambiguous_list(payload: bytes) -> None:
+    runner = _Runner([CommandOutput(1, b""), CommandOutput(0, payload)])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
+    assert caught.value.reason is McpRegistrationReason.PARSE_FAILED
+
+
+def test_status_nonzero_get_rejects_truncated_list_output() -> None:
+    runner = _Runner([CommandOutput(1, b""), CommandOutput(0, b"[]", stdout_truncated=True)])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
+    assert caught.value.reason is McpRegistrationReason.PARSE_FAILED
 
 
 def test_status_yoetz_owned_on_exact_command_match() -> None:
@@ -108,7 +159,7 @@ def test_observe_reports_which_route_is_registered() -> None:
 
 def test_observe_reports_no_route_when_the_entry_is_not_ours() -> None:
     absent = anyio.run(
-        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).observe_registration(_BINARY)
+        lambda: CodexMcpAdapter(_Runner(_absent_outputs())).observe_registration(_BINARY)
     )
     assert absent.state is McpRegistrationState.ABSENT
     assert absent.route_profile is None
@@ -149,8 +200,15 @@ def test_observe_rejects_a_non_codex_binary() -> None:
 
 
 def test_status_parse_failure_is_a_typed_error() -> None:
-    for stdout in (b"not json", b"[1,2]", b"\xff\xfe"):
-        runner = _Runner([CommandOutput(0, stdout)])
+    for output in (
+        CommandOutput(0, b"not json"),
+        CommandOutput(0, b"[1,2]"),
+        CommandOutput(0, b"\xff\xfe"),
+        CommandOutput(0, b'{"command":"yoetz","command":"other"}'),
+        CommandOutput(0, b'{"command":"other","value":NaN}'),
+        CommandOutput(0, b'{"command":"yoetz"}', stdout_truncated=True),
+    ):
+        runner = _Runner([output])
         with pytest.raises(McpRegistrationError) as caught:
             anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
         assert caught.value.reason is McpRegistrationReason.PARSE_FAILED
@@ -158,7 +216,7 @@ def test_status_parse_failure_is_a_typed_error() -> None:
 
 def test_preview_register_for_absent_and_noop_for_owned() -> None:
     absent = anyio.run(
-        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).preview_registration(_BINARY)
+        lambda: CodexMcpAdapter(_Runner(_absent_outputs())).preview_registration(_BINARY)
     )
     assert absent.action is McpRegistrationAction.REGISTER
     assert absent.state_before is McpRegistrationState.ABSENT
@@ -182,11 +240,11 @@ def test_preview_foreign_carries_warning_and_noop() -> None:
 
 def test_strict_preview_binds_exact_command_and_changes_digest() -> None:
     policy = anyio.run(
-        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).preview_registration(_BINARY)
+        lambda: CodexMcpAdapter(_Runner(_absent_outputs())).preview_registration(_BINARY)
     )
     strict = anyio.run(
         lambda: CodexMcpAdapter(
-            _Runner([CommandOutput(1, b"")]),
+            _Runner(_absent_outputs()),
             route_profile="strict",
         ).preview_registration(_BINARY)
     )
@@ -228,10 +286,10 @@ def test_explicit_preview_allows_reregistering_an_owned_route_profile() -> None:
 
 
 def test_apply_requires_explicit_acceptance_and_exact_digest() -> None:
-    adapter = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    adapter = CodexMcpAdapter(_Runner(_absent_outputs()))
     preview = anyio.run(lambda: adapter.preview_registration(_BINARY))
 
-    declined = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    declined = CodexMcpAdapter(_Runner(_absent_outputs()))
     with pytest.raises(McpRegistrationError) as caught:
         anyio.run(
             lambda: declined.apply_registration(
@@ -240,7 +298,7 @@ def test_apply_requires_explicit_acceptance_and_exact_digest() -> None:
         )
     assert caught.value.reason is McpRegistrationReason.CONFIRMATION_REQUIRED
 
-    stale = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    stale = CodexMcpAdapter(_Runner(_absent_outputs()))
     with pytest.raises(McpRegistrationError) as caught:
         anyio.run(
             lambda: stale.apply_registration(
@@ -251,12 +309,13 @@ def test_apply_requires_explicit_acceptance_and_exact_digest() -> None:
 
 
 def test_apply_registers_then_verifies_by_rereading_state() -> None:
-    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    plan_adapter = CodexMcpAdapter(_Runner(_absent_outputs()))
     preview = anyio.run(lambda: plan_adapter.preview_registration(_BINARY))
 
     runner = _Runner(
         [
             CommandOutput(1, b""),  # get: absent
+            CommandOutput(0, b"[]"),  # list: confirms absence
             CommandOutput(0, b""),  # add
             CommandOutput(0, _yoetz_entry()),  # verify get
         ]
@@ -269,7 +328,7 @@ def test_apply_registers_then_verifies_by_rereading_state() -> None:
     assert result.action is McpRegistrationAction.REGISTER
     assert result.state_before is McpRegistrationState.ABSENT
     assert result.state_after is McpRegistrationState.YOETZ_OWNED
-    assert runner.calls[1] == (
+    assert runner.calls[2] == (
         "/opt/harness/bin/codex",
         "mcp",
         "add",
@@ -282,14 +341,16 @@ def test_apply_registers_then_verifies_by_rereading_state() -> None:
 
 
 def test_apply_reports_failure_when_verify_does_not_show_ownership() -> None:
-    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    plan_adapter = CodexMcpAdapter(_Runner(_absent_outputs()))
     preview = anyio.run(lambda: plan_adapter.preview_registration(_BINARY))
 
     runner = _Runner(
         [
             CommandOutput(1, b""),  # get: absent
+            CommandOutput(0, b"[]"),  # list: confirms absence
             CommandOutput(0, b""),  # add claims success
             CommandOutput(1, b""),  # verify still absent
+            CommandOutput(0, b"[]"),  # list: confirms it is still absent
         ]
     )
     with pytest.raises(McpRegistrationError) as caught:
@@ -299,6 +360,20 @@ def test_apply_reports_failure_when_verify_does_not_show_ownership() -> None:
             )
         )
     assert caught.value.reason is McpRegistrationReason.REGISTRATION_FAILED
+
+
+def test_apply_does_not_add_when_failed_get_cannot_confirm_absence() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner(_absent_outputs()))
+    preview = anyio.run(lambda: plan_adapter.preview_registration(_BINARY))
+    runner = _Runner([CommandOutput(1, b""), CommandOutput(1, b"")])
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_registration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+    assert all(call[1:3] != ("mcp", "add") for call in runner.calls)
 
 
 def test_apply_never_replaces_a_foreign_entry() -> None:
@@ -355,7 +430,7 @@ def test_preview_unregistration_of_foreign_entry_warns_without_echoing_argv() ->
     assert preview.warnings == ("foreign_entry_present",)
     assert preview.serve_command == ("yoetz", "mcp", "serve")
     preview = anyio.run(
-        lambda: CodexMcpAdapter(_Runner([CommandOutput(1, b"")])).preview_unregistration(_BINARY)
+        lambda: CodexMcpAdapter(_Runner(_absent_outputs())).preview_unregistration(_BINARY)
     )
     assert preview.action is McpRegistrationAction.NOOP
     assert preview.state_before is McpRegistrationState.ABSENT
@@ -370,6 +445,7 @@ def test_apply_unregistration_removes_owned_entry() -> None:
             CommandOutput(0, _yoetz_entry()),
             CommandOutput(0, b""),
             CommandOutput(1, b""),
+            CommandOutput(0, b"[]"),
         ]
     )
     result = anyio.run(
@@ -404,6 +480,48 @@ def test_apply_unregistration_refuses_replacement_before_name_based_remove() -> 
     assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
 
 
+def test_apply_unregistration_does_not_remove_after_unreadable_ownership_recheck() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(1, b""),
+            CommandOutput(1, b""),
+        ]
+    )
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+    assert all(call[1:3] != ("mcp", "remove") for call in runner.calls)
+
+
+def test_apply_unregistration_does_not_claim_success_after_unreadable_verification() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, b""),
+            CommandOutput(1, b""),
+            CommandOutput(1, b""),
+        ]
+    )
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.HARNESS_UNAVAILABLE
+    assert runner.calls[2][1:3] == ("mcp", "remove")
+
+
 def test_apply_unregistration_refuses_foreign_entry() -> None:
     foreign = CommandOutput(0, json.dumps({"command": "other"}).encode("utf-8"))
     plan_adapter = CodexMcpAdapter(_Runner([foreign]))
@@ -420,9 +538,9 @@ def test_apply_unregistration_refuses_foreign_entry() -> None:
 
 
 def test_apply_unregistration_is_noop_when_absent() -> None:
-    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(1, b"")]))
+    plan_adapter = CodexMcpAdapter(_Runner(_absent_outputs()))
     preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
-    runner = _Runner([CommandOutput(1, b"")])
+    runner = _Runner(_absent_outputs())
     result = anyio.run(
         lambda: CodexMcpAdapter(runner).apply_unregistration(
             _BINARY, McpRegistrationCommand(preview.preview_digest, True)
@@ -430,4 +548,4 @@ def test_apply_unregistration_is_noop_when_absent() -> None:
     )
     assert result.action is McpRegistrationAction.NOOP
     assert result.state_after is McpRegistrationState.ABSENT
-    assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
+    assert [call[1:3] for call in runner.calls] == [("mcp", "get"), ("mcp", "list")]

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -341,6 +341,7 @@ def test_preview_unregistration_of_owned_entry() -> None:
     )
     assert preview.action is McpRegistrationAction.UNREGISTER
     assert preview.state_before is McpRegistrationState.YOETZ_OWNED
+    assert preview.warnings == ("host_remove_not_compare_and_swap",)
 
 
 def test_preview_unregistration_of_foreign_entry_warns_without_echoing_argv() -> None:
@@ -366,6 +367,7 @@ def test_apply_unregistration_removes_owned_entry() -> None:
     runner = _Runner(
         [
             CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, _yoetz_entry()),
             CommandOutput(0, b""),
             CommandOutput(1, b""),
         ]
@@ -377,7 +379,29 @@ def test_apply_unregistration_removes_owned_entry() -> None:
     )
     assert result.action is McpRegistrationAction.UNREGISTER
     assert result.state_after is McpRegistrationState.ABSENT
-    assert runner.calls[1] == ("/opt/harness/bin/codex", "mcp", "remove", "yoetz")
+    assert runner.calls[2] == ("/opt/harness/bin/codex", "mcp", "remove", "yoetz")
+
+
+def test_apply_unregistration_refuses_replacement_before_name_based_remove() -> None:
+    plan_adapter = CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())]))
+    preview = anyio.run(lambda: plan_adapter.preview_unregistration(_BINARY))
+    foreign = CommandOutput(0, json.dumps({"command": "other"}).encode("utf-8"))
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            foreign,
+        ]
+    )
+
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+
+    assert caught.value.reason is McpRegistrationReason.FOREIGN_ENTRY_PRESENT
+    assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
 
 
 def test_apply_unregistration_refuses_foreign_entry() -> None:

--- a/tests/unit/application/test_harness_mcp_service.py
+++ b/tests/unit/application/test_harness_mcp_service.py
@@ -92,6 +92,32 @@ class _Port:
             command.preview_digest,
         )
 
+    async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview:
+        if self.fail_with is not None:
+            raise McpRegistrationError(self.fail_with, {})
+        action = (
+            McpRegistrationAction.NOOP
+            if self.state is McpRegistrationState.ABSENT
+            else McpRegistrationAction.UNREGISTER
+        )
+        return McpRegistrationPreview(binary.harness_id, action, self.state, (), _DIGEST)
+
+    async def apply_unregistration(
+        self,
+        binary: HarnessBinary,
+        command: McpRegistrationCommand,
+    ) -> McpRegistrationResult:
+        self.applied.append(command)
+        if self.fail_with is not None:
+            raise McpRegistrationError(self.fail_with, {})
+        return McpRegistrationResult(
+            binary.harness_id,
+            McpRegistrationAction.UNREGISTER,
+            self.state,
+            McpRegistrationState.ABSENT,
+            command.preview_digest,
+        )
+
 
 def test_status_and_preview_record_success_diagnostics() -> None:
     sink = _Sink()
@@ -200,3 +226,33 @@ def test_invalid_binary_rejected() -> None:
     service = HarnessMcpService(_Port())
     with pytest.raises(ValueError):
         anyio.run(lambda: service.status(object()))  # type: ignore[arg-type]
+
+
+def test_unregister_requires_explicit_acceptance() -> None:
+    sink = _Sink()
+    port = _Port(McpRegistrationState.YOETZ_OWNED)
+    service = HarnessMcpService(port, sink)
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: service.unregister(
+                _BINARY,
+                McpRegistrationConfirmation(_DIGEST, False, "interactive"),
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.CONFIRMATION_REQUIRED
+    assert port.applied == []
+
+
+def test_unregister_passes_exact_digest_and_records_result() -> None:
+    sink = _Sink()
+    port = _Port(McpRegistrationState.YOETZ_OWNED)
+    service = HarnessMcpService(port, sink)
+    result = anyio.run(
+        lambda: service.unregister(
+            _BINARY,
+            McpRegistrationConfirmation(_DIGEST, True, "noninteractive_flag"),
+        )
+    )
+    assert result.state_after is McpRegistrationState.ABSENT
+    assert port.applied == [McpRegistrationCommand(_DIGEST, True)]
+    assert sink.records[-1].phase == "execute"

--- a/tests/unit/cli/test_codex_plugin_cli.py
+++ b/tests/unit/cli/test_codex_plugin_cli.py
@@ -33,6 +33,7 @@ def _preview(home: Path, executable: Path) -> RemovalPreview:
         True,
         True,
         ("0.1.0",),
+        (("0.1.0", "sha256:" + "e" * 64),),
         "absent",
         executable,
         "sha256:" + "b" * 64,
@@ -50,6 +51,25 @@ def _preview(home: Path, executable: Path) -> RemovalPreview:
     )
 
 
+def test_codex_plugin_cli_preserves_symlinked_project_root_for_adapter_rejection(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir(mode=0o700)
+    project_link = tmp_path / "project-link"
+    project_link.symlink_to(project, target_is_directory=True)
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+
+    import yoetz.cli.codex_plugin as module
+
+    target = module._target(project_link)  # pyright: ignore[reportPrivateUsage]
+    assert Path(target.project_root) == project_link.absolute()
+    with pytest.raises(IntegrationError) as caught:
+        module.preview_removal(target, executable_path="codex", codex_home=home)
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+
+
 def test_codex_plugin_cli_preview_status_and_remove(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -61,29 +81,28 @@ def test_codex_plugin_cli_preview_status_and_remove(
     preview = _preview(home, executable)
 
     def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
-        return (
-            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
+        return (HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),)
+
+    def fake_preview(*_args: object, **_kwargs: object) -> RemovalPreview:
+        return preview
+
+    def fake_inspection(*_args: object, **_kwargs: object) -> ActivationInspection:
+        return preview.inspection
+
+    def fake_apply(*_args: object, **_kwargs: object) -> RemovalResult:
+        return RemovalResult(
+            RemovalOutcome.REMOVE,
+            ActivationInspection(True, False, ActivationState.INSTALLED_NOT_ACTIVATED),
+            "absent",
+            False,
         )
 
     import yoetz.cli.codex_plugin as module
 
     monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
-    monkeypatch.setattr(module, "preview_removal", lambda *args, **kwargs: preview)
-    monkeypatch.setattr(
-        module,
-        "inspect_activation",
-        lambda *args, **kwargs: preview.inspection,
-    )
-    monkeypatch.setattr(
-        module,
-        "apply_removal",
-        lambda *args, **kwargs: RemovalResult(
-            RemovalOutcome.REMOVE,
-            ActivationInspection(True, False, ActivationState.INSTALLED_NOT_ACTIVATED),
-            "absent",
-            False,
-        ),
-    )
+    monkeypatch.setattr(module, "preview_removal", fake_preview)
+    monkeypatch.setattr(module, "inspect_activation", fake_inspection)
+    monkeypatch.setattr(module, "apply_removal", fake_apply)
 
     status = _RUNNER.invoke(
         app,
@@ -100,6 +119,7 @@ def test_codex_plugin_cli_preview_status_and_remove(
     body = json.loads(shown.stdout)
     assert body["preview_digest"] == _DIGEST
     assert body["action"] == "remove"
+    assert body["cache_preimages"] == [{"digest": "sha256:" + "e" * 64, "version": "0.1.0"}]
 
     removed = _RUNNER.invoke(
         app,
@@ -130,9 +150,7 @@ def test_codex_plugin_cli_names_remove_refused_conflict(
     executable.chmod(0o700)
 
     def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
-        return (
-            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
-        )
+        return (HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),)
 
     def refuse(*_args: object, **_kwargs: object) -> RemovalPreview:
         raise IntegrationError(IntegrationReason.REMOVE_REFUSED, {"conflict": "cache"})
@@ -160,25 +178,23 @@ def test_codex_plugin_cli_status_reports_foreign_without_previewing_removal(
     executable.chmod(0o700)
 
     def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
-        return (
-            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
-        )
+        return (HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),)
 
     def refuse(*_args: object, **_kwargs: object) -> RemovalPreview:
         raise IntegrationError(IntegrationReason.REMOVE_REFUSED, {"conflict": "cache"})
 
+    def foreign_inspection(*_args: object, **_kwargs: object) -> ActivationInspection:
+        return ActivationInspection(False, False, ActivationState.FOREIGN)
+
+    def absent_skill(_target: object) -> str:
+        return "absent"
+
     import yoetz.cli.codex_plugin as module
 
     monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
-    monkeypatch.setattr(
-        module,
-        "inspect_activation",
-        lambda *args, **kwargs: ActivationInspection(
-            False, False, ActivationState.FOREIGN
-        ),
-    )
+    monkeypatch.setattr(module, "inspect_activation", foreign_inspection)
     monkeypatch.setattr(module, "preview_removal", refuse)
-    monkeypatch.setattr(module, "_skill_tree_state", lambda _target: "absent")
+    monkeypatch.setattr(module, "_skill_tree_state", absent_skill)
 
     result = _RUNNER.invoke(
         app,
@@ -199,14 +215,15 @@ def test_codex_plugin_cli_remove_requires_exact_preview_acceptance(
     preview = _preview(home, executable)
 
     def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
-        return (
-            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
-        )
+        return (HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),)
+
+    def fake_preview(*_args: object, **_kwargs: object) -> RemovalPreview:
+        return preview
 
     import yoetz.cli.codex_plugin as module
 
     monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
-    monkeypatch.setattr(module, "preview_removal", lambda *args, **kwargs: preview)
+    monkeypatch.setattr(module, "preview_removal", fake_preview)
 
     result = _RUNNER.invoke(
         app,

--- a/tests/unit/cli/test_codex_plugin_cli.py
+++ b/tests/unit/cli/test_codex_plugin_cli.py
@@ -25,29 +25,29 @@ _DIGEST = "sha256:" + "a" * 64
 
 def _preview(home: Path, executable: Path) -> RemovalPreview:
     return RemovalPreview(
-        _DIGEST,
-        ActivationInspection(True, True, ActivationState.ACTIVE),
-        RemovalOutcome.REMOVE,
-        False,
-        True,
-        True,
-        True,
-        ("0.1.0",),
-        (("0.1.0", "sha256:" + "e" * 64),),
-        "absent",
-        executable,
-        "sha256:" + "b" * 64,
-        "0.148.0-alpha.6",
-        home,
-        ("--version",),
-        ("plugin", "list", "--marketplace", "yoetz", "--json"),
-        ("plugin", "remove", "yoetz@yoetz", "--json"),
-        ("plugin", "marketplace", "remove", "yoetz", "--json"),
-        "temporary_owner_private_home",
-        (("CODEX_HOME", str(home)), ("CODEX_TESTING_HOME", str(home))),
-        "sha256:" + "c" * 64,
-        "sha256:" + "d" * 64,
-        '[marketplaces.yoetz]\nsource_type = "local"\n',
+        preview_digest=_DIGEST,
+        inspection=ActivationInspection(True, True, ActivationState.ACTIVE),
+        outcome=RemovalOutcome.REMOVE,
+        purge_cache=False,
+        plugin_remove_planned=True,
+        marketplace_remove_planned=True,
+        marketplace_json_planned=True,
+        cache_versions=("0.1.0",),
+        cache_digests=(("0.1.0", "sha256:" + "e" * 64),),
+        skill_tree_state="absent",
+        executable_path=executable,
+        executable_digest="sha256:" + "b" * 64,
+        codex_version="0.148.0-alpha.6",
+        codex_home=home,
+        probe_command=("--version",),
+        inventory_command=("plugin", "list", "--marketplace", "yoetz", "--json"),
+        plugin_remove_command=("plugin", "remove", "yoetz@yoetz", "--json"),
+        marketplace_remove_command=("plugin", "marketplace", "remove", "yoetz", "--json"),
+        probe_environment="temporary_owner_private_home",
+        activation_environment=(("CODEX_HOME", str(home)), ("CODEX_TESTING_HOME", str(home))),
+        marketplace_preimage_digest="sha256:" + "c" * 64,
+        config_preimage_digest="sha256:" + "d" * 64,
+        config_toml_block='[marketplaces.yoetz]\nsource_type = "local"\n',
     )
 
 
@@ -60,14 +60,17 @@ def test_codex_plugin_cli_preserves_symlinked_project_root_for_adapter_rejection
     project_link.symlink_to(project, target_is_directory=True)
     home = tmp_path / "codex-home"
     home.mkdir(mode=0o700)
+    executable = tmp_path / "codex"
+    executable.write_text("#!/bin/sh\nprintf 'codex-cli 0.149.1\\n'\n", encoding="utf-8")
+    executable.chmod(0o700)
 
     import yoetz.cli.codex_plugin as module
 
     target = module._target(project_link)  # pyright: ignore[reportPrivateUsage]
     assert Path(target.project_root) == project_link.absolute()
     with pytest.raises(IntegrationError) as caught:
-        module.preview_removal(target, executable_path="codex", codex_home=home)
-    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+        module.preview_removal(target, executable_path=str(executable), codex_home=home)
+    assert caught.value.reason is IntegrationReason.TARGET_UNTRUSTED
 
 
 def test_codex_plugin_cli_preview_status_and_remove(
@@ -194,7 +197,7 @@ def test_codex_plugin_cli_status_reports_foreign_without_previewing_removal(
     monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
     monkeypatch.setattr(module, "inspect_activation", foreign_inspection)
     monkeypatch.setattr(module, "preview_removal", refuse)
-    monkeypatch.setattr(module, "_skill_tree_state", absent_skill)
+    monkeypatch.setattr(module, "skill_tree_state", absent_skill)
 
     result = _RUNNER.invoke(
         app,

--- a/tests/unit/cli/test_codex_plugin_cli.py
+++ b/tests/unit/cli/test_codex_plugin_cli.py
@@ -1,0 +1,216 @@
+"""CLI wiring for Codex plugin/marketplace removal."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from yoetz.adapters.integrations.codex_marketplace import (
+    ActivationInspection,
+    ActivationState,
+    RemovalOutcome,
+    RemovalPreview,
+    RemovalResult,
+)
+from yoetz.cli.app import app
+from yoetz.ports.harness_mcp import HarnessBinary
+from yoetz.ports.integrations import HarnessId, IntegrationError, IntegrationReason
+
+_RUNNER = CliRunner()
+_DIGEST = "sha256:" + "a" * 64
+
+
+def _preview(home: Path, executable: Path) -> RemovalPreview:
+    return RemovalPreview(
+        _DIGEST,
+        ActivationInspection(True, True, ActivationState.ACTIVE),
+        RemovalOutcome.REMOVE,
+        False,
+        True,
+        True,
+        True,
+        ("0.1.0",),
+        "absent",
+        executable,
+        "sha256:" + "b" * 64,
+        "0.148.0-alpha.6",
+        home,
+        ("--version",),
+        ("plugin", "list", "--marketplace", "yoetz", "--json"),
+        ("plugin", "remove", "yoetz@yoetz", "--json"),
+        ("plugin", "marketplace", "remove", "yoetz", "--json"),
+        "temporary_owner_private_home",
+        (("CODEX_HOME", str(home)), ("CODEX_TESTING_HOME", str(home))),
+        "sha256:" + "c" * 64,
+        "sha256:" + "d" * 64,
+        '[marketplaces.yoetz]\nsource_type = "local"\n',
+    )
+
+
+def test_codex_plugin_cli_preview_status_and_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    executable = home / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+    preview = _preview(home, executable)
+
+    def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
+        return (
+            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
+        )
+
+    import yoetz.cli.codex_plugin as module
+
+    monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
+    monkeypatch.setattr(module, "preview_removal", lambda *args, **kwargs: preview)
+    monkeypatch.setattr(
+        module,
+        "inspect_activation",
+        lambda *args, **kwargs: preview.inspection,
+    )
+    monkeypatch.setattr(
+        module,
+        "apply_removal",
+        lambda *args, **kwargs: RemovalResult(
+            RemovalOutcome.REMOVE,
+            ActivationInspection(True, False, ActivationState.INSTALLED_NOT_ACTIVATED),
+            "absent",
+            False,
+        ),
+    )
+
+    status = _RUNNER.invoke(
+        app,
+        ["integrate", "codex", "plugin", "status", "--codex-home", str(home), "--json"],
+    )
+    assert status.exit_code == 0, status.output
+    assert json.loads(status.stdout)["state"] == "active"
+
+    shown = _RUNNER.invoke(
+        app,
+        ["integrate", "codex", "plugin", "preview", "--codex-home", str(home), "--json"],
+    )
+    assert shown.exit_code == 0, shown.output
+    body = json.loads(shown.stdout)
+    assert body["preview_digest"] == _DIGEST
+    assert body["action"] == "remove"
+
+    removed = _RUNNER.invoke(
+        app,
+        [
+            "integrate",
+            "codex",
+            "plugin",
+            "remove",
+            "--codex-home",
+            str(home),
+            "--accept",
+            "--preview-digest",
+            _DIGEST,
+            "--json",
+        ],
+    )
+    assert removed.exit_code == 0, removed.output
+    assert json.loads(removed.stdout)["outcome"] == "remove"
+
+
+def test_codex_plugin_cli_names_remove_refused_conflict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    executable = home / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+
+    def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
+        return (
+            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
+        )
+
+    def refuse(*_args: object, **_kwargs: object) -> RemovalPreview:
+        raise IntegrationError(IntegrationReason.REMOVE_REFUSED, {"conflict": "cache"})
+
+    import yoetz.cli.codex_plugin as module
+
+    monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
+    monkeypatch.setattr(module, "preview_removal", refuse)
+
+    result = _RUNNER.invoke(
+        app,
+        ["integrate", "codex", "plugin", "preview", "--codex-home", str(home), "--json"],
+    )
+    assert result.exit_code == 2
+    assert "codex_plugin_remove_refused:cache" in result.stderr
+
+
+def test_codex_plugin_cli_status_reports_foreign_without_previewing_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    executable = home / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+
+    def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
+        return (
+            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
+        )
+
+    def refuse(*_args: object, **_kwargs: object) -> RemovalPreview:
+        raise IntegrationError(IntegrationReason.REMOVE_REFUSED, {"conflict": "cache"})
+
+    import yoetz.cli.codex_plugin as module
+
+    monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
+    monkeypatch.setattr(
+        module,
+        "inspect_activation",
+        lambda *args, **kwargs: ActivationInspection(
+            False, False, ActivationState.FOREIGN
+        ),
+    )
+    monkeypatch.setattr(module, "preview_removal", refuse)
+    monkeypatch.setattr(module, "_skill_tree_state", lambda _target: "absent")
+
+    result = _RUNNER.invoke(
+        app,
+        ["integrate", "codex", "plugin", "status", "--codex-home", str(home), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["state"] == "foreign"
+
+
+def test_codex_plugin_cli_remove_requires_exact_preview_acceptance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "codex-home"
+    home.mkdir(mode=0o700)
+    executable = home / "codex"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o700)
+    preview = _preview(home, executable)
+
+    def fake_discover(*, _probe: object = None) -> tuple[HarnessBinary, ...]:
+        return (
+            HarnessBinary(HarnessId.CODEX, str(executable), "0.148.0-alpha.6", "untested"),
+        )
+
+    import yoetz.cli.codex_plugin as module
+
+    monkeypatch.setattr(module, "discover_codex_binaries", fake_discover)
+    monkeypatch.setattr(module, "preview_removal", lambda *args, **kwargs: preview)
+
+    result = _RUNNER.invoke(
+        app,
+        ["integrate", "codex", "plugin", "remove", "--codex-home", str(home), "--json"],
+    )
+    assert result.exit_code == 3
+    assert "codex_plugin_exact_preview_acceptance_required" in result.stderr


### PR DESCRIPTION
## Issue

- Refs #419.
- Duplicate search was completed before the PR was opened.
- Maintainer acknowledgement on issue #419 approves the authority lane, preview-remove shape, default-off cache purge, and installed_not_activated post-state.

## Approved design resolution

1. External MCP removal uses ADR-012 exact preview plus --accept, not Cursor plugin_artifact_apply.
2. yoetz integrate codex mcp preview-remove emits an unregistration preview; noninteractive removal requires its exact digest.
3. --purge-cache remains default-off.
4. Removing activation retains the managed plugin source and reports installed_not_activated per #387.

## Current head

At e8854d2c4c14749aabfc92947e72d07083d6bfda:

- Failed codex mcp get never proves absence by itself; absence requires a successful strict bounded list with no matching name.
- Interactive MCP removal renders the action, route, exact serve command, warnings, and digest.
- Removal previews bind the trusted project root, executable, home, exact host commands, configuration, repository marketplace, and bounded cache preimages.
- Cache traversal and deletion are descriptor-relative, no-follow, bounded, and exact-name, inode, and byte bound through quarantine.
- Activation cache staging, replacement, rollback, and cleanup are descriptor-relative beneath the selected Codex home; an ancestor swap cannot redirect writes outside that root.
- Activation inspection/planning and removal preview now read and enumerate cache versions through the same selected-home descriptor boundary; an ancestor swap cannot redirect preview digests either.
- Empty cache directories fail closed during preview instead of becoming invisible to the approved file-member map and surfacing only after mutation.
- Exact table removal preserves unrelated owner TOML bytes; it no longer globally normalizes blank lines.
- Version, inventory, and mutation commands enforce stdout limits during selector-driven capture, drain stderr without retention, and terminate/reap a flooding direct child.
- Mutation state is operation-wide across host, configuration, repository marketplace, every cache version, and final verification.
- Post-host config read failures are normalized to write_failed, and timeout/unavailable exceptions from the mutating `codex mcp remove` call are normalized to registration_failed because either outcome may already be partially applied.
- Mutating host commands cross the fence before result parsing, so zero-exit malformed or truncated JSON is write_failed.
- Repository marketplace and exact empty-config cleanup retain no-follow descriptors through private quarantine and restore through no-clobber hard links, preserving newly appeared foreign canonical files.
- Cache-version quarantine is restored for every typed validation failure before the first unlink, including newly appeared empty directories; every failure after unlink remains outcome-unknown write_failed.
- The remaining same-UID POSIX final write or unlink and host name-based remove windows are explicit non-CAS limitations requiring quiescent writers.
- Every review thread is answered and resolved.

## Documentation

Behavior change: yes. ADR-005, ADR-007, ADR-010, ADR-012, ADR-015, ADR-016, ADR-023, docs/INTERFACES.md, the Codex runbook, and first-run usage match the approved authority, positive absence proof, mutation boundary, exact tree and owner-config behavior, quarantine behavior, post-state, and non-atomic limits.

## Verification

- Focused marketplace/MCP suite: 115 passed.
- Focused PR acceptance: 213 passed at the final head.
- Ruff check and format: passed.
- Pinned Pyright 1.1.411: 0 errors.
- Resource fixed point: 81 schemas and 118 resources passed.
- git diff --check: passed.
- Independent final post-patch review: no blocker, including ancestor-swap activation review.
- Exact-head GitHub PR CI and Security and Privacy are green.
- Exact-head Codex review at e8854d2c found no major issue; all visible review threads are answered and resolved.
- CodeRabbit exact-head re-review was rate-limited; this is a service availability limit, not a green content review.

## Proof boundary

Removal retains the skill tree, consent records, and observation store. Foreign or modified surfaces fail closed. Local tests and source review do not substitute for exact-head CI. The final non-cooperating same-UID POSIX window remains documented rather than claimed atomic. Process-tree containment for a hostile wrapper and the untouched read-only discovery probe are separate hardening scope; this PR bounds the selected activation/removal command paths.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add consent-gated plugin and MCP uninstall for Codex harness
> - Adds `preview_removal`/`apply_removal` to the Codex marketplace adapter and `preview_unregistration`/`apply_unregistration` to the MCP adapter, both requiring digest-bound `--accept` consent before mutating host state
> - Introduces bounded subprocess execution (`_run_bounded_command`, `_command_output`) with stdout byte limits and hard timeouts across all Codex command invocations
> - Replaces path-following filesystem operations with descriptor-based, no-follow anchored reads/writes (`_read_managed_tree`, `_replace_cache_tree_anchored`, `_installed_cache_digest_anchored`) that reject symlinked ancestors and validate ownership via `fstat`
> - MCP state observation now uses a two-step strategy: `codex mcp get` followed by strict `codex mcp list --json` parsing to confirm absence; duplicate keys, nonstandard constants, truncation, and malformed output all fail closed
> - CLI gains `yoetz integrate <harness> mcp preview-remove|remove` and `yoetz integrate codex plugin preview|remove` (with optional `--purge-cache`); non-Codex harnesses now require `--cursor-config-root` and exit with code 2 if missing
> - Risk: `_classify_get` in [codex_mcp.py](https://github.com/TheGaySupreme123/yoetz/pull/421/files#diff-59e4c636ffcfe379474c3b72c0d65a09e86424065490dbe3ca43458601814d07) now raises `HARNESS_UNAVAILABLE` instead of treating nonzero exit as absence — callers that relied on failed `get` implying ABSENT must use the new `_observe_registration_state` two-step path
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8854d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->