### PR TITLE
fix(service): release ceremony lock on stop and name reverse handshake mismatch

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1572,13 +1572,20 @@ closes a half-open stream on expiry. On-demand startup has one **30-second** mon
 includes its initial attempt, spawn, and polling; an accepted but silent existing endpoint is
 reported unavailable rather than causing a second daemon to be spawned.
 
-The handshake pins the exact schema-manifest digest on both sides. A listening service that does
-not share the client's digest (or hello shape) closes the connection without answering; the client
-names that outcome `handshake_rejected` (distinct from a frame truncated mid-flight) and, together
-with an answered `manifest_mismatch`, maps it to the retryable `ControlError` reason
-`service_incompatible` (public code `SERVICE_UNAVAILABLE`). The singleton lock stamp carries the
-holder's `pid`, `instance_id`, `service_version`, and `schema_manifest_digest` (bounded, advisory;
-older stamps omit the last two and are read as unknown). On-demand startup — the MCP bridge's path
+The handshake pins the exact schema-manifest digest on both sides. When a listening
+service can decode the peer's hello as a known control-hello shape but the digest does
+not match, it answers with a hello-result carrying **this** installation's digest and
+then closes without admitting a session. The client names an answered digest mismatch
+`manifest_mismatch` and a silent close (unknown hello shape, or a peer that still
+closes without answering) `handshake_rejected`; both map to the retryable
+`ControlError` reason `service_incompatible` (public code `SERVICE_UNAVAILABLE`).
+`yoetz service status --json` emits that reason plus the stamped holder identity and a
+`correlation_id` joinable with `yoetz service diagnostics --correlation-id`. Older
+pre-2.2.0 CLIs that lack `handshake_rejected` still decode the answered hello-result
+and fail on the digest themselves (`protocol_mismatch` in those binaries). The
+singleton lock stamp carries the holder's `pid`, `instance_id`, `service_version`, and
+`schema_manifest_digest` (bounded, advisory; older stamps omit the last two and are
+read as unknown). On-demand startup — the MCP bridge's path
 and `yoetz service restart` — treats an incompatible holder as an upgrade to complete: it records a
 `service_supersede` diagnostic, sends the holder its ordinary bounded-shutdown signal, waits for the
 lock to be released inside the same 30-second budget, then spawns and connects to a successor of
@@ -1869,7 +1876,13 @@ monotonic sample with the same floor rule.
 `privacy_policy_decision`, `privacy_disclosure_decision`, and `idle_relock_policy_change`.
 `CEREMONY_EXPIRY_SECONDS = 300` is the one YZH1/YZS1 challenge/binding expiry. It bounds a whole
 human ceremony, including the trip to a provider console to mint an API key, so it is a five-minute
-span rather than a keystroke timeout. The nine fixed
+span rather than a keystroke timeout. While a `SecretRequiredPhase` is live, the human-control
+handler waits for YZS1 **or** a close/cancel on the YZH1 peer. Killing the foreground ceremony
+client (EOF at the passphrase prompt) cancels the one global ceremony immediately. `service stop`
+must not wait on that mutex: `secret_completed` releases it while waiting, `close()` cancels any
+still-active ceremony, and `UnlockCoordinator.cancel` returns UNLOCKING to LOCKED without reversing
+an in-flight DRAINING/FAILED transition. Shutdown that cancels a live ceremony records
+`ceremony_shutdown` / `cancelled` in the owner-only diagnostic ring. The nine fixed
 `ConfidentialSecretPurpose` wire codes are `1=vault_initialize`, `2=vault_unlock`,
 `3=portable_recovery`, `4=provider_reauthentication`, `5=provider_credential`,
 `6=privacy_reauthentication`, `7=security_reauthentication`,

--- a/docs/protocol/compatibility.md
+++ b/docs/protocol/compatibility.md
@@ -192,15 +192,19 @@ Claude Desktop local/SSH, Desktop remote, web/cloud, synced plugins, managed/use
 Agent SDK, and noninteractive/headless behavior are separate unpopulated cells. Claude Code is not
 claimed to consume Agent Plugins 1.0.0.
 
-Local-control schema `2.2.0` is the current append-only service-control wire. Relative to immutable
-`2.1.0`, it adds only `claude_hook` to observation envelope sources and source coverage. Peers must
+Local-control schema `2.3.0` is the current append-only service-control wire. Peers must
 match the schema-manifest digest; no source is inferred across versions. Because every resource
 change moves that digest, an upgraded installation cannot talk to the previous installation's
-still-running service: the handshake is refused as `service_incompatible`, and on-demand startup
+still-running service, and an older CLI cannot talk to a newer still-running service: a
+decodable hello with a foreign digest is answered with this installation's hello-result and then
+refused as `service_incompatible`, and on-demand startup
 (the MCP bridge) or the explicit `yoetz service restart` replaces the stale holder with a service
 of the current installation through its ordinary bounded shutdown. Stale bridges are then refused
