### PR TITLE
fix(mcp): preserve typed service control failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- Cooperative MCP calls no longer collapse typed local-control failures into opaque,
+  non-retryable `INTERNAL_ERROR`. Service absence, an accepted-but-unresponsive listener,
+  incompatible or mismatched installations, unsafe or untrusted endpoints, timeouts, and bounded
+  protocol refusals now retain an actionable public code, truthful retryability, a structural
+  `reason_code`, resolvable correlation diagnostics, and same-`request_id` recovery guidance;
+  genuinely unexpected bridge defects remain `INTERNAL_ERROR` (issue #460).
+
 - `yoetz observe status` no longer collapses bounded observation-store filesystem failures into
   generic `internal_error`. Unsafe state/lock shapes, unavailable open/permission/read-only/
   missing-parent/lock failures, and corrupt stored data retain distinct typed outcomes; fixed

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1665,7 +1665,27 @@ operation request models, and is rejected on every other control method. `strict
 weaken or select this field.
 
 `ControlError` carries one bounded reason, a `retryable` flag, and an optional service-minted
-`correlation_id`. `response_projection_failed` is reserved for the window after a handler returns
+`correlation_id`. The closed reason set includes `endpoint_unsafe` (local AF_UNIX path/mode/peer
+safety refusal). The ordinary client preserves that token instead of folding it into
+`service_unavailable`. The MCP bridge maps it to public `SERVICE_UNAVAILABLE`, `retryable=false`,
+and `safe_details.reason_code=endpoint_unsafe`, with copy that names the endpoint-safety class and
+never a socket path. Unsafe and untrusted endpoint copy forbids retry before local repair and then
+preserves same-`request_id` replay. The CLI control-failure helper is unchanged: it still projects
+the public code and does not add a separate unsafe-endpoint guidance line.
+
+The MCP bridge maps every typed `ControlError` reason onto a public error through the public-error
+recorder (`{tool}_public_error`) with sink `reason` equal to the control-reason token (or
+`accepted_but_unresponsive` for an accepted-but-silent listener). `exception_control_error` and
+`{tool}_internal_error` remain only for genuinely unexpected defects. Absent service uses
+`SERVICE_UNAVAILABLE` with the sanctioned `yoetz service run` supervisor copy and same-`request_id`
+replay; an accepted-but-unresponsive listener uses distinct copy that forbids `yoetz service run`
+and names `yoetz service status` / `yoetz service stop`. `service_incompatible` and
+`protocol_mismatch` share the `yoetz service restart` copy and public `SERVICE_UNAVAILABLE`, and
+are told apart by `safe_details.reason_code`. That MCP `SERVICE_UNAVAILABLE` mapping for
+`protocol_mismatch` is deliberate: the CLI helper still uses `public_error_code_for_control_reason`,
+which keeps `protocol_mismatch` as `INVALID_REQUEST`.
+
+`response_projection_failed` is reserved for the window after a handler returns
 for non-`publish_work` writes (and the impossible minimal-envelope path), where a write may already
 be durable and only the response could not be shaped; it is always `retryable=True`, and the bridge
 answers it with the same-`request_id` replay remedy it uses for its own projection failures. For

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -96,7 +96,8 @@ build the previous build's service still owning the endpoint refuses the new bri
 first plugin tool call (on-demand startup) replaces that service automatically: it asks the stale
 holder to shut down through its ordinary bounded path and starts this installation's service inside
 the same 30-second budget. If that cannot complete, the tool returns `SERVICE_UNAVAILABLE` with
-`reason_code: service_incompatible` and the repair command; run it on a local terminal:
+`reason_code: service_incompatible` (or `protocol_mismatch` when the refusal is a protocol
+generation mismatch) and the repair command; run it on a local terminal:
 
 ```text
 yoetz service restart

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -126,6 +126,24 @@ digest-bound confirmation, preserve entries already observed as foreign, and ver
 state by re-reading it. A "registered" result still never implies Codex will successfully connect
 at runtime.
 
+## Upgrading Yoetz under a running service
+
+The local-control handshake pins the exact schema-manifest digest, so after installing a new Yoetz
+build the previous build's service still owning the endpoint refuses the new bridge and CLI. The
+first MCP tool call (on-demand startup) replaces that service automatically: it asks the stale
+holder to shut down through its ordinary bounded path and starts this installation's service inside
+the same 30-second budget. If that cannot complete, the tool returns `SERVICE_UNAVAILABLE` with
+`reason_code: service_incompatible` (or `protocol_mismatch` when the refusal is a protocol
+generation mismatch) and the repair command; run it on a local terminal:
+
+```text
+yoetz service restart
+```
+
+`yoetz service status` names the incompatible holder's pid, version, and manifest digest. Other
+hosts' sessions still running the previous build's bridge are refused after the switch until they
+restart; that is the intended outcome of an upgrade, not a defect.
+
 The accepted setup path composes four separately reported layers in order: it installs the project
 skill at `.agents/skills/yoetz`, installs managed structural plugin/hook sources at
 `.agents/plugins/yoetz`, applies an explicitly approved Codex activation, then verifies the MCP

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -100,6 +100,24 @@ otherwise hide structured results from the model. It adds no environment or secr
 not widen the service route. Raw initialize and tools/list prove only runtime registration.
 Require a correlated model-controlled `start` or `status` call for use.
 
+## Upgrading Yoetz under a running service
+
+The local-control handshake pins the exact schema-manifest digest, so after installing a new Yoetz
+build the previous build's service still owning the endpoint refuses the new bridge and CLI. The
+first plugin tool call (on-demand startup) replaces that service automatically: it asks the stale
+holder to shut down through its ordinary bounded path and starts this installation's service inside
+the same 30-second budget. If that cannot complete, the tool returns `SERVICE_UNAVAILABLE` with
+`reason_code: service_incompatible` (or `protocol_mismatch` when the refusal is a protocol
+generation mismatch) and the repair command; run it on a local terminal:
+
+```text
+yoetz service restart
+```
+
+`yoetz service status` names the incompatible holder's pid, version, and manifest digest. Other
+hosts' sessions still running the previous build's bridge are refused after the switch until they
+restart; that is the intended outcome of an upgrade, not a defect.
+
 ## SDK TypeScript and Python (deferred)
 
 Operational local SDK support is deferred for the planned `0.2` readiness slice. The TypeScript and

--- a/src/yoetz/cli/hooks.py
+++ b/src/yoetz/cli/hooks.py
@@ -165,6 +165,7 @@ _CONTROL_ERROR_CLASSES: Final[Mapping[str, str]] = MappingProxyType(
         "service_unavailable": "unavailable",
         "service_incompatible": "unavailable",
         "peer_untrusted": "unavailable",
+        "endpoint_unsafe": "unavailable",
         "protocol_mismatch": "unavailable",
         "frame_invalid": "unavailable",
         "frame_too_large": "unavailable",

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -77,7 +77,11 @@ from yoetz.protocol.models import (
     StatusResult,
     public_model_to_wire,
 )
-from yoetz.service.client import ServiceClient, connect_service_on_demand
+from yoetz.service.client import (
+    ServiceClient,
+    accepted_but_unresponsive,
+    connect_service_on_demand,
+)
 
 __all__ = [
     "BRIDGE_RUNTIME",
@@ -374,6 +378,7 @@ def structured_error_result(
     details_reason_code: str | None = None,
     correlation_id: str | None = None,
     operation: str | None = None,
+    diagnostic_reason: str | None = None,
     host_profile: Literal["generic", "cursor"] = "generic",
 ) -> types.CallToolResult:
     """Build a bounded structured tool error with a prevalidated nested fallback.
@@ -383,16 +388,24 @@ def structured_error_result(
     the durable diagnostic line under it, because an id minted straight into the envelope resolves
     to nothing (issue #191). ``operation`` only names the failing tool in that record; it never
     reaches the wire. ``details_reason_code`` rides beside field locations, which no other
-    ``safe_details`` shape can carry.
+    ``safe_details`` shape can carry. ``diagnostic_reason`` names the sink ``reason`` when this
+    boundary mints the id; it must be a bounded token. Unrecognized values fall back to the
+    lowercased public code.
     """
 
+    sink_reason = (
+        diagnostic_reason
+        if type(diagnostic_reason) is str
+        and _SINK_OPERATION.fullmatch(diagnostic_reason) is not None
+        else code.value.lower()
+    )
     resolved_correlation_id = (
         correlation_id
         if correlation_id is not None
         else record_public_error_without_raising(
             component="mcp.bridge",
             operation=_public_error_operation(operation),
-            reason=code.value.lower(),
+            reason=sink_reason,
             request_id=request_id,
         )
     )
@@ -424,6 +437,33 @@ def structured_error_result(
             )
 
 
+def _control_public_error_result(
+    error: ControlError,
+    request_id: str | None,
+    operation: str,
+    *,
+    code: PublicErrorCode,
+    message: str,
+    retryable: bool,
+    host_profile: Literal["generic", "cursor"],
+    safe_details: Mapping[str, object] | None = None,
+    diagnostic_reason: str | None = None,
+) -> types.CallToolResult:
+    """Map a typed ControlError through the public-error recorder, never the unexpected path."""
+
+    return structured_error_result(
+        code,
+        message,
+        retryable=retryable,
+        request_id=request_id,
+        correlation_id=error.correlation_id,
+        operation=operation,
+        safe_details=dict(safe_details) if safe_details is not None else None,
+        diagnostic_reason=diagnostic_reason if diagnostic_reason is not None else error.reason,
+        host_profile=host_profile,
+    )
+
+
 def _control_error_result(
     error: ControlError,
     request_id: str | None,
@@ -434,7 +474,6 @@ def _control_error_result(
     # Prefer the service-minted diagnostic id when present so the agent-facing public error
     # resolves the same durable sink record the daemon already wrote. Never mint a second id for
     # a failure the service already correlated.
-    service_correlation_id = error.correlation_id
     if error.reason == "vault_locked":
         # The daemon's retryable flag distinguishes a soft lock or transient re-unlock
         # failure (heals on a later attempt) from a hard lock or missing setup (needs a
@@ -462,42 +501,43 @@ def _control_error_result(
                 "uninitialized, run `yoetz setup` or prepare `vault_initialize` via "
                 "`yoetz consent catalog` / `prepare` (ADR-015). Never send secrets over MCP."
             )
-        return structured_error_result(
-            PublicErrorCode.VAULT_LOCKED,
-            message,
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.VAULT_LOCKED,
+            message=message,
             retryable=error.retryable,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
             host_profile=host_profile,
         )
     if error.reason == "request_cancelled":
-        return structured_error_result(
-            PublicErrorCode.CANCELLED,
-            "The operation was cancelled.",
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.CANCELLED,
+            message="The operation was cancelled.",
+            retryable=False,
             host_profile=host_profile,
         )
     if error.reason == "privacy_projection_blocked":
-        return structured_error_result(
-            PublicErrorCode.PRIVACY_AUTHORITY_REQUIRED,
-            (
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.PRIVACY_AUTHORITY_REQUIRED,
+            message=(
                 "The receipt is durably recorded, but JSON projection to agent context is blocked "
                 "by the active privacy policy. Re-request with format markdown or text, or widen "
                 "the agent-context policy from a local terminal."
             ),
             retryable=False,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
+            host_profile=host_profile,
             safe_details={
                 "reason_code": "receipt_json_projection_blocked",
                 "operation": "receipt",
                 "field": "format",
             },
-            host_profile=host_profile,
         )
     if error.reason == "response_projection_failed":
         # Accepted durable publish_work usually returns the reduced total-acceptance envelope
@@ -508,37 +548,39 @@ def _control_error_result(
         details: dict[str, object] = dict(_RESPONSE_PROJECTION_FAILED_DETAILS)
         if error.accepted_state:
             details.update(error.accepted_state)
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            _RESPONSE_PROJECTION_FAILED_MESSAGE,
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INTERNAL_ERROR,
+            message=_RESPONSE_PROJECTION_FAILED_MESSAGE,
             retryable=True,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
-            safe_details=details,
             host_profile=host_profile,
+            safe_details=details,
         )
     if error.reason == "read_projection_failed":
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            _READ_PROJECTION_FAILED_MESSAGE,
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INTERNAL_ERROR,
+            message=_READ_PROJECTION_FAILED_MESSAGE,
             retryable=True,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
-            safe_details=dict(_READ_PROJECTION_FAILED_DETAILS),
             host_profile=host_profile,
+            safe_details=dict(_READ_PROJECTION_FAILED_DETAILS),
         )
     if error.reason == "privacy_projection_unavailable":
-        return structured_error_result(
-            PublicErrorCode.SERVICE_UNAVAILABLE,
-            "Receipt projection is temporarily unavailable; retry after the local service is ready.",
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "Receipt projection is temporarily unavailable; retry after the local service is ready."
+            ),
             retryable=True,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
-            safe_details={"reason_code": "privacy_projection_unavailable"},
             host_profile=host_profile,
+            safe_details={"reason_code": "privacy_projection_unavailable"},
         )
     if error.reason == "request_timeout":
         if operation in _WRITE_OPERATIONS:
@@ -552,49 +594,179 @@ def _control_error_result(
                 "The local status read timed out and requested no write. Repeat the read with a "
                 "new request_id."
             )
-        return structured_error_result(
-            PublicErrorCode.SERVICE_UNAVAILABLE,
-            message,
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=message,
             retryable=True,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
             host_profile=host_profile,
+            safe_details={"reason_code": "request_timeout"},
         )
     if error.reason in {"service_incompatible", "protocol_mismatch"}:
         # The one per-user endpoint is owned by a service of another Yoetz installation (or
         # protocol generation) that rejected this bridge's hello. On-demand startup already
         # tried to replace it; name the exact repair instead of an opaque internal failure.
-        return structured_error_result(
-            PublicErrorCode.SERVICE_UNAVAILABLE,
-            "The running local Yoetz service belongs to a different Yoetz installation than "
-            "this bridge (control schema-manifest or protocol mismatch), and the bridge could "
-            "not replace it within its startup budget. On a local terminal run "
-            "`yoetz service restart`, then retry this operation with the same request_id. "
-            "Do not retry `start` until that repair has run.",
+        # MCP keeps SERVICE_UNAVAILABLE for both; CLI maps protocol_mismatch to INVALID_REQUEST.
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "The running local Yoetz service belongs to a different Yoetz installation than "
+                "this bridge (control schema-manifest or protocol mismatch), and the bridge could "
+                "not replace it within its startup budget. On a local terminal run "
+                "`yoetz service restart`, then retry this operation with the same request_id. "
+                "Do not retry `start` until that repair has run."
+            ),
             retryable=error.retryable,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
-            safe_details={"reason_code": "service_incompatible"},
             host_profile=host_profile,
+            safe_details={"reason_code": error.reason},
         )
-    if error.reason in {"service_unavailable", "service_draining"}:
-        return structured_error_result(
-            PublicErrorCode.SERVICE_UNAVAILABLE,
-            "The local service is unavailable; retry after it is ready.",
+    if error.reason == "service_draining":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message="The local service is draining; retry after it is ready.",
             retryable=True,
-            request_id=request_id,
-            correlation_id=service_correlation_id,
-            operation=operation,
             host_profile=host_profile,
+            safe_details={"reason_code": "service_draining"},
         )
-    if service_correlation_id is not None:
+    if error.reason == "service_unavailable":
+        if accepted_but_unresponsive(error):
+            # A listener that accepted and then went silent is running. Prescribing
+            # `yoetz service run` here sent an operator to a command that must refuse (#237).
+            return _control_public_error_result(
+                error,
+                request_id,
+                operation,
+                code=PublicErrorCode.SERVICE_UNAVAILABLE,
+                message=(
+                    "The local Yoetz service is listening but did not answer. Wait and retry; on a "
+                    "local terminal run `yoetz service status`. Do not run `yoetz service run` — "
+                    "it will refuse while that process holds the singleton. If it is wedged, stop "
+                    "it with `yoetz service stop`, then retry this operation with the same "
+                    "request_id."
+                ),
+                retryable=True,
+                host_profile=host_profile,
+                safe_details={"reason_code": "accepted_but_unresponsive"},
+                diagnostic_reason="accepted_but_unresponsive",
+            )
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "The local Yoetz service is not running. On a local terminal run "
+                "'yoetz service run' under your selected user supervisor, then retry this "
+                "operation with the same request_id."
+            ),
+            retryable=True,
+            host_profile=host_profile,
+            safe_details={"reason_code": "service_unavailable"},
+        )
+    if error.reason == "service_generation_changed":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "The local service instance changed after reconnect. Retry this operation with "
+                "the same request_id."
+            ),
+            retryable=True,
+            host_profile=host_profile,
+            safe_details={"reason_code": "service_generation_changed"},
+        )
+    if error.reason == "peer_untrusted":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "The local control endpoint identity could not be trusted. Repair the endpoint "
+                "on a local terminal; do not retry until that repair has run. Then retry this "
+                "operation with the same request_id."
+            ),
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "peer_untrusted"},
+        )
+    if error.reason == "endpoint_unsafe":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.SERVICE_UNAVAILABLE,
+            message=(
+                "The local control endpoint is unsafe to use. Repair the endpoint on a local "
+                "terminal; do not retry until that repair has run. Then retry this operation "
+                "with the same request_id."
+            ),
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "endpoint_unsafe"},
+        )
+    if error.reason == "frame_invalid":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INVALID_REQUEST,
+            message="The local control request was invalid.",
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "frame_invalid"},
+        )
+    if error.reason == "frame_too_large":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INVALID_REQUEST,
+            message="The local control frame exceeded the allowed size.",
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "frame_too_large"},
+        )
+    if error.reason == "method_forbidden":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INVALID_REQUEST,
+            message="The local control method is not allowed.",
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "method_forbidden"},
+        )
+    if error.reason == "internal_error":
+        return _control_public_error_result(
+            error,
+            request_id,
+            operation,
+            code=PublicErrorCode.INTERNAL_ERROR,
+            message="The bridge could not complete the operation.",
+            retryable=False,
+            host_profile=host_profile,
+            safe_details={"reason_code": "internal_error"},
+        )
+    # Last resort: a ControlError reason this mapper does not yet name. Keep the unexpected
+    # recorder so a future vocabulary addition cannot silently ship as a public-error class.
+    if error.correlation_id is not None:
         return structured_error_result(
             PublicErrorCode.INTERNAL_ERROR,
             "The bridge could not complete the operation.",
             request_id=request_id,
-            correlation_id=service_correlation_id,
+            correlation_id=error.correlation_id,
             host_profile=host_profile,
         )
     correlation_id = record_unexpected_exception_without_raising(

--- a/src/yoetz/ports/control.py
+++ b/src/yoetz/ports/control.py
@@ -304,6 +304,7 @@ _CONTROL_ERROR_REASONS = frozenset(
         "response_projection_failed",
         "read_projection_failed",
         "service_generation_changed",
+        "endpoint_unsafe",
     }
 )
 _EMPTY_ACCEPTED_STATE: Final[Mapping[str, SafeDetailValue]] = MappingProxyType({})

