### PR TITLE
fix: scan observation excerpts and check output before encryption

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2680,9 +2680,12 @@ object ID. Revocation disables/removes the active locator and trust binding whil
 encrypted evidence. Visible task messages, tool input/result, task-linked terminal output,
 changed-file/diff material, approved-check output, lifecycle, and readiness facts may be captured.
 Hidden reasoning, system/platform/developer prompts, credentials, detected secrets, unrelated files,
-and untethered logs are excluded before storage. Secret spans are redacted in memory before
-encryption. SQLite/envelopes retain only encrypted object IDs, commitments, classifications, sizes,
-and relations. Vault/service failure records `content_capture_unavailable` and no plaintext spool.
+and untethered logs are excluded before storage. Every byte that reaches encrypted observation
+persistence passes `prepare_persisted_plaintext`: known secret spans are redacted in memory before
+encoding, matches persist only redaction metadata, and scanner failure or a canary match records
+`content_capture_unavailable` and stores no excerpt or approved-check output object. SQLite/envelopes
+retain only encrypted object IDs, commitments, classifications, sizes, and relations.
+Vault/service failure records `content_capture_unavailable` and no plaintext spool.
 Unrecognized visible events accept an opaque stable envelope plus encrypted content and
 `unsupported_event`; a session-stream file that is the wrong grammar, an untested `cli_version`,
 or a compressed `.jsonl.zst` rollout records `unsupported_format` instead. Unknown semantics never
@@ -3719,6 +3722,8 @@ facade and are never MCP tools.
   is exactly `service|cli|mcp_stdio|confidential_helper` so each process installs only its bounded
   sink/filter profile.
   `observability/privacy.py`: canary-testable redaction helpers,
+  `prepare_persisted_plaintext(data, *, canaries=())` (fail-closed scan before encrypted
+  observation persistence: redact known spans, withhold on canary or scanner failure),
   `session_id_hash(session_id, log_mac: MacKeyHandle)`, and
   `privacy_request_commitment(final_request_body, audit_mac: MacKeyHandle)`; raw MAC keys are never
   accepted.

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2682,8 +2682,9 @@ changed-file/diff material, approved-check output, lifecycle, and readiness fact
 Hidden reasoning, system/platform/developer prompts, credentials, detected secrets, unrelated files,
 and untethered logs are excluded before storage. Every byte that reaches encrypted observation
 persistence passes `prepare_persisted_plaintext`: known secret spans are redacted in memory before
-encoding, matches persist only redaction metadata, and scanner failure or a canary match records
-`content_capture_unavailable` and stores no excerpt or approved-check output object. SQLite/envelopes
+encoding, matches persist only redaction metadata, and scanner failure, finding-capacity exhaustion,
+or a canary match records `content_capture_unavailable` and stores no excerpt or approved-check
+output object. SQLite/envelopes
 retain only encrypted object IDs, commitments, classifications, sizes, and relations.
 Vault/service failure records `content_capture_unavailable` and no plaintext spool.
 Unrecognized visible events accept an opaque stable envelope plus encrypted content and

--- a/docs/adr/ADR-009-data-egress-privacy.md
+++ b/docs/adr/ADR-009-data-egress-privacy.md
@@ -340,7 +340,11 @@ case → single-use authorization → bounded gateway → bound sink/provider �
     task-linked terminal results, selected changed-file/diff material, approved-check output,
     lifecycle structure, and composition readiness. Reject hidden reasoning, system/developer/
     platform prompts, credentials, detected secret spans, unrelated files, and ambient logs before
-    persistence. Secret-bearing spans are redacted in memory before authenticated encryption.
+    persistence. Secret-bearing spans — including selected changed-file excerpts and
+    approved-check output — are classified by the shared fail-closed scanner and redacted in
+    memory before encoding or authenticated encryption. Matches persist only redaction
+    metadata, never the original bytes. Scanner failure or an explicit canary match records
+    `content_capture_unavailable` and stores no excerpt or output object.
     SQLite, observation envelopes, cursors, local outboxes, status, hook context, and logs contain
     only allowlisted structure, encrypted object identities/commitments, sizes, classifications,
     and relations. A locked vault, absent service, or failed encryption keeps the structural
@@ -357,7 +361,9 @@ case → single-use authorization → bounded gateway → bound sink/provider �
     raw `.yoetz/checks.toml` digest; any byte change suspends all listed commands. Approved checks
     use exact argv, `shell=False`, sanitized environment, bounded output/time, and an enforcing
     sandbox. Network-requiring checks fail closed unless a separately reviewed authorization and
-    sandbox prove the permission. Redacted output is encrypted before durable retention. Optional
+    sandbox prove the permission. Output bytes pass the same fail-closed secret scanner before
+    encryption; compound environment assignments such as `AWS_SECRET_ACCESS_KEY` and bounded
+    `*_TOKEN` forms are redacted, while near-miss non-secret identifiers are left unchanged.
     semantic observation advice remains additive and passes only minimized approved packets through
     the existing privacy gateway. Observation, trust, verification management, and local advice
     diagnostics are local control, not network-egress channels and not additional MCP tools.

--- a/docs/adr/ADR-009-data-egress-privacy.md
+++ b/docs/adr/ADR-009-data-egress-privacy.md
@@ -343,8 +343,9 @@ case → single-use authorization → bounded gateway → bound sink/provider �
     persistence. Secret-bearing spans — including selected changed-file excerpts and
     approved-check output — are classified by the shared fail-closed scanner and redacted in
     memory before encoding or authenticated encryption. Matches persist only redaction
-    metadata, never the original bytes. Scanner failure or an explicit canary match records
-    `content_capture_unavailable` and stores no excerpt or output object.
+    metadata, never the original bytes. Scanner failure, finding-capacity exhaustion, or an
+    explicit canary match records `content_capture_unavailable` and stores no excerpt or output
+    object.
     SQLite, observation envelopes, cursors, local outboxes, status, hook context, and logs contain
     only allowlisted structure, encrypted object identities/commitments, sizes, classifications,
     and relations. A locked vault, absent service, or failed encryption keeps the structural

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -115,7 +115,7 @@ from yoetz.domain.values import (
 )
 from yoetz.kernel.projections import ProjectionRecord, ProjectionState
 from yoetz.observability.logging import record_unexpected_exception_without_raising