-in turn until their host restarts them. The 2026-08-27 Claude dogfood hit exactly this transition
-and saw an opaque `INTERNAL_ERROR`; it is now a bounded `SERVICE_UNAVAILABLE` naming the repair.
+in turn until their host restarts them. The 2026-08-27 Claude dogfood hit the newer-client /
+older-service direction and saw an opaque `INTERNAL_ERROR`; that is now a bounded
+`SERVICE_UNAVAILABLE` naming the repair. The 2026-08-28 dogfood hit the older-CLI / newer-service
+direction as an opaque `invalid_request` with no correlation id; the service now answers the
+hello-result so current CLIs name `service_incompatible` with holder identity and a diagnostic id.
 
 ## Change and deprecation process
 

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -451,6 +451,52 @@ def _with_holder_identity(line: str) -> str:
     return f"{line} (holder pid {holder.pid}, service version {version}, schema manifest {digest})"
 
 
+def _with_correlation(line: str, error: ControlError) -> str:
+    if error.correlation_id is None:
+        return line
+    return f"{line}; correlation_id {error.correlation_id}"
+
+
+def _holder_identity_json() -> dict[str, JsonValue] | None:
+    """Bounded singleton-stamp fields for machine-readable control failures."""
+
+    try:
+        from yoetz.config.paths import state_dir
+        from yoetz.service.lifecycle import SINGLETON_LOCK_NAME, probe_singleton_holder_identity
+
+        holder = probe_singleton_holder_identity(state_dir() / SINGLETON_LOCK_NAME)
+    except Exception:
+        return None
+    if holder is None:
+        return None
+    body: dict[str, JsonValue] = {"pid": holder.pid}
+    if holder.service_version is not None:
+        body["service_version"] = holder.service_version
+    if holder.schema_manifest_digest is not None:
+        body["schema_manifest_digest"] = holder.schema_manifest_digest
+    return body
+
+
+def _bind_handshake_correlation(error: ControlError) -> ControlError:
+    if error.reason not in {"service_incompatible", "protocol_mismatch"}:
+        return error
+    if error.correlation_id is not None:
+        return error
+    from yoetz.observability.logging import record_public_error_without_raising
+
+    correlation_id = record_public_error_without_raising(
+        component="cli.service",
+        operation="control_handshake",
+        reason=error.reason,
+    )
+    return ControlError(
+        error.reason,
+        retryable=error.retryable,
+        accepted_state=error.accepted_state or None,
+        correlation_id=correlation_id,
+    )
+
+
 def _lifecycle_exit_code(error: BaseException) -> int | None:
     """Exit code for a bounded lifecycle refusal, or None for anything else.
 
@@ -478,20 +524,36 @@ def _lifecycle_failure(error: LifecycleError) -> int:
     return exit_code_for(code)
 
 
-def _control_failure(error: ControlError) -> int:
+def _control_failure(error: ControlError, *, json_output: bool = False) -> int:
+    error = _bind_handshake_correlation(error)
     code = public_error_code_for_control_reason(error.reason)
     if error.reason in {"service_incompatible", "protocol_mismatch"}:
         # The endpoint answered, but with a service of another installation or protocol
         # generation. Neither 'service run' (refused while the holder lives) nor a plain retry
         # helps; the explicit repair replaces that holder with this installation's service.
-        _stderr(
+        guidance = _with_correlation(
             _with_holder_identity(
                 f"{error.reason}: the running local service was started by a different Yoetz "
                 "installation than this command and rejected its handshake. Run "
                 "'yoetz service restart' on a local terminal to replace it with this "
                 "installation's service, then retry"
-            )
+            ),
+            error,
         )
+        _stderr(guidance)
+        if json_output:
+            payload: dict[str, JsonValue] = {
+                "ok": False,
+                "public_code": code.value,
+                "reason": error.reason,
+                "retryable": error.retryable,
+            }
+            if error.correlation_id is not None:
+                payload["correlation_id"] = error.correlation_id
+            holder = _holder_identity_json()
+            if holder is not None:
+                payload["holder"] = holder
+            _stdout_json(payload)
         return exit_code_for(code)
     if code is PublicErrorCode.SERVICE_UNAVAILABLE and accepted_but_unresponsive(error):
         # A service that answered the connect and then went silent is running. Prescribing
@@ -1074,7 +1136,7 @@ async def _service_call(method: str, json_output: bool) -> int:
         _human_or_json(result, json_output=json_output)
         return 0
     except ControlError as error:
-        return _control_failure(error)
+        return _control_failure(error, json_output=json_output)
 
 
 def _service_command(method: str) -> Callable[..., None]:
@@ -1112,9 +1174,9 @@ async def _service_restart(json_output: bool) -> int:
         except ControlError as error:
             if error.reason in {"service_incompatible", "protocol_mismatch"}:
                 if not await supersede_incompatible_service(deadline=deadline):
-                    return _control_failure(error)
+                    return _control_failure(error, json_output=json_output)
             elif error.reason != "service_unavailable":
-                return _control_failure(error)
+                return _control_failure(error, json_output=json_output)
         else:
             try:
                 await client.stop()
@@ -1141,7 +1203,7 @@ async def _service_restart(json_output: bool) -> int:
         finally:
             await successor.close()
     except ControlError as error:
-        return _control_failure(error)
+        return _control_failure(error, json_output=json_output)
     _human_or_json(status, json_output=json_output)
     return 0
 

--- a/src/yoetz/service/control_protocol.py
+++ b/src/yoetz/service/control_protocol.py
@@ -705,6 +705,20 @@ def _allowed_for(kind: ControlClientKind) -> tuple[ControlMethod, ...]:
     return _WORKFLOW_METHODS if kind is ControlClientKind.MCP_BRIDGE else _ALL_METHODS
 
 
+def _hello_result_wire(
+    service_status: ServiceStatus, allowed: tuple[ControlMethod, ...]
+) -> dict[str, JsonValue]:
+    return {
+        "protocol_version": CONTROL_PROTOCOL_VERSION,
+        "service_version": service_status.service_version,
+        "service_instance_id": service_status.service_instance_id,
+        "service_generation": service_status.service_generation,
+        "status": _status_wire(service_status),
+        "allowed_methods": [method.value for method in allowed],
+        "schema_manifest_digest": _manifest_digest(),
+    }
+
+
 def _manifest_digest() -> str:
     # sha256(manifest.json) only — never build the catalog to hash it (#210).
     return schema_manifest_digest()
@@ -816,9 +830,15 @@ async def server_handshake(
         _validated_wire(hello, "control-hello")
         if hello["protocol_version"] != CONTROL_PROTOCOL_VERSION:
             _fail("protocol_mismatch")
-        if hello["schema_manifest_digest"] != _manifest_digest():
-            _fail("manifest_mismatch")
         kind = ControlClientKind(cast(str, hello["client_kind"]))
+        if hello["schema_manifest_digest"] != _manifest_digest():
+            # Answer with this installation's hello-result so a peer that still
+            # decodes the frozen 2.x shape names `manifest_mismatch` instead of
+            # treating a silent close as `frame_invalid`. The session is not admitted.
+            await write_control_frame(
+                stream, _hello_result_wire(service_status, _allowed_for(kind))
+            )
+            _fail("manifest_mismatch")
         raw_presentation = hello.get("presentation_context")
         render_mode = ProjectionRenderMode.MACHINE_READABLE
         output_is_controlling_tty = False
@@ -846,18 +866,8 @@ async def server_handshake(
                 and type(repository_context) is not RepositoryPrivacyContext
             ):
                 _fail("protocol_mismatch")
-        status = _status_wire(service_status)
         allowed = _allowed_for(kind)
-        response: dict[str, JsonValue] = {
-            "protocol_version": CONTROL_PROTOCOL_VERSION,
-            "service_version": service_status.service_version,
-            "service_instance_id": service_status.service_instance_id,
-            "service_generation": service_status.service_generation,
-            "status": status,
-            "allowed_methods": [method.value for method in allowed],
-            "schema_manifest_digest": _manifest_digest(),
-        }
-        await write_control_frame(stream, response)
+        await write_control_frame(stream, _hello_result_wire(service_status, allowed))
         return ControlSession(
             protocol_version="1.0",
             client_kind=kind,

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -1269,6 +1269,14 @@ class ServiceDaemon:
                     )
             except TimeoutError:
                 return
+            except ControlProtocolError as exc:
+                if exc.reason in {"manifest_mismatch", "protocol_mismatch"}:
+                    record_public_error_without_raising(
+                        component="service.daemon",
+                        operation="control_handshake",
+                        reason=exc.reason,
+                    )
+                return
             while not self._stop_event.is_set():
                 try:
                     frame = await self._read_control_frame_idle_aware(stream, calls)
@@ -3428,12 +3436,13 @@ class _HumanConnectionServer:
             await _write_human_envelope(stream, response)
             while True:
                 # ServerOpenedEnvelope (step 1) and later ServerPhaseEnvelope both carry
-                # SecretRequiredPhase; the daemon must await YZS1 completion either way.
+                # SecretRequiredPhase; the daemon must await YZS1 completion either way,
+                # and must still observe a foreground peer that disappears at the prompt.
                 phase = getattr(response, "phase", None)
                 if isinstance(phase, SecretRequiredPhase):
                     error_step = cast(int, getattr(response, "step")) + 1
-                    response = await self._service.secret_completed(
-                        cast(str, getattr(response, "ceremony_id"))
+                    response = await self._advance_secret_phase(
+                        stream, cast(str, getattr(response, "ceremony_id"))
                     )
                 else:
                     incoming = await _read_human_envelope(stream)
@@ -3494,6 +3503,29 @@ class _HumanConnectionServer:
                 except Exception:
                     pass
             await stream.aclose()
+
+    async def _advance_secret_phase(self, stream: ControlStream, ceremony_id: str) -> object:
+        """Wait for YZS1 or a human-control peer close/cancel, never only the secret socket."""
+
+        secret_wait = asyncio.create_task(self._service.secret_completed(ceremony_id))
+        peer_wait = asyncio.create_task(_read_human_envelope(stream))
+        done, pending = await asyncio.wait(
+            {secret_wait, peer_wait}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        if secret_wait in done and not secret_wait.cancelled():
+            return secret_wait.result()
+        incoming: object | None = None
+        if peer_wait in done and not peer_wait.cancelled():
+            incoming = peer_wait.result()
+        if type(incoming) is ClientCancelEnvelope:
+            return await self._service.cancel(incoming.ceremony_id)
+        await self._service.cancel(ceremony_id)
+        if incoming is None:
+            raise HumanControlError("cancelled")
+        raise HumanControlError("kind_forbidden")
 
 
 async def _production_composition(

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -3514,7 +3514,11 @@ class _HumanConnectionServer:
         )
         for task in pending:
             task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+        for task in pending:
+            try:
+                await task
+            except asyncio.CancelledError, Exception:
+                pass
         if secret_wait in done and not secret_wait.cancelled():
             return secret_wait.result()
         incoming: object | None = None

--- a/src/yoetz/service/human_control.py
+++ b/src/yoetz/service/human_control.py
@@ -359,7 +359,10 @@ class HumanControlService:
                 await self._consume_failed(session)
                 if isinstance(failure, HumanControlError):
                     raise failure
-                raise HumanControlError(self._map_error(failure)) from failure
+                mapped = (
+                    self._map_error(failure) if isinstance(failure, Exception) else "internal_error"
+                )
+                raise HumanControlError(mapped) from failure
             secret = secret_task.result()
             session.secret_task = None
             try:

--- a/src/yoetz/service/human_control.py
+++ b/src/yoetz/service/human_control.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import secrets
-from asyncio import Lock, Task, create_task
+from asyncio import CancelledError, Lock, Task, create_task, wait
 from dataclasses import dataclass
 from typing import Final, Literal, Protocol, cast
 
@@ -338,9 +338,31 @@ class HumanControlService:
             binding = session.secret_binding
             if binding is None or binding != session.phase.binding:
                 raise HumanControlError("stale_generation")
+            secret_task = session.secret_task
+        # Do not hold the ceremony mutex while YZS1 waits: stop()/cancel()/peer EOF must
+        # be able to release the singleton without waiting out CEREMONY_EXPIRY_SECONDS.
+        try:
+            await wait({secret_task})
+        except CancelledError:
+            async with self._mutex:
+                if self._active is session:
+                    await self._consume_failed(session)
+            raise
+        async with self._mutex:
+            if self._active is not session:
+                raise HumanControlError("cancelled")
+            if secret_task.cancelled():
+                await self._consume_failed(session)
+                raise HumanControlError("cancelled")
+            failure = secret_task.exception()
+            if failure is not None:
+                await self._consume_failed(session)
+                if isinstance(failure, HumanControlError):
+                    raise failure
+                raise HumanControlError(self._map_error(failure)) from failure
+            secret = secret_task.result()
+            session.secret_task = None
             try:
-                secret = await session.secret_task
-                session.secret_task = None
                 purpose = binding.purpose
                 if purpose is ConfidentialSecretPurpose.VAULT_INITIALIZE:
                     challenge = self._require_unlock_challenge(session)
@@ -512,6 +534,13 @@ class HumanControlService:
     async def close(self) -> None:
         async with self._mutex:
             if self._active is not None:
+                from yoetz.observability.logging import record_public_error_without_raising
+
+                record_public_error_without_raising(
+                    component="service.human_control",
+                    operation="ceremony_shutdown",
+                    reason="cancelled",
+                )
                 await self._consume_failed(self._active)
             await self._secret_ingress.close()
             if self._user_presence is not None:
@@ -783,9 +812,10 @@ class HumanControlService:
         return ServerCloseEnvelope(session.binding.ceremony_id, session.next_step + 1, "cancelled")
 
     async def _consume_failed(self, session: _Ceremony) -> None:
-        if session.secret_task is not None:
-            session.secret_task.cancel()
-            session.secret_task = None
+        secret_task = session.secret_task
+        session.secret_task = None
+        if secret_task is not None and not secret_task.done():
+            secret_task.cancel()
         await self._secret_ingress.cancel_pending()
         await self._unlock.cancel()
         if type(session.request.target) is InstallationRecoveryTarget:
@@ -902,6 +932,7 @@ class HumanControlService:
         reason = getattr(exc, "reason", None)
         mapping = {
             "binding_expired": "binding_expired",
+            "cancelled": "cancelled",
             "challenge_mismatch": "stale_generation",
             "closed": "closed",
             "human_authority_unavailable": "presence_unavailable",

--- a/src/yoetz/service/unlock.py
+++ b/src/yoetz/service/unlock.py
@@ -1084,7 +1084,7 @@ class UnlockCoordinator:
                 "vault_initialize",
                 "vault_unlock",
             }:
-                await self._lifecycle.transition(ServiceState.LOCKED)
+                await self._release_unlocking()
 
     async def close(self) -> None:
         async with self._mutex:
@@ -1098,7 +1098,7 @@ class UnlockCoordinator:
                 "vault_initialize",
                 "vault_unlock",
             }:
-                await self._lifecycle.transition(ServiceState.LOCKED)
+                await self._release_unlocking()
             self._closed = True
 
     def _new_challenge(
@@ -1163,6 +1163,12 @@ class UnlockCoordinator:
 
     def _lifecycle_state(self) -> ServiceState:
         return self._lifecycle.state
+
+    async def _release_unlocking(self) -> None:
+        """Return UNLOCKING to LOCKED; never reverse an in-flight drain or failure."""
+
+        if self._lifecycle_state() is ServiceState.UNLOCKING:
+            await self._lifecycle.transition(ServiceState.LOCKED)
 
     def _require_open_idle(self) -> None:
         if self._closed:

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -68,10 +68,13 @@ from yoetz.protocol.models import (
 from yoetz.service.client import _connected_client  # pyright: ignore[reportPrivateUsage]
 from yoetz.service.confidential_protocol import (
     ClientOpenEnvelope,
+    ConfidentialSecretPurpose,
     EmptyVaultTarget,
     HumanCeremonyBinding,
     HumanCeremonyKind,
     KeyringRetryPhase,
+    SecretIngressBinding,
+    SecretRequiredPhase,
     ServerCloseEnvelope,
     ServerErrorEnvelope,
     ServerOpenedEnvelope,
@@ -2616,3 +2619,98 @@ async def test_human_connection_cancels_an_open_ceremony_when_terminal_disconnec
         ServerOpenedEnvelope,
         ServerErrorEnvelope,
     ]
+
+
+@pytest.mark.anyio
+async def test_human_connection_cancels_secret_phase_when_terminal_disconnects() -> None:
+    """Issue #434: EOF at a passphrase prompt must not wait on YZS1."""
+
+    ceremony_id = "a" * 64
+    binding = SecretIngressBinding(
+        binding_version=1,
+        ceremony_id=ceremony_id,
+        secret_challenge="c" * 64,
+        purpose=ConfidentialSecretPurpose.VAULT_UNLOCK,
+        service_instance_id=_INSTANCE_ID,
+        service_generation=7,
+        vault_generation=3,
+        policy_generation=None,
+        target_digest="sha256:" + "2" * 64,
+        expires_at_monotonic_ms=1_000_000,
+    )
+
+    class _Stream:
+        def __init__(self) -> None:
+            self._incoming = bytearray(
+                encode_human_frame(
+                    ClientOpenEnvelope(
+                        "b" * 64,
+                        HumanCeremonyKind.VAULT_UNLOCK,
+                        EmptyVaultTarget(expected_mode="passphrase"),
+                    )
+                )
+            )
+            self.sent: list[bytes] = []
+            self.closed = False
+
+        @property
+        def peer_identity(self) -> object:
+            return object()
+
+        async def receive(self, max_bytes: int) -> bytes:
+            if not self._incoming:
+                return b""
+            size = min(max_bytes, len(self._incoming))
+            chunk = bytes(self._incoming[:size])
+            del self._incoming[:size]
+            return chunk
+
+        async def send_all(self, data: Buffer) -> None:
+            self.sent.append(bytes(data))
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    class _HumanService:
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+            self.secret_started = asyncio.Event()
+
+        async def open_ceremony(self, request: ClientOpenEnvelope) -> ServerOpenedEnvelope:
+            return ServerOpenedEnvelope(
+                ceremony_id,
+                1,
+                HumanCeremonyBinding(
+                    binding_version=1,
+                    ceremony_id=ceremony_id,
+                    connection_nonce=request.connection_nonce,
+                    ceremony_kind=HumanCeremonyKind.VAULT_UNLOCK,
+                    service_instance_id=_INSTANCE_ID,
+                    service_generation=7,
+                    vault_generation=3,
+                    policy_generation=None,
+                    target_digest="sha256:" + "2" * 64,
+                    expires_at_monotonic_ms=1_000_000,
+                ),
+                VaultUnlockPreview(),
+                SecretRequiredPhase(binding),
+            )
+
+        async def secret_completed(self, received_ceremony_id: str) -> ServerOpenedEnvelope:
+            del received_ceremony_id
+            self.secret_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("secret_wait_should_have_been_cancelled")
+
+        async def cancel(self, received_ceremony_id: str) -> ServerCloseEnvelope:
+            self.cancelled.append(received_ceremony_id)
+            return ServerCloseEnvelope(received_ceremony_id, 3, "cancelled")
+
+    stream = _Stream()
+    service = _HumanService()
+    handler = daemon_module._HumanConnectionServer(service)  # pyright: ignore[reportPrivateUsage, reportArgumentType]
+
+    await asyncio.wait_for(handler(stream), 1.0)
+
+    assert service.cancelled == [ceremony_id]
+    assert stream.closed

