### PR TITLE
fix(plugins): bind rollback to canonical native bytes

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3344,7 +3344,8 @@ observation store are intentionally left in place.
 The implemented artifact operation is exactly `plugin_artifact_apply`. Its prepare target is the
 portable preview digest, which already binds target identity, current-state digest, action,
 format/schema/renderer versions, intended and current MCP ownership, optional route profile, exact
-route bytes through the artifact inventory/digest, and the complete sorted future inventory.
+route bytes through the artifact inventory/digest, the exact rollback digest when present, and the
+complete sorted future inventory.
 It is `review_only`, never agent-chat-authorizable, and its one pending review is consumed before
 one install/replace/remove attempt. Same-request replay returns the stored process result; after
 restart or an ambiguous filesystem outcome the caller must reconcile through `status_artifact`,
@@ -3366,8 +3367,12 @@ The #150 artifact wire-neutral domain shapes are closed:
   the adapter consumes the corresponding injected authority port, and the default adapter denies
   both channels.
 - `PluginArtifactPreview` carries request ID, action, state before, current `McpOwnershipState`, target-identity digest,
-  current-state digest, artifact digest, preview digest, the complete `PortablePluginPlan`, and
-  sorted structural warnings. It carries no raw target path or member contents.
+  current-state digest, artifact digest, the exact canonical-native rollback digest when migration
+  would preserve or removal would restore one, preview digest, the complete `PortablePluginPlan`,
+  and sorted structural warnings. The preview digest binds the rollback digest, so the consumed
+  authority target binds those exact bytes; a missing or changed rollback is stale and refuses
+  before mutation. Apply revalidates the bound preview after authority consumption and before its
+  first filesystem mutation. It carries no raw target path or member contents.
   For plugin-managed mode that owner state must be composed from plugin and external/global
   observations by the caller; the neutral artifact adapter cannot infer the latter from tree
   absence, so its uncomposed default is `ambiguous` and refuses preview.
@@ -3384,6 +3389,10 @@ The `yoetz.portable-plugin-install/1` marker contains only schema, format profil
 renderer versions, exact MCP ownership and optional route profile, artifact digest, complete sorted managed-file rows
 (`relative_path`, `size`, `sha256`), and its canonical marker digest. It contains no project path,
 user value, timestamp, credential, secret reference, transcript, host-activation claim, or receipt.
+The native rollback candidate must additionally byte-match the current canonical
+`render_plugin_install_tree(codex_version=None)` projection, including its native marker's adapter,
+harness, scope, and Yoetz version identity. A marker-consistent prior or fabricated native tree is
+not a rollback candidate and remains preserved as `modified` or `recovery_required`.
 
 ### Cursor local harness contract (issue #153)
 

--- a/docs/runbooks/portable-plugin-authoring.md
+++ b/docs/runbooks/portable-plugin-authoring.md
@@ -53,8 +53,11 @@ delivery, MCP runtime, observation, semantic dispatch, or workflow closure.
 
 The preview digest binds the trusted target identity, current-state digest, requested action,
 format/schema/renderer versions, complete sorted member inventory, selected MCP ownership,
-optional strict/policy profile, complete route bytes, and current `McpOwnershipState`. Apply rejects
-stale previews or changed ownership before mutation.
+optional strict/policy profile, complete route bytes, current `McpOwnershipState`, and the exact
+native rollback digest when migration would preserve or removal would restore one. The consumed
+authority target therefore binds those exact rollback bytes. Apply rejects stale previews,
+missing or changed rollback bytes, or changed ownership before mutation. It repeats the preview
+validation after authority consumption so a change during review cannot reach the swap.
 
 Before a plugin-managed preview, inspect both native/global registration and the project plugin
 root. Proceed only from exclusive `absent` or already exact `plugin` ownership. `external`, `dual`,
@@ -66,8 +69,10 @@ absence.
 
 Codex uses the existing `.agents/plugins/yoetz` root. Migration is a whole-directory swap between
 marker-identified native and portable trees; files are never merged. A preserved exact native tree