--- a/src/yoetz/protocol/errors.py
+++ b/src/yoetz/protocol/errors.py
@@ -50,6 +50,7 @@ type SafeDetailValue = str | int
 
 
 _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
+    "accepted_but_unresponsive",
     "accepted_record_shape_invalid",
     "actor_id_malformed",
     "actor_id_not_generated",
@@ -61,6 +62,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "empty_check_types",
     "empty_publication_channels",
     "empty_subject_state",
+    "endpoint_unsafe",
     "engine_family_wrong_author",
     "entry_digest_mismatch",
     "event_family_not_admitted",
@@ -76,6 +78,8 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "finding_json_shape_invalid",
     "finding_priority_mismatch",
     "float_forbidden",
+    "frame_invalid",
+    "frame_too_large",
     "frontier_changed",
     "frontier_digest_mismatch",
     "id_malformed_uuid",
@@ -89,6 +93,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "input_not_bytes",
     "integer_out_of_safe_range",
     "integer_out_of_sqlite_range",
+    "internal_error",
     "invalid_actor_type",
     "invalid_approved_check",
     "invalid_approved_check_policy",
@@ -136,6 +141,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "ledger_assigned_field_in_request_identity",
     "lone_surrogate",
     "malformed_json",
+    "method_forbidden",
     "missing_payload_field",
     "nesting_too_deep",
     "no_obligations_reason_conflict",
