### PR TITLE
fix(packaging): admit exact public Claude alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- A tracked root `CLAUDE.md` whose complete bytes are the reviewed `@AGENTS.md` alias no longer
+  makes every later pull request fail the source publication-boundary gate. The exception is
+  source-only and exact; nested aliases, changed content, and packaged copies remain blocked
+  (issue #455).
+
 - Codex skill install, replace, and remove now refuse a symlink at `.agents` or `.agents/skills`
   as `target_unsafe`, bind the managed parent's identity into the preview digest, and perform the
   stage/replace/remove swap through a directory-fd no-follow walk so a parent swapped between

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ entries.
 - Keep release-related and security-sensitive changes clearly labeled in your commit/PR description.
 - Preserve the public/private boundary: nothing under `docs/architecture/` or any other gitignored
   local drafting input belongs in a public file. `scripts/scan_public_boundary.py` enforces this.
+  The tracked root `CLAUDE.md` is a reviewed public alias only while its complete bytes remain
+  exactly `@AGENTS.md\n`; changing its content, nesting another copy, or packaging it fails closed.
 
 ## Honesty rules that bind every change
 

--- a/docs/adr/ADR-007-packaging-platform-release.md
+++ b/docs/adr/ADR-007-packaging-platform-release.md
@@ -52,8 +52,11 @@ manifests, the packaging/capability suites, and the release workflows under `.gi
    PyPI publication and with trusted-publisher provenance plus byte-for-byte download verification.
 8. **Release artifacts:** sdist + wheel, SHA-256 checksums, CycloneDX SBOM via `uv export`,
    dependency lock, support matrix, conformance summary, known limitations, changelog, security
-   policy. Sigstore signing deferred until a documented verification command exists (a signature
-   without a verifier is not a gate).
+   policy. The source publication-boundary scanner admits the reviewed repository-root
+   `CLAUDE.md` alias only when its complete bytes are exactly `@AGENTS.md\n`; nested paths,
+   different bytes, and every artifact occurrence remain blocked (issue #455). Sigstore signing
+   is deferred until a documented verification command exists (a signature without a verifier is
+   not a gate).
 9. **Install/upgrade/uninstall:** documented and tested: `uv tool install/upgrade/uninstall`, the
    foreground `yoetz service run` entrypoint suitable for a user-selected external
    supervisor, `codex mcp add/remove yoetz`, and data-retention behavior on uninstall. Native

--- a/scripts/scan_public_boundary.py
+++ b/scripts/scan_public_boundary.py
@@ -267,6 +267,10 @@ _TEXT_DECODE_EXTENSIONS: Final = frozenset(
     {".py", ".md", ".txt", ".json", ".toml", ".yml", ".yaml", ".sql", ".cfg", ".ini", ".lock"}
 )
 
+_REVIEWED_SOURCE_ROOT_ALIASES: Final[dict[tuple[str, str], bytes]] = {
+    ("PRIV-SESSION-002", "CLAUDE.md"): b"@AGENTS.md\n",
+}
+
 
 # --------------------------------------------------------------------------
 # Rule loading
@@ -623,9 +627,15 @@ def scan_filename(
     rules: Sequence[BoundaryRule],
     *,
     target_label: str,
+    target_kind: str | None = None,
     canary: bytes | None = None,
 ) -> tuple[BoundaryFinding, ...]:
-    """Apply every ``filename``-scoped rule to one entry's relative path."""
+    """Apply every ``filename``-scoped rule to one entry's relative path.
+
+    One reviewed repository-root agent-instruction alias is admitted only for a source tree and
+    only when both its normalized path and bytes match exactly. The same filename remains blocked
+    in artifacts, nested paths, and source files carrying any other content.
+    """
 
     findings: list[BoundaryFinding] = []
     path_bytes = entry.relative_path.encode("utf-8", errors="surrogateescape")
@@ -644,6 +654,9 @@ def scan_filename(
         )
     for rule in rules:
         if rule.detector != "filename":
+            continue
+        reviewed_alias = _REVIEWED_SOURCE_ROOT_ALIASES.get((rule.rule_id, entry.relative_path))
+        if target_kind == "source" and reviewed_alias is not None and entry.data == reviewed_alias:
             continue
         matches = len(re.findall(rule.pattern, entry.relative_path))
         if matches:
@@ -887,7 +900,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         target_rules = _applicable_rules(rules, target.kind)
         for entry in entries:
             all_findings.extend(
-                scan_filename(entry, target_rules, target_label=target.label, canary=canary)
+                scan_filename(
+                    entry,
+                    target_rules,
+                    target_label=target.label,
+                    target_kind=target.kind,
+                    canary=canary,
+                )
             )
             all_findings.extend(
                 scan_bytes(entry, target_rules, target_label=target.label, canary=canary)

--- a/tests/packaging/test_private_boundary_and_secret_scan.py
+++ b/tests/packaging/test_private_boundary_and_secret_scan.py
@@ -8,7 +8,10 @@ absolute paths, and exceptions (where they exist) are exact.
 
 Scope notes (verbatim conflicts, reported rather than guessed around):
 
-1. The scanner (``scripts/scan_public_boundary.py``) is documented as supporting a reviewed
+1. The scanner has one built-in, exact source-root exception for the public ``CLAUDE.md`` alias
+   whose complete bytes are ``@AGENTS.md\n``. It is not a general exception mechanism: the same
+   path in an artifact, a nested alias, or any different source bytes remain blocked. The scanner
+   is otherwise documented as supporting a reviewed
    per-file exception mechanism ("Allow exceptions match exact rule ID + normalized file + bounded
    digest/line context ... every exception states ... keys cannot be allowlisted"). The actual
    ``scripts/scan_public_boundary.py`` has no such mechanism: ``BoundaryRule``/``ScanReport`` carry
@@ -146,6 +149,39 @@ def test_scanner_cli_passes_on_the_clean_synthetic_tree(
     root = _clean_git_source_tree(tmp_path / "clean-repo-cli")
     rc = scanner.main(["--source-tree", str(root)])
     assert rc == 0
+
+
+def test_scanner_cli_admits_only_the_exact_public_root_claude_alias(
+    scanner: ModuleType, tmp_path: Path
+) -> None:
+    root = _clean_git_source_tree(tmp_path / "clean-repo-claude-alias")
+    (root / "CLAUDE.md").write_bytes(b"@AGENTS.md\n")
+    subprocess.run(["git", "add", "CLAUDE.md"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "public agent alias"], cwd=root, check=True)
+
+    assert scanner.main(["--source-tree", str(root)]) == 0
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "data", "target_kind"),
+    [
+        ("CLAUDE.md", b"private instructions\n", "source"),
+        ("nested/CLAUDE.md", b"@AGENTS.md\n", "source"),
+        ("CLAUDE.md", b"@AGENTS.md\n", "artifact"),
+    ],
+)
+def test_public_root_claude_alias_exception_fails_closed(
+    scanner: ModuleType, relative_path: str, data: bytes, target_kind: str
+) -> None:
+    entry = scanner.FileEntry(relative_path=relative_path, size=len(data), data=data)
+    findings = scanner.scan_filename(
+        entry,
+        scanner.load_rules(),
+        target_label="candidate",
+        target_kind=target_kind,
+    )
+
+    assert {finding.rule_id for finding in findings} == {"PRIV-SESSION-002"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #455
- Duplicate search found no open or closed issue/PR covering the `CLAUDE.md` / `PRIV-SESSION-002` conflict.
- This adjusts a release/public-boundary gate. The maintainer explicitly authorized the dedicated follow-up PR after the regression was recorded on #455.

PR #456 added the reviewed root `CLAUDE.md` alias, but its source scan ran before the file was tracked. Because source enumeration uses `git ls-files`, every subsequent PR then failed `source-and-artifact-boundary` once the alias reached `main`.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/adr/ADR-007-packaging-platform-release.md`, `CONTRIBUTING.md`, `CHANGELOG.md`

## Verification

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache PYTHONPATH=src python -m pytest \
  tests/packaging/test_private_boundary_and_secret_scan.py \
  tests/packaging/test_wheel_and_sdist_contents.py -q --tb=short
# 59 passed, 2 xfailed

PYTHONPATH=src python scripts/scan_public_boundary.py --source-tree .
# scan_public_boundary: PASS (1078 file(s) scanned)

ruff check .
ruff format --check .
npx --no-install pyright
python scripts/sync_resource_ripple.py --check
# 92 schemas, 131 resources; fixed point
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

The source scanner now admits only a repository-root `CLAUDE.md` whose complete bytes are exactly `@AGENTS.md\n`. The same filename remains blocked for nested paths, changed source content, and every artifact target. Regression tests exercise the real CLI path and all three fail-closed cases.

Model: GPT-5.6 Sol · Harness: Codex desktop


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrowly permits the reviewed root `CLAUDE.md` alias during source-tree boundary scans while retaining fail-closed behavior for altered content, nested paths, and artifacts.

- Adds an exact rule-ID, path, byte-content, and source-target exception.
- Adds CLI-path and fail-closed regression coverage.
- Documents the exception in contributor, release, and changelog guidance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the exception is restricted to the exact reviewed root source alias and all relevant fail-closed cases remain enforced.

The source scanner admits only `CLAUDE.md` at the repository root with exact approved bytes, while nested paths, modified content, symlinks, and artifact contexts remain blocked.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/scan_public_boundary.py | Adds a tightly scoped source-only exception for the exact reviewed root alias while preserving artifact and content scanning. |
| tests/packaging/test_private_boundary_and_secret_scan.py | Covers the real CLI success path and rejects changed bytes, nested aliases, and artifact occurrences. |
| docs/adr/ADR-007-packaging-platform-release.md | Records the exact source-boundary exception and its fail-closed limits. |
| CONTRIBUTING.md | Documents the permitted alias bytes and prohibited variants for contributors. |
| CHANGELOG.md | Accurately describes the boundary-gate regression fix and exception scope. |

<sub>Reviews (1): Last reviewed commit: ["fix(packaging): admit exact public Claud..."](https://github.com/thegaysupreme123/yoetz/commit/a61fe63268e4b8099d67e796c7b0b73e64fdc14f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58200668)</sub>

<!-- /greptile_comment -->