### PR TITLE
fix(mcp): bound stdio frame nesting and keep the bridge alive on deep JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- The MCP stdio bridge no longer exits on a size-valid but excessively nested JSON frame.
+  Inbound nesting is bounded at the canonical codec's 64 levels with a non-recursive walk, any
+  decoder `RecursionError` is converted to the fixed `invalid_json` parse error, and a valid
+  request succeeds immediately after a rejected deeply nested one (issue #394).
+
 - Cooperative MCP calls no longer collapse typed local-control failures into opaque,
   non-retryable `INTERNAL_ERROR`. Service absence, an accepted-but-unresponsive listener,
   incompatible or mismatched installations, unsafe or untrusted endpoints, timeouts, and bounded

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -292,7 +292,10 @@ free text from input. CLI exit classes (0/2/10/11/20/30/40/70/130) map from code
   `MAX_REVIEW_OMISSIONS = 64`, and `MAX_REVIEW_CHALLENGES = 3`.
 - MCP transport cap (`adapters/mcp_stdio.py`): `MAX_JSON_FRAME_BYTES = 1_048_576` payload bytes
   excluding the single LF. This is adapter-owned and is not exported or mirrored by
-  `protocol/models.py`.
+  `protocol/models.py`. The same adapter bounds inbound nesting at
+  `MAX_JSON_NESTING_DEPTH = MAX_JSON_DEPTH` (64 container levels including the root object) with a
+  non-recursive walk; a deeper or otherwise undecodable frame yields the fixed null-id
+  `invalid_json` parse error and the bridge keeps serving later frames (issue #394).
 - Local-service control framing (`service/control_protocol.py`):
   `MAX_CONTROL_FRAME_BYTES = 6_291_456` payload bytes excluding the four-byte length prefix, with
   `MAX_ORDINARY_CONTROL_FRAME_BYTES = 1_048_576` for every frame except the exact closed

--- a/src/yoetz/adapters/mcp_stdio.py
+++ b/src/yoetz/adapters/mcp_stdio.py
@@ -17,7 +17,16 @@ from mcp import types
 from mcp.shared.message import SessionMessage
 from pydantic import ValidationError
 
+from yoetz.protocol.canonical import MAX_JSON_DEPTH
+
 MAX_JSON_FRAME_BYTES: Final = 1_048_576
+# Nesting bound for one inbound frame, shared with the canonical codec so a
+# frame the bridge admits can never exceed what the protocol layer accepts.
+# Enforced without recursion: a size-valid frame can nest far deeper than the
+# interpreter's recursion limit, and a RecursionError escaping the parser is
+# not a TransportFailure, so it used to terminate the bridge task group
+# instead of producing the fixed `invalid_json` response (issue #394).
+MAX_JSON_NESTING_DEPTH: Final = MAX_JSON_DEPTH
 _MAX_READ_CHUNK: Final = 65_536
 _EOF_DRAIN_SECONDS: Final = 5.0
 _PARSE_REASONS: Final = frozenset(
@@ -44,7 +53,12 @@ _FAILURE_REASONS: Final = frozenset(
     }
 )
 
-__all__ = ["MAX_JSON_FRAME_BYTES", "TransportFailure", "bounded_stdio_server"]
+__all__ = [
+    "MAX_JSON_FRAME_BYTES",
+    "MAX_JSON_NESTING_DEPTH",
+    "TransportFailure",
+    "bounded_stdio_server",
+]
 
 
 class TransportFailure(Exception):
@@ -126,31 +140,48 @@ def _parse_frame(frame: bytes) -> SessionMessage:
         )
     except TransportFailure:
         raise
-    except (ValueError, json.JSONDecodeError) as exc:
+    except (ValueError, json.JSONDecodeError, RecursionError) as exc:
+        # The decoder recurses per nesting level; past the interpreter limit it
+        # raises RecursionError rather than a decode error.
         raise TransportFailure("invalid_json") from exc
     if type(parsed) is not dict:
         raise TransportFailure("not_jsonrpc")
-    try:
-        _validate_unicode(cast(dict[object, object], parsed))
-    except UnicodeEncodeError as exc:
-        raise TransportFailure("invalid_json") from exc
+    _validate_tree(cast(dict[object, object], parsed))
     try:
         message = types.JSONRPCMessage.model_validate(parsed)
-    except ValidationError as exc:
+    except (ValidationError, RecursionError) as exc:
         raise TransportFailure("not_jsonrpc") from exc
     return SessionMessage(message)
 
 
-def _validate_unicode(value: object) -> None:
-    if type(value) is str:
-        value.encode("utf-8", errors="strict")
-    elif type(value) is list:
-        for item in cast(list[object], value):
-            _validate_unicode(item)
-    elif type(value) is dict:
-        for key, item in cast(dict[object, object], value).items():
-            _validate_unicode(key)
-            _validate_unicode(item)
+def _validate_tree(root: dict[object, object]) -> None:
+    """Bound nesting and require strictly encodable text, without recursion.
+
+    Depth counts containers along a path including the root object, so a frame
+    is admitted only while every container sits at depth <= MAX_JSON_NESTING_DEPTH
+    — the same envelope the canonical codec enforces. The walk is an explicit
+    stack so its cost is linear in the frame and never in interpreter frames.
+    """
+
+    stack: list[tuple[object, int]] = [(root, 1)]
+    while stack:
+        value, depth = stack.pop()
+        if type(value) is str:
+            try:
+                value.encode("utf-8", errors="strict")
+            except UnicodeEncodeError as exc:
+                raise TransportFailure("invalid_json") from exc
+        elif type(value) is list:
+            if depth > MAX_JSON_NESTING_DEPTH:
+                raise TransportFailure("invalid_json")
+            for item in cast(list[object], value):
+                stack.append((item, depth + 1))
+        elif type(value) is dict:
+            if depth > MAX_JSON_NESTING_DEPTH:
+                raise TransportFailure("invalid_json")
+            for key, item in cast(dict[object, object], value).items():
+                stack.append((key, depth + 1))
+                stack.append((item, depth + 1))
 
 
 def _serialize_session_message(message: SessionMessage) -> bytes:
@@ -292,6 +323,11 @@ async def _reader(
                         message = _parse_frame(frame)
                     except TransportFailure as exc:
                         await _emit_transport_error(items, exc.reason)
+                        continue
+                    except RecursionError:
+                        # Belt and braces: no parse-stage recursion may end the
+                        # bridge; the frame is malformed for this transport.
+                        await _emit_transport_error(items, "invalid_json")
                         continue
                     if isinstance(message.message.root, types.JSONRPCRequest):
                         tracker.request_started()

--- a/tests/subprocess/test_mcp_stdio_frames.py
+++ b/tests/subprocess/test_mcp_stdio_frames.py
@@ -97,6 +97,31 @@ def test_exact_payload_limit_is_accepted() -> None:
     assert json.loads(result.stdout)["id"] == 9
 
 
+def test_deeply_nested_frame_is_invalid_json_and_the_bridge_keeps_serving() -> None:
+    """Excessive nesting yields the fixed parse error, never a RecursionError exit (#394)."""
+
+    from yoetz.adapters.mcp_stdio import MAX_JSON_FRAME_BYTES
+
+    levels = sys.getrecursionlimit() * 4
+    nested = (
+        b'{"jsonrpc":"2.0","id":7,"method":"ping","params":{"a":'
+        + (b"[" * levels + b"]" * levels)
+        + b"}}"
+    )
+    assert len(nested) < MAX_JSON_FRAME_BYTES
+    result = _run(nested + b"\n" + _request(8) + b"\n", MAX_JSON_FRAME_BYTES)
+    assert result.returncode == 0, result.stderr
+    assert b"Traceback" not in result.stderr
+    assert b"RecursionError" not in result.stderr
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [row.get("id") for row in rows] == [None, 8]
+    assert rows[0]["error"] == {
+        "code": -32700,
+        "message": "Parse error",
+        "data": {"reason": "invalid_json"},
+    }
+
+
 def test_invalid_utf8_nul_and_partial_eof_never_enter_sdk_stream() -> None:
     result = _run(b'\xff\n{"jsonrpc":"2.0",\x00}\n' + _request(4)[:-1])
     rows = [json.loads(line) for line in result.stdout.splitlines()]

--- a/tests/unit/adapters/test_mcp_stdio_depth.py
+++ b/tests/unit/adapters/test_mcp_stdio_depth.py
@@ -1,0 +1,100 @@
+"""Bounded nesting for the MCP stdio frame parser (#394)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from yoetz.adapters import mcp_stdio as transport
+from yoetz.adapters.mcp_stdio import MAX_JSON_NESTING_DEPTH, TransportFailure
+from yoetz.protocol.canonical import MAX_JSON_DEPTH
+
+
+def _frame(params: object) -> bytes:
+    return json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": params},
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _nested_arrays(levels: int) -> bytes:
+    return b"[" * levels + b"]" * levels
+
+
+def _frame_with_nested_params(array_levels: int) -> bytes:
+    # Root object (1) -> params object (2) -> "a" arrays (3 ..).
+    prefix = b'{"jsonrpc":"2.0","id":1,"method":"ping","params":{"a":'
+    return prefix + _nested_arrays(array_levels) + b"}}"
+
+
+def test_depth_bound_is_the_canonical_codec_bound() -> None:
+    assert MAX_JSON_NESTING_DEPTH == MAX_JSON_DEPTH == 64
+
+
+def test_frame_at_the_exact_nesting_bound_is_admitted() -> None:
+    # 2 container levels of envelope + (MAX - 2) array levels == MAX total.
+    frame = _frame_with_nested_params(MAX_JSON_NESTING_DEPTH - 2)
+    message = transport._parse_frame(frame)  # pyright: ignore[reportPrivateUsage]
+    assert message.message.model_dump(by_alias=True)["id"] == 1
+
+
+def test_frame_one_level_past_the_bound_is_invalid_json() -> None:
+    frame = _frame_with_nested_params(MAX_JSON_NESTING_DEPTH - 1)
+    with pytest.raises(TransportFailure) as caught:
+        transport._parse_frame(frame)  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "invalid_json"
+
+
+def test_nesting_past_the_interpreter_recursion_limit_is_invalid_json() -> None:
+    levels = sys.getrecursionlimit() * 4
+    frame = _frame_with_nested_params(levels)
+    assert len(frame) < transport.MAX_JSON_FRAME_BYTES
+    with pytest.raises(TransportFailure) as caught:
+        transport._parse_frame(frame)  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "invalid_json"
+
+
+def test_object_nesting_is_bounded_like_array_nesting() -> None:
+    levels = MAX_JSON_NESTING_DEPTH + 8
+    body = b'{"k":' * levels + b"1" + b"}" * levels
+    frame = b'{"jsonrpc":"2.0","id":1,"method":"ping","params":' + body + b"}"
+    with pytest.raises(TransportFailure) as caught:
+        transport._parse_frame(frame)  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "invalid_json"
+
+
+def test_tree_walk_is_iterative_and_bounded_without_recursion() -> None:
+    """A parsed structure deeper than any interpreter frame budget still yields the fixed reason."""
+
+    levels = sys.getrecursionlimit() * 8
+    deep: list[object] = []
+    cursor = deep
+    for _ in range(levels):
+        inner: list[object] = []
+        cursor.append(inner)
+        cursor = inner
+    with pytest.raises(TransportFailure) as caught:
+        transport._validate_tree({"params": deep})  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "invalid_json"
+
+
+def test_unencodable_text_deep_inside_an_admitted_frame_is_still_invalid_json() -> None:
+    levels = MAX_JSON_NESTING_DEPTH - 3
+    parsed = json.loads(_frame_with_nested_params(levels))
+    cursor = parsed["params"]["a"]
+    for _ in range(levels - 1):
+        cursor = cursor[0]
+    cursor.append("\udc80")
+    with pytest.raises(TransportFailure) as caught:
+        transport._validate_tree(parsed)  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "invalid_json"
+
+
+def test_wide_shallow_frames_are_unaffected_by_the_depth_bound() -> None:
+    frame = _frame(
+        {"items": [[i] for i in range(2_000)], "keys": {str(i): i for i in range(2_000)}}
+    )
+    message = transport._parse_frame(frame)  # pyright: ignore[reportPrivateUsage]
+    assert message.message.model_dump(by_alias=True)["id"] == 1


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #394
- I searched existing issues and PRs for duplicates before opening this PR (#129 concerns corrective validation feedback, not bridge lifetime; #470 typed control failures, not transport parsing).
- Not design-gated: no wire change. The `invalid_json` null-id parse error already exists; the nesting bound reuses the canonical codec's `MAX_JSON_DEPTH`, so nothing the bridge now rejects could have been accepted downstream.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (MCP transport cap bullet now states the nesting bound and the fixed response), `CHANGELOG.md`.

## Verification

Commands run (paste):

```text
uv run ruff check src/yoetz/adapters/mcp_stdio.py tests/unit/adapters/test_mcp_stdio_depth.py tests/subprocess/test_mcp_stdio_frames.py
uv run ruff format src/yoetz/adapters/mcp_stdio.py tests/unit/adapters/test_mcp_stdio_depth.py tests/subprocess/test_mcp_stdio_frames.py
node_modules/.bin/pyright src/yoetz/adapters/mcp_stdio.py tests/unit/adapters/test_mcp_stdio_depth.py tests/subprocess/test_mcp_stdio_frames.py   # 0 errors
uv run pytest tests/unit/adapters/test_mcp_stdio_depth.py tests/subprocess/test_mcp_stdio_frames.py tests/subprocess/test_mcp_backpressure_and_partial_write.py tests/subprocess/test_mcp_stdout_purity.py -q   # 29 passed
uv run pytest tests/capability/test_mcp_gate1_protocol_conformance.py tests/capability/test_mcp_protocol_and_sdk.py -q   # 5 passed, 13 skipped (environment-gated Codex cells)
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

**Problem.** `adapters/mcp_stdio.py` parsed size-valid frames with `json.loads` and then walked the result with a recursive `_validate_unicode`. Neither had a depth bound. A frame nested past the interpreter's recursion limit raised `RecursionError`, which is not a `TransportFailure`, so it escaped `_reader`, crossed the task group, and terminated the bridge instead of yielding the fixed `invalid_json` frame.

**Fix.**
- `MAX_JSON_NESTING_DEPTH = MAX_JSON_DEPTH` (64 container levels including the root object) — the same envelope the canonical codec enforces, so the bridge never admits what the protocol layer would reject.
- `_validate_unicode` is replaced by `_validate_tree`, an explicit-stack walk that enforces the depth bound and the strict UTF-8 check in one linear pass with no recursion.
- `RecursionError` from the decoder (nesting past the interpreter limit before our walk can run) and from `JSONRPCMessage.model_validate` is converted to the normal transport failure; `_reader` keeps a belt-and-braces `RecursionError` guard so no parse-stage recursion can end the bridge.
- Tests: unit (`tests/unit/adapters/test_mcp_stdio_depth.py`) cover the exact bound, one past it, arrays and objects, nesting past the interpreter limit through the decoder, the iterative walk on a structure 8× the recursion limit deep, an unencodable string deep inside an admitted frame, and wide-but-shallow frames staying accepted; subprocess (`tests/subprocess/test_mcp_stdio_frames.py`) proves a deeply nested frame yields the null-id `invalid_json` error and the next valid request is answered, with no traceback on stderr.

**Surfaces walked.** Delivery paths: MCP stdio transport only (the local-service control framing has its own bound and canonical validation). Contracts: none. Hosts: transport-level, host-agnostic.

**Model / harness.** Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds MCP stdio JSON nesting using the canonical 64-container limit and converts parser recursion failures into fixed transport errors so subsequent frames remain serviceable.

- Replaces recursive Unicode validation with an explicit-stack depth and UTF-8 validation pass.
- Handles decoder and model-validation recursion failures at transport boundaries.
- Adds boundary, malformed-input, bridge-liveness, and shallow-wide-frame coverage.
- Documents the transport behavior in the interface reference and changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or non-blocking defect was identified in the changed behavior.

The transport and canonical codec enforce the same root-inclusive 64-container envelope, the iterative walk preserves strict text validation, recursion failures are contained, and the added tests cover the relevant boundary and bridge-liveness paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/mcp_stdio.py | Adds an iterative, root-inclusive 64-container validation bound and contains recursion failures without terminating the bridge. |
| tests/unit/adapters/test_mcp_stdio_depth.py | Covers exact and exceeded depth boundaries, extreme nesting, strict Unicode validation, object nesting, and wide shallow inputs. |
| tests/subprocess/test_mcp_stdio_frames.py | Demonstrates that excessive nesting emits the fixed parse error and that the bridge serves the following valid request. |
| docs/INTERFACES.md | Documents the inbound nesting limit, fixed error response, and continued bridge operation. |
| CHANGELOG.md | Records the user-visible MCP stdio bridge-liveness fix. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Reader as MCP stdio reader
    participant Parser as Frame parser
    participant SDK as MCP SDK
    Client->>Reader: Deep JSON frame
    Reader->>Parser: Parse and validate
    Parser-->>Reader: invalid_json
    Reader-->>Client: Fixed null-id parse error
    Client->>Reader: Next valid request
    Reader->>Parser: Parse and validate
    Parser->>SDK: SessionMessage
    SDK-->>Client: Valid response
```

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): bound stdio frame nesting and ..."](https://github.com/thegaysupreme123/yoetz/commit/8bd972d094fc3967a70a2df16421aaa06e4734d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58257262)</sub>

<!-- /greptile_comment -->