-is restored when the portable tree is removed. Modified, partial, unmanaged, foreign, unsafe, or
-ambiguous trees are preserved and refused. Stage or rollback remnants produce
+is restored when the portable tree is removed. Native rollback admission requires byte equality
+with the canonical native renderer and its exact adapter/harness/scope/Yoetz version marker;
+marker and inventory self-consistency alone is insufficient. Modified, partial, stale, unmanaged,
+foreign, unsafe, or ambiguous trees are preserved and refused. Stage or rollback remnants produce
 `recovery_required`; status reports them and never deletes or chooses between them.
 Removing or rolling back a plugin never removes Yoetz data, vault keys, credentials, privacy
 grants, provider bindings, or foreign host configuration.

--- a/src/yoetz/adapters/integrations/portable_plugin.py
+++ b/src/yoetz/adapters/integrations/portable_plugin.py
@@ -15,6 +15,7 @@ from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
 
 from yoetz import __version__
+from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
 from yoetz.domain.values import RequestId
 from yoetz.domain.values import request_id as validate_request_id
 from yoetz.ports.plugin_artifacts import (
@@ -204,7 +205,11 @@ class _Inspection:
     current_state_digest: str
     installed_digest: str | None
     marker_valid: bool
-    rollback_available: bool
+    rollback_digest: str | None
+
+    @property
+    def rollback_available(self) -> bool:
+        return self.rollback_digest is not None
 
     def __repr__(self) -> str:
         return (
@@ -824,35 +829,45 @@ def _recorded_tree_valid(
     return True, artifact if type(artifact) is str else _tree_digest(content)
 
 
-def _native_rollback_valid(path: Path) -> bool:
+def _canonical_native_tree_digest(
+    path: Path,
+    canonical_members: Mapping[str, bytes],
+) -> str | None:
     if path.is_symlink() or not path.is_dir():
-        return False
+        return None
     try:
         files = _safe_tree_files(path)
-    except PluginArtifactError:
-        return False
-    marker = _parsed_marker(files)
-    if (
-        marker is None
-        or marker.get("schema") != _NATIVE_MARKER_SCHEMA
-        or not _marker_self_valid(marker)
-    ):
-        return False
-    valid, _ = _recorded_tree_valid(files, marker)
-    return valid
+    except OSError, PluginArtifactError:
+        return None
+    if files != canonical_members:
+        return None
+    return _tree_digest(files)
 
 
 def _inspect(
     target: ArtifactTarget,
     rendered: RenderedPortablePlugin,
+    resource_source: PortableResourceSource | None,
 ) -> _Inspection:
+    canonical_native_members: Mapping[str, bytes] | None = None
+
+    def _canonical_native_members() -> Mapping[str, bytes]:
+        nonlocal canonical_native_members
+        if canonical_native_members is None:
+            canonical_native_members = render_plugin_install_tree(resource_source=resource_source)
+        return canonical_native_members
+
     root, target_identity = _validate_project(target)
     parent = _plugin_parent(root, create=False)
     destination = parent / "yoetz"
     rollback = parent / _NATIVE_ROLLBACK_NAME
     rollback_present = rollback.exists() or rollback.is_symlink()
-    rollback_valid = rollback_present and _native_rollback_valid(rollback)
-    if rollback_present and not rollback_valid:
+    rollback_digest = (
+        _canonical_native_tree_digest(rollback, _canonical_native_members())
+        if rollback_present
+        else None
+    )
+    if rollback_present and rollback_digest is None:
         return _Inspection(
             root,
             parent,
@@ -862,7 +877,7 @@ def _inspect(
             canonical_digest({"state": "rollback_ambiguous"}),
             None,
             False,
-            False,
+            None,
         )
     if parent.exists():
         interrupted = any(
@@ -878,10 +893,10 @@ def _inspect(
                 canonical_digest({"state": "recovery_required"}),
                 None,
                 False,
-                rollback_valid,
+                rollback_digest,
             )
     if not destination.exists():
-        if rollback_valid:
+        if rollback_digest is not None:
             return _Inspection(
                 root,
                 parent,
@@ -891,7 +906,7 @@ def _inspect(
                 canonical_digest({"state": "rollback_without_destination"}),
                 None,
                 False,
-                True,
+                rollback_digest,
             )
         return _Inspection(
             root,
@@ -902,7 +917,7 @@ def _inspect(
             canonical_digest({"state": "absent"}),
             None,
             False,
-            False,
+            None,
         )
     if destination.is_symlink() or not destination.is_dir():
         raise _error(PluginArtifactReason.TARGET_UNSAFE)
@@ -919,7 +934,7 @@ def _inspect(
             current_digest,
             None,
             False,
-            rollback_valid,
+            rollback_digest,
         )
     recorded_valid, installed_digest = _recorded_tree_valid(files, marker)
     if not recorded_valid:
@@ -932,11 +947,15 @@ def _inspect(
             current_digest,
             installed_digest,
             False,
-            rollback_valid,
+            rollback_digest,
         )
     schema = marker.get("schema")
     if schema == _NATIVE_MARKER_SCHEMA:
-        state = PluginArtifactState.NATIVE_MANAGED
+        state = (
+            PluginArtifactState.NATIVE_MANAGED
+            if files == _canonical_native_members()
+            else PluginArtifactState.MODIFIED
+        )
     elif schema == _MARKER_SCHEMA:
         state = (
             PluginArtifactState.PORTABLE_EXACT
@@ -954,7 +973,7 @@ def _inspect(
         current_digest,
         installed_digest,
         state is not PluginArtifactState.UNMANAGED,
-        rollback_valid,
+        rollback_digest,
     )
 
 
@@ -1017,6 +1036,11 @@ def _preview(
             key=str.encode,
         )
     )
+    rollback_digest = (
+        inspection.current_state_digest
+        if inspection.state is PluginArtifactState.NATIVE_MANAGED
+        else inspection.rollback_digest
+    )
     preview_digest = canonical_digest(
         {
             "action": effective.value,
@@ -1036,22 +1060,24 @@ def _preview(
             "mcp_route_profile": rendered.plan.mcp_route_profile,
             "renderer_version": rendered.plan.renderer_version,
             "request_id": request,
+            "rollback_digest": rollback_digest,
             "schema_version": rendered.plan.specification_version,
             "state_before": inspection.state.value,
             "target_identity": inspection.target_identity,
         }
     )
     return PluginArtifactPreview(
-        request,
-        effective,
-        inspection.state,
-        mcp_owner_state,
-        inspection.target_identity,
-        inspection.current_state_digest,
-        rendered.artifact_digest,
-        preview_digest,
-        rendered.plan,
-        warnings,
+        request_id=request,
+        action=effective,
+        state_before=inspection.state,
+        mcp_ownership_state=mcp_owner_state,
+        target_identity=inspection.target_identity,
+        current_state_digest=inspection.current_state_digest,
+        artifact_digest=rendered.artifact_digest,
+        rollback_digest=rollback_digest,
+        preview_digest=preview_digest,
+        plan=rendered.plan,
+        warnings=warnings,
     )
 
 
@@ -1263,7 +1289,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         return _preview(
             normalized,
             action,
-            _inspect(target, rendered),
+            _inspect(target, rendered, self._resource_source),
             rendered,
             self._owner_state(target),
         )
@@ -1302,7 +1328,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         if type(command) is not PluginArtifactStatusCommand:
             raise _error(PluginArtifactReason.SOURCE_INVALID)
         rendered = self._rendered()
-        inspection = _inspect(command.target, rendered)
+        inspection = _inspect(command.target, rendered, self._resource_source)
         operation_state = PluginOperationState.NOT_STARTED
         if command.request_id is not None and command.request_id in self._operations:
             operation_state = self._operations[command.request_id][1].operation_state
@@ -1351,7 +1377,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         if replay is not None:
             return replay
         rendered = self._rendered()
-        inspection = _inspect(command.target, rendered)
+        inspection = _inspect(command.target, rendered, self._resource_source)
         preview = _preview(
             command.request_id,
             command.action,
@@ -1362,6 +1388,16 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         if preview.preview_digest != command.accepted_preview_digest:
             raise _error(PluginArtifactReason.PREVIEW_STALE)
         self._authorize(command)
+        inspection = _inspect(command.target, rendered, self._resource_source)
+        preview = _preview(
+            command.request_id,
+            command.action,
+            inspection,
+            rendered,
+            self._owner_state(command.target),
+        )
+        if preview.preview_digest != command.accepted_preview_digest:
+            raise _error(PluginArtifactReason.PREVIEW_STALE)
         if preview.action is PluginArtifactAction.NOOP:
             return self._store(
                 command,
@@ -1399,7 +1435,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
                 _fsync_dir(parent)
             os.replace(stage, destination)
             _fsync_dir(parent)
-            final = _inspect(command.target, rendered)
+            final = _inspect(command.target, rendered, self._resource_source)
             if final.state is not PluginArtifactState.PORTABLE_EXACT:
                 raise OSError("installed_verification_failed")
             if portable_moved is not None and portable_moved.exists():
@@ -1465,7 +1501,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         if replay is not None:
             return replay
         rendered = self._rendered()
-        inspection = _inspect(command.target, rendered)
+        inspection = _inspect(command.target, rendered, self._resource_source)
         preview = _preview(
             command.request_id,
             command.action,
@@ -1476,6 +1512,16 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
         if preview.preview_digest != command.accepted_preview_digest:
             raise _error(PluginArtifactReason.PREVIEW_STALE)
         self._authorize(command)
+        inspection = _inspect(command.target, rendered, self._resource_source)
+        preview = _preview(
+            command.request_id,
+            command.action,
+            inspection,
+            rendered,
+            self._owner_state(command.target),
+        )
+        if preview.preview_digest != command.accepted_preview_digest:
+            raise _error(PluginArtifactReason.PREVIEW_STALE)
         parent = inspection.parent
         destination = inspection.destination
         removal = parent / f"{_REMOVE_PREFIX}{command.request_id}"
@@ -1511,7 +1557,7 @@ class PortablePluginArtifactAdapter(PluginArtifactPort):
                 PluginArtifactReason.WRITE_FAILED,
                 {"operation_state": PluginOperationState.OUTCOME_UNKNOWN.value},
             ) from exc
-        final = _inspect(command.target, rendered)
+        final = _inspect(command.target, rendered, self._resource_source)
         expected = PluginArtifactState.NATIVE_MANAGED if restored else PluginArtifactState.ABSENT
         if final.state is not expected:
             raise _error(PluginArtifactReason.WRITE_FAILED)

--- a/src/yoetz/ports/plugin_artifacts.py
+++ b/src/yoetz/ports/plugin_artifacts.py
@@ -321,6 +321,7 @@ class PluginArtifactPreview:
     target_identity: str
     current_state_digest: str
     artifact_digest: str
+    rollback_digest: str | None
     preview_digest: str
     plan: PortablePluginPlan
     warnings: tuple[str, ...]
@@ -342,6 +343,8 @@ class PluginArtifactPreview:
             self.preview_digest,
         ):
             validate_sha256_digest(digest)
+        if self.rollback_digest is not None:
+            validate_sha256_digest(self.rollback_digest)
         warnings = tuple(_token(item) for item in self.warnings)
         if warnings != tuple(sorted(set(warnings), key=str.encode)):
             raise ValueError("plugin_preview_invalid")

--- a/tests/unit/adapters/test_portable_plugin.py
+++ b/tests/unit/adapters/test_portable_plugin.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+import shutil
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -42,7 +43,12 @@ from yoetz.ports.plugin_artifacts import (
     PluginOperationState,
     PluginProofFacet,
 )
-from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import (
+    JsonValue,
+    canonical_digest,
+    canonical_encode,
+    strict_json_parse,
+)
 from yoetz.service.elevated_bootstrap import catalog_payload, load_pending
 from yoetz.version import read_verified_resource
 
@@ -58,6 +64,53 @@ def _target(tmp_path: Path) -> ArtifactTarget:
 
 def _setup_authority(preview_digest: str) -> ArtifactAuthority:
     return ArtifactAuthority("setup_composition", preview_digest)
+
+
+def _tree_digest(members: Mapping[str, bytes]) -> str:
+    return canonical_digest(
+        {
+            "files": [
+                {
+                    "relative_path": path,
+                    "sha256": f"sha256:{hashlib.sha256(data).hexdigest()}",
+                    "size": len(data),
+                }
+                for path, data in sorted(members.items(), key=lambda item: item[0].encode("ascii"))
+            ]
+        }
+    )
+
+
+def _make_native_tree_self_consistent_but_noncanonical(
+    root: Path,
+    mutation: str,
+) -> None:
+    marker_path = root / ".yoetz-plugin-install.json"
+    parsed = strict_json_parse(marker_path.read_bytes())
+    assert isinstance(parsed, Mapping)
+    marker = dict(cast(Mapping[str, Any], parsed))
+    if mutation == "member":
+        member_path = root / "hooks/hooks.json"
+        changed = member_path.read_bytes() + b"\n"
+        member_path.write_bytes(changed)
+        raw_rows = marker["managed_files"]
+        assert type(raw_rows) is list
+        rows: list[dict[str, Any]] = []
+        for raw_row in cast(list[object], raw_rows):
+            assert isinstance(raw_row, Mapping)
+            row = dict(cast(Mapping[str, Any], raw_row))
+            if row["relative_path"] == "hooks/hooks.json":
+                row["sha256"] = f"sha256:{hashlib.sha256(changed).hexdigest()}"
+                row["size"] = len(changed)
+            rows.append(row)
+        marker["managed_files"] = rows
+    elif mutation == "renderer":
+        marker["adapter_version"] = "codex-plugin/noncanonical"
+    else:
+        raise AssertionError("unknown mutation")
+    body = {name: value for name, value in marker.items() if name != "marker_digest"}
+    body["marker_digest"] = canonical_digest(cast(JsonValue, body))
+    marker_path.write_bytes(canonical_encode(cast(JsonValue, body)) + b"\n")
 
 
 class _Presence:
@@ -81,6 +134,15 @@ class _SetupAuthority:
     def consume_artifact_review(self, authority: ArtifactAuthority, preview_digest: str) -> None:
         del authority, preview_digest
         raise AssertionError("review-only authority was not expected")
+
+
+class _MutatingSetupAuthority(_SetupAuthority):
+    def __init__(self, mutation: Callable[[], None]) -> None:
+        self._mutation = mutation
+
+    def consume_setup_authority(self, authority: ArtifactAuthority, preview_digest: str) -> None:
+        super().consume_setup_authority(authority, preview_digest)
+        self._mutation()
 
 
 class _Resources:
@@ -742,6 +804,7 @@ async def test_codex_native_tree_migrates_as_one_directory_and_remove_rolls_back
         request_id(_request(4)), target, PluginArtifactAction.REPLACE
     )
     assert replace_preview.state_before is PluginArtifactState.NATIVE_MANAGED
+    assert replace_preview.rollback_digest == _tree_digest(native_before)
     await adapter.install_artifact(
         PluginArtifactApplyCommand(
             request_id(_request(4)),
@@ -754,6 +817,7 @@ async def test_codex_native_tree_migrates_as_one_directory_and_remove_rolls_back
     remove_preview = await adapter.preview_artifact(
         request_id(_request(5)), target, PluginArtifactAction.REMOVE
     )
+    assert remove_preview.rollback_digest == replace_preview.rollback_digest
     removed = await adapter.remove_artifact(
         PluginArtifactApplyCommand(
             request_id(_request(5)),
@@ -770,6 +834,157 @@ async def test_codex_native_tree_migrates_as_one_directory_and_remove_rolls_back
         if path.is_file()
     }
     assert native_after == native_before
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("mutation", ["member", "renderer"])
+async def test_self_consistent_noncanonical_native_tree_is_not_a_rollback_candidate(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    target = _target(tmp_path)
+    install_plugin(
+        IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path)),
+        allow_untested=True,
+    )
+    _make_native_tree_self_consistent_but_noncanonical(
+        tmp_path / AGENT_PLUGIN_ROOT,
+        mutation,
+    )
+    adapter = PortablePluginArtifactAdapter(review=_SetupAuthority())
+
+    status = await adapter.status_artifact(PluginArtifactStatusCommand(target))
+    assert status.state is PluginArtifactState.MODIFIED
+    with pytest.raises(PluginArtifactError) as caught:
+        await adapter.preview_artifact(
+            request_id(_request(18)), target, PluginArtifactAction.REPLACE
+        )
+    assert caught.value.reason is PluginArtifactReason.DESTINATION_CONFLICT
+    assert (tmp_path / AGENT_PLUGIN_ROOT).is_dir()
+
+
+@pytest.mark.anyio
+async def test_replace_rechecks_native_rollback_bytes_after_authority(tmp_path: Path) -> None:
+    target = _target(tmp_path)
+    install_plugin(
+        IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path)),
+        allow_untested=True,
+    )
+    native_root = tmp_path / AGENT_PLUGIN_ROOT
+    adapter = PortablePluginArtifactAdapter(
+        review=_MutatingSetupAuthority(
+            lambda: _make_native_tree_self_consistent_but_noncanonical(native_root, "member")
+        )
+    )
+    preview = await adapter.preview_artifact(
+        request_id(_request(23)), target, PluginArtifactAction.REPLACE
+    )
+
+    with pytest.raises(PluginArtifactError) as caught:
+        await adapter.install_artifact(
+            PluginArtifactApplyCommand(
+                request_id(_request(23)),
+                target,
+                PluginArtifactAction.REPLACE,
+                preview.preview_digest,
+                _setup_authority(preview.preview_digest),
+            )
+        )
+    assert caught.value.reason is PluginArtifactReason.DESTINATION_CONFLICT
+    assert native_root.is_dir()
+    assert not (tmp_path / ".agents/plugins/.yoetz.plugin-native-rollback").exists()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("mutation", ["member", "renderer"])
+async def test_self_consistent_noncanonical_rollback_is_preserved_and_refused(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    target = _target(tmp_path)
+    install_plugin(
+        IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path)),
+        allow_untested=True,
+    )
+    adapter = PortablePluginArtifactAdapter(review=_SetupAuthority())
+    replace_preview = await adapter.preview_artifact(
+        request_id(_request(19)), target, PluginArtifactAction.REPLACE
+    )
+    await adapter.install_artifact(
+        PluginArtifactApplyCommand(
+            request_id(_request(19)),
+            target,
+            PluginArtifactAction.REPLACE,
+            replace_preview.preview_digest,
+            _setup_authority(replace_preview.preview_digest),
+        )
+    )
+    rollback = tmp_path / ".agents/plugins/.yoetz.plugin-native-rollback"
+    remove_adapter = PortablePluginArtifactAdapter(
+        review=_MutatingSetupAuthority(
+            lambda: _make_native_tree_self_consistent_but_noncanonical(rollback, mutation)
+        )
+    )
+    remove_preview = await remove_adapter.preview_artifact(
+        request_id(_request(20)), target, PluginArtifactAction.REMOVE
+    )
+
+    with pytest.raises(PluginArtifactError) as caught:
+        await remove_adapter.remove_artifact(
+            PluginArtifactApplyCommand(
+                request_id(_request(20)),
+                target,
+                PluginArtifactAction.REMOVE,
+                remove_preview.preview_digest,
+                _setup_authority(remove_preview.preview_digest),
+            )
+        )
+    assert caught.value.reason is PluginArtifactReason.RECOVERY_REQUIRED
+    status = await remove_adapter.status_artifact(PluginArtifactStatusCommand(target))
+    assert status.state is PluginArtifactState.RECOVERY_REQUIRED
+    assert status.rollback_available is False
+    assert rollback.is_dir()
+    assert (tmp_path / AGENT_PLUGIN_ROOT / "plugin.json").is_file()
+
+
+@pytest.mark.anyio
+async def test_remove_rejects_missing_previewed_rollback_before_mutation(tmp_path: Path) -> None:
+    target = _target(tmp_path)
+    install_plugin(
+        IntegrationTarget(IntegrationScope.TRUSTED_PROJECT, str(tmp_path)),
+        allow_untested=True,
+    )
+    adapter = PortablePluginArtifactAdapter(review=_SetupAuthority())
+    replace_preview = await adapter.preview_artifact(
+        request_id(_request(21)), target, PluginArtifactAction.REPLACE
+    )
+    await adapter.install_artifact(
+        PluginArtifactApplyCommand(
+            request_id(_request(21)),
+            target,
+            PluginArtifactAction.REPLACE,
+            replace_preview.preview_digest,
+            _setup_authority(replace_preview.preview_digest),
+        )
+    )
+    remove_preview = await adapter.preview_artifact(
+        request_id(_request(22)), target, PluginArtifactAction.REMOVE
+    )
+    rollback = tmp_path / ".agents/plugins/.yoetz.plugin-native-rollback"
+    shutil.rmtree(rollback)
+
+    with pytest.raises(PluginArtifactError) as caught:
+        await adapter.remove_artifact(
+            PluginArtifactApplyCommand(
+                request_id(_request(22)),
+                target,
+                PluginArtifactAction.REMOVE,
+                remove_preview.preview_digest,
+                _setup_authority(remove_preview.preview_digest),
+            )
+        )
+    assert caught.value.reason is PluginArtifactReason.PREVIEW_STALE
+    assert (tmp_path / AGENT_PLUGIN_ROOT / "plugin.json").is_file()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #395
- I searched existing issues and PRs for duplicates before opening this PR.
- This is a bounded bug fix under the accepted #150 / ADR-023 artifact-lifecycle contract; it does
  not introduce a new protocol, privacy, storage, packaging, or architecture decision.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` and `docs/runbooks/portable-plugin-authoring.md` now define the
  canonical-native rollback admission rule, explicit rollback digest, authority binding, and
  post-authority revalidation boundary.

## Verification

Commands run (paste):

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue-395 uv sync --frozen
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue-395 uv run pytest tests/unit/adapters/test_codex_plugin.py tests/unit/adapters/test_portable_plugin.py -q
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue-395 uv run ruff check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue-395 uv run ruff format --check .
/Users/shayb/yoetz-core/node_modules/.bin/pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue-395 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Results:

- focused native/portable adapter slice: 84 passed
- Ruff: clean; format: 638 files already formatted
- Pyright: 0 errors, 0 warnings
- public-boundary scan: passed, 1,089 files scanned
- broader `tests/unit/adapters` run: 557 passed and one unrelated macOS sandbox test failed;
  `test_approved_true_succeeds_inside_enforcing_sandbox` reproduces unchanged at exact base
  `baa553a187a61b0dbb4b81bf771e3bf8ca6f52c2`
- GitHub required PR CI and Security and Privacy workflows: green at exact head
  `66c2db65f243ed5c40a89a6083655c4a4c8334ac`

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Portable rollback admission now requires byte equality with the canonical native Codex render,
including its adapter, harness, scope, and Yoetz version marker identity. Marker and inventory
self-consistency alone can no longer make arbitrary native bytes restorable.

The portable preview exposes the exact rollback digest and includes it in the preview digest
consumed as authority. Install and removal revalidate the full bound preview after authority
consumption and before their first filesystem mutation, so missing, changed, or stale rollback
bytes fail closed while the active tree remains untouched.

Regression coverage exercises member-byte and renderer-identity forgeries, changes during authority
consumption, missing rollback after preview, and exact interrupted migration restoration.

Model / harness: GPT-5 via Codex desktop.