--- a/tests/integration/service/test_human_control.py
+++ b/tests/integration/service/test_human_control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -842,3 +843,45 @@ async def test_disclosure_consent_needs_no_strong_reauth_and_wrong_phase_is_cons
         await service.submit_action(ClientActionEnvelope(reopened.ceremony_id, 2, RetryAction()))
     with pytest.raises(HumanControlError, match="replay"):
         await service.cancel(reopened.ceremony_id)
+
+
+@pytest.mark.anyio
+async def test_close_during_secret_wait_does_not_deadlock(tmp_path: Path) -> None:
+    """Issue #434: stop()/close() must not wait on the YZS1 acceptor mutex."""
+
+    started = asyncio.Event()
+    hang = asyncio.Event()
+
+    class _HangIngress:
+        cancelled = 0
+
+        async def accept_once(self, expected_binding: object) -> SecretHandle:
+            del expected_binding
+            started.set()
+            await hang.wait()
+            raise AssertionError("secret_wait_should_have_been_cancelled")
+
+        async def cancel_pending(self) -> None:
+            self.cancelled += 1
+            hang.set()
+
+        async def close(self) -> None:
+            return None
+
+    service, _, lifecycle, _, _ = _service(
+        tmp_path, mode="passphrase", ready=False, handles=[]
+    )
+    service._secret_ingress = _HangIngress()  # pyright: ignore[reportPrivateUsage]
+    opened = await service.open_ceremony(
+        ClientOpenEnvelope(
+            "1" * 64,
+            HumanCeremonyKind.VAULT_UNLOCK,
+            EmptyVaultTarget(expected_mode="passphrase"),
+        )
+    )
+    waiter = asyncio.create_task(service.secret_completed(opened.ceremony_id))
+    await asyncio.wait_for(started.wait(), 1.0)
+    await asyncio.wait_for(service.close(), 1.0)
+    with pytest.raises(HumanControlError, match="cancelled"):
+        await asyncio.wait_for(waiter, 1.0)
+    assert lifecycle.state is ServiceState.LOCKED