-from yoetz.observability.privacy import redact_sensitive_content
+from yoetz.observability.privacy import prepare_persisted_plaintext
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.ids import IdPort
 from yoetz.ports.ledger import (
@@ -139,6 +139,7 @@ from yoetz.ports.runtime import (
     TaskRuntime,
 )
 from yoetz.ports.subject_state import SubjectStateCaptureCommand, SubjectStateFormat
+from yoetz.ports.workspace_inspect import InspectedArtifact
 from yoetz.protocol.canonical import canonical_digest, canonical_encode, strict_json_parse
 from yoetz.protocol.coverage import EvidenceImmutability, PublicationChannel, coverage_for_channel
 from yoetz.protocol.errors import ProtocolValueError, PublicErrorCode, PublicOperationError
@@ -218,7 +219,72 @@ __all__ = [
     "ObservationAdviceHook",
     "ObservationCoordinator",
     "ObservationMappingLoader",
+    "build_inspection_excerpt_manifest",
 ]
+
+_INSPECT_EXCERPT_FORMAT: Final = "yoetz.observation-inspect-excerpt/1"
+_MAX_INSPECT_EXCERPT_ARTIFACTS: Final = 16
+_MAX_INSPECT_EXCERPT_PREFIX_BYTES: Final = 512
+
+
+def build_inspection_excerpt_manifest(
+    artifacts: Sequence[InspectedArtifact],
+    *,
+    canaries: tuple[bytes, ...] = (),
+) -> tuple[bytes | None, bool]:
+    """Scan changed-file excerpts before base64 encoding.
+
+    Returns ``(canonical_bytes, capture_unavailable)``. Secret matches persist
+    only path/digest/finding-kind metadata. A scanner failure or canary match
+    stores no excerpt object.
+    """
+
+    parts: list[JsonObject] = []
+    capture_unavailable = False
+    seen = 0
+    for item in artifacts:
+        if type(item) is not InspectedArtifact:
+            continue
+        if seen >= _MAX_INSPECT_EXCERPT_ARTIFACTS:
+            break
+        seen += 1
+        if not item.excerpt:
+            continue
+        prefix = item.excerpt[:_MAX_INSPECT_EXCERPT_PREFIX_BYTES]
+        scan = prepare_persisted_plaintext(prefix, canaries=canaries)
+        if not scan.persist:
+            capture_unavailable = True
+            break
+        if scan.redacted:
+            parts.append(
+                JsonObject(
+                    {
+                        "path": item.relative_path,
+                        "digest": item.content_digest,
+                        "redacted": True,
+                        "finding_kinds": list(scan.finding_kinds),
+                    }
+                )
+            )
+            continue
+        parts.append(
+            JsonObject(
+                {
+                    "path": item.relative_path,
+                    "digest": item.content_digest,
+                    "redacted": False,
+                    "excerpt_b64": base64.b64encode(scan.content).decode("ascii"),
+                }
+            )
+        )
+    if capture_unavailable:
+        return None, True
+    if not parts:
+        return None, False
+    return (
+        canonical_encode(JsonObject({"format": _INSPECT_EXCERPT_FORMAT, "artifacts": parts})),
+        False,
+    )
 
 
 class ObservationMappingLoader(Protocol):
@@ -1320,7 +1386,19 @@ class ObservationCoordinator:
                 object_ids.add(existing)
                 any_redacted = any_redacted or chunk.redacted
                 continue
-            safe_content, detected = redact_sensitive_content(chunk.content)
+            scan = prepare_persisted_plaintext(chunk.content)
+            if not scan.persist:
+                any_redacted = True
+                await self._local(
+                    partial(
+                        self.local.note_coverage_gap,
+                        workspace,
+                        ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value,
+                    )
+                )
+                continue
+            safe_content = scan.content
+            detected = scan.redacted
             any_redacted = any_redacted or chunk.redacted or detected
             stored_chunk = replace(
                 chunk,
@@ -1554,40 +1632,9 @@ class ObservationCoordinator:
         repository = cast(ObservationVerificationRepository, store.verification_repository())
 
         async def persist_output(job: ObservationVerificationJob, content: bytes) -> str | None:
-            chunk = ObservationContentChunk(
-                content_kind=ObservationContentKind.APPROVED_CHECK_OUTPUT,
-                correlation_identity=f"check:{job.job_id}",
-                source_commitment=f"hmac-sha256:{'0' * 64}",
-                media_type="text/plain",
-                part_index=0,
-                part_count=1,
-                content=content,
-                redacted=True,
+            return await self._persist_approved_check_output(
+                runtime, store, workspace, job, content
             )
-            manifest = canonical_encode(
-                JsonObject(
-                    {
-                        "format": "yoetz.observation-content/1",
-                        "content_kind": chunk.content_kind.value,
-                        "correlation_identity": chunk.correlation_identity,
-                        "source_commitment": chunk.source_commitment,
-                        "media_type": chunk.media_type,
-                        "part_index": 0,
-                        "part_count": 1,
-                        "redacted": True,
-                        "content_b64": base64.b64encode(content).decode("ascii"),
-                    }
-                )
-            )
-            ref = await self._encrypt_captured_content(runtime, manifest)
-            store.record_content_manifest(
-                workspace=workspace,
-                logical_identity=f"verification:{job.job_id}",
-                chunk=chunk,
-                ref=ref,
-                recorded_at=timestamp_from_datetime(self.clock.now_utc()),
-            )
-            return ref.object_id
 
         def now_wire() -> str:
             return timestamp_from_datetime(self.clock.now_utc()).wire
@@ -1659,24 +1706,18 @@ class ObservationCoordinator:
                     facts_ref = await self._encrypt_captured_content(runtime, fact_bytes)
                     facts_object_id = facts_ref.object_id
                 if orchestration.inspect is not None and orchestration.inspect.artifacts:
-                    excerpt_parts = tuple(
-                        {
-                            "path": item.relative_path,
-                            "digest": item.content_digest,
-                            "excerpt_b64": base64.b64encode(item.excerpt[:512]).decode("ascii"),
-                        }
-                        for item in orchestration.inspect.artifacts[:16]
-                        if item.excerpt
+                    excerpt_bytes, excerpt_unavailable = build_inspection_excerpt_manifest(
+                        orchestration.inspect.artifacts
                     )
-                    if excerpt_parts:
-                        excerpt_bytes = canonical_encode(
-                            JsonObject(
-                                {
-                                    "format": "yoetz.observation-inspect-excerpt/1",
-                                    "artifacts": list(excerpt_parts),
-                                }
+                    if excerpt_unavailable:
+                        await self._local(
+                            partial(
+                                self.local.note_coverage_gap,
+                                workspace,
+                                ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value,
                             )
                         )
+                    elif excerpt_bytes is not None:
                         excerpt_ref = await self._encrypt_captured_content(runtime, excerpt_bytes)
                         excerpt_object_id = excerpt_ref.object_id
             except Exception:
@@ -1760,40 +1801,9 @@ class ObservationCoordinator:
         repository = cast(ObservationVerificationRepository, store.verification_repository())
 
         async def persist_output(job: ObservationVerificationJob, content: bytes) -> str | None:
-            chunk = ObservationContentChunk(
-                content_kind=ObservationContentKind.APPROVED_CHECK_OUTPUT,
-                correlation_identity=f"check:{job.job_id}",
-                source_commitment=f"hmac-sha256:{'0' * 64}",
-                media_type="text/plain",
-                part_index=0,
-                part_count=1,
-                content=content,
-                redacted=True,
+            return await self._persist_approved_check_output(
+                runtime, store, workspace, job, content
             )
-            manifest = canonical_encode(
-                JsonObject(
-                    {
-                        "format": "yoetz.observation-content/1",
-                        "content_kind": chunk.content_kind.value,
-                        "correlation_identity": chunk.correlation_identity,
-                        "source_commitment": chunk.source_commitment,
-                        "media_type": chunk.media_type,
-                        "part_index": 0,
-                        "part_count": 1,
-                        "redacted": True,
-                        "content_b64": base64.b64encode(content).decode("ascii"),
-                    }
-                )
-            )
-            ref = await self._encrypt_captured_content(runtime, manifest)
-            store.record_content_manifest(
-                workspace=workspace,
-                logical_identity=f"verification:{job.job_id}",
-                chunk=chunk,
-                ref=ref,
-                recorded_at=timestamp_from_datetime(self.clock.now_utc()),
-            )
-            return ref.object_id
 
         def now_wire() -> str:
             return timestamp_from_datetime(self.clock.now_utc()).wire
@@ -1827,6 +1837,61 @@ class ObservationCoordinator:
         """Deprecated alias: enqueue (+ inline drain without supervisor)."""
 
         await self._enqueue_verification(runtime, workspace, store, envelope)
+
+    async def _persist_approved_check_output(
+        self,
+        runtime: TaskRuntime,
+        store: TaskObservationPort,
+        workspace: str,
+        job: ObservationVerificationJob,
+        content: bytes,
+    ) -> str | None:
+        """Encrypt approved-check output only after the shared fail-closed scan."""
+
+        scan = prepare_persisted_plaintext(content)
+        if not scan.persist:
+            await self._local(
+                partial(
+                    self.local.note_coverage_gap,
+                    workspace,
+                    ObservationGapCode.CONTENT_CAPTURE_UNAVAILABLE.value,
+                )
+            )
+            return None
+        chunk = ObservationContentChunk(
+            content_kind=ObservationContentKind.APPROVED_CHECK_OUTPUT,
+            correlation_identity=f"check:{job.job_id}",
+            source_commitment=f"hmac-sha256:{'0' * 64}",
+            media_type="text/plain",
+            part_index=0,
+            part_count=1,
+            content=scan.content,
+            redacted=scan.redacted,
+        )
+        manifest = canonical_encode(
+            JsonObject(
+                {
+                    "format": "yoetz.observation-content/1",
+                    "content_kind": chunk.content_kind.value,
+                    "correlation_identity": chunk.correlation_identity,
+                    "source_commitment": chunk.source_commitment,
+                    "media_type": chunk.media_type,
+                    "part_index": 0,
+                    "part_count": 1,
+                    "redacted": scan.redacted,
+                    "content_b64": base64.b64encode(scan.content).decode("ascii"),
+                }
+            )
+        )
+        ref = await self._encrypt_captured_content(runtime, manifest)
+        store.record_content_manifest(
+            workspace=workspace,
+            logical_identity=f"verification:{job.job_id}",
+            chunk=chunk,
+            ref=ref,
+            recorded_at=timestamp_from_datetime(self.clock.now_utc()),
+        )
+        return ref.object_id
 
     async def _encrypt_captured_content(self, runtime: TaskRuntime, content: bytes) -> ObjectRef:
         metadata = ObjectMetadata(

--- a/src/yoetz/observability/privacy.py
+++ b/src/yoetz/observability/privacy.py
@@ -456,6 +456,11 @@ def prepare_persisted_plaintext(
     kinds = tuple(dict.fromkeys(finding.kind for finding in findings))
     if any(finding.kind == "canary" for finding in findings):
         return PersistenceScanResult(False, b"", True, kinds)
+    # The public scanner deliberately caps structural findings. Reaching that
+    # cap does not prove there is no later match, so encrypted persistence must
+    # withhold instead of redacting only the visible prefix of the finding set.
+    if len(findings) >= _MAX_SCAN_FINDINGS:
+        return PersistenceScanResult(False, b"", True, kinds)
     if not findings:
         return PersistenceScanResult(True, data, False, ())
     return PersistenceScanResult(True, _replace_sensitive_spans(data, findings), True, kinds)

--- a/src/yoetz/observability/privacy.py
+++ b/src/yoetz/observability/privacy.py
@@ -17,11 +17,13 @@ __all__ = [
     "PRIVACY_REQUEST_BODY_DOMAIN",
     "SESSION_HASH_DOMAIN",
     "DiagnosticRedactionProfile",
+    "PersistenceScanResult",
     "PrivacyFenceError",
     "ScanFinding",
     "Sensitivity",
     "assert_plaintext_safe",
     "build_diagnostic_manifest",
+    "prepare_persisted_plaintext",
     "privacy_request_commitment",
     "redact_diagnostic_record",
     "redact_diagnostic_value",
@@ -73,10 +75,22 @@ _CREDENTIAL_PATTERNS: Final = (
     re.compile(rb"(?<![A-Z0-9])AKIA[A-Z0-9]{16}(?![A-Z0-9])"),
 )
 _URI_PASSWORD = re.compile(rb"[A-Za-z][A-Za-z0-9+.-]{0,31}://[^\s/:@]{1,128}:[^\s/@]{1,256}@")
+# Compound names such as AWS_SECRET_ACCESS_KEY and AZURE_CLIENT_SECRET keep the
+# secret token as one underscore/hyphen component, not the entire identifier.
 _SECRET_ASSIGNMENT = re.compile(
     rb"(?i)(?:^|[^A-Za-z0-9_])['\"]?"
+    rb"(?:[A-Za-z][A-Za-z0-9]{0,63}[_-])*"
     rb"(?:api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|private[_-]?key|secret)"
+    rb"(?:[_-][A-Za-z][A-Za-z0-9]{0,63})*"
     rb"['\"]?\s*[:=]\s*['\"]?[^\s,'\";}{]{1,512}"
+)
+# `*_TOKEN` only as the final identifier component. The value must contain a
+# non-digit and be at least eight bytes so MAX_TOKEN=4096 and TOKEN_COUNT=12
+# are not treated as secrets.
+_TOKEN_ASSIGNMENT = re.compile(
+    rb"(?i)(?:^|[^A-Za-z0-9_])['\"]?"
+    rb"(?:[A-Za-z][A-Za-z0-9]{0,63}[_-])*token"
+    rb"['\"]?\s*[:=]\s*['\"]?(?=[^\s,'\";}{]{0,511}[A-Za-z_/=+-])[^\s,'\";}{]{8,512}"
 )
 
 _LOG_FIELDS: Final = frozenset(
@@ -340,7 +354,7 @@ def scan_for_sensitive_content(
                 )
                 offset = found + len(marker)
 
-    for pattern in (*_CREDENTIAL_PATTERNS, _URI_PASSWORD, _SECRET_ASSIGNMENT):
+    for pattern in (*_CREDENTIAL_PATTERNS, _URI_PASSWORD, _SECRET_ASSIGNMENT, _TOKEN_ASSIGNMENT):
         for chunk_start, chunk in _scan_chunks(data):
             for match in pattern.finditer(chunk):
                 _append_finding(
@@ -378,12 +392,7 @@ def assert_plaintext_safe(
     raise PrivacyFenceError(reason, surface)
 
 
-def redact_sensitive_content(data: bytes) -> tuple[bytes, bool]:
-    """Replace every detected credential/key span without retaining the match."""
-
-    findings = scan_for_sensitive_content(data)
-    if not findings:
-        return data, False
+def _replace_sensitive_spans(data: bytes, findings: tuple[ScanFinding, ...]) -> bytes:
     pieces: list[bytes] = []
     cursor = 0
     for finding in findings:
@@ -393,7 +402,72 @@ def redact_sensitive_content(data: bytes) -> tuple[bytes, bool]:
         pieces.append(b"[REDACTED]")
         cursor = finding.end_offset
     pieces.append(data[cursor:])
-    return b"".join(pieces), True
+    return b"".join(pieces)
+
+
+@dataclass(frozen=True, slots=True)
+class PersistenceScanResult:
+    """Fail-closed scan outcome for bytes about to be encrypted at rest.
+
+    ``persist`` is false when the payload must be withheld entirely. Matched
+    secret bytes are never retained: redacted content substitutes ``[REDACTED]``,
+    and withheld results carry empty content plus finding kinds only.
+    """
+
+    persist: bool
+    content: bytes
+    redacted: bool
+    finding_kinds: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.persist) is not bool or type(self.redacted) is not bool:
+            raise TypeError("persistence_scan_flag_invalid")
+        if type(self.content) is not bytes:
+            raise TypeError("persistence_scan_content_invalid")
+        if type(self.finding_kinds) is not tuple:
+            raise TypeError("persistence_scan_kinds_invalid")
+        if any(
+            type(kind) is not str
+            or kind not in {"canary", "credential_pattern", "private_key_marker"}
+            for kind in self.finding_kinds
+        ):
+            raise ValueError("persistence_scan_kind_invalid")
+        if not self.persist and self.content:
+            raise ValueError("persistence_scan_withheld_must_be_empty")
+
+
+def prepare_persisted_plaintext(
+    data: bytes,
+    *,
+    canaries: tuple[bytes, ...] = (),
+) -> PersistenceScanResult:
+    """Classify bytes before encoding or encrypted persistence.
+
+    Known secret spans are redacted in memory. A canary match or scanner
+    failure withholds the payload so original bytes never reach an object.
+    """
+
+    if type(data) is not bytes:
+        return PersistenceScanResult(False, b"", True, ())
+    try:
+        findings = scan_for_sensitive_content(data, canaries=canaries)
+    except PrivacyFenceError, TypeError, ValueError:
+        return PersistenceScanResult(False, b"", True, ())
+    kinds = tuple(dict.fromkeys(finding.kind for finding in findings))
+    if any(finding.kind == "canary" for finding in findings):
+        return PersistenceScanResult(False, b"", True, kinds)
+    if not findings:
+        return PersistenceScanResult(True, data, False, ())
+    return PersistenceScanResult(True, _replace_sensitive_spans(data, findings), True, kinds)
+
+
+def redact_sensitive_content(data: bytes) -> tuple[bytes, bool]:
+    """Replace every detected credential/key span without retaining the match."""
+
+    findings = scan_for_sensitive_content(data)
+    if not findings:
+        return data, False
+    return _replace_sensitive_spans(data, findings), True
 
 
 def _safe_mac(handle: MacKeyHandle, domain: bytes, message: bytes) -> str:

--- a/tests/integration/privacy/test_inspection_excerpt_canary_sweep.py
+++ b/tests/integration/privacy/test_inspection_excerpt_canary_sweep.py
@@ -1,0 +1,213 @@
+"""Plaintext and encrypted-object canary sweeps for inspection snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import apsw
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
+
+from yoetz.adapters.objects.encrypted_files import EncryptedFilesObjectStore
+from yoetz.adapters.sqlite.migrations import initialize_bundle
+from yoetz.adapters.sqlite.observation import SqliteObservationStore
+from yoetz.application.observation_coordinator import build_inspection_excerpt_manifest
+from yoetz.domain.values import Timestamp
+from yoetz.observability.privacy import scan_for_sensitive_content
+from yoetz.ports.keys import BundleKeys, WrappedDek
+from yoetz.ports.objects import (
+    ObjectKind,
+    ObjectMetadata,
+    ObjectRef,
+    ObjectRootSnapshot,
+    ObjectSource,
+)
+from yoetz.ports.secret_memory import SecretConsumer, SecretMemoryCapability, SecretPurpose
+from yoetz.ports.workspace_inspect import InspectedArtifact
+from yoetz.protocol.ids import IdKind
+
+if TYPE_CHECKING:
+    from yoetz.ports.secret_memory import SecretHandle
+
+_DIGEST = "sha256:" + "0" * 64
+_TASK_ID = "tsk_30000000-0000-4000-8000-000000000001"
+_WORKSPACE = "hmac-sha256:" + "11" * 32
+_SESSION = "ses_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_SECRET = b"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+
+class _Secret:
+    def __init__(self, value: bytes | bytearray) -> None:
+        self._value = bytearray(value)
+        self._consumed = False
+
+    @property
+    def purpose(self) -> SecretPurpose:
+        return SecretPurpose.OBJECT_PAYLOAD
+
+    def consume[T](self, consumer: SecretConsumer, fn: Callable[[memoryview], T]) -> T:
+        if consumer is not SecretConsumer.OBJECT_CRYPTO or self._consumed:
+            raise ValueError("secret_handle_invalid")
+        self._consumed = True
+        try:
+            return fn(memoryview(self._value))
+        finally:
+            self._value[:] = b"\0" * len(self._value)
+
+
+class _SecretMemory:
+    def capability(self) -> SecretMemoryCapability:
+        return SecretMemoryCapability("active", "unavailable", "unavailable", "active", "active")
+
+    def capture(self, purpose: SecretPurpose, source: bytearray) -> _Secret:
+        assert purpose is SecretPurpose.OBJECT_PAYLOAD
+        result = _Secret(source)
+        source[:] = b"\0" * len(source)
+        return result
+
+    def allocate(self, purpose: SecretPurpose, size: int) -> _Secret:
+        assert purpose is SecretPurpose.OBJECT_PAYLOAD
+        return _Secret(bytes(size))
+
+    def close(self) -> None:
+        return None
+
+
+class _WrapKey:
+    def __init__(self, key: bytes) -> None:
+        self._key = key
+
+    def wrap_dek(self, dek: SecretHandle) -> WrappedDek:
+        wrapped = dek.consume(
+            SecretConsumer.OBJECT_CRYPTO,
+            lambda value: aes_key_wrap(self._key, bytes(value)),
+        )
+        return WrappedDek("aes-256-kw-rfc3394", wrapped)
+
+    def unwrap_dek(self, wrapped: WrappedDek) -> _Secret:
+        return _Secret(aes_key_unwrap(self._key, wrapped.wrapped))
+
+
+class _MacKey:
+    def __init__(self, key: bytes) -> None:
+        self._key = key
+
+    def mac(self, domain: bytes, message: bytes) -> str:
+        return "hmac-sha256:" + hmac.new(self._key, domain + message, hashlib.sha256).hexdigest()
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self._next = 1
+
+    def new(self, kind: IdKind) -> str:
+        assert kind is IdKind.OBJECT
+        value = f"obj_{self._next:08x}-0000-4000-8000-000000000001"
+        self._next += 1
+        return value
+
+
+class _Roots:
+    def __init__(self, value: ObjectRootSnapshot) -> None:
+        self.value = value
+
+    async def current(self) -> ObjectRootSnapshot:
+        return self.value
+
+
+def _snapshot(now: datetime) -> ObjectRootSnapshot:
+    return ObjectRootSnapshot(
+        task_id=_TASK_ID,
+        route_identity_digest=_DIGEST,
+        route_generation=1,
+        bundle_generation=1,
+        privacy_root_generation=0,
+        ledger_roots_digest=_DIGEST,
+        importer_roots_digest=_DIGEST,
+        privacy_roots_digest=_DIGEST,
+        maintenance_pin_digest=_DIGEST,
+        captured_at=now,
+        live_object_ids=(),
+    )
+
+
+def _artifact(relative_path: str, excerpt: bytes) -> InspectedArtifact:
+    digest = "sha256:" + hashlib.sha256(excerpt).hexdigest()
+    return InspectedArtifact(relative_path, digest, excerpt, False, len(excerpt))
+
+
+def test_inspection_snapshot_plaintext_and_ciphertext_stay_canary_free(tmp_path: Path) -> None:
+    now = datetime(2026, 3, 4, 5, 6, 7, tzinfo=UTC)
+    bundle = tmp_path / "bundle"
+    bundle.mkdir(mode=0o700)
+    keys = BundleKeys("bmk-1", _WrapKey(bytes(range(32))), _MacKey(bytes(range(32, 64))))
+    objects = EncryptedFilesObjectStore(
+        bundle_root=bundle,
+        bundle_keys=keys,
+        secret_memory=_SecretMemory(),
+        id_port=_Ids(),
+        current_root_snapshot=_Roots(_snapshot(now)).current,
+    )
+    db = apsw.Connection(str(tmp_path / "task.sqlite"))
+    initialize_bundle(db, {"task_id": "task_obs", "owner_generation": "1"})
+    store = SqliteObservationStore(db)
+
+    encoded, unavailable = build_inspection_excerpt_manifest(
+        (_artifact("src/env.py", b"export " + _SECRET + b"\n"),)
+    )
+    assert unavailable is False
+    assert encoded is not None
+    assert _SECRET not in encoded
+    assert b"wJalrXUtnFEMI" not in encoded
+
+    async def persist() -> ObjectRef:
+        metadata = ObjectMetadata(
+            ObjectKind.CAPTURED_CONTENT,
+            "application/vnd.yoetz.observation-content+json",
+            _TASK_ID,
+            now,
+        )
+        staged = await objects.stage(
+            ObjectSource(data=encoded, declared_size=len(encoded)), metadata
+        )
+        return await objects.finalize(staged)
+
+    ref = asyncio.run(persist())
+    store.record_inspection_snapshot(
+        workspace=_WORKSPACE,
+        yoetz_session_id=_SESSION,
+        subject_state_digest=_DIGEST,
+        changed_paths_digest=_DIGEST,
+        relative_paths=("src/env.py",),
+        facts_object_id=None,
+        excerpt_object_id=ref.object_id,
+        recorded_at=Timestamp("2026-03-04T05:06:07.000Z"),
+    )
+
+    surfaces = {
+        "catalog_db": Path(tmp_path / "task.sqlite").read_bytes(),
+        **{
+            str(path): path.read_bytes()
+            for path in bundle.rglob("*")
+            if path.is_file() and ".staging" not in path.parts
+        },
+    }
+    assert surfaces, "inspection persistence must write sqlite and object bytes"
+    for name, data in surfaces.items():
+        findings = scan_for_sensitive_content(data, canaries=(_SECRET, b"wJalrXUtnFEMI"))
+        assert findings == (), f"inspection canary leaked into {name!r}: {findings}"
+        assert _SECRET not in data
+        assert b"wJalrXUtnFEMI" not in data
+
+    async def decrypt() -> bytes:
+        return b"".join([chunk async for chunk in objects.open_verified(ref)])
+
+    recovered = asyncio.run(decrypt())
+    assert recovered == encoded
+    assert b"excerpt_b64" not in recovered
+    assert _SECRET not in recovered

--- a/tests/unit/application/test_observation_secret_persistence.py
+++ b/tests/unit/application/test_observation_secret_persistence.py
@@ -1,0 +1,260 @@
+"""Changed-file excerpts and approved-check output share the fail-closed scanner."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import apsw
+import pytest
+
+from yoetz.adapters.approved_checks import (
+    ApprovedCheckApproval,
+    ApprovedCheckCommand,
+    ApprovedCheckRunner,
+    approval_commitment,
+)
+from yoetz.adapters.integrations.observation_local import LocalObservationStore
+from yoetz.adapters.sqlite.migrations import initialize_bundle
+from yoetz.adapters.sqlite.observation import SqliteObservationStore
+from yoetz.adapters.workspace_inspect import open_inspect_workspace
+from yoetz.application.observation_coordinator import (
+    ObservationCoordinator,
+    build_inspection_excerpt_manifest,
+)
+from yoetz.application.observation_verification import ObservationVerificationJob
+from yoetz.observability.privacy import PersistenceScanResult
+from yoetz.ports.check_sandbox import CheckSandboxLaunch, CheckSandboxStatus
+from yoetz.ports.objects import ObjectMetadata, ObjectRef, ObjectSource
+from yoetz.ports.workspace_inspect import InspectedArtifact
+from yoetz.protocol.ids import PREFIX_BY_KIND, IdKind
+
+_TASK = "tsk_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+_DIGEST = "sha256:" + "ab" * 32
+_COMMITMENT = "hmac-sha256:" + "cd" * 32
+_WORKSPACE = "hmac-sha256:" + "11" * 32
+_SECRET = b"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+_AZURE = b"AZURE_CLIENT_SECRET=abc123secretvalue0001"
+_TOKEN = b"GITHUB_TOKEN=notakeybutlongenoughvalue"
+
+
+class _ReadySandbox:
+    def prepare(
+        self,
+        *,
+        argv: Sequence[str],
+        cwd: Path,
+        env: Mapping[str, str],
+        deny_network: bool,
+    ) -> CheckSandboxLaunch:
+        del deny_network
+        return CheckSandboxLaunch(
+            argv=tuple(argv),
+            env=dict(env),
+            cwd=cwd,
+            status=CheckSandboxStatus.READY,
+            network_isolated=True,
+        )
+
+
+class _Clock:
+    def now_utc(self) -> datetime:
+        return datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class _CapturingObjects:
+    def __init__(self) -> None:
+        self.payloads: list[bytes] = []
+
+    async def stage(self, source: ObjectSource, metadata: ObjectMetadata) -> ObjectMetadata:
+        assert source.data is not None
+        self.payloads.append(source.data)
+        return metadata
+
+    async def finalize(self, staged: ObjectMetadata) -> ObjectRef:
+        payload = self.payloads[-1]
+        return ObjectRef(
+            PREFIX_BY_KIND[IdKind.OBJECT] + str(uuid.uuid4()),
+            len(payload),
+            _COMMITMENT,
+            _DIGEST,
+            "yoetz-object/1",
+            "slot1",
+            staged,
+        )
+
+
+def _artifact(relative_path: str, excerpt: bytes) -> InspectedArtifact:
+    digest = "sha256:" + hashlib.sha256(excerpt).hexdigest()
+    return InspectedArtifact(relative_path, digest, excerpt, False, len(excerpt))
+
+
+def _job() -> ObservationVerificationJob:
+    return ObservationVerificationJob(
+        job_id="job_1",
+        workspace_commitment=_WORKSPACE,
+        policy_digest=_DIGEST,
+        approval_commitment=_DIGEST,
+        subject_state_digest=_DIGEST,
+        state_token=1,
+    )
+
+
+def _coordinator(tmp_path: Path, objects: _CapturingObjects) -> ObservationCoordinator:
+    return ObservationCoordinator(
+        runtime=SimpleNamespace(task_id=_TASK, objects=objects),  # type: ignore[arg-type]
+        local=LocalObservationStore(_state=tmp_path),
+        clock=_Clock(),  # type: ignore[arg-type]
+        ids=object(),  # type: ignore[arg-type]
+        state_root=tmp_path,
+    )
+
+
+def test_changed_file_prefix_canary_persists_only_redaction_metadata() -> None:
+    secret_file = _artifact("src/env.py", b"export " + _SECRET + b"\nprint(1)\n")
+    clean_file = _artifact("src/ok.py", b"print('hello-advice')\n")
+    encoded, unavailable = build_inspection_excerpt_manifest((secret_file, clean_file))
+    assert unavailable is False
+    assert encoded is not None
+    parsed = json.loads(encoded)
+    artifacts = parsed["artifacts"]
+    assert artifacts[0]["path"] == "src/env.py"
+    assert artifacts[0]["redacted"] is True
+    assert artifacts[0]["finding_kinds"] == ["credential_pattern"]
+    assert "excerpt_b64" not in artifacts[0]
+    assert artifacts[1]["redacted"] is False
+    recovered = base64.b64decode(artifacts[1]["excerpt_b64"])
+    assert b"hello-advice" in recovered
+    assert _SECRET not in encoded
+    assert b"wJalrXUtnFEMI" not in encoded
+
+
+def test_changed_file_canary_withholds_excerpt_object() -> None:
+    canary = b"unique-inspect-canary-\x00-secret"
+    encoded, unavailable = build_inspection_excerpt_manifest(
+        (_artifact("notes.txt", b"prefix " + canary),),
+        canaries=(canary,),
+    )
+    assert encoded is None
+    assert unavailable is True
+
+
+def test_changed_file_scanner_failure_stores_no_excerpt(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _withhold(data: bytes, *, canaries: tuple[bytes, ...] = ()) -> PersistenceScanResult:
+        del data, canaries
+        return PersistenceScanResult(False, b"", True, ())
+
+    monkeypatch.setattr(
+        "yoetz.application.observation_coordinator.prepare_persisted_plaintext",
+        _withhold,
+    )
+    encoded, unavailable = build_inspection_excerpt_manifest(
+        (_artifact("notes.txt", b"ordinary excerpt bytes"),)
+    )
+    assert encoded is None
+    assert unavailable is True
+
+
+def test_azure_and_token_prefixes_are_classified_before_encoding() -> None:
+    encoded, unavailable = build_inspection_excerpt_manifest(
+        (_artifact("a.env", _AZURE + b"\n"), _artifact("b.env", _TOKEN + b"\n"))
+    )
+    assert unavailable is False
+    assert encoded is not None
+    assert _AZURE not in encoded
+    assert _TOKEN not in encoded
+    parsed = json.loads(encoded)
+    for item in parsed["artifacts"]:
+        assert item["redacted"] is True
+        assert "excerpt_b64" not in item
+
+
+@pytest.mark.anyio
+async def test_approved_check_persistence_path_redacts_compound_secrets(
+    tmp_path: Path,
+) -> None:
+    handle = open_inspect_workspace(tmp_path)
+    captured: list[bytes] = []
+    assignment = "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    argv = ("/bin/echo", assignment)
+    approval = ApprovedCheckApproval(
+        approval_id="pytest-unit",
+        argv=argv,
+        allow_network=False,
+        timeout_seconds=10.0,
+        approval_commitment=approval_commitment("pytest-unit", argv, allow_network=False),
+    )
+    runner = ApprovedCheckRunner(
+        {approval.approval_commitment: approval},
+        sandbox=_ReadySandbox(),
+        output_sink=captured.append,
+    )
+    runner.run(
+        ApprovedCheckCommand(
+            workspace=handle,
+            approval=approval,
+            subject_state_digest=_DIGEST,
+        )
+    )
+    assert captured
+    assert b"wJalrXUtnFEMI" not in captured[0]
+    assert b"[REDACTED]" in captured[0]
+
+    db = apsw.Connection(":memory:")
+    initialize_bundle(db, {"task_id": "task_obs", "owner_generation": "1"})
+    store = SqliteObservationStore(db)
+    objects = _CapturingObjects()
+    coordinator = _coordinator(tmp_path, objects)
+    object_id = await coordinator._persist_approved_check_output(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        SimpleNamespace(task_id=_TASK, objects=objects),  # type: ignore[arg-type]
+        store,
+        _WORKSPACE,
+        _job(),
+        captured[0] + b"\n" + _AZURE,
+    )
+    assert object_id is not None
+    assert objects.payloads
+    payload = objects.payloads[0]
+    assert b"wJalrXUtnFEMI" not in payload
+    assert b"abc123secretvalue0001" not in payload
+    parsed = json.loads(payload)
+    decoded = base64.b64decode(parsed["content_b64"])
+    assert b"[REDACTED]" in decoded
+    assert parsed["redacted"] is True
+    rows = db.execute("SELECT redacted, content_kind FROM observation_content_manifests").fetchall()
+    assert rows == [(1, "approved_check_output")]
+
+
+@pytest.mark.anyio
+async def test_approved_check_persistence_withholds_when_scan_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _withhold(data: bytes, *, canaries: tuple[bytes, ...] = ()) -> PersistenceScanResult:
+        del data, canaries
+        return PersistenceScanResult(False, b"", True, ("canary",))
+
+    monkeypatch.setattr(
+        "yoetz.application.observation_coordinator.prepare_persisted_plaintext",
+        _withhold,
+    )
+    db = apsw.Connection(":memory:")
+    initialize_bundle(db, {"task_id": "task_obs", "owner_generation": "1"})
+    store = SqliteObservationStore(db)
+    objects = _CapturingObjects()
+    coordinator = _coordinator(tmp_path, objects)
+    object_id = await coordinator._persist_approved_check_output(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        SimpleNamespace(task_id=_TASK, objects=objects),  # type: ignore[arg-type]
+        store,
+        _WORKSPACE,
+        _job(),
+        b"AWS_SECRET_ACCESS_KEY=should-not-be-stored",
+    )
+    assert object_id is None
+    assert objects.payloads == []
+    assert db.execute("SELECT COUNT(*) FROM observation_content_manifests").fetchone() == (0,)

--- a/tests/unit/observability/test_privacy.py
+++ b/tests/unit/observability/test_privacy.py
@@ -181,6 +181,13 @@ def test_prepare_persisted_plaintext_withholds_canary_and_scanner_failure() -> N
     assert failed.redacted is True
 
 
+def test_prepare_persisted_plaintext_withholds_at_finding_capacity() -> None:
+    secret = b"AWS_SECRET_ACCESS_KEY=not-a-real-but-sensitive-value"
+    saturated = prepare_persisted_plaintext(b"\n".join([secret] * 128))
+
+    assert saturated == PersistenceScanResult(False, b"", True, ("credential_pattern",))
+
+
 def test_privacy_helpers_are_deterministic() -> None:
     record = {
         "engine_version": "0.1.0",

--- a/tests/unit/observability/test_privacy.py
+++ b/tests/unit/observability/test_privacy.py
@@ -10,10 +10,12 @@ from yoetz.observability.privacy import (
     PRIVACY_REQUEST_BODY_DOMAIN,
     SESSION_HASH_DOMAIN,
     DiagnosticRedactionProfile,
+    PersistenceScanResult,
     PrivacyFenceError,
     Sensitivity,
     assert_plaintext_safe,
     build_diagnostic_manifest,
+    prepare_persisted_plaintext,
     privacy_request_commitment,
     redact_diagnostic_record,
     redact_diagnostic_value,
@@ -128,6 +130,10 @@ def test_canary_spanning_scan_chunk_boundary_is_detected() -> None:
         (b"OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456", "credential_pattern"),
         (b"https://" + b"user:password@" + b"example.invalid/resource", "credential_pattern"),
         (b"github_pat_abcdefghijklmnopqrstuvwxyz123456", "credential_pattern"),
+        (b"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "credential_pattern"),
+        (b"AZURE_CLIENT_SECRET=abc123secretvalue0001", "credential_pattern"),
+        (b"GITHUB_TOKEN=notakeybutlongenoughvalue", "credential_pattern"),
+        (b"NPM_TOKEN=npm_notarealtokenvalue12", "credential_pattern"),
     ],
 )
 def test_sensitive_scanner_positive_patterns(data: bytes, kind: str) -> None:
@@ -142,10 +148,37 @@ def test_sensitive_scanner_positive_patterns(data: bytes, kind: str) -> None:
         b"random structural identifier sk-short",
         b"sha256:" + b"a" * 64,
         b"\xff\xfe\x80 ordinary invalid utf8 bytes",
+        b"AWS_ACCESS_KEY_ID=not-an-akia-identifier",
+        b"TOKEN_COUNT=12",
+        b"MAX_TOKEN=4096",
+        b"SECRETARY=Alice",
+        b"tokenize=falsehood",
     ],
 )
 def test_sensitive_scanner_negative_patterns(data: bytes) -> None:
     assert scan_for_sensitive_content(data) == ()
+
+
+def test_prepare_persisted_plaintext_redacts_without_retaining_match() -> None:
+    secret = b"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    data = b"export " + secret + b"\n"
+    result = prepare_persisted_plaintext(data)
+    assert result.persist is True
+    assert result.redacted is True
+    assert result.finding_kinds == ("credential_pattern",)
+    assert b"[REDACTED]" in result.content
+    assert b"wJalrXUtnFEMI" not in result.content
+    assert secret not in result.content
+
+
+def test_prepare_persisted_plaintext_withholds_canary_and_scanner_failure() -> None:
+    canary = b"unique-binary-canary-\x00-credential"
+    withheld = prepare_persisted_plaintext(b"prefix" + canary + b"suffix", canaries=(canary,))
+    assert withheld == PersistenceScanResult(False, b"", True, ("canary",))
+    failed = prepare_persisted_plaintext(canary, canaries=(b"",))
+    assert failed.persist is False
+    assert failed.content == b""
+    assert failed.redacted is True
 
 
 def test_privacy_helpers_are_deterministic() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: Fixes #397 (carries the merged #398 checklist)
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging, ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

Maintainer acknowledgement: issue #397 comment consolidating #398 (2026-08-28, maintainer-authorized). Duplicate search found no open PR covering this scanner path.

## Documentation

- Behavior change? `yes`
- Docs updated (ADR, `docs/` page, `docs/INTERFACES.md` entry), or `n/a — no behavior change`:
  `docs/adr/ADR-009-data-egress-privacy.md`, `docs/INTERFACES.md`

## Verification

Commands run (paste):

```text
uv run ruff check src/yoetz/observability/privacy.py src/yoetz/application/observation_coordinator.py tests/unit/observability/test_privacy.py tests/unit/application/test_observation_secret_persistence.py tests/integration/privacy/test_inspection_excerpt_canary_sweep.py
uv run ruff format --check src/yoetz/observability/privacy.py src/yoetz/application/observation_coordinator.py tests/unit/observability/test_privacy.py tests/unit/application/test_observation_secret_persistence.py tests/integration/privacy/test_inspection_excerpt_canary_sweep.py
npx --no-install pyright src/yoetz/observability/privacy.py src/yoetz/application/observation_coordinator.py tests/unit/observability/test_privacy.py tests/unit/application/test_observation_secret_persistence.py tests/integration/privacy/test_inspection_excerpt_canary_sweep.py
uv run pytest tests/unit/observability/test_privacy.py tests/unit/application/test_observation_secret_persistence.py tests/integration/privacy/test_inspection_excerpt_canary_sweep.py tests/property/test_privacy_properties.py tests/unit/adapters/test_approved_checks.py tests/unit/application/test_observation_coordinator.py tests/unit/adapters/test_workspace_inspect.py
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Changed-file excerpts were base64-encoded and encrypted without the shared secret scanner. Approved-check persistence re-encoded runner output without a second fail-closed scan, and `_SECRET_ASSIGNMENT` missed compound names such as `AWS_SECRET_ACCESS_KEY` and `AZURE_CLIENT_SECRET` plus bounded `*_TOKEN` assignments.

This PR:

- Classifies bytes with `prepare_persisted_plaintext` before any observation `content_b64` / `excerpt_b64` encoding.
- Persists secret matches as redaction metadata (path, digest, finding kinds) and never the original span.
- Withholds the excerpt or approved-check object on scanner failure or canary match and records `content_capture_unavailable`.
- Recognizes compound environment assignments without over-redacting near-miss identifiers (`AWS_ACCESS_KEY_ID`, `TOKEN_COUNT`, `MAX_TOKEN`, `SECRETARY`).
- Covers changed-file prefix canaries, the approved-check runner-to-manifest path, and plaintext plus encrypted-object inspection-snapshot sweeps.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b37131c3-d28a-4333-ba6b-091d101dfab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b37131c3-d28a-4333-ba6b-091d101dfab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


