### PR TITLE
fix(mcp): serialize the first availability probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,14 @@ reverse-chronological released versions.
 
 - The cooperative MCP bridge latches the first availability failure of its host binding
   (`service_unavailable`, `service_incompatible`, `protocol_mismatch`, `endpoint_unsafe`,
-  `peer_untrusted`). Later calls under a new `request_id` — including delegated workers sharing
-  the MCP process — inherit the same public error and `correlation_id` with
+  `peer_untrusted`). Concurrent first arrivals before that result share one on-demand attempt and
+  one diagnostic; later calls under a new `request_id` — including delegated workers sharing the
+  MCP process — inherit the same public error and `correlation_id` with
   `safe_details.availability: terminal_unavailable` and `availability_inherited: true`, and mint no
   new diagnostic, spawn, or supersede. The original `request_id` replay, a changed service holder,
   or one quiet successful handshake clears it. Agent guidance now carries a bounded
   `yoetz_availability` block into delegated assignments and forbids lifecycle commands from
-  `INTERNAL_ERROR` (issue #469).
+  `INTERNAL_ERROR` (issues #469, #476).
 
 - Codex activation recommendation decisions now bind the exact executable path/bytes/version,
   canonical home, activation preview, and rendered-cache digest. Another Codex home or a target

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1697,9 +1697,12 @@ about its host binding (this bridge process, its route profile, and the fixed en
 one request. The first such failure is returned with `safe_details.availability =
 "terminal_unavailable"`, `host_profile`, and `route_profile` beside the existing `reason_code`, and
 is latched in the bridge's private client slot together with the request id, the public error, its
-correlation id, and the advisory singleton-holder stamp observed at that moment. Every later call
-under a *different* request id — any tool, any delegate sharing the MCP process — is answered from
-that latch: same public code, same `correlation_id`, same `retryable`, the same `safe_details` plus
+correlation id, and the advisory singleton-holder stamp observed at that moment. Concurrent first
+arrivals before that result share one on-demand attempt: a slot-scoped in-flight gate parks later
+calls until the first probe completes, then they re-check the latch and inherit it (issue #476).
+Every later call under a *different* request id — any tool, any delegate sharing the MCP process —
+is answered from that latch: same public code, same `correlation_id`, same `retryable`, the same
+`safe_details` plus
 `availability_inherited: true` and `availability_request_id` (the original id), and a message
 suffix stating that no new diagnostic was recorded; no spawn, supersede, or diagnostic occurs.
 Three continuations clear the latch: the original request id replays (the sanctioned repair-then-

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1700,6 +1700,8 @@ is latched in the bridge's private client slot together with the request id, the
 correlation id, and the advisory singleton-holder stamp observed at that moment. Concurrent first
 arrivals before that result share one on-demand attempt: a slot-scoped in-flight gate parks later
 calls until the first probe completes, then they re-check the latch and inherit it (issue #476).
+The same in-flight gate covers a previously live client that then fails its handshake or
+reconnects after an availability `ControlError`, so that path also produces one on-demand attempt.
 Every later call under a *different* request id — any tool, any delegate sharing the MCP process —
 is answered from that latch: same public code, same `correlation_id`, same `retryable`, the same
 `safe_details` plus

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1699,7 +1699,9 @@ one request. The first such failure is returned with `safe_details.availability 
 is latched in the bridge's private client slot together with the request id, the public error, its
 correlation id, and the advisory singleton-holder stamp observed at that moment. Concurrent first
 arrivals before that result share one on-demand attempt: a slot-scoped in-flight gate parks later
-calls until the first probe completes, then they re-check the latch and inherit it (issue #476).
+calls until the first probe completes, then they inherit that completed latch without a quiet
+probe. This includes a concurrent duplicate of the winning request id; only a replay that arrives
+after the first attempt has completed takes the sanctioned repair path (issue #476).
 The same in-flight gate covers a previously live client that then fails its handshake or
 reconnects after an availability `ControlError`, so that path also produces one on-demand attempt.
 Every later call under a *different* request id — any tool, any delegate sharing the MCP process —

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -105,7 +105,10 @@ yoetz service restart
 
 `yoetz service status` names the incompatible holder's pid, version, and manifest digest. Other
 hosts' sessions still running the previous build's bridge are refused after the switch until they
-restart; that is the intended outcome of an upgrade, not a defect.
+restart; that is the intended outcome of an upgrade, not a defect. The cooperative MCP bridge
+latches that availability failure for the process and serializes the first on-demand attempt so
+concurrent tool calls share one diagnostic (issues #469, #476); that behaviour is shared across
+hosts that use this bridge, not Claude-Code-specific.
 
 ## Static and host validation
 

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -142,7 +142,10 @@ yoetz service restart
 
 `yoetz service status` names the incompatible holder's pid, version, and manifest digest. Other
 hosts' sessions still running the previous build's bridge are refused after the switch until they
-restart; that is the intended outcome of an upgrade, not a defect.
+restart; that is the intended outcome of an upgrade, not a defect. The cooperative MCP bridge
+latches that availability failure for the process and serializes the first on-demand attempt so
+concurrent tool calls share one diagnostic (issues #469, #476); that behaviour is shared across
+hosts that use this bridge, not Codex-specific.
 
 The accepted setup path composes four separately reported layers in order: it installs the project
 skill at `.agents/skills/yoetz`, installs managed structural plugin/hook sources at

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -151,7 +151,9 @@ bridge process. The bridge latches the first availability failure of that bindin
 `peer_untrusted`): the parent's error carries `safe_details.availability: terminal_unavailable`
 with `host_profile`/`route_profile`, and every later call under a new `request_id` — any tool,
 any worker — returns the same `correlation_id` with `availability_inherited: true` and mints no
-new diagnostic, startup, or supersede. It clears when the original `request_id` replays after the
+new diagnostic, startup, or supersede. Parallel first calls (ordinary host behaviour) share that
+same single attempt: they do not each mint a diagnostic before the latch exists (issue #476). The
+latch clears when the original `request_id` replays after the
 named repair, when `yoetz service run|restart|stop` changes the stamped holder, or (retryable
 classes only) when one quiet handshake succeeds. The skill tells the coordinator to carry a
 bounded `yoetz_availability` block into each assignment and tells delegates that inherit it to

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -1032,15 +1032,10 @@ async def _prepare_availability(
 
     slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
     while True:
-        inherited = await _inherit_terminal_availability(runtime, request_id)
-        if inherited is not None:
-            return _AvailabilityDecision(inherited, False)
         waiter: asyncio.Event | None = None
         async with slot.lock:
             if slot.availability is not None:
-                # Inherit returned None: this is the original request identity, which always
-                # replays (issue #469).
-                return _AvailabilityDecision(None, False)
+                break
             if slot.attempting:
                 waiter = slot.attempt_finished
             elif slot.client is not None:
@@ -1050,8 +1045,13 @@ async def _prepare_availability(
                 slot.attempt_finished = asyncio.Event()
                 return _AvailabilityDecision(None, True)
         if waiter is None:
-            return _AvailabilityDecision(None, False)
+            break
         await waiter.wait()
+    inherited = await _inherit_terminal_availability(runtime, request_id)
+    if inherited is not None:
+        return _AvailabilityDecision(inherited, False)
+    # Latch present and inherit returned None: original request identity replay (issue #469).
+    return _AvailabilityDecision(None, False)
 
 
 async def _inherit_after_inflight_availability(

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -318,14 +318,16 @@ async def ensure_service_client(
     runtime: BridgeRuntime = BRIDGE_RUNTIME,
     *,
     request_id: str | None = None,
+    retain_availability_failure_for_latch: bool = False,
 ) -> ServiceClient:
     """Return one live ordinary client, lazily connecting without starting the service.
 
     On-demand connect is slot-scoped: concurrent callers share one probe (issue #476), including
     the path where a previously live client then fails its handshake and must reconnect.
-    Non-availability failures release the gate so the next caller can probe; availability
-    failures leave it set until ``_latch_availability`` stores the latch. The original request
-    identity still replays through a latched outage (issue #469).
+    Failures release the gate so the next caller cannot be stranded. The ordinary dispatch path
+    opts into retaining an availability failure only long enough for ``_latch_availability`` to
+    store the shared public result. The original request identity still replays through a latched
+    outage (issue #469).
     """
 
     slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
@@ -360,12 +362,13 @@ async def ensure_service_client(
                             workspace_locator=runtime.workspace_locator,
                         )
                         await connected_attempt.connect()
-                    except Exception as exc:
+                    except BaseException as exc:
                         slot.client = None
                         if connected_attempt is not None:
                             await _close_client(connected_attempt)
                         keep_gate = (
-                            isinstance(exc, ControlError)
+                            retain_availability_failure_for_latch
+                            and isinstance(exc, ControlError)
                             and exc.reason in _AVAILABILITY_LATCH_REASONS
                         )
                         raise
@@ -377,7 +380,7 @@ async def ensure_service_client(
             if waiter is None:
                 continue
             await waiter.wait()
-    except Exception:
+    except BaseException:
         if not keep_gate:
             await _finish_availability_attempt(runtime)
         raise
@@ -1013,7 +1016,10 @@ async def _quiet_probe(runtime: BridgeRuntime) -> ServiceClient | None:
 
 
 async def _inherit_terminal_availability(
-    runtime: BridgeRuntime, request_id: str | None
+    runtime: BridgeRuntime,
+    request_id: str | None,
+    *,
+    concurrent_waiter: bool = False,
 ) -> types.CallToolResult | None:
     """Answer a new request identity from the latched availability result, or clear the latch.
 
@@ -1028,20 +1034,21 @@ async def _inherit_terminal_availability(
         latch = slot.availability
         if latch is None:
             return None
-        if request_id is not None and request_id == latch.request_id:
-            return None
-        if _holder_snapshot() != latch.holder:
-            slot.availability = None
-            return None
-        if latch.retryable:
-            probe = await _quiet_probe(runtime)
-            if probe is not None:
-                stale = slot.client
-                slot.client = probe
-                slot.availability = None
-                if stale is not None and stale is not probe:
-                    await _close_client(stale)
+        if not concurrent_waiter:
+            if request_id is not None and request_id == latch.request_id:
                 return None
+            if _holder_snapshot() != latch.holder:
+                slot.availability = None
+                return None
+            if latch.retryable:
+                probe = await _quiet_probe(runtime)
+                if probe is not None:
+                    stale = slot.client
+                    slot.client = probe
+                    slot.availability = None
+                    if stale is not None and stale is not probe:
+                        await _close_client(stale)
+                    return None
         latch.inherited += 1
         details = dict(latch.safe_details)
         details["availability_inherited"] = True
@@ -1088,6 +1095,7 @@ async def _inherit_after_inflight_availability(
     """
 
     slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+    waited = False
     while True:
         waiter: asyncio.Event | None = None
         async with slot.lock:
@@ -1096,8 +1104,9 @@ async def _inherit_after_inflight_availability(
             waiter = slot.attempt_finished
         if waiter is None:
             break
+        waited = True
         await waiter.wait()
-    return await _inherit_terminal_availability(runtime, request_id)
+    return await _inherit_terminal_availability(runtime, request_id, concurrent_waiter=waited)
 
 
 async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
@@ -1105,8 +1114,14 @@ async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
     request: RequestT,
     invoke: Callable[[ServiceClient, RequestT], Awaitable[ResultT]],
     request_id: str | None,
+    *,
+    retain_availability_failure_for_latch: bool = False,
 ) -> ResultT:
-    client = await ensure_service_client(runtime, request_id=request_id)
+    client = await ensure_service_client(
+        runtime,
+        request_id=request_id,
+        retain_availability_failure_for_latch=retain_availability_failure_for_latch,
+    )
     try:
         return await invoke(client, request)
     except ControlError as error:
@@ -1114,7 +1129,11 @@ async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
             await _discard_client(runtime, client)
         if not error.retryable or error.reason not in _RECONNECT_REASONS:
             raise
-        replacement = await ensure_service_client(runtime, request_id=request_id)
+        replacement = await ensure_service_client(
+            runtime,
+            request_id=request_id,
+            retain_availability_failure_for_latch=retain_availability_failure_for_latch,
+        )
         return await invoke(replacement, request)
 
 
@@ -1161,7 +1180,13 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
     # Invoke first. Once this returns, a write may already be durable; response shaping must not
     # collapse that into a non-retryable INTERNAL_ERROR that steers agents away from same-id resume.
     try:
-        result = await _invoke_with_reconnect(runtime, request, invoke, request_id)
+        result = await _invoke_with_reconnect(
+            runtime,
+            request,
+            invoke,
+            request_id,
+            retain_availability_failure_for_latch=True,
+        )
     except PublicOperationError as exc:
         # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
         # PublicOperationError escapes the service boundary, keep the exact public code.
@@ -1414,7 +1439,6 @@ async def _publish_recovery_from_envelope(
         return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
 
     try:
-        await ensure_service_client(runtime, request_id=recovery_request_id)
         status_result = await _invoke_with_reconnect(
             runtime,
             status_request,

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -127,8 +127,10 @@ _DISCARD_CLIENT_REASONS: Final = _RECONNECT_REASONS | {"vault_locked"}
 # service holder), not one request. Once one call has reported such a failure, later calls under
 # a *new* request identity inherit that terminal state instead of re-probing, re-spawning, or
 # minting another diagnostic (issue #469: delegated Cursor workers each retried `start`). The
-# latch clears when the stamped service holder changes, when a quiet handshake succeeds for a
-# retryable class, or when the original request identity replays — the sanctioned continuation.
+# first probe is slot-scoped: concurrent arrivals before that result wait for it rather than each
+# minting a diagnostic (issue #476). The latch clears when the stamped service holder changes,
+# when a quiet handshake succeeds for a retryable class, or when the original request identity
+# replays — the sanctioned continuation.
 _AVAILABILITY_LATCH_REASONS: Final = frozenset(
     {
         "service_unavailable",
@@ -235,11 +237,23 @@ class _AvailabilityLatch:
     inherited: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class _AvailabilityDecision:
+    """Whether this call inherits a latched outage or proceeds, possibly owning the first probe."""
+
+    result: types.CallToolResult | None
+    claimed_attempt: bool
+
+
 @dataclass(slots=True)
 class _ClientSlot:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     client: ServiceClient | None = None
     availability: _AvailabilityLatch | None = None
+    # Concurrent first arrivals share one on-demand probe: the owner sets attempting, waiters
+    # park on attempt_finished, then re-check the completed latch (issue #476).
+    attempting: bool = False
+    attempt_finished: asyncio.Event | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -993,6 +1007,75 @@ async def _inherit_terminal_availability(
         )
 
 
+async def _finish_availability_attempt(runtime: BridgeRuntime) -> None:
+    """Release the first-probe gate so waiters can inherit the completed latch or proceed."""
+
+    slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+    async with slot.lock:
+        slot.attempting = False
+        finished = slot.attempt_finished
+        slot.attempt_finished = None
+    if finished is not None:
+        finished.set()
+
+
+async def _prepare_availability(
+    runtime: BridgeRuntime, request_id: str | None
+) -> _AvailabilityDecision:
+    """Inherit a completed latch, wait for an in-flight first probe, or claim that probe.
+
+    ``ensure_service_client`` holds the slot lock for the whole on-demand connect, so a completed
+    latch stored *after* that release is what concurrent first arrivals used to miss. Claiming
+    ``attempting`` before the connect closes that window: later arrivals wait, then inherit
+    (issue #476). A live client or the original request-id replay proceeds without claiming.
+    """
+
+    slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+    while True:
+        inherited = await _inherit_terminal_availability(runtime, request_id)
+        if inherited is not None:
+            return _AvailabilityDecision(inherited, False)
+        waiter: asyncio.Event | None = None
+        async with slot.lock:
+            if slot.availability is not None:
+                # Inherit returned None: this is the original request identity, which always
+                # replays (issue #469).
+                return _AvailabilityDecision(None, False)
+            if slot.attempting:
+                waiter = slot.attempt_finished
+            elif slot.client is not None:
+                return _AvailabilityDecision(None, False)
+            else:
+                slot.attempting = True
+                slot.attempt_finished = asyncio.Event()
+                return _AvailabilityDecision(None, True)
+        if waiter is None:
+            return _AvailabilityDecision(None, False)
+        await waiter.wait()
+
+
+async def _inherit_after_inflight_availability(
+    runtime: BridgeRuntime, request_id: str | None
+) -> types.CallToolResult | None:
+    """Wait for an in-flight first probe, then inherit a completed latch without claiming one.
+
+    Envelope-first publish recovery is an oracle read: it must not start a second on-demand
+    attempt while another tool call already owns the first probe.
+    """
+
+    slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+    while True:
+        waiter: asyncio.Event | None = None
+        async with slot.lock:
+            if not slot.attempting:
+                break
+            waiter = slot.attempt_finished
+        if waiter is None:
+            break
+        await waiter.wait()
+    return await _inherit_terminal_availability(runtime, request_id)
+
+
 async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
     runtime: BridgeRuntime,
     request: RequestT,
@@ -1047,38 +1130,64 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
             correlation_id=correlation_id,
             host_profile=runtime.host_profile,
         )
-    inherited = await _inherit_terminal_availability(runtime, request_id)
-    if inherited is not None:
-        return inherited
+    prepared = await _prepare_availability(runtime, request_id)
+    if prepared.result is not None:
+        return prepared.result
+    claimed = prepared.claimed_attempt
     # Invoke first. Once this returns, a write may already be durable; response shaping must not
     # collapse that into a non-retryable INTERNAL_ERROR that steers agents away from same-id resume.
     try:
-        result = await _invoke_with_reconnect(runtime, request, invoke)
-    except PublicOperationError as exc:
-        # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
-        # PublicOperationError escapes the service boundary, keep the exact public code.
         try:
-            bound = (
-                exc
-                if exc.correlation_id is not None
-                else exc.bind_correlation_id(
-                    record_public_error_without_raising(
-                        component="mcp.bridge",
-                        operation=_public_error_operation(operation),
-                        reason=exc.code.value.lower(),
-                        request_id=request_id,
+            result = await _invoke_with_reconnect(runtime, request, invoke)
+        except PublicOperationError as exc:
+            # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
+            # PublicOperationError escapes the service boundary, keep the exact public code.
+            try:
+                bound = (
+                    exc
+                    if exc.correlation_id is not None
+                    else exc.bind_correlation_id(
+                        record_public_error_without_raising(
+                            component="mcp.bridge",
+                            operation=_public_error_operation(operation),
+                            reason=exc.code.value.lower(),
+                            request_id=request_id,
+                        )
                     )
                 )
-            )
-            return _result_from_wire(
-                tool_error_envelope(bound, request_id=request_id),
+                return _result_from_wire(
+                    tool_error_envelope(bound, request_id=request_id),
+                    host_profile=runtime.host_profile,
+                )
+            except Exception as mapping_exc:
+                correlation_id = record_unexpected_exception_without_raising(
+                    mapping_exc,
+                    component="mcp.bridge",
+                    operation=f"{operation}_public_error_internal_error",
+                    request_id=request_id,
+                )
+                return structured_error_result(
+                    PublicErrorCode.INTERNAL_ERROR,
+                    "The bridge could not complete the operation.",
+                    request_id=request_id,
+                    correlation_id=correlation_id,
+                    host_profile=runtime.host_profile,
+                )
+        except ControlError as exc:
+            failure = _control_error_result(
+                exc,
+                request_id,
+                operation,
                 host_profile=runtime.host_profile,
             )
-        except Exception as mapping_exc:
+            if exc.reason in _AVAILABILITY_LATCH_REASONS:
+                return await _latch_availability(runtime, request_id, exc, failure)
+            return failure
+        except Exception as exc:
             correlation_id = record_unexpected_exception_without_raising(
-                mapping_exc,
+                exc,
                 component="mcp.bridge",
-                operation=f"{operation}_public_error_internal_error",
+                operation=f"{operation}_internal_error",
                 request_id=request_id,
             )
             return structured_error_result(
@@ -1088,52 +1197,31 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
                 correlation_id=correlation_id,
                 host_profile=runtime.host_profile,
             )
-    except ControlError as exc:
-        failure = _control_error_result(
-            exc,
-            request_id,
-            operation,
-            host_profile=runtime.host_profile,
-        )
-        if exc.reason in _AVAILABILITY_LATCH_REASONS:
-            return await _latch_availability(runtime, request_id, exc, failure)
-        return failure
-    except Exception as exc:
-        correlation_id = record_unexpected_exception_without_raising(
-            exc,
-            component="mcp.bridge",
-            operation=f"{operation}_internal_error",
-            request_id=request_id,
-        )
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            "The bridge could not complete the operation.",
-            request_id=request_id,
-            correlation_id=correlation_id,
-            host_profile=runtime.host_profile,
-        )
 
-    await _clear_availability(runtime)
-    try:
-        wire = public_model_to_wire(result)
-        validated = result_type.model_validate(wire)
-        return result_from_public_model(validated, host_profile=runtime.host_profile)
-    except Exception as exc:
-        correlation_id = record_unexpected_exception_without_raising(
-            exc,
-            component="mcp.bridge",
-            operation=f"{operation}_response_projection_failed",
-            request_id=request_id,
-        )
-        return structured_error_result(
-            PublicErrorCode.INTERNAL_ERROR,
-            _RESPONSE_PROJECTION_FAILED_MESSAGE,
-            retryable=True,
-            request_id=request_id,
-            correlation_id=correlation_id,
-            safe_details=dict(_RESPONSE_PROJECTION_FAILED_DETAILS),
-            host_profile=runtime.host_profile,
-        )
+        await _clear_availability(runtime)
+        try:
+            wire = public_model_to_wire(result)
+            validated = result_type.model_validate(wire)
+            return result_from_public_model(validated, host_profile=runtime.host_profile)
+        except Exception as exc:
+            correlation_id = record_unexpected_exception_without_raising(
+                exc,
+                component="mcp.bridge",
+                operation=f"{operation}_response_projection_failed",
+                request_id=request_id,
+            )
+            return structured_error_result(
+                PublicErrorCode.INTERNAL_ERROR,
+                _RESPONSE_PROJECTION_FAILED_MESSAGE,
+                retryable=True,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                safe_details=dict(_RESPONSE_PROJECTION_FAILED_DETAILS),
+                host_profile=runtime.host_profile,
+            )
+    finally:
+        if claimed:
+            await _finish_availability_attempt(runtime)
 
 
 async def dispatch_start(
@@ -1412,7 +1500,7 @@ async def dispatch_publish_work(
             # The recovery oracle is the service itself. Under a latched availability result a
             # new request identity must not reach it (no startup, supersede, or diagnostic); the
             # lookup is simply unavailable and the certain authoring error leads (#239, #469).
-            if await _inherit_terminal_availability(runtime, request_id) is not None:
+            if await _inherit_after_inflight_availability(runtime, request_id) is not None:
                 recovery = _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
             else:
                 recovery = await _publish_recovery_from_envelope(arguments, runtime, request_id)

--- a/src/yoetz/mcp/server.py
+++ b/src/yoetz/mcp/server.py
@@ -237,14 +237,6 @@ class _AvailabilityLatch:
     inherited: int = 0
 
 
-@dataclass(frozen=True, slots=True)
-class _AvailabilityDecision:
-    """Whether this call inherits a latched outage or proceeds, possibly owning the first probe."""
-
-    result: types.CallToolResult | None
-    claimed_attempt: bool
-
-
 @dataclass(slots=True)
 class _ClientSlot:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -322,33 +314,73 @@ async def _discard_client(runtime: BridgeRuntime, client: ServiceClient) -> None
     await _close_client(client)
 
 
-async def ensure_service_client(runtime: BridgeRuntime = BRIDGE_RUNTIME) -> ServiceClient:
-    """Return one live ordinary client, lazily connecting without starting the service."""
+async def ensure_service_client(
+    runtime: BridgeRuntime = BRIDGE_RUNTIME,
+    *,
+    request_id: str | None = None,
+) -> ServiceClient:
+    """Return one live ordinary client, lazily connecting without starting the service.
 
-    async with runtime._slot.lock:  # pyright: ignore[reportPrivateUsage]
-        existing = runtime._slot.client  # pyright: ignore[reportPrivateUsage]
-        if existing is not None:
-            try:
-                await existing.connect()
-            except Exception:
-                runtime._slot.client = None  # pyright: ignore[reportPrivateUsage]
-                await _close_client(existing)
-            else:
-                return existing
-        connected: ServiceClient | None = None
-        try:
-            connected = await connect_service_on_demand(
-                ControlClientKind.MCP_BRIDGE,
-                workspace_locator=runtime.workspace_locator,
-            )
-            await connected.connect()
-        except Exception:
-            runtime._slot.client = None  # pyright: ignore[reportPrivateUsage]
+    On-demand connect is slot-scoped: concurrent callers share one probe (issue #476), including
+    the path where a previously live client then fails its handshake and must reconnect.
+    Non-availability failures release the gate so the next caller can probe; availability
+    failures leave it set until ``_latch_availability`` stores the latch. The original request
+    identity still replays through a latched outage (issue #469).
+    """
+
+    slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+    keep_gate = False
+    try:
+        while True:
+            waiter: asyncio.Event | None = None
+            connected: ServiceClient | None = None
+            async with slot.lock:
+                if slot.availability is not None:
+                    latch = slot.availability
+                    if request_id is None or request_id != latch.request_id:
+                        raise ControlError(latch.reason, retryable=latch.retryable)
+                existing = slot.client
+                if existing is not None:
+                    try:
+                        await existing.connect()
+                    except Exception:
+                        slot.client = None
+                        await _close_client(existing)
+                    else:
+                        return existing
+                if slot.attempting:
+                    waiter = slot.attempt_finished
+                else:
+                    slot.attempting = True
+                    slot.attempt_finished = asyncio.Event()
+                    connected_attempt: ServiceClient | None = None
+                    try:
+                        connected_attempt = await connect_service_on_demand(
+                            ControlClientKind.MCP_BRIDGE,
+                            workspace_locator=runtime.workspace_locator,
+                        )
+                        await connected_attempt.connect()
+                    except Exception as exc:
+                        slot.client = None
+                        if connected_attempt is not None:
+                            await _close_client(connected_attempt)
+                        keep_gate = (
+                            isinstance(exc, ControlError)
+                            and exc.reason in _AVAILABILITY_LATCH_REASONS
+                        )
+                        raise
+                    slot.client = connected_attempt
+                    connected = connected_attempt
             if connected is not None:
-                await _close_client(connected)
-            raise
-        runtime._slot.client = connected  # pyright: ignore[reportPrivateUsage]
-        return connected
+                await _finish_availability_attempt(runtime)
+                return connected
+            if waiter is None:
+                continue
+            await waiter.wait()
+    except Exception:
+        if not keep_gate:
+            await _finish_availability_attempt(runtime)
+        raise
 
 
 async def close_bridge_runtime(runtime: BridgeRuntime = BRIDGE_RUNTIME) -> None:
@@ -895,48 +927,67 @@ async def _latch_availability(
 ) -> types.CallToolResult:
     """Record a terminal availability result for this binding and return it with that fact."""
 
-    wire = _wire_error(result)
-    if wire is None:
-        return result
-    code_value = wire.get("code")
-    message = wire.get("message")
-    retryable = wire.get("retryable")
-    correlation_id = wire.get("correlation_id")
-    if (
-        type(code_value) is not str
-        or type(message) is not str
-        or type(retryable) is not bool
-        or type(correlation_id) is not str
-    ):
-        return result
     try:
-        code = PublicErrorCode(code_value)
-    except ValueError:
-        return result
-    details = _availability_details(
-        wire.get("safe_details"), runtime.host_profile, runtime.route_profile
-    )
-    latch = _AvailabilityLatch(
-        request_id,
-        error.reason,
-        code,
-        message,
-        retryable,
-        correlation_id,
-        details,
-        _holder_snapshot(),
-    )
-    async with runtime._slot.lock:  # pyright: ignore[reportPrivateUsage]
-        runtime._slot.availability = latch  # pyright: ignore[reportPrivateUsage]
-    return structured_error_result(
-        code,
-        message,
-        retryable=retryable,
-        request_id=request_id,
-        correlation_id=correlation_id,
-        safe_details=details,
-        host_profile=runtime.host_profile,
-    )
+        slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
+        wire = _wire_error(result)
+        if wire is None:
+            return result
+        code_value = wire.get("code")
+        message = wire.get("message")
+        retryable = wire.get("retryable")
+        correlation_id = wire.get("correlation_id")
+        if (
+            type(code_value) is not str
+            or type(message) is not str
+            or type(retryable) is not bool
+            or type(correlation_id) is not str
+        ):
+            return result
+        try:
+            code = PublicErrorCode(code_value)
+        except ValueError:
+            return result
+        details = _availability_details(
+            wire.get("safe_details"), runtime.host_profile, runtime.route_profile
+        )
+        latch = _AvailabilityLatch(
+            request_id,
+            error.reason,
+            code,
+            message,
+            retryable,
+            correlation_id,
+            details,
+            _holder_snapshot(),
+        )
+        already = False
+        async with slot.lock:
+            existing = slot.availability
+            if (
+                existing is not None
+                and request_id is not None
+                and request_id == existing.request_id
+            ):
+                slot.availability = latch
+            elif existing is not None:
+                already = True
+            else:
+                slot.availability = latch
+        if already:
+            inherited = await _inherit_terminal_availability(runtime, request_id)
+            if inherited is not None:
+                return inherited
+        return structured_error_result(
+            code,
+            message,
+            retryable=retryable,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            safe_details=details,
+            host_profile=runtime.host_profile,
+        )
+    finally:
+        await _finish_availability_attempt(runtime)
 
 
 async def _clear_availability(runtime: BridgeRuntime) -> None:
@@ -1021,37 +1072,10 @@ async def _finish_availability_attempt(runtime: BridgeRuntime) -> None:
 
 async def _prepare_availability(
     runtime: BridgeRuntime, request_id: str | None
-) -> _AvailabilityDecision:
-    """Inherit a completed latch, wait for an in-flight first probe, or claim that probe.
+) -> types.CallToolResult | None:
+    """Wait for an in-flight on-demand probe, then inherit a completed latch if one exists."""
 
-    ``ensure_service_client`` holds the slot lock for the whole on-demand connect, so a completed
-    latch stored *after* that release is what concurrent first arrivals used to miss. Claiming
-    ``attempting`` before the connect closes that window: later arrivals wait, then inherit
-    (issue #476). A live client or the original request-id replay proceeds without claiming.
-    """
-
-    slot = runtime._slot  # pyright: ignore[reportPrivateUsage]
-    while True:
-        waiter: asyncio.Event | None = None
-        async with slot.lock:
-            if slot.availability is not None:
-                break
-            if slot.attempting:
-                waiter = slot.attempt_finished
-            elif slot.client is not None:
-                return _AvailabilityDecision(None, False)
-            else:
-                slot.attempting = True
-                slot.attempt_finished = asyncio.Event()
-                return _AvailabilityDecision(None, True)
-        if waiter is None:
-            break
-        await waiter.wait()
-    inherited = await _inherit_terminal_availability(runtime, request_id)
-    if inherited is not None:
-        return _AvailabilityDecision(inherited, False)
-    # Latch present and inherit returned None: original request identity replay (issue #469).
-    return _AvailabilityDecision(None, False)
+    return await _inherit_after_inflight_availability(runtime, request_id)
 
 
 async def _inherit_after_inflight_availability(
@@ -1080,8 +1104,9 @@ async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
     runtime: BridgeRuntime,
     request: RequestT,
     invoke: Callable[[ServiceClient, RequestT], Awaitable[ResultT]],
+    request_id: str | None,
 ) -> ResultT:
-    client = await ensure_service_client(runtime)
+    client = await ensure_service_client(runtime, request_id=request_id)
     try:
         return await invoke(client, request)
     except ControlError as error:
@@ -1089,7 +1114,7 @@ async def _invoke_with_reconnect[RequestT: BaseModel, ResultT: BaseModel](
             await _discard_client(runtime, client)
         if not error.retryable or error.reason not in _RECONNECT_REASONS:
             raise
-        replacement = await ensure_service_client(runtime)
+        replacement = await ensure_service_client(runtime, request_id=request_id)
         return await invoke(replacement, request)
 
 
@@ -1130,64 +1155,38 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
             correlation_id=correlation_id,
             host_profile=runtime.host_profile,
         )
-    prepared = await _prepare_availability(runtime, request_id)
-    if prepared.result is not None:
-        return prepared.result
-    claimed = prepared.claimed_attempt
+    inherited = await _prepare_availability(runtime, request_id)
+    if inherited is not None:
+        return inherited
     # Invoke first. Once this returns, a write may already be durable; response shaping must not
     # collapse that into a non-retryable INTERNAL_ERROR that steers agents away from same-id resume.
     try:
+        result = await _invoke_with_reconnect(runtime, request, invoke, request_id)
+    except PublicOperationError as exc:
+        # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
+        # PublicOperationError escapes the service boundary, keep the exact public code.
         try:
-            result = await _invoke_with_reconnect(runtime, request, invoke)
-        except PublicOperationError as exc:
-            # Defense in depth: the ordinary client normally returns ok:false bodies, but if a
-            # PublicOperationError escapes the service boundary, keep the exact public code.
-            try:
-                bound = (
-                    exc
-                    if exc.correlation_id is not None
-                    else exc.bind_correlation_id(
-                        record_public_error_without_raising(
-                            component="mcp.bridge",
-                            operation=_public_error_operation(operation),
-                            reason=exc.code.value.lower(),
-                            request_id=request_id,
-                        )
+            bound = (
+                exc
+                if exc.correlation_id is not None
+                else exc.bind_correlation_id(
+                    record_public_error_without_raising(
+                        component="mcp.bridge",
+                        operation=_public_error_operation(operation),
+                        reason=exc.code.value.lower(),
+                        request_id=request_id,
                     )
                 )
-                return _result_from_wire(
-                    tool_error_envelope(bound, request_id=request_id),
-                    host_profile=runtime.host_profile,
-                )
-            except Exception as mapping_exc:
-                correlation_id = record_unexpected_exception_without_raising(
-                    mapping_exc,
-                    component="mcp.bridge",
-                    operation=f"{operation}_public_error_internal_error",
-                    request_id=request_id,
-                )
-                return structured_error_result(
-                    PublicErrorCode.INTERNAL_ERROR,
-                    "The bridge could not complete the operation.",
-                    request_id=request_id,
-                    correlation_id=correlation_id,
-                    host_profile=runtime.host_profile,
-                )
-        except ControlError as exc:
-            failure = _control_error_result(
-                exc,
-                request_id,
-                operation,
+            )
+            return _result_from_wire(
+                tool_error_envelope(bound, request_id=request_id),
                 host_profile=runtime.host_profile,
             )
-            if exc.reason in _AVAILABILITY_LATCH_REASONS:
-                return await _latch_availability(runtime, request_id, exc, failure)
-            return failure
-        except Exception as exc:
+        except Exception as mapping_exc:
             correlation_id = record_unexpected_exception_without_raising(
-                exc,
+                mapping_exc,
                 component="mcp.bridge",
-                operation=f"{operation}_internal_error",
+                operation=f"{operation}_public_error_internal_error",
                 request_id=request_id,
             )
             return structured_error_result(
@@ -1197,31 +1196,60 @@ async def _dispatch[RequestT: BaseModel, ResultT: BaseModel](
                 correlation_id=correlation_id,
                 host_profile=runtime.host_profile,
             )
-
-        await _clear_availability(runtime)
-        try:
-            wire = public_model_to_wire(result)
-            validated = result_type.model_validate(wire)
-            return result_from_public_model(validated, host_profile=runtime.host_profile)
-        except Exception as exc:
-            correlation_id = record_unexpected_exception_without_raising(
+    except ControlError as exc:
+        if exc.reason in _AVAILABILITY_LATCH_REASONS:
+            inherited_failure = await _inherit_terminal_availability(runtime, request_id)
+            if inherited_failure is not None:
+                return inherited_failure
+            failure = _control_error_result(
                 exc,
-                component="mcp.bridge",
-                operation=f"{operation}_response_projection_failed",
-                request_id=request_id,
-            )
-            return structured_error_result(
-                PublicErrorCode.INTERNAL_ERROR,
-                _RESPONSE_PROJECTION_FAILED_MESSAGE,
-                retryable=True,
-                request_id=request_id,
-                correlation_id=correlation_id,
-                safe_details=dict(_RESPONSE_PROJECTION_FAILED_DETAILS),
+                request_id,
+                operation,
                 host_profile=runtime.host_profile,
             )
-    finally:
-        if claimed:
-            await _finish_availability_attempt(runtime)
+            return await _latch_availability(runtime, request_id, exc, failure)
+        return _control_error_result(
+            exc,
+            request_id,
+            operation,
+            host_profile=runtime.host_profile,
+        )
+    except Exception as exc:
+        correlation_id = record_unexpected_exception_without_raising(
+            exc,
+            component="mcp.bridge",
+            operation=f"{operation}_internal_error",
+            request_id=request_id,
+        )
+        return structured_error_result(
+            PublicErrorCode.INTERNAL_ERROR,
+            "The bridge could not complete the operation.",
+            request_id=request_id,
+            correlation_id=correlation_id,
+            host_profile=runtime.host_profile,
+        )
+
+    await _clear_availability(runtime)
+    try:
+        wire = public_model_to_wire(result)
+        validated = result_type.model_validate(wire)
+        return result_from_public_model(validated, host_profile=runtime.host_profile)
+    except Exception as exc:
+        correlation_id = record_unexpected_exception_without_raising(
+            exc,
+            component="mcp.bridge",
+            operation=f"{operation}_response_projection_failed",
+            request_id=request_id,
+        )
+        return structured_error_result(
+            PublicErrorCode.INTERNAL_ERROR,
+            _RESPONSE_PROJECTION_FAILED_MESSAGE,
+            retryable=True,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            safe_details=dict(_RESPONSE_PROJECTION_FAILED_DETAILS),
+            host_profile=runtime.host_profile,
+        )
 
 
 async def dispatch_start(
@@ -1386,11 +1414,12 @@ async def _publish_recovery_from_envelope(
         return _PublishRecoveryOutcome(_PublishRecoveryKind.UNAVAILABLE)
 
     try:
-        await ensure_service_client(runtime)
+        await ensure_service_client(runtime, request_id=recovery_request_id)
         status_result = await _invoke_with_reconnect(
             runtime,
             status_request,
             lambda service, request: service.status(request, deadline_ms=_WORKFLOW_RPC_DEADLINE_MS),
+            recovery_request_id,
         )
     except PublicOperationError as exc:
         # A nested public failure (session conflict, projection, etc.) does not prove the

--- a/tests/unit/mcp/test_availability_latch.py
+++ b/tests/unit/mcp/test_availability_latch.py
@@ -11,6 +11,7 @@ parent's correlation with ``availability_inherited: true``, and only the sanctio
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import cast
@@ -131,11 +132,17 @@ class _Harness:
         self.on_demand_failure: BaseException | None = None
         self.on_demand_client: _FakeClient | None = None
         self.quiet_client: _FakeClient | None = None
+        self.entered_on_demand = asyncio.Event()
+        self.release_on_demand = asyncio.Event()
+        self.stall_on_demand = False
         original = bridge.record_public_error_without_raising
 
         async def on_demand(_kind: object, *, workspace_locator: object = None) -> object:
             del workspace_locator
             self.on_demand.append("connect")
+            self.entered_on_demand.set()
+            if self.stall_on_demand:
+                await self.release_on_demand.wait()
             if self.on_demand_failure is not None:
                 raise self.on_demand_failure
             assert self.on_demand_client is not None
@@ -220,6 +227,95 @@ async def test_parent_terminal_start_is_inherited_by_three_delegates_without_any
     assert harness.on_demand == ["connect"]
     assert harness.recorded == ["service_incompatible"]
     assert harness.quiet == len(_DELEGATES)
+
+
+@pytest.mark.anyio
+async def test_concurrent_first_arrivals_share_one_on_demand_attempt_and_one_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Issue #476: N parallel first calls share one probe, one diagnostic, and N−1 inheritances."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_unavailable", retryable=True)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+    request_ids = (_PARENT, *_DELEGATES)
+
+    tasks = [
+        asyncio.create_task(bridge.dispatch_start(_start(request_id), runtime))
+        for request_id in request_ids
+    ]
+    await harness.entered_on_demand.wait()
+    assert harness.on_demand == ["connect"]
+    harness.release_on_demand.set()
+    results = [_error(result) for result in await asyncio.gather(*tasks)]
+
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded == ["service_unavailable"]
+    correlations = {result["correlation_id"] for result in results}
+    assert len(correlations) == 1
+    first = [
+        result
+        for result in results
+        if "availability_inherited" not in cast(dict[str, object], result["safe_details"])
+    ]
+    inherited = [
+        result
+        for result in results
+        if cast(dict[str, object], result["safe_details"]).get("availability_inherited") is True
+    ]
+    assert len(first) == 1
+    assert len(inherited) == len(request_ids) - 1
+    winner_details = cast(dict[str, object], inherited[0]["safe_details"])
+    winner_request_id = winner_details["availability_request_id"]
+    assert winner_request_id in request_ids
+    for result in inherited:
+        details = cast(dict[str, object], result["safe_details"])
+        assert result["correlation_id"] == first[0]["correlation_id"]
+        assert result["retryable"] is True
+        assert details["availability"] == "terminal_unavailable"
+        assert details["availability_inherited"] is True
+        assert details["availability_request_id"] == winner_request_id
+        assert "no new diagnostic was recorded" in cast(str, result["message"])
+
+    harness.stall_on_demand = False
+    harness.on_demand_failure = None
+    harness.on_demand_client = _FakeClient()
+    assert type(winner_request_id) is str
+    replay = _error(await bridge.dispatch_start(_start(winner_request_id), runtime))
+    assert replay["code"] == "SESSION_CONFLICT"
+    assert harness.on_demand == ["connect", "connect"]
+
+
+@pytest.mark.anyio
+async def test_invalid_publish_waits_for_in_flight_first_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Envelope-first recovery must not start a second on-demand probe during the first attempt."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_incompatible", retryable=True)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+
+    start_task = asyncio.create_task(bridge.dispatch_start(_start(_PARENT), runtime))
+    await harness.entered_on_demand.wait()
+    invalid = _status(_DELEGATES[0])
+    invalid.pop("view")
+    invalid.pop("limit")
+    invalid["expected_frontier"] = {"sequence": "0", "head_digest": "genesis"}
+    invalid["event_drafts"] = "not-a-list"
+    publish_task = asyncio.create_task(bridge.dispatch_publish_work(invalid, runtime))
+    harness.release_on_demand.set()
+
+    parent = _error(await start_task)
+    result = _error(await publish_task)
+    assert parent["code"] == "SERVICE_UNAVAILABLE"
+    assert result["code"] == "INVALID_REQUEST"
+    details = cast(dict[str, object], result["safe_details"])
+    assert details["reason_code"] == "operation_recovery_unavailable"
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded.count("service_incompatible") == 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/mcp/test_availability_latch.py
+++ b/tests/unit/mcp/test_availability_latch.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from pydantic import BaseModel
@@ -89,16 +89,27 @@ def _failure[ResultT: BaseModel](result_type: type[ResultT], request_id: str) ->
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        connect_error: BaseException | None = None,
+        call_error: BaseException | None = None,
+    ) -> None:
         self.calls: list[str] = []
         self.closed = False
+        self.connect_error = connect_error
+        self.call_error = call_error
 
     async def connect(self) -> None:
+        if self.connect_error is not None:
+            raise self.connect_error
         return None
 
     async def _call[ResultT: BaseModel](
         self, name: str, request: PublicRequestModel, result_type: type[ResultT]
     ) -> ResultT:
+        if self.call_error is not None:
+            raise self.call_error
         self.calls.append(name)
         return _failure(result_type, request.request_id)
 
@@ -285,6 +296,74 @@ async def test_concurrent_first_arrivals_share_one_on_demand_attempt_and_one_dia
     replay = _error(await bridge.dispatch_start(_start(winner_request_id), runtime))
     assert replay["code"] == "SESSION_CONFLICT"
     assert harness.on_demand == ["connect", "connect"]
+
+
+@pytest.mark.anyio
+async def test_live_client_handshake_failure_shares_one_on_demand_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A live slot client that then fails handshake must not bypass the probe gate."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_unavailable", retryable=True)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+    runtime._slot.client = cast(  # pyright: ignore[reportPrivateUsage]
+        Any, _FakeClient(connect_error=ControlError("service_unavailable", retryable=True))
+    )
+    request_ids = (_PARENT, *_DELEGATES)
+
+    tasks = [
+        asyncio.create_task(bridge.dispatch_start(_start(request_id), runtime))
+        for request_id in request_ids
+    ]
+    await harness.entered_on_demand.wait()
+    assert harness.on_demand == ["connect"]
+    harness.release_on_demand.set()
+    results = [_error(result) for result in await asyncio.gather(*tasks)]
+
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded == ["service_unavailable"]
+    inherited = [
+        result
+        for result in results
+        if cast(dict[str, object], result["safe_details"]).get("availability_inherited") is True
+    ]
+    assert len(inherited) == len(request_ids) - 1
+
+
+@pytest.mark.anyio
+async def test_live_client_invoke_failure_reconnect_shares_one_on_demand_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reconnect after a live-client RPC availability error is one probe, not N."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_unavailable", retryable=True)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+    runtime._slot.client = cast(  # pyright: ignore[reportPrivateUsage]
+        Any, _FakeClient(call_error=ControlError("service_unavailable", retryable=True))
+    )
+    request_ids = (_PARENT, *_DELEGATES)
+
+    tasks = [
+        asyncio.create_task(bridge.dispatch_start(_start(request_id), runtime))
+        for request_id in request_ids
+    ]
+    await harness.entered_on_demand.wait()
+    assert harness.on_demand == ["connect"]
+    harness.release_on_demand.set()
+    results = [_error(result) for result in await asyncio.gather(*tasks)]
+
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded == ["service_unavailable"]
+    inherited = [
+        result
+        for result in results
+        if cast(dict[str, object], result["safe_details"]).get("availability_inherited") is True
+    ]
+    assert len(inherited) == len(request_ids) - 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/mcp/test_availability_latch.py
+++ b/tests/unit/mcp/test_availability_latch.py
@@ -263,6 +263,7 @@ async def test_concurrent_first_arrivals_share_one_on_demand_attempt_and_one_dia
 
     assert harness.on_demand == ["connect"]
     assert harness.recorded == ["service_unavailable"]
+    assert harness.quiet == 0
     correlations = {result["correlation_id"] for result in results}
     assert len(correlations) == 1
     first = [
@@ -295,6 +296,67 @@ async def test_concurrent_first_arrivals_share_one_on_demand_attempt_and_one_dia
     assert type(winner_request_id) is str
     replay = _error(await bridge.dispatch_start(_start(winner_request_id), runtime))
     assert replay["code"] == "SESSION_CONFLICT"
+    assert harness.on_demand == ["connect", "connect"]
+
+
+@pytest.mark.anyio
+async def test_concurrent_same_request_id_inherits_before_later_replay(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Concurrent duplicates share the first result; only a later replay probes again."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_unavailable", retryable=True)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+
+    tasks = [asyncio.create_task(bridge.dispatch_start(_start(_PARENT), runtime)) for _ in range(4)]
+    await harness.entered_on_demand.wait()
+    assert harness.on_demand == ["connect"]
+    harness.release_on_demand.set()
+    results = [_error(result) for result in await asyncio.gather(*tasks)]
+
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded == ["service_unavailable"]
+    assert harness.quiet == 0
+    assert len({result["correlation_id"] for result in results}) == 1
+    inherited = [
+        result
+        for result in results
+        if cast(dict[str, object], result["safe_details"]).get("availability_inherited") is True
+    ]
+    assert len(inherited) == len(tasks) - 1
+
+    harness.stall_on_demand = False
+    harness.on_demand_failure = None
+    harness.on_demand_client = _FakeClient()
+    replay = _error(await bridge.dispatch_start(_start(_PARENT), runtime))
+    assert replay["code"] == "SESSION_CONFLICT"
+    assert harness.on_demand == ["connect", "connect"]
+
+
+@pytest.mark.anyio
+async def test_cancelled_first_attempt_releases_waiters(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cancelling the probe owner must not strand the process-local availability gate."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.stall_on_demand = True
+    runtime = bridge.build_bridge_runtime()
+
+    owner = asyncio.create_task(bridge.dispatch_start(_start(_PARENT), runtime))
+    await harness.entered_on_demand.wait()
+    owner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+
+    assert runtime._slot.attempting is False  # pyright: ignore[reportPrivateUsage]
+    assert runtime._slot.attempt_finished is None  # pyright: ignore[reportPrivateUsage]
+    harness.stall_on_demand = False
+    harness.on_demand_client = _FakeClient()
+    fresh = _error(await bridge.dispatch_start(_start(_DELEGATES[0]), runtime))
+    assert fresh["code"] == "SESSION_CONFLICT"
     assert harness.on_demand == ["connect", "connect"]
 
 
@@ -395,6 +457,45 @@ async def test_invalid_publish_waits_for_in_flight_first_attempt(
     assert details["reason_code"] == "operation_recovery_unavailable"
     assert harness.on_demand == ["connect"]
     assert harness.recorded.count("service_incompatible") == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("live_client_fails_during_call", [False, True])
+async def test_invalid_publish_recovery_releases_its_failed_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    live_client_fails_during_call: bool,
+) -> None:
+    """A non-latching recovery oracle must release both initial and reconnect failures."""
+
+    harness = _Harness(monkeypatch, tmp_path)
+    harness.on_demand_failure = ControlError("service_incompatible", retryable=True)
+    runtime = bridge.build_bridge_runtime()
+    if live_client_fails_during_call:
+        runtime._slot.client = cast(  # pyright: ignore[reportPrivateUsage]
+            Any, _FakeClient(call_error=ControlError("service_unavailable", retryable=True))
+        )
+
+    invalid = _status(_DELEGATES[0])
+    invalid.pop("view")
+    invalid.pop("limit")
+    invalid["expected_frontier"] = {"sequence": "0", "head_digest": "genesis"}
+    invalid["event_drafts"] = "not-a-list"
+    result = _error(await bridge.dispatch_publish_work(invalid, runtime))
+
+    assert result["code"] == "INVALID_REQUEST"
+    details = cast(dict[str, object], result["safe_details"])
+    assert details["reason_code"] == "operation_recovery_unavailable"
+    assert runtime._slot.attempting is False  # pyright: ignore[reportPrivateUsage]
+    assert runtime._slot.attempt_finished is None  # pyright: ignore[reportPrivateUsage]
+    assert harness.on_demand == ["connect"]
+    assert harness.recorded == ["invalid_request"]
+
+    harness.on_demand_failure = None
+    harness.on_demand_client = _FakeClient()
+    fresh = _error(await bridge.dispatch_start(_start(_DELEGATES[1]), runtime))
+    assert fresh["code"] == "SESSION_CONFLICT"
+    assert harness.on_demand == ["connect", "connect"]
 
 
 @pytest.mark.anyio

--- a/tests/unit/mcp/test_publish_recovery_precedence.py
+++ b/tests/unit/mcp/test_publish_recovery_precedence.py
@@ -107,13 +107,14 @@ def _install_recovery_oracle(
 
     seen: list[object] = []
 
-    async def ensure(_runtime: object = bridge.BRIDGE_RUNTIME) -> object:
+    async def ensure(_runtime: object = bridge.BRIDGE_RUNTIME, **_kwargs: object) -> object:
         return object()
 
     async def invoke(
         _runtime: object,
         request: object,
         _call: Callable[[object, object], Awaitable[object]],
+        _request_id: object = None,
     ) -> object:
         seen.append(request)
         if raise_on_status is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

- Linked issue: Fixes #476
- I searched existing issues and PRs for duplicates before opening this PR. Follow-up to #469 / PR #474 (CodeRabbit concurrent first-arrival finding, deferred as out of scope there). No other open issue covers serializing the first MCP availability attempt.
- This change is not design-gated (protocol, privacy/egress, storage/durability, release/packaging, ADR / `OPEN_QUESTIONS`). It is a narrowly scoped MCP bridge bugfix of the #469 latch.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (Availability latch: concurrent first-arrival gate, issue #476), `docs/runbooks/cursor-integration.md`, `docs/runbooks/claude-code-integration.md`, `docs/runbooks/codex-integration.md` (shared-bridge decision: supported on all three hosts), `CHANGELOG.md`.

## Verification

Commands run (paste):

```text
uv sync
uv run pytest tests/unit/mcp/test_availability_latch.py -q
uv run pytest tests/unit/mcp -q
uv run ruff check src/yoetz/mcp/server.py tests/unit/mcp/test_availability_latch.py tests/unit/mcp/test_publish_recovery_precedence.py
uv run ruff format --check src/yoetz/mcp/server.py tests/unit/mcp/test_availability_latch.py tests/unit/mcp/test_publish_recovery_precedence.py
npx --no-install pyright src/yoetz/mcp/server.py tests/unit/mcp/test_availability_latch.py tests/unit/mcp/test_publish_recovery_precedence.py
```

Results: `test_availability_latch.py` 11 passed; `tests/unit/mcp` 198 passed; ruff clean; pyright 0 errors.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

The #469 availability latch only observed a *completed* latch. Concurrent first MCP tool calls (ordinary host parallel tools) could all pass that preflight, each run `connect_service_on_demand`, and each mint a diagnostic before `_latch_availability` stored the slot.

`ensure_service_client` now owns a slot-scoped in-flight gate for on-demand connect, including a previously live client that then fails its handshake or reconnects after an availability error. Waiters inherit the same `correlation_id`. Envelope-first `publish_work` recovery waits on that gate. Original `request_id` replay and the retryable quiet handshake keep their current semantics.

Model/harness: Cursor Grok 4.6 (cloud agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab899cdd-b106-4b1e-8ee1-3b2545f9ec8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab899cdd-b106-4b1e-8ee1-3b2545f9ec8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize concurrent first availability probes in `_ClientSlot` and `_dispatch`
> - Concurrent first arrivals to the MCP bridge now block behind a single on-demand probe instead of each starting their own; waiters park on `attempt_finished` and then inherit the latched result.
> - Adds `_AvailabilityDecision` dataclass, `_prepare_availability`, `_finish_availability_attempt`, and `_inherit_after_inflight_availability` to coordinate slot-scoped in-flight state in [server.py](https://github.com/TheGaySupreme123/yoetz/pull/477/files#diff-c616ccad24db0e2cd8e339a92a3879eb0913ea6c8fa89377d28d7f2b5b3a2df8).
> - `dispatch_publish_work` now waits for an in-flight first attempt before reporting unavailability, preventing a second on-demand probe.
> - Risk: `_ClientSlot` gains `attempting` and `attempt_finished` fields; any out-of-tree code that constructs or inspects `_ClientSlot` directly must account for the new state and the `attempt_finished` event lifecycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46b71d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a slot-scoped asynchronous gate intended to serialize concurrent initial MCP availability probes and make envelope-first publish recovery wait for an in-flight probe.

- Adds availability-attempt ownership and waiter signaling to the MCP client slot.
- Extends availability-latch concurrency tests and integration documentation.
- Leaves concurrent stale-client reconnects outside the new gate, allowing duplicate attempts and diagnostics.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until concurrent failures from an existing stale client are brought under the same single-attempt gate.

The no-client first-arrival case is serialized, but callers that concurrently observe a non-null failing client all bypass the gate and can independently reconnect, record diagnostics, and replace the latch.

**Files Needing Attention:** src/yoetz/mcp/server.py, tests/unit/mcp/test_availability_latch.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/mcp/server.py | Adds the in-flight availability gate, but bypassing it for an existing client leaves concurrent reconnect failures capable of producing repeated attempts and diagnostics. |
| tests/unit/mcp/test_availability_latch.py | Adds useful first-arrival and publish-recovery concurrency coverage, but does not cover parallel calls starting from a stale non-null client. |
| docs/INTERFACES.md | Documents the intended single-attempt behavior and inheritance semantics for concurrent first arrivals. |

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): re-check the latch after waiti..."](https://github.com/thegaysupreme123/yoetz/commit/46b71d8223439d792f1db12b9fdef52ed86ffd3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58372751)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->