--- a/tests/integration/service/test_human_control.py
+++ b/tests/integration/service/test_human_control.py
@@ -868,9 +868,7 @@ async def test_close_during_secret_wait_does_not_deadlock(tmp_path: Path) -> Non
         async def close(self) -> None:
             return None
 
-    service, _, lifecycle, _, _ = _service(
-        tmp_path, mode="passphrase", ready=False, handles=[]
-    )
+    service, _, lifecycle, _, _ = _service(tmp_path, mode="passphrase", ready=False, handles=[])
     service._secret_ingress = _HangIngress()  # pyright: ignore[reportPrivateUsage]
     opened = await service.open_ceremony(
         ClientOpenEnvelope(

--- a/tests/unit/cli/test_service_status_remediation.py
+++ b/tests/unit/cli/test_service_status_remediation.py
@@ -10,6 +10,7 @@ need opposite next steps. Sending an operator from an unresponsive-but-live daem
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 from typer.testing import CliRunner
@@ -92,7 +93,7 @@ def test_incompatible_service_status_json_names_reason_holder_and_correlation(
 ) -> None:
     import os
 
-    from yoetz.protocol.canonical import canonical_encode, strict_json_parse
+    from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 
     lock = tmp_path / "service.lock"
     lock.write_bytes(
@@ -112,19 +113,23 @@ def test_incompatible_service_status_json_names_reason_holder_and_correlation(
         raise ControlError("service_incompatible", retryable=True)
 
     monkeypatch.setattr(cli, "build_service_client", refuse)
+
+    def record_correlation(**_kwargs: object) -> str:
+        return "err_00000000-0000-4000-8000-000000000099"
+
     monkeypatch.setattr(
         "yoetz.observability.logging.record_public_error_without_raising",
-        lambda **_kwargs: "err_00000000-0000-4000-8000-000000000099",
+        record_correlation,
     )
     result = CliRunner().invoke(cli.app, ["service", "status", "--json"])
     assert result.exit_code == 20
     assert "service_incompatible" in result.stderr
     assert "correlation_id err_" in result.stderr
-    payload = strict_json_parse(result.stdout.encode("utf-8"))
+    payload = cast(dict[str, JsonValue], strict_json_parse(result.stdout.encode("utf-8")))
     assert payload["ok"] is False
     assert payload["reason"] == "service_incompatible"
     assert payload["public_code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
     assert payload["correlation_id"] == "err_00000000-0000-4000-8000-000000000099"
-    holder = payload["holder"]
+    holder = cast(dict[str, JsonValue], payload["holder"])
     assert holder["pid"] == os.getpid()
     assert holder["schema_manifest_digest"] == "sha256:" + "a" * 64

--- a/tests/unit/cli/test_service_status_remediation.py
+++ b/tests/unit/cli/test_service_status_remediation.py
@@ -85,3 +85,46 @@ def test_other_control_failures_keep_their_existing_guidance(
     assert code == 20
     assert guidance.startswith(PublicErrorCode.VAULT_LOCKED.value.lower())
     assert "yoetz service unlock" in guidance
+
+
+def test_incompatible_service_status_json_names_reason_holder_and_correlation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os
+
+    from yoetz.protocol.canonical import canonical_encode, strict_json_parse
+
+    lock = tmp_path / "service.lock"
+    lock.write_bytes(
+        canonical_encode(
+            {
+                "instance_id": "svc_00000000-0000-4000-8000-000000000001",
+                "pid": os.getpid(),
+                "service_version": "0.1.0",
+                "schema_manifest_digest": "sha256:" + "a" * 64,
+            }
+        )
+        + b"\n"
+    )
+    lock.chmod(0o600)
+
+    async def refuse(*_args: object, **_kwargs: object) -> ServiceClient:
+        raise ControlError("service_incompatible", retryable=True)
+
+    monkeypatch.setattr(cli, "build_service_client", refuse)
+    monkeypatch.setattr(
+        "yoetz.observability.logging.record_public_error_without_raising",
+        lambda **_kwargs: "err_00000000-0000-4000-8000-000000000099",
+    )
+    result = CliRunner().invoke(cli.app, ["service", "status", "--json"])
+    assert result.exit_code == 20
+    assert "service_incompatible" in result.stderr
+    assert "correlation_id err_" in result.stderr
+    payload = strict_json_parse(result.stdout.encode("utf-8"))
+    assert payload["ok"] is False
+    assert payload["reason"] == "service_incompatible"
+    assert payload["public_code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert payload["correlation_id"] == "err_00000000-0000-4000-8000-000000000099"
+    holder = payload["holder"]
+    assert holder["pid"] == os.getpid()
+    assert holder["schema_manifest_digest"] == "sha256:" + "a" * 64

--- a/tests/unit/service/test_control_protocol.py
+++ b/tests/unit/service/test_control_protocol.py
@@ -25,7 +25,7 @@ from yoetz.ports.control import (
 )
 from yoetz.protocol.canonical import JsonValue, canonical_encode
 from yoetz.protocol.errors import PublicErrorCode
-from yoetz.protocol.schemas import load_schema_catalog
+from yoetz.protocol.schemas import load_schema_catalog, validate_schema_instance
 from yoetz.service.control_protocol import (
     CONTROL_PROTOCOL_VERSION,
     MAX_ACTIVE_REQUESTS_PER_SESSION,
@@ -637,6 +637,7 @@ def test_server_answers_hello_result_then_refuses_a_foreign_manifest() -> None:
             await server_handshake(server, client_peer, _status())
         _assert_reason(refused, "manifest_mismatch")
         result = await read_control_frame(client)
+        validate_schema_instance("control-hello-result", "2.1.0", result)
         assert result["schema_manifest_digest"] == load_schema_catalog().manifest_digest
         assert result["service_instance_id"] == _SERVICE_ID
 

--- a/tests/unit/service/test_control_protocol.py
+++ b/tests/unit/service/test_control_protocol.py
@@ -43,6 +43,7 @@ from yoetz.service.control_protocol import (
     read_control_frame,
     schema_for_method,
     server_handshake,
+    write_control_frame,
 )
 
 _SERVICE_ID = "svc_00000000-0000-4000-8000-000000000001"
@@ -620,6 +621,49 @@ def test_client_handshake_names_a_peer_that_closes_on_the_hello_as_rejected() ->
         with pytest.raises(ControlProtocolError) as partial:
             await client_handshake(truncated, ControlClientKind.MCP_BRIDGE, "0.1.0")
         _assert_reason(partial, "frame_invalid")
+
+    asyncio.run(exercise())
+
+
+def test_server_answers_hello_result_then_refuses_a_foreign_manifest() -> None:
+    """Issue #436: a decodable older hello must not be a silent close."""
+
+    async def exercise() -> None:
+        client, server, client_peer = _stream_pair()
+        hello = _hello()
+        hello["schema_manifest_digest"] = "sha256:" + "a" * 64
+        await write_control_frame(client, hello)
+        with pytest.raises(ControlProtocolError) as refused:
+            await server_handshake(server, client_peer, _status())
+        _assert_reason(refused, "manifest_mismatch")
+        result = await read_control_frame(client)
+        assert result["schema_manifest_digest"] == load_schema_catalog().manifest_digest
+        assert result["service_instance_id"] == _SERVICE_ID
+
+    asyncio.run(exercise())
+
+
+def test_client_handshake_names_an_answered_foreign_digest_as_manifest_mismatch() -> None:
+    """A 2.1.0-shaped hello-result with another installation's digest is not frame_invalid."""
+
+    async def exercise() -> None:
+        import yoetz.service.control_protocol as proto
+
+        client, server, _peer = _stream_pair()
+
+        async def answer_foreign() -> None:
+            await read_control_frame(server)
+            result = proto._hello_result_wire(  # pyright: ignore[reportPrivateUsage]
+                _status(), proto._allowed_for(ControlClientKind.CLI)  # pyright: ignore[reportPrivateUsage]
+            )
+            result["schema_manifest_digest"] = "sha256:" + "b" * 64
+            await write_control_frame(server, result)
+
+        task = asyncio.create_task(answer_foreign())
+        with pytest.raises(ControlProtocolError) as mismatch:
+            await client_handshake(client, ControlClientKind.CLI, "0.1.0")
+        await task
+        _assert_reason(mismatch, "manifest_mismatch")
 
     asyncio.run(exercise())
 

--- a/tests/unit/service/test_control_protocol.py
+++ b/tests/unit/service/test_control_protocol.py
@@ -654,7 +654,8 @@ def test_client_handshake_names_an_answered_foreign_digest_as_manifest_mismatch(
         async def answer_foreign() -> None:
             await read_control_frame(server)
             result = proto._hello_result_wire(  # pyright: ignore[reportPrivateUsage]
-                _status(), proto._allowed_for(ControlClientKind.CLI)  # pyright: ignore[reportPrivateUsage]
+                _status(),
+                proto._allowed_for(ControlClientKind.CLI),  # pyright: ignore[reportPrivateUsage]
             )
             result["schema_manifest_digest"] = "sha256:" + "b" * 64
             await write_control_frame(server, result)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: Fixes #434 and Fixes #436
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging, ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened.

Handshake *behavior* is protocol-adjacent; #436 already has owner direction matching the #424 `service_incompatible` contract in the reverse direction. Frozen hello shape is unchanged (no new schema version).

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md`, `docs/protocol/compatibility.md`

## Verification

Commands run (paste):

```text
uv sync
uv run pytest tests/unit/service/test_control_protocol.py \
  tests/unit/cli/test_service_status_remediation.py \
  tests/integration/service/test_human_control.py \
  tests/integration/service/test_daemon_clients.py -q --tb=short
# 97 passed

uv run ruff check <touched files>
npx --no-install pyright
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

**#434:** `secret_completed` no longer holds the one-ceremony mutex while waiting on YZS1. The human handler races YZS1 against YZH1 EOF/cancel during `SecretRequiredPhase`. `close()` records `ceremony_shutdown`. Unlock cancel only returns `UNLOCKING` → `LOCKED` and does not reverse `DRAINING`. After an aborted `initialize-passphrase`, `service stop` can release `service.lock`.

**#436:** A decodable foreign-digest hello now gets a hello-result, then `manifest_mismatch` (session not admitted). The current CLI maps that to `service_incompatible`; `status --json` writes `reason`, holder stamp, and `correlation_id`. Unknown hello shapes still close silently (`handshake_rejected`).

Known gap: already-installed 2.1.0 binaries still cannot print the `service_incompatible` string; they can decode an answered hello-result instead of treating a silent close as `frame_invalid`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73dec761-e2d4-4eeb-b83b-16699f02cb99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73dec761-e2d4-4eeb-b83b-16699f02cb99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



