### PR TITLE
fix(codex): skill parent safety and honest plugin activation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- Codex skill install, replace, and remove now refuse a symlink at `.agents` or `.agents/skills`
+  as `target_unsafe`, bind the managed parent's identity into the preview digest, and perform the
+  stage/replace/remove swap through a directory-fd no-follow walk so a parent swapped between
+  preview and apply fails closed (issue #396).
+- `inspect_activation` / `yoetz observe status` report `installed_not_activated` for a byte-present
+  modified or untrusted plugin tree instead of collapsing it to `not_installed`. `not_installed`
+  remains absence only, and a modified tree is never `active`. Apply still requires a current
+  renderer variant (issues #347 and #387).
+
 - Replaying a check that was suspended on a standing repository grant no longer fails with a
   non-retryable `STORAGE_CORRUPT` after the trusted `yoetz --privacy` ceremony, and a task whose
   ledger holds `evidence_recorded/1.1.0` events (any evidence carrying a `digest_binding`) no

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2951,7 +2951,10 @@ the exact preview digest and explicit acceptance; a generic `--yes` cannot stand
 partial, unmanaged, unsafe, or changed-after-preview copies are preserved. v0.1 writes only the
 profile's exact `skill_root` — `.agents/skills/yoetz/` for `codex` — inside one explicitly supplied
 trusted project; it never edits harness/MCP configuration, Git state, package resources, or
-arbitrary skills.
+arbitrary skills. Existing `.agents` and `.agents/skills` parents must be real owner-controlled
+directories: a symlink at either component is `target_unsafe`, creation/replacement/removal use
+directory-fd no-follow operations, and a parent identity change between preview and apply is
+`preview_stale` (issue #396).
 
 Filesystem presence and capability compatibility are independent facts: an unprofiled source is
 `unsupported`, while its destination state remains `absent|installed_exact|modified|partial|unsafe`
@@ -2965,7 +2968,10 @@ digest refuses the whole apply before a file is written. Setup separately report
 `project_skill_installation`, structural plugin-source installation, `plugin_activation`, MCP
 registration, hooks/consent, service routing, and semantic readiness; none of those fields implies
 another. `plugin_activation` uses the closed state
-`active|installed_not_activated|not_installed|foreign`. When an explicitly supplied Codex home is
+`active|installed_not_activated|not_installed|foreign`. `not_installed` is actual source
+absence only. A byte-present plugin tree that is not a current renderer variant — including
+`installed_untrusted_unknown` / modified copies that Codex may still be serving — is
+`installed_not_activated`, never `not_installed` and never `active` (issue #347). When an explicitly supplied Codex home is
 bound, the registration and readiness `plugin_activation` blocks echo that home and its config
 path even when the activation preview or inspection fails, and they carry the actual failure
 reason; `codex_home_required` appears only when no home was provided. Readiness facts that were
@@ -3198,8 +3204,8 @@ content window, so the operator must quiesce such writers. After a successful re
 `codex plugin list
 --marketplace yoetz --json` is empty and `config.toml` has no yoetz tables;
 `inspect_activation` / observe status reports `installed_not_activated` when the managed plugin
-source at `.agents/plugins/yoetz` remains (issue #387) and `not_installed` only when that source
-is also absent. A second removal is `already_absent`. The skill tree, consent records, and
+source at `.agents/plugins/yoetz` remains (issues #387 and #347), including a modified or
+untrusted copy, and `not_installed` only when that source is also absent. A second removal is `already_absent`. The skill tree, consent records, and
 observation store are intentionally left in place.
 
 The implemented artifact operation is exactly `plugin_artifact_apply`. Its prepare target is the

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -159,7 +159,9 @@ exactly those contracts and connects the steps without weakening any existing tr
    repository, and the inventory's versioned cache is byte-identical to the managed plugin tree.
    Otherwise the closed state is
    `installed_not_activated`, `not_installed`, or `foreign`; installed bytes, configuration, cache,
-   and inventory remain separately reported facts. Declining changes none of them. This ceremony
+   and inventory remain separately reported facts. `not_installed` is source absence only; a
+   modified or untrusted byte-present tree is `installed_not_activated` and never `active`
+   (issue #347). Declining changes none of them. This ceremony
    authorizes a standing Codex trust change for future sessions in that exact Codex home; it does
    not prove that a later session loaded a hook or delivered an observation.
 
@@ -257,7 +259,8 @@ exactly those contracts and connects the steps without weakening any existing tr
    shows the command, route, all warning tokens, and exact preview digest before confirmation.
    After activation removal,
    observe/inspect reports
-   `installed_not_activated` when the managed plugin source remains (issue #387) and
+   `installed_not_activated` when the managed plugin source remains (issues #387 and #347),
+   including a modified copy, and
    `not_installed` only when that source is also absent.
 
 The short `yoetz --set --fireworks --model MODEL` and `yoetz --set --grok --model MODEL` paths are

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -56,6 +56,7 @@ yoetz integrate codex skill status --json
 
 Destination states: `absent`, `installed_exact`, `modified`/`unmanaged`, `partial`, `unsafe`.
 Compatibility is reported separately as `supported`, `unsupported`, or `untested`.
+A symlink at `.agents` or `.agents/skills` is `target_unsafe` and is never followed (issue #396).
 Status is read-only — it never repairs or updates anything. An identical directory without a valid
 managed marker is treated as unmanaged/modified and is protected from removal. `installed_exact`
 does **not** by itself prove Codex has discovered the skill or that MCP is available.
@@ -156,7 +157,9 @@ pathname rollback that could delete or overwrite a concurrent change. `active` m
 agree: managed source installed, repository marketplace and selected-home config exact, canonical
 inventory says `yoetz@yoetz` is installed and enabled from this repository, and the installed
 version cache is byte-identical to the host-specific render of the managed source. Other closed
-states are `installed_not_activated`, `not_installed`, and `foreign`. None of them—and not even
+states are `installed_not_activated`, `not_installed`, and `foreign`. `not_installed` is source
+absence only; a modified or untrusted byte-present tree is `installed_not_activated` and is never
+`active` (issue #347). None of them—and not even
 `active`—proves a later Codex process loaded a hook or delivered an observation.
 
 The managed project source always carries the canonical async-free render; the host-specific form
@@ -304,7 +307,7 @@ retry.
 After a successful removal, `codex plugin list --marketplace yoetz --json` is empty and
 `config.toml` has no yoetz tables. `yoetz observe status` reports the existing activation
 classification: `installed_not_activated` when the managed plugin source at
-`.agents/plugins/yoetz` remains (issue #387), or `not_installed` when that source is also absent.
+`.agents/plugins/yoetz` remains (issues #387 and #347), including a modified copy, or `not_installed` when that source is also absent.
 The command reports whether the skill tree remains; it does not remove it. Consent records and the
 observation store are intentionally left in place.
 

--- a/src/yoetz/adapters/integrations/codex_marketplace.py
+++ b/src/yoetz/adapters/integrations/codex_marketplace.py
@@ -659,6 +659,26 @@ def _cache_version_path(root: Path, version: str) -> Path:
     return root / version
 
 
+def _plugin_source_presence(target: IntegrationTarget, *, codex_version: str) -> PluginHookPresence:
+    """Classify source presence independently of host-variant byte parity.
+
+    ``INSTALLED`` when either current renderer variant matches. ``ABSENT`` only
+    when both variants report absence. Any other byte-present tree, including a
+    modified or untrusted copy that Codex may still be serving, is
+    ``INSTALLED_UNTRUSTED_UNKNOWN`` so status never collapses it to
+    ``not_installed`` (#347).
+    """
+
+    seen = tuple(
+        inspect_plugin(target, codex_version=variant).presence for variant in (None, codex_version)
+    )
+    if PluginHookPresence.INSTALLED in seen:
+        return PluginHookPresence.INSTALLED
+    if all(presence is PluginHookPresence.ABSENT for presence in seen):
+        return PluginHookPresence.ABSENT
+    return PluginHookPresence.INSTALLED_UNTRUSTED_UNKNOWN
+
+
 def _plugin_source_installed(target: IntegrationTarget, *, codex_version: str) -> bool:
     """True when the project tree is byte-exactly one current managed renderer variant.
 
@@ -666,11 +686,12 @@ def _plugin_source_installed(target: IntegrationTarget, *, codex_version: str) -
     render (``codex_version=None``); the host-specific form belongs only to the
     activation cache. Either byte-exact form counts as an installed source, so a
     canonical source on an async-capable host never reads as ``not_installed``.
+    Apply fences keep using this exact-variant check; status uses
+    ``_plugin_source_presence`` so a modified tree is not reported absent.
     """
 
-    return any(
-        inspect_plugin(target, codex_version=variant).presence is PluginHookPresence.INSTALLED
-        for variant in (None, codex_version)
+    return (
+        _plugin_source_presence(target, codex_version=codex_version) is PluginHookPresence.INSTALLED
     )
 
 
@@ -896,11 +917,14 @@ def inspect_activation(
     project, home, marketplace_path, config_path = _paths(target, binary.codex_home)
     # The committed project tree carries the canonical render; judging ``installed``
     # against the host-specific render alone would keep an async-capable host at
-    # ``not_installed`` forever (#387).
-    installed = _plugin_source_installed(target, codex_version=binary.codex_version)
+    # ``not_installed`` forever (#387). A byte-present modified tree is still
+    # installed for status (#347): ``not_installed`` is absence only.
+    presence = _plugin_source_presence(target, codex_version=binary.codex_version)
+    installed = presence is not PluginHookPresence.ABSENT
+    exact_source = presence is PluginHookPresence.INSTALLED
     plugin_cached = False
     cache_foreign = False
-    if installed:
+    if exact_source:
         try:
             cache_members = _source_cache_members(target, codex_version=binary.codex_version)
             local_digest = _installed_cache_digest_anchored(home, __version__, cache_members)

--- a/src/yoetz/adapters/integrations/codex_plugin.py
+++ b/src/yoetz/adapters/integrations/codex_plugin.py
@@ -18,6 +18,7 @@ from yoetz.adapters.integrations.codex_skill import (
     SkillResourceSource,
     load_packaged_skill_members,
     load_packaged_skill_source,
+    validated_managed_parent,
 )
 from yoetz.domain.values import JsonValue as DomainJsonValue
 from yoetz.ports.harness_mcp import MCP_SERVE_COMMAND, MCP_SERVER_NAME
@@ -370,28 +371,7 @@ def _validated_project(target: IntegrationTarget) -> Path:
 def _validated_plugin_parent(root: Path, *, create: bool) -> Path:
     """Resolve the managed parent without following project-local symlink ancestors."""
 
-    current = root
-    for component in (".agents", "plugins"):
-        candidate = current / component
-        if not candidate.exists() and not candidate.is_symlink():
-            if not create:
-                return root / ".agents" / "plugins"
-            try:
-                candidate.mkdir(mode=0o700)
-            except OSError as exc:
-                raise _error(IntegrationReason.WRITE_FAILED) from exc
-        if candidate.is_symlink() or not candidate.is_dir():
-            raise _error(IntegrationReason.TARGET_UNSAFE)
-        try:
-            stat = candidate.stat()
-        except OSError as exc:
-            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-        if hasattr(os, "geteuid") and stat.st_uid != os.geteuid():
-            raise _error(IntegrationReason.TARGET_UNSAFE)
-        if stat.st_mode & 0o022:
-            raise _error(IntegrationReason.TARGET_UNSAFE)
-        current = candidate
-    return current
+    return validated_managed_parent(root, (".agents", "plugins"), create=create)
 
 
 def plugin_tree_matches_marker(members: Mapping[str, bytes]) -> bool:

--- a/src/yoetz/adapters/integrations/codex_skill.py
+++ b/src/yoetz/adapters/integrations/codex_skill.py
@@ -731,11 +731,24 @@ def _remove_tree_fd(parent_fd: int, name: str, *, depth: int = 0) -> None:
     os.rmdir(name, dir_fd=parent_fd)
 
 
-def _open_skill_parent_fd(root: Path, *, create: bool) -> int:
+def _open_skill_parent_fd(
+    root: Path,
+    *,
+    create: bool,
+    target_identity: str,
+    parent_identity: str,
+) -> int:
+    """Open the managed parent and prove the previewed inode is on the retained walk."""
+
     _require_dir_fd_primitives()
     current_fd = os.open(root, _directory_open_flags())
     try:
-        _owned_stat_not_writable(os.fstat(current_fd), directory=True)
+        root_facts = os.fstat(current_fd)
+        _owned_stat_not_writable(root_facts, directory=True)
+        root_identity = _inode_identity(root_facts)
+        if root_identity != target_identity:
+            raise _error(IntegrationReason.PREVIEW_STALE)
+        preview_parent_seen = root_identity == parent_identity
         for component in (".agents", "skills"):
             try:
                 child_fd = os.open(component, _directory_open_flags(), dir_fd=current_fd)
@@ -753,21 +766,22 @@ def _open_skill_parent_fd(root: Path, *, create: bool) -> int:
             except OSError as exc:
                 raise _error(IntegrationReason.TARGET_UNSAFE) from exc
             try:
-                _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+                child_facts = os.fstat(child_fd)
+                _owned_stat_not_writable(child_facts, directory=True)
+                preview_parent_seen = (
+                    preview_parent_seen or _inode_identity(child_facts) == parent_identity
+                )
             except BaseException:
                 os.close(child_fd)
                 raise
             os.close(current_fd)
             current_fd = child_fd
+        if not preview_parent_seen:
+            raise _error(IntegrationReason.PREVIEW_STALE)
         return current_fd
     except BaseException:
         os.close(current_fd)
         raise
-
-
-def _assert_parent_identity(root: Path, expected: str) -> None:
-    if _skill_parent_identity(root) != expected:
-        raise _error(IntegrationReason.PREVIEW_STALE)
 
 
 def recover_interrupted_swap(
@@ -883,8 +897,12 @@ class CodexSkillIntegration(IntegrationsPort):
             )
             raise _error(reason)
         root, _target_identity = _validated_project(command.target)
-        _assert_parent_identity(root, inspection.parent_identity)
-        parent_fd = _open_skill_parent_fd(root, create=True)
+        parent_fd = _open_skill_parent_fd(
+            root,
+            create=True,
+            target_identity=inspection.target_identity,
+            parent_identity=inspection.parent_identity,
+        )
         stage_name = f".yoetz.stage-{command.request_id}"
         rollback_name = f".yoetz.rollback-{command.request_id}"
         destination_name = "yoetz"
@@ -957,8 +975,12 @@ class CodexSkillIntegration(IntegrationsPort):
         ):
             raise _error(IntegrationReason.REMOVE_REFUSED)
         root, _target_identity = _validated_project(command.target)
-        _assert_parent_identity(root, inspection.parent_identity)
-        parent_fd = _open_skill_parent_fd(root, create=False)
+        parent_fd = _open_skill_parent_fd(
+            root,
+            create=False,
+            target_identity=inspection.target_identity,
+            parent_identity=inspection.parent_identity,
+        )
         staging_name = f".yoetz.remove-{command.request_id}"
         try:
             if staging_name in os.listdir(parent_fd):

--- a/src/yoetz/adapters/integrations/codex_skill.py
+++ b/src/yoetz/adapters/integrations/codex_skill.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-import shutil
+import stat
 from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib import resources
@@ -50,6 +50,7 @@ __all__ = [
     "load_packaged_skill_members",
     "load_packaged_skill_source",
     "recover_interrupted_swap",
+    "validated_managed_parent",
 ]
 
 _ADAPTER_VERSION = "codex-skill/0.1.0"
@@ -108,6 +109,7 @@ class DestinationInspection:
     file_states: tuple[JsonObject, ...]
     managed_marker_valid: bool
     target_identity: str
+    parent_identity: str
 
     def __repr__(self) -> str:
         return (
@@ -386,17 +388,76 @@ def _validated_project(target: IntegrationTarget) -> tuple[Path, str]:
         if current.is_symlink():
             raise _error(IntegrationReason.TARGET_UNSAFE)
     try:
-        stat = root.stat()
+        facts = root.stat()
     except OSError as exc:
         raise _error(IntegrationReason.TARGET_UNSAFE) from exc
-    if hasattr(os, "geteuid") and stat.st_uid != os.geteuid():
+    if hasattr(os, "geteuid") and facts.st_uid != os.geteuid():
         raise _error(IntegrationReason.TARGET_UNSAFE)
-    if stat.st_mode & 0o022:
+    if facts.st_mode & 0o022:
         raise _error(IntegrationReason.TARGET_UNSAFE)
-    identity = canonical_digest(
-        {"device": stat.st_dev, "inode": stat.st_ino, "mode": stat.st_mode & 0o777}
-    )
+    identity = _inode_identity(facts)
     return root, identity
+
+
+def _inode_identity(facts: os.stat_result) -> str:
+    return canonical_digest(
+        {"device": facts.st_dev, "inode": facts.st_ino, "mode": facts.st_mode & 0o777}
+    )
+
+
+def _owned_stat_not_writable(facts: os.stat_result, *, directory: bool) -> None:
+    expected = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected(facts.st_mode):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    if hasattr(os, "geteuid") and facts.st_uid != os.geteuid():
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    if facts.st_mode & 0o022:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+
+
+def validated_managed_parent(root: Path, components: tuple[str, ...], *, create: bool) -> Path:
+    """Resolve a managed parent without following project-local symlink ancestors."""
+
+    if not components or any(part in {"", ".", ".."} or "/" in part for part in components):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    current = root
+    for component in components:
+        candidate = current / component
+        if not candidate.exists() and not candidate.is_symlink():
+            if not create:
+                return root.joinpath(*components)
+            try:
+                candidate.mkdir(mode=0o700)
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+        if candidate.is_symlink() or not candidate.is_dir():
+            raise _error(IntegrationReason.TARGET_UNSAFE)
+        try:
+            facts = candidate.stat()
+        except OSError as exc:
+            raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+        _owned_stat_not_writable(facts, directory=True)
+        current = candidate
+    return current
+
+
+def _skill_parent_identity(root: Path) -> str:
+    current = root
+    identity_path = root
+    for component in (".agents", "skills"):
+        candidate = current / component
+        if not candidate.exists() and not candidate.is_symlink():
+            break
+        if candidate.is_symlink() or not candidate.is_dir():
+            raise _error(IntegrationReason.TARGET_UNSAFE)
+        identity_path = candidate
+        current = candidate
+    try:
+        facts = identity_path.lstat()
+    except OSError as exc:
+        raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+    _owned_stat_not_writable(facts, directory=True)
+    return _inode_identity(facts)
 
 
 def _file_state(path: Path, expected: IntegrationFile) -> JsonObject:
@@ -423,7 +484,9 @@ def inspect_destination(target: IntegrationTarget, source: SkillSource) -> Desti
     """Classify only the profile-fixed destination without mutating it."""
 
     root, target_identity = _validated_project(target)
-    destination = root / CODEX_HARNESS_PROFILE.skill_root.rstrip("/")
+    parent = validated_managed_parent(root, (".agents", "skills"), create=False)
+    parent_identity = _skill_parent_identity(root)
+    destination = parent / "yoetz"
     if destination.is_symlink():
         raise _error(IntegrationReason.TARGET_UNSAFE)
     siblings = destination.parent
@@ -481,6 +544,7 @@ def inspect_destination(target: IntegrationTarget, source: SkillSource) -> Desti
         rows,
         marker_valid,
         target_identity,
+        parent_identity,
     )
 
 
@@ -544,6 +608,7 @@ def _preview(
             "scope": command.target.scope.value,
             "source_digest": source.resource_set_digest,
             "target_identity": inspection.target_identity,
+            "parent_identity": inspection.parent_identity,
             "warnings": list(warnings),
         }
     )
@@ -559,32 +624,150 @@ def _preview(
     )
 
 
-def _fsync_dir(path: Path) -> None:
-    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+def _directory_open_flags() -> int:
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def _require_dir_fd_primitives() -> None:
+    required = (os.open, os.mkdir, os.rename, os.rmdir, os.unlink, os.listdir)
+    if (
+        not getattr(os, "O_NOFOLLOW", 0)
+        or not getattr(os, "O_DIRECTORY", 0)
+        or any(function not in os.supports_dir_fd for function in required[:-1])
+        or os.listdir not in os.supports_fd
+    ):
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+
+
+def _fsync_fd(directory_fd: int) -> None:
+    os.fsync(directory_fd)
+
+
+def _open_or_create_nested(root_fd: int, relative: Path) -> int:
+    current_fd = os.dup(root_fd)
     try:
-        os.fsync(fd)
+        for part in relative.parts:
+            if part in {"", ".", ".."}:
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            try:
+                os.mkdir(part, mode=0o700, dir_fd=current_fd)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            try:
+                child_fd = os.open(part, _directory_open_flags(), dir_fd=current_fd)
+            except OSError as exc:
+                raise _error(IntegrationReason.WRITE_FAILED) from exc
+            try:
+                _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+            except BaseException:
+                os.close(child_fd)
+                raise
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _write_file_fd(directory_fd: int, name: str, payload: bytes) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(name, flags, 0o600, dir_fd=directory_fd)
+    try:
+        written = 0
+        while written < len(payload):
+            written += os.write(descriptor, payload[written:])
+        os.fsync(descriptor)
     finally:
-        os.close(fd)
+        os.close(descriptor)
 
 
-def _write_bundle(stage: Path, bundle: _SourceBundle) -> None:
-    stage.mkdir(mode=0o700)
+def _write_bundle_fd(stage_fd: int, bundle: _SourceBundle) -> None:
     for relative_path, data in bundle.members.items():
-        destination = stage / relative_path
-        destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        relative = Path(relative_path)
+        if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+            raise _error(IntegrationReason.SOURCE_INVALID)
+        directory_fd = _open_or_create_nested(stage_fd, relative.parent)
         try:
-            written = 0
-            while written < len(data):
-                written += os.write(fd, data[written:])
-            os.fsync(fd)
+            _write_file_fd(directory_fd, relative.name, data)
         finally:
-            os.close(fd)
-    marker = stage / _MARKER_NAME
-    marker.write_bytes(build_managed_marker(bundle.source, IntegrationScope.TRUSTED_PROJECT))
-    with marker.open("rb") as handle:
-        os.fsync(handle.fileno())
-    _fsync_dir(stage)
+            os.close(directory_fd)
+    marker = build_managed_marker(bundle.source, IntegrationScope.TRUSTED_PROJECT)
+    _write_file_fd(stage_fd, _MARKER_NAME, marker)
+    _fsync_fd(stage_fd)
+
+
+def _remove_tree_fd(parent_fd: int, name: str, *, depth: int = 0) -> None:
+    if depth > 16 or name in {"", ".", ".."} or "/" in name:
+        raise _error(IntegrationReason.TARGET_UNSAFE)
+    directory_fd = os.open(name, _directory_open_flags(), dir_fd=parent_fd)
+    try:
+        _owned_stat_not_writable(os.fstat(directory_fd), directory=True)
+        for child in os.listdir(directory_fd):
+            if child in {"", ".", ".."} or "/" in child:
+                raise _error(IntegrationReason.TARGET_UNSAFE)
+            facts = os.stat(child, dir_fd=directory_fd, follow_symlinks=False)
+            if stat.S_ISLNK(facts.st_mode):
+                os.unlink(child, dir_fd=directory_fd)
+            elif stat.S_ISDIR(facts.st_mode):
+                _remove_tree_fd(directory_fd, child, depth=depth + 1)
+            else:
+                os.unlink(child, dir_fd=directory_fd)
+    finally:
+        os.close(directory_fd)
+    os.rmdir(name, dir_fd=parent_fd)
+
+
+def _open_skill_parent_fd(root: Path, *, create: bool) -> int:
+    _require_dir_fd_primitives()
+    current_fd = os.open(root, _directory_open_flags())
+    try:
+        _owned_stat_not_writable(os.fstat(current_fd), directory=True)
+        for component in (".agents", "skills"):
+            try:
+                child_fd = os.open(component, _directory_open_flags(), dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise _error(IntegrationReason.TARGET_UNSAFE) from None
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=current_fd)
+                except OSError as exc:
+                    raise _error(IntegrationReason.WRITE_FAILED) from exc
+                try:
+                    child_fd = os.open(component, _directory_open_flags(), dir_fd=current_fd)
+                except OSError as exc:
+                    raise _error(IntegrationReason.WRITE_FAILED) from exc
+            except OSError as exc:
+                raise _error(IntegrationReason.TARGET_UNSAFE) from exc
+            try:
+                _owned_stat_not_writable(os.fstat(child_fd), directory=True)
+            except BaseException:
+                os.close(child_fd)
+                raise
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _assert_parent_identity(root: Path, expected: str) -> None:
+    if _skill_parent_identity(root) != expected:
+        raise _error(IntegrationReason.PREVIEW_STALE)
 
 
 def recover_interrupted_swap(
@@ -699,29 +882,46 @@ class CodexSkillIntegration(IntegrationsPort):
                 else IntegrationReason.PARTIAL_INSTALL
             )
             raise _error(reason)
-        parent = inspection.destination.parent
-        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        stage = parent / f".yoetz.stage-{command.request_id}"
-        rollback = parent / f".yoetz.rollback-{command.request_id}"
-        if stage.exists() or rollback.exists():
-            raise _error(IntegrationReason.PREVIEW_STALE)
+        root, _target_identity = _validated_project(command.target)
+        _assert_parent_identity(root, inspection.parent_identity)
+        parent_fd = _open_skill_parent_fd(root, create=True)
+        stage_name = f".yoetz.stage-{command.request_id}"
+        rollback_name = f".yoetz.rollback-{command.request_id}"
+        destination_name = "yoetz"
         try:
-            _write_bundle(stage, bundle)
+            existing_names = set(os.listdir(parent_fd))
+            if stage_name in existing_names or rollback_name in existing_names:
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            os.mkdir(stage_name, mode=0o700, dir_fd=parent_fd)
+            stage_fd = os.open(stage_name, _directory_open_flags(), dir_fd=parent_fd)
+            try:
+                _owned_stat_not_writable(os.fstat(stage_fd), directory=True)
+                _write_bundle_fd(stage_fd, bundle)
+            finally:
+                os.close(stage_fd)
+            _fsync_fd(parent_fd)
             if replacing:
-                os.replace(inspection.destination, rollback)
-                _fsync_dir(parent)
-            os.replace(stage, inspection.destination)
-            _fsync_dir(parent)
+                os.rename(
+                    destination_name,
+                    rollback_name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                _fsync_fd(parent_fd)
+            os.rename(stage_name, destination_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            _fsync_fd(parent_fd)
             final = inspect_destination(command.target, bundle.source)
             if final.state is not IntegrationState.INSTALLED_EXACT:
                 raise _error(IntegrationReason.WRITE_FAILED)
-            if rollback.exists():
-                shutil.rmtree(rollback)
-                _fsync_dir(parent)
+            if rollback_name in os.listdir(parent_fd):
+                _remove_tree_fd(parent_fd, rollback_name)
+                _fsync_fd(parent_fd)
         except IntegrationError:
             raise
         except OSError as exc:
             raise _error(IntegrationReason.WRITE_FAILED) from exc
+        finally:
+            os.close(parent_fd)
         return IntegrationResult(
             command.requested_action,
             inspection.state,
@@ -756,17 +956,23 @@ class CodexSkillIntegration(IntegrationsPort):
             or inspection.state is not IntegrationState.INSTALLED_EXACT
         ):
             raise _error(IntegrationReason.REMOVE_REFUSED)
-        parent = inspection.destination.parent
-        staging = parent / f".yoetz.remove-{command.request_id}"
-        if staging.exists():
-            raise _error(IntegrationReason.PREVIEW_STALE)
+        root, _target_identity = _validated_project(command.target)
+        _assert_parent_identity(root, inspection.parent_identity)
+        parent_fd = _open_skill_parent_fd(root, create=False)
+        staging_name = f".yoetz.remove-{command.request_id}"
         try:
-            os.replace(inspection.destination, staging)
-            _fsync_dir(parent)
-            shutil.rmtree(staging)
-            _fsync_dir(parent)
+            if staging_name in os.listdir(parent_fd):
+                raise _error(IntegrationReason.PREVIEW_STALE)
+            os.rename("yoetz", staging_name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            _fsync_fd(parent_fd)
+            _remove_tree_fd(parent_fd, staging_name)
+            _fsync_fd(parent_fd)
+        except IntegrationError:
+            raise
         except OSError as exc:
             raise _error(IntegrationReason.WRITE_FAILED) from exc
+        finally:
+            os.close(parent_fd)
         return IntegrationResult(
             IntegrationAction.REMOVE,
             inspection.state,

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -38,7 +38,11 @@ from yoetz.adapters.integrations.codex_marketplace import (
 from yoetz.adapters.integrations.codex_marketplace import (
     preview_removal as _preview_removal,
 )
-from yoetz.adapters.integrations.codex_plugin import install_plugin
+from yoetz.adapters.integrations.codex_plugin import (
+    PluginHookPresence,
+    inspect_plugin,
+    install_plugin,
+)
 from yoetz.ports.integrations import (
     IntegrationError,
     IntegrationReason,
@@ -400,6 +404,70 @@ def test_canonical_source_activates_on_async_host_and_seeds_host_rendered_cache(
     )
     handler = cache_hooks["hooks"]["PreToolUse"][0]["hooks"][0]
     assert handler.get("async") is True
+
+
+def test_plugin_source_installed_accepts_either_current_renderer_variant(tmp_path: Path) -> None:
+    target, _project, home = _target(tmp_path)
+    host = "0.148.0-alpha.6"
+    _install(target, codex_version=None)
+    assert inspect_plugin(target, codex_version=None).presence is PluginHookPresence.INSTALLED
+    assert (
+        inspect_plugin(target, codex_version=host).presence
+        is PluginHookPresence.INSTALLED_UNTRUSTED_UNKNOWN
+    )
+    assert (
+        inspect_activation(target, codex_home=home).state is ActivationState.INSTALLED_NOT_ACTIVATED
+    )
+
+    _install(target, codex_version=host)
+    assert inspect_plugin(target, codex_version=host).presence is PluginHookPresence.INSTALLED
+    assert (
+        inspect_plugin(target, codex_version=None).presence
+        is PluginHookPresence.INSTALLED_UNTRUSTED_UNKNOWN
+    )
+    runner = _FakeCodex(target, home, codex_version=host)
+    assert (
+        _inspect_activation(
+            target, executable_path=str(runner.executable), codex_home=home, _run=runner
+        ).state
+        is ActivationState.INSTALLED_NOT_ACTIVATED
+    )
+
+
+def test_modified_plugin_source_is_installed_not_activated(tmp_path: Path) -> None:
+    """#347: a byte-present modified tree is not classified as not_installed."""
+
+    target, project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    hooks = project / ".agents/plugins/yoetz/hooks/hooks.json"
+    hooks.write_bytes(hooks.read_bytes() + b"\n")
+
+    inspection = inspect_activation(target, codex_home=home)
+
+    assert (
+        inspect_plugin(target, codex_version=None).presence
+        is PluginHookPresence.INSTALLED_UNTRUSTED_UNKNOWN
+    )
+    assert inspection.state is ActivationState.INSTALLED_NOT_ACTIVATED
+    assert inspection.plugin_cached is False
+
+
+def test_inventory_enabled_modified_source_never_reads_active(tmp_path: Path) -> None:
+    target, project, home = _target(tmp_path)
+    _install(target, codex_version=None)
+    (project / ".agents/plugins/yoetz/hooks/hooks.json").write_bytes(b"{}\n")
+    (home / "config.toml").write_text(
+        '[marketplaces.yoetz]\nsource_type = "local"\n'
+        f'source = "{project}"\n\n[plugins."yoetz@yoetz"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    (home / "plugins/cache/yoetz/yoetz/0.1.0").mkdir(parents=True, mode=0o700)
+
+    inspection = inspect_activation(target, codex_home=home)
+
+    assert inspection.state is ActivationState.INSTALLED_NOT_ACTIVATED
+    assert inspection.state is not ActivationState.ACTIVE
+    assert inspection.state is not ActivationState.NOT_INSTALLED
 
 
 def test_same_version_cache_refresh_replaces_prior_managed_render(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_codex_skill_integration.py
+++ b/tests/unit/adapters/test_codex_skill_integration.py
@@ -12,6 +12,7 @@ from yoetz.adapters.integrations.codex_skill import (
     CODEX_HARNESS_PROFILE,
     CodexSkillIntegration,
     build_managed_marker,
+    inspect_destination,
     load_packaged_skill_source,
 )
 from yoetz.domain.values import request_id
@@ -236,6 +237,109 @@ async def test_explicit_allow_untested_installs_discoverable_project_skill(
     assert status.state is IntegrationState.INSTALLED_EXACT
     assert status.compatibility == "unsupported"
     assert (tmp_path / ".agents/skills/yoetz/SKILL.md").is_file()
+
+
+@pytest.mark.anyio
+async def test_symlinked_agents_and_skills_parents_are_target_unsafe(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    adapter = CodexSkillIntegration(_resources(), allow_untested=True)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path))
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o700)
+    (tmp_path / ".agents").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(IntegrationError) as caught:
+        inspect_destination(target, load_packaged_skill_source(_resources()))
+    assert caught.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert not (outside / "skills").exists()
+
+    (tmp_path / ".agents").unlink()
+    agents = tmp_path / ".agents"
+    agents.mkdir(mode=0o700)
+    (agents / "skills").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(IntegrationError) as caught_skills:
+        await adapter.status_skill(HarnessId.CODEX, SkillStatusCommand(target))
+    assert caught_skills.value.reason is IntegrationReason.TARGET_UNSAFE
+    assert not (outside / "yoetz").exists()
+
+
+@pytest.mark.anyio
+async def test_parent_replaced_between_preview_and_apply_fails_closed(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    skills = tmp_path / ".agents" / "skills"
+    skills.mkdir(parents=True, mode=0o700)
+    (tmp_path / ".agents").chmod(0o700)
+    adapter = CodexSkillIntegration(_resources(), allow_untested=True)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path))
+    request = request_id("req_00000000-0000-4000-8000-000000000033")
+    preview = await adapter.preview_skill(
+        HarnessId.CODEX,
+        SkillPreviewCommand(request, target, IntegrationAction.INSTALL, False),
+    )
+
+    replaced = tmp_path / ".agents" / "skills.replaced"
+    skills.rename(replaced)
+    skills.mkdir(mode=0o700)
+
+    with pytest.raises(IntegrationError) as caught:
+        await adapter.install_skill(
+            HarnessId.CODEX,
+            SkillApplyCommand(
+                request,
+                target,
+                IntegrationAction.INSTALL,
+                preview.preview_digest,
+                True,
+                False,
+            ),
+        )
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert not (skills / "yoetz").exists()
+    assert not (replaced / "yoetz").exists()
+
+
+@pytest.mark.anyio
+async def test_install_and_remove_stay_atomic_on_owner_directories(tmp_path: Path) -> None:
+    tmp_path.chmod(0o700)
+    adapter = CodexSkillIntegration(_resources(), allow_untested=True)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path))
+    install_request = request_id("req_00000000-0000-4000-8000-000000000034")
+    preview = await adapter.preview_skill(
+        HarnessId.CODEX,
+        SkillPreviewCommand(install_request, target, IntegrationAction.INSTALL, False),
+    )
+    await adapter.install_skill(
+        HarnessId.CODEX,
+        SkillApplyCommand(
+            install_request,
+            target,
+            IntegrationAction.INSTALL,
+            preview.preview_digest,
+            True,
+            False,
+        ),
+    )
+    destination = tmp_path / ".agents/skills/yoetz"
+    assert destination.is_dir()
+    assert not destination.is_symlink()
+
+    remove_request = request_id("req_00000000-0000-4000-8000-000000000035")
+    remove_preview = await adapter.preview_skill(
+        HarnessId.CODEX,
+        SkillPreviewCommand(remove_request, target, IntegrationAction.REMOVE, False),
+    )
+    await adapter.remove_skill(
+        HarnessId.CODEX,
+        SkillApplyCommand(
+            remove_request,
+            target,
+            IntegrationAction.REMOVE,
+            remove_preview.preview_digest,
+            True,
+            False,
+        ),
+    )
+    assert not destination.exists()
 
 
 def test_package_import_has_no_filesystem_side_effect(

--- a/tests/unit/adapters/test_codex_skill_integration.py
+++ b/tests/unit/adapters/test_codex_skill_integration.py
@@ -299,6 +299,55 @@ async def test_parent_replaced_between_preview_and_apply_fails_closed(tmp_path: 
 
 
 @pytest.mark.anyio
+async def test_parent_swap_after_path_identity_check_is_caught_by_retained_fd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#396: the descriptor itself, not a prior pathname check, binds the preview."""
+
+    import yoetz.adapters.integrations.codex_skill as module
+
+    tmp_path.chmod(0o700)
+    skills = tmp_path / ".agents" / "skills"
+    skills.mkdir(parents=True, mode=0o700)
+    (tmp_path / ".agents").chmod(0o700)
+    adapter = CodexSkillIntegration(_resources(), allow_untested=True)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path))
+    request = request_id("req_00000000-0000-4000-8000-000000000036")
+    preview = await adapter.preview_skill(
+        HarnessId.CODEX,
+        SkillPreviewCommand(request, target, IntegrationAction.INSTALL, False),
+    )
+
+    original = module._skill_parent_identity  # pyright: ignore[reportPrivateUsage]
+    replaced = tmp_path / ".agents" / "skills.replaced-after-check"
+
+    def swap_after_identity(root: Path) -> str:
+        identity = original(root)
+        skills.rename(replaced)
+        skills.mkdir(mode=0o700)
+        monkeypatch.setattr(module, "_skill_parent_identity", original)
+        return identity
+
+    monkeypatch.setattr(module, "_skill_parent_identity", swap_after_identity)
+
+    with pytest.raises(IntegrationError) as caught:
+        await adapter.install_skill(
+            HarnessId.CODEX,
+            SkillApplyCommand(
+                request,
+                target,
+                IntegrationAction.INSTALL,
+                preview.preview_digest,
+                True,
+                False,
+            ),
+        )
+    assert caught.value.reason is IntegrationReason.PREVIEW_STALE
+    assert not (skills / "yoetz").exists()
+    assert not (replaced / "yoetz").exists()
+
+
+@pytest.mark.anyio
 async def test_install_and_remove_stay_atomic_on_owner_directories(tmp_path: Path) -> None:
     tmp_path.chmod(0o700)
     adapter = CodexSkillIntegration(_resources(), allow_untested=True)

--- a/tests/unit/cli/test_observe_cli.py
+++ b/tests/unit/cli/test_observe_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -304,6 +305,38 @@ def test_status_inspects_only_the_explicit_codex_target(
     assert payload["plugin_activation"] == "active"
     assert observed["executable_path"] == str(codex_path)
     assert observed["codex_home"] == codex_home
+
+
+def test_status_reports_modified_present_plugin_as_installed_not_activated(
+    tmp_path: Path, capsys: object
+) -> None:
+    """#347: exercise the production activation classifier through observe status."""
+
+    from yoetz.adapters.integrations.codex_plugin import install_plugin
+    from yoetz.ports.integrations import IntegrationScope, IntegrationTarget
+
+    state = tmp_path / "state"
+    project = tmp_path / "project"
+    project.mkdir(mode=0o700)
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(mode=0o700)
+    target = IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(project))
+    install_plugin(target, allow_untested=True, codex_version=None)
+    hooks = project / ".agents/plugins/yoetz/hooks/hooks.json"
+    hooks.write_bytes(hooks.read_bytes() + b"\n")
+
+    assert (
+        observe_cli.observe_status(
+            workspace=str(project),
+            codex_path=Path(sys.executable),
+            codex_home=codex_home,
+            json_output=True,
+            _state=state,
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)  # type: ignore[attr-defined]
+    assert payload["plugin_activation"] == "installed_not_activated"
 
 
 def test_status_help_exposes_exact_activation_target_options() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: Fixes #396, Fixes #347, Refs #420
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging,
  ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

Not design-gated: #396 is adapter parent validation using existing `target_unsafe` / `preview_stale`; #347 reuses existing activation enum values (`installed_not_activated` vs `not_installed`) with no new public state. #420 was closed by #441; this PR-B grouping re-pins the remaining Codex residuals (git-root subdirectory binding and Stop `decision: block` per the current Codex hooks reference) without changing that already-landed behavior.

## Documentation

- Behavior change? `yes`
- Docs updated (ADR, `docs/` page, `docs/INTERFACES.md` entry), or `n/a — no behavior change`:
  `docs/INTERFACES.md`, `docs/adr/ADR-012-first-run-setup-wizard.md`, `docs/runbooks/codex-integration.md`, `CHANGELOG.md`

## Verification

Commands run (paste):

```text
uv sync
uv run ruff check src/yoetz/adapters/integrations/codex_skill.py src/yoetz/adapters/integrations/codex_plugin.py src/yoetz/adapters/integrations/codex_marketplace.py tests/unit/adapters/test_codex_skill_integration.py tests/unit/adapters/test_codex_marketplace.py
npx --no-install pyright src/yoetz/adapters/integrations/codex_skill.py src/yoetz/adapters/integrations/codex_plugin.py src/yoetz/adapters/integrations/codex_marketplace.py tests/unit/adapters/test_codex_skill_integration.py tests/unit/adapters/test_codex_marketplace.py
uv run pytest tests/unit/adapters/test_codex_skill_integration.py tests/unit/adapters/test_codex_plugin.py tests/unit/adapters/test_codex_marketplace.py tests/unit/cli/test_observe_cli.py
```

138 passed.

Exact-target `codex-testing observe status` was re-run on 2026-08-29 against this repaired branch and returned `plugin_activation: installed_not_activated`; canonical inventory remained a separate proof layer. The production classifier regression covers the 2026-08-28 exact-target failure mode: a byte-present modified tree with host inventory still must not report `not_installed`.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

PR-B from the #415 delivery plan: Codex skill lifecycle safety and activation-status honesty.

**#396.** `inspect_destination` now walks `.agents` and `.agents/skills` with the same no-follow parent rules as the plugin adapter. Symlinked parents are `target_unsafe`. Preview digests include parent inode identity. Install/replace/remove create, rename, and delete through an `O_DIRECTORY|O_NOFOLLOW` fd so a parent replaced between preview and apply is `preview_stale`. Owner-controlled directories still install and remove atomically.

**#347.** `_plugin_source_installed` still means byte-exact current renderer variant (canonical or host form) and still fences apply. Status uses a presence classifier: `not_installed` only when the source is absent; a modified/`installed_untrusted_unknown` tree is `installed_not_activated` and never `active`.

**#420.** Workspace git-root normalisation, `workspace_unconsented` vs `workspace_unresolvable`, and Codex Stop `decision: block` already landed in #441. This PR does not reopen that stdout contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39101370-cc5e-4ab2-aa76-d1005af3f978?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39101370-cc5e-4ab2-aa76-d1005af3f978&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `CodexSkillIntegration` install/remove with no-follow fd ops and fix plugin activation status
> - Reworks skill install/remove in [codex_skill.py](https://github.com/TheGaySupreme123/yoetz/pull/449/files#diff-c2b8d4df84cf73c25ff57ba0d81ccd4cfe1643d88cfe759f0e5a3198304ada38) to use directory-fd, `O_NOFOLLOW` operations that reject symlinked `.agents`/`.agents/skills` as `TARGET_UNSAFE` and fail with `PREVIEW_STALE` if the managed parent identity changes between preview and apply
> - Binds a new `parent_identity` (device/inode/mode) into preview digests and asserts it at apply time via `_assert_parent_identity`"- Fixes `inspect_activation` in [codex_marketplace.py](https://github.com/TheGaySupreme123/yoetz/pull/449/files#diff-015bbf4b0444e9f14bfac65ffde563eb17775d94b0933d2a36801f0752dd6bc3) so a byte-present but modified/untrusted plugin tree reports `INSTALLED_NOT_ACTIVATED` instead of `NOT_INSTALLED`; cache and inventory checks run only for exact sources
> - Platforms lacking dir-fd primitives now fail closed with `TARGET_UNSAFE` via `_require_dir_fd_primitives`
> - Behavioral Change: symlinked `.agents` or `.agents/skills` are now rejected (`TARGET_UNSAFE`) where previously they could be followed; preview digests change due to the new `parent_identity` binding, so existing digests are not compatible
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d414503.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