@@ -149,9 +155,11 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "operation_recovery_unavailable",
     "ownership_contended",
     "payload_redaction_mismatch",
+    "peer_untrusted",
     "plan_version_conflict",
     "privacy_projection_unavailable",
     "privacy_receipt_not_durable",
+    "protocol_mismatch",
     "provider_attempt_provenance_is_not_final",
     "public_error_invalid_correlation_id",
     "public_error_invalid_message",
@@ -164,6 +172,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "redaction_target_required",
     "ref_mirror_mismatch",
     "request_identity_conflict",
+    "request_timeout",
     "response_fields_invalid",
     "response_projection_failed",
     "schema_artifact_role_invalid",
@@ -186,7 +195,10 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
     "schema_reference_unresolved",
     "schema_version_mismatch",
     "semantic_provenance_json_shape_invalid",
+    "service_draining",
+    "service_generation_changed",
     "service_incompatible",
+    "service_unavailable",
     "session_superseded",
     "set_member_not_ascii",
     "timestamp_not_utc",
@@ -202,7 +214,7 @@ _PROTOCOL_REASON_CODE_VALUES: tuple[str, ...] = (
 )
 
 _REASON_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$", re.ASCII)
-assert len(_PROTOCOL_REASON_CODE_VALUES) == 149
+assert len(_PROTOCOL_REASON_CODE_VALUES) == 161
 assert len(_PROTOCOL_REASON_CODE_VALUES) == len(set(_PROTOCOL_REASON_CODE_VALUES))
 assert _PROTOCOL_REASON_CODE_VALUES == tuple(sorted(_PROTOCOL_REASON_CODE_VALUES, key=str.encode))
 assert all(_REASON_CODE_PATTERN.fullmatch(value) for value in _PROTOCOL_REASON_CODE_VALUES)

