### PR TITLE
fix(kernel): decode projection snapshots under every known schema version (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable user-visible changes to Yoetz are documented in this file. Format is
 project-native heading style that marks the pending version as unreleased above
 reverse-chronological released versions.
 
+## Unreleased
+
+### Fixed
+
+- Replaying a check that was suspended on a standing repository grant no longer fails with a
+  non-retryable `STORAGE_CORRUPT` after the trusted `yoetz --privacy` ceremony, and a task whose
+  ledger holds `evidence_recorded/1.1.0` events (any evidence carrying a `digest_binding`) no
+  longer becomes unreadable the moment a pending check has to be rehydrated from its durable resume
+  checkpoint. The checkpoint's projection snapshot records no schema version and its decoder pinned
+  every event family to `1.0.0`, so a digest-bound evidence record encoded fine but could never be
+  decoded again; every deferred rehydration — the same-request replay after the grant, and ledger
+  recovery after a service re-ready while the check was pending — was reported as corruption of an
+  intact bundle. Snapshot records now decode under the newest wire version their family admits
+  (issue #427).
+
 ## 0.1.0 — Public alpha (2026-08-20)
 
 Initial public alpha release. The earlier 0.0.1 registry packages only reserved the project name

--- a/src/yoetz/kernel/projections.py
+++ b/src/yoetz/kernel/projections.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import Final, Protocol, cast
 
 from yoetz.domain.events import (
+    PAYLOAD_TYPES,
     ActionRecordedPayload,
     AssignmentRecordedPayload,
     ClaimRecordedPayload,
@@ -887,18 +888,40 @@ def _snapshot_uint(value: object, *, safe: bool = False) -> int:
     return parsed
 
 
+def _schema_versions(schema_name: str) -> tuple[str, ...]:
+    """Every known wire version of one schema name, newest first."""
+
+    versions = sorted(
+        {schema.version for schema in PAYLOAD_TYPES if schema.name == schema_name},
+        key=lambda version: tuple(int(part) for part in version.split(".")),
+        reverse=True,
+    )
+    if not versions:
+        raise _invalid()
+    return tuple(versions)
+
+
 def _decoded_payload(value: JsonValue, schemas: tuple[str, ...]) -> EventPayload:
+    # A snapshot record carries no schema version: generation-1 snapshots were minted when every
+    # family had exactly one, and adding the version to the record would change the canonical
+    # bytes every stored case_digest and resume pointer is bound to. Decoding with a pinned
+    # "1.0.0" therefore rejected any payload a later version admits — an evidence record with a
+    # ``digest_binding`` (evidence_recorded/1.1.0) failed as ``unknown_payload_field``, which
+    # turned every deferred rehydration of a frozen case (privacy-wait replay, ledger recovery)
+    # into a non-retryable STORAGE_CORRUPT on an intact bundle (issue #427). Each name decodes
+    # under its newest admitting version instead; the name ambiguity check is unchanged.
     decoded: list[EventPayload] = []
     for schema_name in schemas:
-        try:
-            decoded.append(
-                decode_payload(
-                    EventSchema(schema_name, "1.0.0"),
+        for version in _schema_versions(schema_name):
+            try:
+                payload = decode_payload(
+                    EventSchema(schema_name, version),
                     cast(DomainJsonValue, value),
                 )
-            )
-        except ValueError:
-            continue
+            except ValueError:
+                continue
+            decoded.append(payload)
+            break
     if len(decoded) != 1:
         raise _invalid()
     return decoded[0]

--- a/tests/integration/service/test_check_repository_grant_replay.py
+++ b/tests/integration/service/test_check_repository_grant_replay.py
@@ -1,0 +1,412 @@
+"""Same-request replay of a check suspended on a standing repository grant (issue #427).
+
+The full ready composition (SQLite ledger, encrypted object store, catalog privacy store) runs a
+``semantic_required`` check that suspends with the ``repository_privacy_setup`` continuation, the
+trusted ceremony grants the Assisted-review policy for the repository, and the exact original
+request is replayed. The replay must consume the new authority and reach a terminal result; it
+must never wedge the frozen case behind a non-retryable STORAGE_CORRUPT.
+
+The ledger deliberately holds an ``evidence_recorded/1.1.0`` event carrying a ``digest_binding``:
+the resume checkpoint's projection snapshot records no schema version, and the decoder used to pin
+every family to "1.0.0", so this evidence made every deferred rehydration of the frozen case fail
+as corruption. The restart variants exercise the same decode through ledger recovery, which is the
+path a service re-ready between the ceremony and the replay takes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import yoetz.adapters.sqlite.connection as connection_module
+from builders.privacy_policies import minimal_external_policy
+from yoetz.adapters.keys.encrypted_vault import EncryptedVaultStore
+from yoetz.adapters.keys.secret_memory import LocalSecretMemory
+from yoetz.application.privacy_policy import (
+    DecidePrivacyPolicyRequest,
+    PolicyDecisionRequired,
+    ProposePrivacyPolicyRequest,
+    decide_privacy_policy,
+    privacy_propose_policy,
+)
+from yoetz.application.service import Application
+from yoetz.config.models import YoetzConfig
+from yoetz.config.write import fireworks_provider
+from yoetz.domain.privacy import AuthorizationScope, AuthorizationScopeKind
+from yoetz.ports.control import RepositoryPrivacyContext, ServiceState
+from yoetz.ports.diagnostics import StartupCheckResult
+from yoetz.ports.ledger import CheckAwaitingHuman, CheckCommitResult
+from yoetz.ports.privacy import HumanAuthorityCapability, HumanPolicyDecision
+from yoetz.ports.secret_memory import HumanAuthorizationProof, SecretPurpose
+from yoetz.protocol.canonical import JsonValue, canonical_digest
+from yoetz.protocol.models import CheckRequest, PublishWorkRequest, StartRequest, StatusRequest
+from yoetz.service.lifecycle import ServiceLifecycle
+from yoetz.service.ready_composition import build_ready_application_factory
+from yoetz.service.vault import VaultMode, VaultService, provider_credential_profile_binding
+
+_INSTALLATION_ID = "ins_00000000-0000-4000-8000-000000000001"
+_INSTANCE_ID = "svc_00000000-0000-4000-8000-000000000002"
+_REPOSITORY = RepositoryPrivacyContext("hmac-sha256:" + "4" * 64, "git_common_root")
+_CHECK_REQUEST_ID = "req_00000000-0000-4000-8000-000000000427"
+_COMMON: dict[str, JsonValue] = {
+    "protocol_version": "0.1",
+    "schema_version": "1.0.0",
+    "actor": {"actor_id": "harness:pytest", "actor_type": "harness"},
+    "client": {"kind": "cooperative_agent", "version": "0.1.0", "integration": "cooperative_mcp"},
+}
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 8, 27, 17, 5, 0, tzinfo=UTC)
+
+    def now_utc(self) -> datetime:
+        return self.now
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _GenerationStore:
+    def advance(self, instance_id: str) -> int:
+        assert instance_id == _INSTANCE_ID
+        return 1
+
+
+class _Paths:
+    def __init__(self, bundle: Path) -> None:
+        self._bundle = bundle
+
+    @property
+    def bundle(self) -> Path:
+        return self._bundle
+
+    @property
+    def state(self) -> Path:
+        return self._bundle / "state"
+
+
+class _Diagnostics:
+    def record(self, result: StartupCheckResult) -> None:
+        assert type(result) is StartupCheckResult
+
+
+def _accept_private_path(_path: Path) -> None:
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _private_paths(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    monkeypatch.setattr(connection_module, "verify_private_local_bundle", _accept_private_path)
+
+
+def _event_batches() -> tuple[tuple[str, list[JsonValue]], ...]:
+    """A plan, an action, digest-bound evidence (1.1.0), a result, and a completion claim."""
+
+    return (
+        (
+            "req_00000000-0000-4000-8000-000000000102",
+            [
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000201",
+                    "schema": {"name": "plan_published", "version": "1.0.0"},
+                    "occurred_at": "2026-08-27T17:00:00.000Z",
+                    "causal_parents": [],
+                    "payload": {
+                        "plan_version": 1,
+                        "summary": "Replay a suspended check after the repository grant.",
+                        "obligation_refs": [],
+                    },
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                }
+            ],
+        ),
+        (
+            "req_00000000-0000-4000-8000-000000000103",
+            [
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000202",
+                    "schema": {"name": "action_recorded", "version": "1.0.0"},
+                    "occurred_at": "2026-08-27T17:01:00.000Z",
+                    "causal_parents": ["evt_00000000-0000-4000-8000-000000000201"],
+                    "payload": {
+                        "action_id": "act_00000000-0000-4000-8000-000000000201",
+                        "action_kind": "review",
+                        "description": "Reviewed the change under test.",
+                    },
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                },
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000203",
+                    "schema": {"name": "evidence_recorded", "version": "1.1.0"},
+                    "occurred_at": "2026-08-27T17:02:00.000Z",
+                    "causal_parents": ["evt_00000000-0000-4000-8000-000000000202"],
+                    "payload": {
+                        "evidence_id": "evd_00000000-0000-4000-8000-000000000201",
+                        "evidence_kind": "artifact",
+                        "strength": "content_digest",
+                        "content_digest": "sha256:" + "11" * 32,
+                        "observed_at": "2026-08-27T17:02:00.000Z",
+                        "description": "Diff of the reviewed change.",
+                        "digest_binding": {
+                            "subject": "source_diff",
+                            "content_availability": "digest_only",
+                            "byte_count": 128,
+                            "provenance": "caller_asserted",
+                        },
+                    },
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                },
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000204",
+                    "schema": {"name": "result_recorded", "version": "1.0.0"},
+                    "occurred_at": "2026-08-27T17:03:00.000Z",
+                    "causal_parents": ["evt_00000000-0000-4000-8000-000000000202"],
+                    "payload": {
+                        "result_id": "res_00000000-0000-4000-8000-000000000201",
+                        "action_id": "act_00000000-0000-4000-8000-000000000201",
+                        "outcome": "success",
+                        "summary": "The review completed.",
+                    },
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                },
+                {
+                    "event_id": "evt_00000000-0000-4000-8000-000000000205",
+                    "schema": {"name": "claim_recorded", "version": "1.0.0"},
+                    "occurred_at": "2026-08-27T17:04:00.000Z",
+                    "causal_parents": ["evt_00000000-0000-4000-8000-000000000204"],
+                    "payload": {
+                        "claim_id": "clm_00000000-0000-4000-8000-000000000201",
+                        "claim_kind": "completion",
+                        "statement": "The change was reviewed against its diff.",
+                        "supporting_refs": ["evd_00000000-0000-4000-8000-000000000201"],
+                    },
+                    "artifact_refs": [],
+                    "evidence_refs": [],
+                },
+            ],
+        ),
+    )
+
+
+async def _grant_repository_policy(app: Application, vault: VaultService, clock: _Clock) -> None:
+    """Run the trusted ceremony: propose the widened workspace policy, then approve it."""
+
+    policy_app = app.privacy.policy_application
+    assert policy_app is not None
+    scope = AuthorizationScope(
+        AuthorizationScopeKind.WORKSPACE, _INSTALLATION_ID, _REPOSITORY.commitment
+    )
+    authority = await policy_app.policy_store.repository_authority(scope)
+    assert authority.grant_state == "missing"
+    candidate = replace(
+        minimal_external_policy(), effective_scope=scope, created_at=clock.now_utc()
+    )
+    proposed = await privacy_propose_policy(
+        policy_app,
+        ProposePrivacyPolicyRequest(
+            authority.effective.effective_digest, candidate, authority.authority_digest, scope
+        ),
+    )
+    assert type(proposed) is PolicyDecisionRequired
+    await decide_privacy_policy(
+        policy_app,
+        DecidePrivacyPolicyRequest(
+            proposed.prepared,
+            HumanPolicyDecision(
+                proposed.prepared.prepared_digest, True, clock.now_utc(), "hmac-sha256:" + "5" * 64
+            ),
+            HumanAuthorityCapability(
+                "established_passphrase",
+                canonical_digest({"source": "test"}),
+                1,
+                str(getattr(vault.mode, "value", vault.mode)),
+                vault.generation,
+                True,
+            ),
+        ),
+    )
+    granted = await policy_app.policy_store.repository_authority(scope)
+    assert granted.grant_state == "granted"
+
+
+async def _store_provider_credential(
+    vault: VaultService, memory: LocalSecretMemory, provider: object
+) -> None:
+    binding = provider_credential_profile_binding(
+        provider.provider_id,  # type: ignore[attr-defined]
+        provider.model,  # type: ignore[attr-defined]
+        provider.endpoint_profile_id,  # type: ignore[attr-defined]
+        provider.endpoint_profile_version,  # type: ignore[attr-defined]
+    )
+    proof = HumanAuthorizationProof(
+        "provider-proof-after-composition",
+        "provider_credential_set",
+        binding.target_digest("set"),
+        1,
+        vault.generation,
+        None,
+        1.0,
+        60.0,
+    )
+    credential = memory.capture(
+        SecretPurpose.PROVIDER_CREDENTIAL, bytearray(b"test-provider-token")
+    )
+    await vault.store_provider_credential("set", binding, credential, proof, 2.0)
+
+
+@pytest.mark.parametrize(
+    "variant",
+    ["same_service", "same_service_with_credential", "restart", "restart_with_credential"],
+)
+@pytest.mark.anyio
+async def test_same_request_replay_after_repository_grant_reaches_terminal_result(
+    tmp_path: Path, variant: str
+) -> None:
+    tmp_path.chmod(0o700)
+    clock = _Clock()
+    memory = LocalSecretMemory()
+    lifecycle = ServiceLifecycle(
+        clock,
+        generation_store=_GenerationStore(),
+        process_start_identity_commitment="sha256:" + "d" * 64,
+        instance_id=_INSTANCE_ID,
+    )
+    await lifecycle.acquire_singleton()
+    await lifecycle.transition(ServiceState.LOCKED)
+    vault = VaultService(
+        installation_id=_INSTALLATION_ID,
+        service_generation=1,
+        mode=VaultMode.UNINITIALIZED,
+        secret_memory=memory,
+        clock=clock,
+        vault_store_factory=lambda: EncryptedVaultStore(tmp_path / "vault"),
+        pristine_state_digest="sha256:" + "e" * 64,
+    )
+    initialize = memory.capture(SecretPurpose.VAULT_INITIALIZE, bytearray(b"correct horse battery"))
+    await vault.initialize_passphrase(initialize, "sha256:" + "f" * 64)
+    provider = fireworks_provider(model="accounts/fireworks/models/minimax-m3")
+    config = YoetzConfig(profile="local-openai", provider=provider)
+    app = None
+    try:
+        factory = build_ready_application_factory(
+            lifecycle=lifecycle,
+            vault=vault,
+            config=config,
+            paths=_Paths(tmp_path),
+            clock=clock,
+            secret_memory=memory,
+            diagnostics=_Diagnostics(),
+        )
+        app = await factory(1, vault.generation)
+        started = await app.start(
+            StartRequest.model_validate(
+                {
+                    **_COMMON,
+                    "request_id": "req_00000000-0000-4000-8000-000000000101",
+                    "mode": "create",
+                    "task_title": "Replay a suspended check after the repository grant",
+                    "requested_view": "compact",
+                }
+            ),
+            repository_privacy_context=_REPOSITORY,
+        )
+        frontier = started.frontier
+        for request_id, drafts in _event_batches():
+            published = await app.publish_work(
+                PublishWorkRequest.model_validate(
+                    {
+                        **_COMMON,
+                        "request_id": request_id,
+                        "session_id": started.session_id,
+                        "writer_id": started.writer_id,
+                        "expected_frontier": {
+                            "sequence": str(frontier.sequence),
+                            "head_digest": frontier.head_digest,
+                        },
+                        "event_drafts": drafts,
+                    }
+                ),
+                repository_privacy_context=_REPOSITORY,
+            )
+            assert published.ok is True
+            frontier = published.result_frontier
+        request = CheckRequest.model_validate(
+            {
+                **_COMMON,
+                "request_id": _CHECK_REQUEST_ID,
+                "session_id": started.session_id,
+                "writer_id": started.writer_id,
+                "expected_frontier": {
+                    "sequence": str(frontier.sequence),
+                    "head_digest": frontier.head_digest,
+                },
+                "mode": "semantic_required",
+                "max_findings": "3",
+                "policy_packs": ["work-integrity/0.1.0"],
+            }
+        )
+
+        suspended = await app.check(request, repository_privacy_context=_REPOSITORY)
+        assert type(suspended) is CheckAwaitingHuman
+        assert suspended.continuation.kind == "repository_privacy_setup"
+        assert suspended.continuation.request_id == _CHECK_REQUEST_ID
+
+        await _grant_repository_policy(app, vault, clock)
+        if "credential" in variant:
+            await _store_provider_credential(vault, memory, provider)
+        if "restart" in variant:
+            # A service re-ready between the ceremony and the replay reopens the bundle and
+            # rehydrates the pending check from its durable resume checkpoint.
+            await app.close()
+            app = None
+            app = await factory(2, vault.generation)
+        clock.now = clock.now.replace(minute=12)
+
+        replayed = await app.check(request, repository_privacy_context=_REPOSITORY)
+        assert type(replayed) is CheckCommitResult, replayed
+        assert replayed.request_id == _CHECK_REQUEST_ID
+        assert replayed.outcome == "committed"
+        assert replayed.subject_frontier == frontier
+        # The grant was consumed: the check is past the standing-grant fence either way, and the
+        # only remaining reasons are provider-side, never a policy or storage verdict.
+        assert replayed.semantic_status.value in {"unavailable", "failed", "succeeded"}
+        assert replayed.semantic_reason.value != "human_approval_required"
+        assert replayed.semantic_reason.value != "scope_not_authorized"
+
+        # Exact same-request replay of the terminal result is idempotent.
+        again = await app.check(request, repository_privacy_context=_REPOSITORY)
+        assert type(again) is CheckCommitResult
+        assert again.outcome == "replayed"
+        assert again.result_frontier == replayed.result_frontier
+
+        status = await app.status(
+            StatusRequest.model_validate(
+                {
+                    **_COMMON,
+                    "request_id": "req_00000000-0000-4000-8000-000000000428",
+                    "session_id": started.session_id,
+                    "writer_id": started.writer_id,
+                    "view": "operation",
+                    "limit": "1",
+                    "filter": {"operation_request_id": _CHECK_REQUEST_ID},
+                }
+            ),
+            repository_privacy_context=_REPOSITORY,
+        )
+        page = status.page
+        assert getattr(page, "state", None) == "complete", page
+        assert getattr(page, "continuation", None) is None
+    finally:
+        if app is not None:
+            await app.close()
+        await vault.close()
+        memory.close()
+        await lifecycle.close()

--- a/tests/unit/kernel/test_replay_and_projections.py
+++ b/tests/unit/kernel/test_replay_and_projections.py
@@ -7,21 +7,32 @@ import subprocess
 import sys
 from copy import deepcopy
 from dataclasses import FrozenInstanceError, replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+from builders.policy_cases import evd, evidence_record
 from fixture_loader import load_fixture_json
 from yoetz.domain.events import (
+    EVIDENCE_SCHEMA_VERSION,
     ActionKind,
     ActionRecordedPayload,
+    EventSchema,
+    EvidenceContentAvailability,
+    EvidenceDigestBinding,
+    EvidenceDigestProvenance,
+    EvidenceDigestSubject,
+    EvidenceKind,
+    EvidenceRecordedPayload,
     ObligationChangeKind,
     ObligationPublishedPayload,
     ObligationStatus,
+    decode_payload,
     encode_payload,
 )
-from yoetz.domain.values import action_id, event_id, obligation_id
+from yoetz.domain.values import action_id, event_id, obligation_id, timestamp_from_datetime
 from yoetz.kernel.projections import (
     PROJECTION_GENERATION,
     PROJECTION_VERSION,
@@ -34,7 +45,7 @@ from yoetz.kernel.projections import (
     projection_snapshot,
 )
 from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
-from yoetz.protocol.coverage import LedgerFreshness
+from yoetz.protocol.coverage import EvidenceImmutability, LedgerFreshness
 
 _DIGEST = "sha256:" + "1" * 64
 _EVENT_ID = event_id("evt_00000000-0000-4000-8000-000000000001")
@@ -163,6 +174,57 @@ def test_projection_snapshot_codec_round_trips_canonical_bytes() -> None:
     snapshot = projection_snapshot(state)
     decoded = projection_from_snapshot(snapshot)
     assert decoded == state
+    assert canonical_encode(projection_snapshot(decoded)) == canonical_encode(snapshot)
+
+
+def _digest_bound_evidence_payload() -> EvidenceRecordedPayload:
+    """An evidence payload only ``evidence_recorded/1.1.0`` admits (it carries a digest binding)."""
+
+    return EvidenceRecordedPayload(
+        evidence_id=evd(1),
+        evidence_kind=EvidenceKind.ARTIFACT,
+        strength=EvidenceImmutability.CONTENT_DIGEST,
+        observed_at=timestamp_from_datetime(datetime(2026, 8, 27, 17, 5, tzinfo=UTC)),
+        content_digest="sha256:" + "11" * 32,
+        description="Diff of the reviewed change.",
+        digest_binding=EvidenceDigestBinding(
+            subject=EvidenceDigestSubject.SOURCE_DIFF,
+            content_availability=EvidenceContentAvailability.DIGEST_ONLY,
+            byte_count=128,
+            provenance=EvidenceDigestProvenance.CALLER_ASSERTED,
+        ),
+    )
+
+
+def test_projection_snapshot_codec_round_trips_later_schema_versions() -> None:
+    """A record whose payload only a later wire version admits still rehydrates (issue #427).
+
+    Snapshot records carry no schema version. The decoder used to pin every family to "1.0.0", so
+    an evidence record published as ``evidence_recorded/1.1.0`` with a ``digest_binding`` encoded
+    fine but could never be decoded again: every frozen-case rehydration (privacy-wait replay,
+    ledger recovery) of a task holding such evidence failed as ``invalid_projection_state`` and was
+    reported as non-retryable STORAGE_CORRUPT on an intact bundle.
+    """
+
+    payload = _digest_bound_evidence_payload()
+    encoded = encode_payload(payload)
+    with pytest.raises(ValueError):
+        decode_payload(EventSchema("evidence_recorded", "1.0.0"), encoded)
+    assert decode_payload(EventSchema("evidence_recorded", EVIDENCE_SCHEMA_VERSION), encoded) == (
+        payload
+    )
+
+    state = replace(
+        empty_projection_state(),
+        frontier=1,
+        head_digest=_DIGEST,
+        evidence=cast(Any, {payload.evidence_id: evidence_record(payload, 1)}),
+        freshness=LedgerFreshness.CURRENT,
+    )
+    snapshot = projection_snapshot(state)
+    decoded = projection_from_snapshot(snapshot)
+    assert decoded == state
+    assert decoded.evidence[payload.evidence_id].payload == payload
     assert canonical_encode(projection_snapshot(decoded)) == canonical_encode(snapshot)
 
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #427 (follow-ups filed as #443, #444, #445)
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated (storage/durability, privacy-wait replay): the maintainer acknowledged #427 (`ack` comment) before this PR was opened.

## Documentation

- Behavior change? `yes` (bug fix; no interface change)
- Docs updated: `CHANGELOG.md` (Unreleased › Fixed). No ADR / `docs/INTERFACES.md` change: the snapshot wire bytes, error codes, and continuation contract are unchanged.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/kernel/test_replay_and_projections.py -q
  13 passed
uv run pytest tests/integration/service/test_check_repository_grant_replay.py -q
  4 passed   (same_service, same_service_with_credential, restart, restart_with_credential)
uv run pytest tests/conformance/compatibility/test_backward_read.py tests/property/test_reducer_equivalence.py \
  tests/unit/kernel/test_deterministic_checks.py tests/conformance/protocol/test_unknown_events.py \
  tests/integration/application/test_check.py tests/conformance/adapters/test_ledger_port.py -q
  82 passed
uv run pytest tests/unit/kernel tests/unit/domain/test_event_payloads.py tests/integration/service/test_ready_composition.py \
  tests/integration/service/test_semantic_non_dispatch.py tests/integration/application/test_status_operation_view.py \
  tests/integration/application/test_status_pending_operation_projection.py -q
  358 passed
uv run ruff format src tests && uv run ruff check src tests
  All checks passed!
npx --no-install pyright src/yoetz/kernel/projections.py tests/unit/kernel/test_replay_and_projections.py \
  tests/integration/service/test_check_repository_grant_replay.py
  0 errors, 0 warnings, 0 informations
```

Offline validation against a copy of the reporter's real bundle (`tsk_5ed351e0…`, op `req_3c9d64f1…`): before the fix, ledger recovery raised `STORAGE_CORRUPT` ← `deterministic_case_invalid` ← `invalid_projection_state` (`projections.py:903`, evidence collection) and latched; after the fix, recovery succeeds, `freeze_case` reclaims the suspended check in `SEMANTIC_WAIT`, and `_load_deterministic_result` loads the checkpoint (1 finding, 2 policy executions). The copy was deleted afterwards.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

The privacy-wait replay in #427 never reached the grant logic. The frozen case's resume checkpoint stores a projection snapshot whose records carry no schema version, and `kernel/projections.py::_decoded_payload` pinned every family to `EventSchema(name, "1.0.0")`. Evidence published as `evidence_recorded/1.1.0` with a `digest_binding` (the current `EVIDENCE_SCHEMA_VERSION`) encoded fine but then failed `unknown_payload_field` on decode → `invalid_projection_state` → `deterministic_case_invalid` → non-retryable `STORAGE_CORRUPT`. Only *deferred* rehydration hits this — the same-request replay after the standing grant, and `SqliteLedger` recovery after the service re-readied between the ceremony and the replay (which is what happened: the ceremony committed policy generation 7 at 17:11:48Z, the replay at 17:12:46Z reopened the bundle). Recovery then latched the verdict for the whole task, which is why the durable row kept its stale `repository_privacy_setup` continuation and only a brand-new task worked.

Fix: each snapshot record decodes under the newest wire version its family admits (driven by `PAYLOAD_TYPES`), keeping the cross-name ambiguity check. Deliberately no wire change — persisting the version in the snapshot would change the canonical bytes every stored `case_digest` / resume pointer is bound to and re-break existing checkpoints.

Tests: a snapshot round-trip unit test for later-version evidence (fails on `main`), and the integration test from the issue's suggested direction — real composition, freeze → `repository_privacy_setup` → trusted grant → identical replay → terminal result, idempotent re-replay, `status view=operation` complete — in same-service and restart (recovery-path) variants, with a digest-bound 1.1.0 evidence event in the ledger.

Follow-ups filed, not addressed here: #443 (one undecodable pending op latches the whole task ledger), #444 (repository fence blocks read-only inspection of a stranded op), #445 (standing-grant suspension refuses observation appends for the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed failures when replaying suspended checks after repository authorization is granted.
  - Resolved corrupted or unreadable ledger errors involving digest-bound evidence records.
  - Projection snapshots now correctly decode evidence recorded under newer supported schema versions.
  - Replay remains reliable across service restarts and repeated attempts, with grants consumed as expected.

- **Tests**
  - Added coverage for authorization, credential, restart, replay, and snapshot restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->