--- a/src/yoetz/service/client.py
+++ b/src/yoetz/service/client.py
@@ -373,6 +373,8 @@ class _ReceiptCommon(TypedDict):
 def _transport_error(error: LocalControlTransportError) -> ControlError:
     if error.reason == "peer_untrusted":
         return ControlError("peer_untrusted")
+    if error.reason == "endpoint_unsafe":
+        return ControlError("endpoint_unsafe")
     return ControlError("service_unavailable", retryable=True)
 
 

--- a/src/yoetz/service/control_protocol.py
+++ b/src/yoetz/service/control_protocol.py
@@ -895,6 +895,9 @@ def public_error_code_for_control_reason(reason: str) -> PublicErrorCode:
         "service_unavailable",
         "service_incompatible",
         "request_timeout",
+        "endpoint_unsafe",
+        "peer_untrusted",
+        "service_draining",
     }:
         return PublicErrorCode.SERVICE_UNAVAILABLE
     if reason == "privacy_projection_blocked":

--- a/tests/subprocess/test_mcp_service_bridge.py
+++ b/tests/subprocess/test_mcp_service_bridge.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sys
 from collections.abc import Awaitable, Callable, Iterator
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -16,6 +17,7 @@ from pydantic import BaseModel
 import yoetz.mcp.server as bridge
 from yoetz.config.models import LoggingConfig
 from yoetz.mcp.resources import read_resource
+from yoetz.observability.diagnostics import append_diagnostic_record, lookup_diagnostic_records
 from yoetz.observability.logging import LogMode, configure_logging
 from yoetz.ports.control import ControlError
 from yoetz.protocol.canonical import JsonValue, canonical_encode
@@ -35,6 +37,7 @@ from yoetz.protocol.models import (
     StatusRequest,
     StatusResult,
 )
+from yoetz.service.client import _AcceptedServiceUnresponsive  # pyright: ignore[reportPrivateUsage]
 
 _PREFIXES = {
     "request": "req_",
@@ -231,6 +234,50 @@ def _install_clients(
         cast(Callable[[object], Awaitable[object]], connect),
     )
     return remaining
+
+
+def _install_connect_failure(monkeypatch: pytest.MonkeyPatch, failure: BaseException) -> None:
+    """Raise at connect time so `_RECONNECT_REASONS` cannot swallow service_unavailable."""
+
+    async def connect(_kind: object, *, workspace_locator: object = None) -> object:
+        del _kind, workspace_locator
+        raise failure
+
+    monkeypatch.setattr(
+        bridge,
+        "connect_service_on_demand",
+        cast(Callable[[object], Awaitable[object]], connect),
+    )
+
+
+_LEAK_TOKENS = (
+    "Traceback",
+    "/tmp/",
+    ".sock",
+    "Application Support",
+    "must-not-reach-public-output",
+    "YZH1-",
+    "Bearer ",
+)
+_ABSENT_SERVICE_MESSAGE = (
+    "The local Yoetz service is not running. On a local terminal run "
+    "'yoetz service run' under your selected user supervisor, then retry this "
+    "operation with the same request_id."
+)
+_SERVICE_CORRELATION = "err_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+
+def _assert_no_leakage(*blobs: object) -> None:
+    rendered = json.dumps(blobs, default=str)
+    for token in _LEAK_TOKENS:
+        assert token not in rendered
+
+
+def _start_error(result: object, request_id: str) -> dict[str, object]:
+    structured = cast(dict[str, object], getattr(result, "structuredContent"))
+    assert getattr(result, "isError") is True
+    assert structured["request_id"] == request_id
+    return cast(dict[str, object], structured["error"])
 
 
 @pytest.mark.anyio
@@ -436,6 +483,7 @@ async def test_write_timeout_preserves_unknown_outcome_and_same_request_remedy(
     error = cast(dict[str, JsonValue], result.structuredContent["error"])
     assert error["code"] == "SERVICE_UNAVAILABLE"
     assert error["retryable"] is True
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "request_timeout"
     assert error["message"] == (
         "The local operation timed out and may still have committed. Retry with the same "
         "request_id to recover the stored outcome; for an existing Yoetz session, status "
@@ -459,6 +507,7 @@ async def test_status_timeout_names_read_only_fresh_request_remedy(
     assert result.structuredContent is not None
     error = cast(dict[str, JsonValue], result.structuredContent["error"])
     assert error["code"] == "SERVICE_UNAVAILABLE"
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "request_timeout"
     assert "requested no write" in cast(str, error["message"])
     assert "new request_id" in cast(str, error["message"])
     await bridge.close_bridge_runtime(runtime)
@@ -933,4 +982,175 @@ async def test_transient_projection_failure_stays_retryable_service_unavailable(
     assert error["retryable"] is True
     details = cast(dict[str, JsonValue], error["safe_details"])
     assert details["reason_code"] == "privacy_projection_unavailable"
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.fixture
+def diagnostic_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    import yoetz.observability.diagnostics as diagnostics
+
+    monkeypatch.setattr(diagnostics, "log_dir", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.mark.anyio
+async def test_connect_absent_service_names_the_supervisor_repair(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    _install_connect_failure(monkeypatch, ControlError("service_unavailable", retryable=True))
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is True
+    assert error["message"] == _ABSENT_SERVICE_MESSAGE
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "service_unavailable"
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "service_unavailable"
+    assert found[0]["reason"] != "exception_control_error"
+    _assert_no_leakage(result.structuredContent, found)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_connect_accepted_but_unresponsive_does_not_prescribe_service_run(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    _install_connect_failure(
+        monkeypatch,
+        _AcceptedServiceUnresponsive(),  # pyright: ignore[reportPrivateUsage]
+    )
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is True
+    message = cast(str, error["message"])
+    assert message != _ABSENT_SERVICE_MESSAGE
+    assert "under your selected user supervisor" not in message
+    assert "Do not run `yoetz service run`" in message
+    assert (
+        cast(dict[str, object], error["safe_details"])["reason_code"] == "accepted_but_unresponsive"
+    )
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "accepted_but_unresponsive"
+    _assert_no_leakage(result.structuredContent, found)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_connect_incompatible_holder_reuses_service_correlation_id(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    append_diagnostic_record(
+        correlation_id=_SERVICE_CORRELATION,
+        component="service.daemon",
+        operation="start_service_incompatible",
+        reason="service_incompatible",
+        request_id=cast(str, _requests()["start"]["request_id"]),
+        root=diagnostic_root,
+    )
+    _install_connect_failure(
+        monkeypatch,
+        ControlError("service_incompatible", retryable=True, correlation_id=_SERVICE_CORRELATION),
+    )
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is True
+    assert error["correlation_id"] == _SERVICE_CORRELATION
+    assert "yoetz service restart" in str(error["message"])
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "service_incompatible"
+    found = lookup_diagnostic_records(_SERVICE_CORRELATION, root=diagnostic_root)
+    assert len(found) == 1
+    _assert_no_leakage(result.structuredContent, found)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_connect_protocol_mismatch_is_distinct_and_ships_non_retryable(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    append_diagnostic_record(
+        correlation_id=_SERVICE_CORRELATION,
+        component="service.daemon",
+        operation="start_protocol_mismatch",
+        reason="protocol_mismatch",
+        request_id=cast(str, _requests()["start"]["request_id"]),
+        root=diagnostic_root,
+    )
+    _install_connect_failure(
+        monkeypatch,
+        ControlError("protocol_mismatch", correlation_id=_SERVICE_CORRELATION),
+    )
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is False
+    assert error["correlation_id"] == _SERVICE_CORRELATION
+    assert "yoetz service restart" in str(error["message"])
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "protocol_mismatch"
+    found = lookup_diagnostic_records(_SERVICE_CORRELATION, root=diagnostic_root)
+    assert len(found) == 1
+    _assert_no_leakage(result.structuredContent, found)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_connect_endpoint_unsafe_is_non_retryable_without_a_socket_path(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    _install_connect_failure(monkeypatch, ControlError("endpoint_unsafe"))
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is False
+    assert "unsafe to use" in str(error["message"])
+    assert "same request_id" in str(error["message"])
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "endpoint_unsafe"
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "endpoint_unsafe"
+    _assert_no_leakage(result.structuredContent, found)
+    await bridge.close_bridge_runtime(runtime)
+
+
+@pytest.mark.anyio
+async def test_unexpected_start_error_stays_internal_without_exception_text(
+    monkeypatch: pytest.MonkeyPatch, diagnostic_root: Path
+) -> None:
+    _install_clients(monkeypatch, [_FakeClient(RuntimeError("must-not-reach-public-output"))])
+    runtime = bridge.build_bridge_runtime()
+    request = _requests()["start"]
+
+    result = await bridge.dispatch_start(request, runtime)
+
+    error = _start_error(result, cast(str, request["request_id"]))
+    assert error["code"] == PublicErrorCode.INTERNAL_ERROR.value
+    assert error["retryable"] is False
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["operation"] == "start_internal_error"
+    assert str(found[0]["reason"]).startswith("exception_")
+    _assert_no_leakage(result.structuredContent, found)
     await bridge.close_bridge_runtime(runtime)

--- a/tests/unit/mcp/test_control_error_correlation.py
+++ b/tests/unit/mcp/test_control_error_correlation.py
@@ -7,6 +7,7 @@ only bridge-local faults mint a fresh one.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import cast
 
@@ -18,9 +19,44 @@ from yoetz.observability.diagnostics import append_diagnostic_record, lookup_dia
 from yoetz.observability.logging import LogMode, configure_logging
 from yoetz.ports.control import ControlError
 from yoetz.protocol.errors import PublicErrorCode
+from yoetz.service.client import _AcceptedServiceUnresponsive  # pyright: ignore[reportPrivateUsage]
 
 _CORRELATION = "err_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 _REQUEST = "req_bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+_ABSENT_SERVICE_MESSAGE = (
+    "The local Yoetz service is not running. On a local terminal run "
+    "'yoetz service run' under your selected user supervisor, then retry this "
+    "operation with the same request_id."
+)
+_LEAK_TOKENS = (
+    "Traceback",
+    "/tmp/",
+    ".sock",
+    "Application Support",
+    "must-not-reach-public-output",
+    "YZH1-",
+    "Bearer ",
+)
+
+
+@pytest.fixture
+def diagnostic_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    import yoetz.observability.diagnostics as diagnostics
+
+    monkeypatch.setattr(diagnostics, "log_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def _error_of(result: object) -> dict[str, object]:
+    structured = cast(dict[str, object], getattr(result, "structuredContent"))
+    assert structured["request_id"] == _REQUEST
+    return cast(dict[str, object], structured["error"])
+
+
+def _assert_no_leakage(*blobs: object) -> None:
+    rendered = json.dumps(blobs, default=str)
+    for token in _LEAK_TOKENS:
+        assert token not in rendered
 
 
 def test_bridge_reuses_service_correlation_for_response_projection_failed(
@@ -123,10 +159,11 @@ def test_bridge_level_failure_without_service_id_still_resolves(
     found = lookup_diagnostic_records(correlation_id, root=tmp_path)
     assert len(found) == 1
     assert found[0]["component"] == "mcp.bridge"
-    assert found[0]["operation"] == "check_internal_error"
-    # stderr structural line matches the public id when the sink is installed.
+    assert found[0]["operation"] == "check_public_error"
+    assert found[0]["reason"] == "internal_error"
+    # Typed ControlError now records as a public error, which is a warning. Error-level
+    # MCP_STDIO logging therefore has no stderr line; the durable ring is the join key.
     err = capsys.readouterr().err
-    assert correlation_id in err
     assert "traceback" not in err.lower()
 
 
@@ -234,3 +271,202 @@ def test_incompatible_service_is_a_bounded_service_unavailable_with_the_repair_c
     assert error["correlation_id"] == _CORRELATION
     assert cast(dict[str, object], error["safe_details"])["reason_code"] == "service_incompatible"
     assert "yoetz service restart" in str(error["message"])
+
+
+def test_absent_service_maps_to_supervisor_copy_and_control_class_reason(
+    diagnostic_root: Path,
+) -> None:
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError("service_unavailable", retryable=True),
+        request_id=_REQUEST,
+        operation="start",
+    )
+    error = _error_of(result)
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is True
+    assert error["message"] == _ABSENT_SERVICE_MESSAGE
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "service_unavailable"
+    correlation_id = cast(str, error["correlation_id"])
+    found = lookup_diagnostic_records(correlation_id, root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "service_unavailable"
+    assert found[0]["reason"] != "exception_control_error"
+    assert found[0]["operation"] == "start_public_error"
+    _assert_no_leakage(error, found)
+
+
+def test_accepted_but_unresponsive_is_distinct_from_absent_service(
+    diagnostic_root: Path,
+) -> None:
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        _AcceptedServiceUnresponsive(),  # pyright: ignore[reportPrivateUsage]
+        request_id=_REQUEST,
+        operation="start",
+    )
+    error = _error_of(result)
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is True
+    message = cast(str, error["message"])
+    assert message != _ABSENT_SERVICE_MESSAGE
+    assert "under your selected user supervisor" not in message
+    assert "Do not run `yoetz service run`" in message
+    assert (
+        cast(dict[str, object], error["safe_details"])["reason_code"] == "accepted_but_unresponsive"
+    )
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "accepted_but_unresponsive"
+    _assert_no_leakage(error, found)
+
+
+def test_protocol_mismatch_uses_restart_copy_and_ships_non_retryable(
+    diagnostic_root: Path,
+) -> None:
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError("protocol_mismatch", correlation_id=_CORRELATION),
+        request_id=_REQUEST,
+        operation="start",
+    )
+    error = _error_of(result)
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is False
+    assert error["correlation_id"] == _CORRELATION
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "protocol_mismatch"
+    assert "yoetz service restart" in str(error["message"])
+    assert lookup_diagnostic_records(_CORRELATION, root=diagnostic_root) == ()
+    _assert_no_leakage(error)
+
+
+def test_endpoint_unsafe_is_non_retryable_service_unavailable_without_a_socket_path(
+    diagnostic_root: Path,
+) -> None:
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError("endpoint_unsafe"),
+        request_id=_REQUEST,
+        operation="start",
+    )
+    error = _error_of(result)
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is False
+    assert "unsafe to use" in str(error["message"])
+    assert "same request_id" in str(error["message"])
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "endpoint_unsafe"
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "endpoint_unsafe"
+    _assert_no_leakage(error, found)
+
+
+def test_control_public_error_result_reuses_service_correlation_id(
+    diagnostic_root: Path,
+) -> None:
+    append_diagnostic_record(
+        correlation_id=_CORRELATION,
+        component="service.daemon",
+        operation="start_peer_untrusted",
+        reason="peer_untrusted",
+        request_id=_REQUEST,
+        root=diagnostic_root,
+    )
+    result = bridge._control_public_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError("peer_untrusted", correlation_id=_CORRELATION),
+        _REQUEST,
+        "start",
+        code=PublicErrorCode.SERVICE_UNAVAILABLE,
+        message="The local control endpoint identity could not be trusted.",
+        retryable=False,
+        host_profile="generic",
+        safe_details={"reason_code": "peer_untrusted"},
+    )
+    error = _error_of(result)
+    assert error["correlation_id"] == _CORRELATION
+    found = lookup_diagnostic_records(_CORRELATION, root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "peer_untrusted"
+    _assert_no_leakage(error, found)
+
+
+def test_peer_untrusted_requires_local_repair_then_same_request_replay(
+    diagnostic_root: Path,
+) -> None:
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError("peer_untrusted"),
+        request_id=_REQUEST,
+        operation="start",
+    )
+
+    error = _error_of(result)
+    assert error["code"] == PublicErrorCode.SERVICE_UNAVAILABLE.value
+    assert error["retryable"] is False
+    assert "could not be trusted" in str(error["message"])
+    assert "same request_id" in str(error["message"])
+    assert cast(dict[str, object], error["safe_details"])["reason_code"] == "peer_untrusted"
+    found = lookup_diagnostic_records(cast(str, error["correlation_id"]), root=diagnostic_root)
+    assert len(found) == 1
+    assert found[0]["reason"] == "peer_untrusted"
+    _assert_no_leakage(error, found)
+
+
+@pytest.mark.parametrize(
+    ("reason", "retryable"),
+    (
+        ("vault_locked", True),
+        ("vault_locked", False),
+        ("request_cancelled", False),
+        ("privacy_projection_blocked", False),
+        ("response_projection_failed", True),
+        ("read_projection_failed", True),
+        ("privacy_projection_unavailable", True),
+        ("request_timeout", True),
+        ("service_incompatible", True),
+        ("protocol_mismatch", False),
+        ("service_draining", False),
+        ("service_unavailable", True),
+        ("service_generation_changed", True),
+        ("peer_untrusted", False),
+        ("endpoint_unsafe", False),
+        ("frame_invalid", False),
+        ("frame_too_large", False),
+        ("method_forbidden", False),
+        ("internal_error", False),
+    ),
+)
+def test_every_mapped_control_reason_reuses_a_service_correlation_id(
+    reason: str, retryable: bool, diagnostic_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    minted: list[str] = []
+
+    def forbid_public_mint(**kwargs: object) -> str:
+        del kwargs
+        minted.append("public")
+        return "err_ffffffff-ffff-4fff-8fff-ffffffffffff"
+
+    def forbid_unexpected_mint(*args: object, **kwargs: object) -> str:
+        del args, kwargs
+        minted.append("unexpected")
+        return "err_ffffffff-ffff-4fff-8fff-ffffffffffff"
+
+    monkeypatch.setattr(bridge, "record_public_error_without_raising", forbid_public_mint)
+    monkeypatch.setattr(
+        bridge, "record_unexpected_exception_without_raising", forbid_unexpected_mint
+    )
+    append_diagnostic_record(
+        correlation_id=_CORRELATION,
+        component="service.daemon",
+        operation=f"start_{reason}",
+        reason=reason,
+        request_id=_REQUEST,
+        root=diagnostic_root,
+    )
+
+    result = bridge._control_error_result(  # pyright: ignore[reportPrivateUsage]
+        ControlError(reason, retryable=retryable, correlation_id=_CORRELATION),
+        request_id=_REQUEST,
+        operation="start",
+    )
+    error = _error_of(result)
+    assert error["correlation_id"] == _CORRELATION
+    assert minted == []
+    found = lookup_diagnostic_records(_CORRELATION, root=diagnostic_root)
+    assert len(found) == 1
+    _assert_no_leakage(error, found)

--- a/tests/unit/protocol/test_errors.py
+++ b/tests/unit/protocol/test_errors.py
@@ -29,7 +29,8 @@ _VALID_CORRELATION_ID = "err_00000000-0000-4000-8000-000000000000"
 _OTHER_CORRELATION_ID = "err_00000000-0000-4000-8000-000000000001"
 
 _EXPECTED_REASON_CODES = tuple(
-    """accepted_record_shape_invalid
+    """accepted_but_unresponsive
+accepted_record_shape_invalid
 actor_id_malformed
 actor_id_not_generated
 byte_order_mark_forbidden
@@ -40,6 +41,7 @@ duplicate_set_member
 empty_check_types
 empty_publication_channels
 empty_subject_state
+endpoint_unsafe
 engine_family_wrong_author
 entry_digest_mismatch
 event_family_not_admitted
@@ -55,6 +57,8 @@ expected_frontier_required
 finding_json_shape_invalid
 finding_priority_mismatch
 float_forbidden
+frame_invalid
+frame_too_large
 frontier_changed
 frontier_digest_mismatch
 id_malformed_uuid
@@ -68,6 +72,7 @@ import_report_invalid
 input_not_bytes
 integer_out_of_safe_range
 integer_out_of_sqlite_range
+internal_error
 invalid_actor_type
 invalid_approved_check
 invalid_approved_check_policy
@@ -115,6 +120,7 @@ invalid_utf8
 ledger_assigned_field_in_request_identity
 lone_surrogate
 malformed_json
+method_forbidden
 missing_payload_field
 nesting_too_deep
 no_obligations_reason_conflict
@@ -128,9 +134,11 @@ obligation_resolution_mismatch
 operation_recovery_unavailable
 ownership_contended
 payload_redaction_mismatch
+peer_untrusted
 plan_version_conflict
 privacy_projection_unavailable
 privacy_receipt_not_durable
+protocol_mismatch
 provider_attempt_provenance_is_not_final
 public_error_invalid_correlation_id
 public_error_invalid_message
@@ -143,6 +151,7 @@ receipt_json_shape_invalid
 redaction_target_required
 ref_mirror_mismatch
 request_identity_conflict
+request_timeout
 response_fields_invalid
 response_projection_failed
 schema_artifact_role_invalid
@@ -165,7 +174,10 @@ schema_path_unsafe
 schema_reference_unresolved
 schema_version_mismatch
 semantic_provenance_json_shape_invalid
+service_draining
+service_generation_changed
 service_incompatible
+service_unavailable
 session_superseded
 set_member_not_ascii
 timestamp_not_utc
@@ -346,7 +358,7 @@ def test_public_error_code_membership() -> None:
 def test_protocol_reason_registry_is_exact_and_import_order_independent() -> None:
     source_values = cast(tuple[str, ...], getattr(errors_module, "_PROTOCOL_REASON_CODE_VALUES"))
     assert source_values == _EXPECTED_REASON_CODES
-    assert len(source_values) == 149
+    assert len(source_values) == 161
     assert source_values == tuple(sorted(source_values, key=str.encode))
     assert len(source_values) == len(set(source_values))
     assert PROTOCOL_REASON_CODES == frozenset(_EXPECTED_REASON_CODES)

--- a/tests/unit/service/test_client.py
+++ b/tests/unit/service/test_client.py
@@ -1064,6 +1064,17 @@ def test_protocol_rejection_reasons_map_to_service_incompatible() -> None:
     assert mismatch.reason == "protocol_mismatch"
 
 
+def test_transport_error_preserves_endpoint_unsafe() -> None:
+    import yoetz.service.client as client_module
+    from yoetz.adapters.control.unix_socket import LocalControlTransportError
+
+    mapped = client_module._transport_error(  # pyright: ignore[reportPrivateUsage]
+        LocalControlTransportError("endpoint_unsafe")
+    )
+    assert mapped.reason == "endpoint_unsafe"
+    assert mapped.retryable is False
+
+
 @pytest.mark.anyio
 async def test_supersede_signals_only_a_live_foreign_identity_holder(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/service/test_control_protocol.py
+++ b/tests/unit/service/test_control_protocol.py
@@ -585,6 +585,18 @@ def test_wire_only_errors_map_to_existing_public_codes() -> None:
     )
     assert public_error_code_for_control_reason("vault_locked") is PublicErrorCode.VAULT_LOCKED
     assert public_error_code_for_control_reason("frame_invalid") is PublicErrorCode.INVALID_REQUEST
+    assert (
+        public_error_code_for_control_reason("endpoint_unsafe")
+        is PublicErrorCode.SERVICE_UNAVAILABLE
+    )
+    assert (
+        public_error_code_for_control_reason("peer_untrusted")
+        is PublicErrorCode.SERVICE_UNAVAILABLE
+    )
+    assert (
+        public_error_code_for_control_reason("service_draining")
+        is PublicErrorCode.SERVICE_UNAVAILABLE
+    )
 
 
 def test_client_handshake_names_a_peer_that_closes_on_the_hello_as_rejected() -> None:


### PR DESCRIPTION
## Issue

- Linked issue: `Fixes #460`.
- I searched open pull requests for `460` before opening this PR; none matched.
- This changes the public control-error contract. Issue #460 is maintainer-authored and defines the acknowledged acceptance contract for this fix.

## Documentation

- Behavior change? `yes`
- Updated `docs/INTERFACES.md`, the Codex, Cursor, and Claude Code integration runbooks, and the Unreleased changelog.

## Verification

Commands run:

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit/protocol/test_errors.py tests/unit/service/test_control_protocol.py tests/unit/service/test_client.py tests/unit/mcp/test_control_error_correlation.py tests/subprocess/test_mcp_service_bridge.py -q
# 127 passed

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/unit/mcp tests/unit/protocol/test_errors.py tests/unit/service/test_client.py tests/unit/service/test_control_protocol.py tests/unit/cli/test_hooks.py tests/unit/cli/test_service_status_remediation.py tests/unit/cli/test_service_restart.py tests/conformance/surfaces/test_mcp_contract_matrix.py tests/subprocess/test_mcp_service_bridge.py tests/subprocess/test_installed_upgrade_supersedes_stale_service.py -q
# 331 passed; the installed-upgrade case was sandbox-blocked before setup

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run pytest tests/subprocess/test_installed_upgrade_supersedes_stale_service.py -q
# 1 passed in its required owner-private installation environment

UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff check <touched files>
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run ruff format --check <touched Python files>
npx --no-install pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache uv run python scripts/sync_resource_ripple.py --check
git diff --check
```

Installed-product fault cell:

- Built a disposable wheel from this tree, SHA-256 `5e6c0fd09da56d62aead4ad693e5a25ec17636a33c4f95eedcf5d3e6850a5818`.
- Codex CLI 0.148.0 made a model-controlled call through an MCP registration bound by absolute path to that wheel.
- A deliberately unsafe isolated endpoint returned `SERVICE_UNAVAILABLE`, `retryable=false`, `safe_details.reason_code=endpoint_unsafe`, same-request replay guidance, and correlation `err_3d4c735b-f3db-44e1-9f48-0893f9252b40`.
- `yoetz service diagnostics --correlation-id` resolved exactly one `mcp.bridge / start_public_error / endpoint_unsafe` record.
- An earlier XDG-only probe did not propagate its isolation variables into the MCP child; its successful ambient `start` is excluded from this evidence.

Implementation/review harness: Codex desktop; the model identity was not exposed to this task. Installed host probe: Codex CLI 0.148.0.

The ambient cooperative MCP bridge still exhibits #460 and returned non-retryable `INTERNAL_ERROR` before a Yoetz task could attach, so this implementation run has no Yoetz completion receipt.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.
- Cross-host evidence remains owned by #155; this PR fixes the product defect and contributes one bounded Codex fault-cell result without expanding into that gate.

## Summary

Preserve typed local-control failures across the cooperative MCP bridge instead of collapsing them into opaque non-retryable `INTERNAL_ERROR`. The bridge now retains bounded root-class reason codes, truthful retryability, service-minted correlation IDs, and recovery copy for absent, unresponsive, incompatible, unsafe, timed-out, and protocol-refused control paths while keeping genuinely unexpected defects on the internal-error boundary.

The change also preserves endpoint-safety reasons through the ordinary client and CLI hook classifier, documents the upgrade and recovery contract for every current host, and adds end-to-end bridge tests that assert safe output and resolvable diagnostics.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserve typed local-control failures as actionable MCP errors rather than collapsing them into generic internal failures.
- Adds explicit public mappings, retryability, recovery guidance, reason codes, and diagnostic correlation for the complete control-error vocabulary.
- Propagates the new `endpoint_unsafe` reason through transport, client, protocol, CLI hook, and MCP boundaries.
- Extends interface and host-integration documentation and adds unit and subprocess coverage for the revised contract.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable defects identified in the changed control-error paths.

The complete closed control-error vocabulary is explicitly handled, endpoint-safety failures propagate consistently across surfaces, and service-supplied correlation IDs are recorded before the bridge reuses them.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/mcp/server.py | Expands the bridge’s typed control-error mappings and preserves correlation, retryability, bounded reason codes, and condition-specific recovery guidance. |
| src/yoetz/protocol/errors.py | Adds `endpoint_unsafe` to the closed protocol reason-code vocabulary and updates its cardinality guard. |
| src/yoetz/service/client.py | Preserves endpoint-safety transport failures as `endpoint_unsafe` and exposes accepted-but-unresponsive classification to the bridge. |
| src/yoetz/service/control_protocol.py | Maps unsafe endpoint control failures to the documented public service-unavailable classification. |
| src/yoetz/cli/hooks.py | Classifies unsafe endpoint failures as unavailable for best-effort hook handling. |
| tests/unit/mcp/test_control_error_correlation.py | Covers the complete control-reason mapping, correlation reuse, diagnostic reasons, retryability, and public error shapes. |
| tests/subprocess/test_mcp_service_bridge.py | Adds process-boundary coverage for incompatible protocols, unsafe endpoints, typed bridge failures, and resolvable diagnostics. |
| docs/INTERFACES.md | Documents the revised MCP control-error, recovery, retryability, and correlation contract. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Host as MCP Host
    participant Bridge as MCP Bridge
    participant Client as Service Client
    participant Service as Local Service
    participant Diagnostics as Diagnostic Ring

    Host->>Bridge: Workflow tool call
    Bridge->>Client: Invoke typed control request
    Client->>Service: Local control protocol
    alt Successful operation
        Service-->>Client: Typed result
        Client-->>Bridge: Public model
        Bridge-->>Host: Structured success
    else Service-recorded control failure
        Service->>Diagnostics: Record correlation ID and bounded reason
        Service-->>Client: ControlError with correlation ID
        Client-->>Bridge: Preserve typed ControlError
        Bridge-->>Host: Public error with reason code and recovery guidance
    else Bridge-local control failure
        Client-->>Bridge: ControlError without correlation ID
        Bridge->>Diagnostics: Mint and record correlation ID
        Bridge-->>Host: Public error with reason code and recovery guidance
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): preserve typed service control..."](https://github.com/thegaysupreme123/yoetz/commit/aeb2866e860fd7f8ea601de6d1071295a507922f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58249898)</sub>

<!-- /greptile_comment -->