### PR TITLE
fix(semantic): recover awaiting-human checks

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -580,6 +580,13 @@ unavailable reconciliation capability, or activation/reconciliation failure is t
 `blocked_by_policy/scope_not_authorized`, with no provider construction, job, attempt, dispatch, or
 trusted-approval instruction. Neither suspension branch is committed as a terminal result.
 
+Bundle restart recovery reconstructs the pending check operation, semantic job, physical attempt,
+and disclosure wait as one resumable state. Restoring only the wait marker is insufficient: the
+attempt coordinator would have no job to reclaim and could not preserve the approved provider
+request identity. A denial, expiry, stale-authority result, or cancellation terminalizes the job
+and attempt first, then resolves the one-use wait; a crash between those writes recovers the
+terminal job and finishes the wait cleanup without dispatching or minting a replacement attempt.
+
 The agent-facing handoff preserves that state distinction. Both a missing standing repository grant
 and a one-use `confirm_every_request` decision are nonterminal `awaiting_human` continuations bound
 to the exact original check request id. The continuation kind distinguishes them: repository setup

--- a/src/yoetz/adapters/sqlite/repository.py
+++ b/src/yoetz/adapters/sqlite/repository.py
@@ -14,6 +14,8 @@ import apsw
 from yoetz.adapters.memory.ledger import (
     MemoryLedgerAdapter,
     MemoryLedgerState,
+    _AttemptState,  # pyright: ignore[reportPrivateUsage]
+    _case_dependency_digest,  # pyright: ignore[reportPrivateUsage]
     build_append_operation_record,
     compact_status_coverage,
     load_frozen_case_from_resume,
@@ -961,12 +963,156 @@ class SqliteLedger:
                     )
                 await asyncio.sleep(0)
             self._persist_quarantined_operations(tuple(newly_quarantined))
+            # Semantic jobs and attempts back every durable disclosure wait. Recovering only the
+            # side-table marker makes operation status look resumable while the attempt
+            # coordinator sees no job and cannot actually resume it after restart.
+            for job_row in self._db.execute(
+                "SELECT job_id,writer_id,operation_id,case_digest,case_object_id,state,"
+                "active_attempt_id,selected_attempt_id,attempt_count,lease_owner_id,"
+                "lease_generation,lease_expires_at,selected_result_object_id,terminal_code,"
+                "terminal_at FROM semantic_jobs AS jobs WHERE EXISTS ("
+                "SELECT 1 FROM operations AS operations "
+                "WHERE operations.writer_id=jobs.writer_id "
+                "AND operations.operation_id=jobs.operation_id "
+                "AND operations.state='pending')"
+            ):
+                (
+                    job_id_value,
+                    job_writer,
+                    job_operation,
+                    case_digest,
+                    case_object_id,
+                    job_state,
+                    active_attempt_id,
+                    selected_attempt_id,
+                    attempt_count,
+                    job_lease_owner,
+                    job_lease_generation,
+                    job_lease_expires,
+                    selected_result_object_id,
+                    terminal_code,
+                    terminal_at,
+                ) = job_row
+                try:
+                    case_ref = self._object_ref_from_inventory(
+                        cast(str, case_object_id),
+                        self._task_id,
+                        "application/vnd.yoetz.semantic-case+json",
+                    )
+                    selected_ref = (
+                        None
+                        if selected_result_object_id is None
+                        else self._object_ref_from_inventory(
+                            cast(str, selected_result_object_id),
+                            self._task_id,
+                            "application/vnd.yoetz.semantic-response+json",
+                        )
+                    )
+                    job = SemanticJobRecord(
+                        cast(str, job_id_value),
+                        cast(str, job_writer),
+                        cast(str, job_operation),
+                        cast(str, case_digest),
+                        case_ref,
+                        cast(
+                            Literal["queued", "leased", "succeeded", "failed", "quarantined"],
+                            job_state,
+                        ),
+                        cast(int, attempt_count),
+                        cast(str | None, active_attempt_id),
+                        cast(str | None, selected_attempt_id),
+                        cast(str | None, job_lease_owner),
+                        cast(int | None, job_lease_generation),
+                        None
+                        if job_lease_expires is None
+                        else parse_rfc3339_millis(cast(str, job_lease_expires)),
+                        selected_ref,
+                        None if terminal_code is None else SemanticReason(cast(str, terminal_code)),
+                        None
+                        if terminal_at is None
+                        else parse_rfc3339_millis(cast(str, terminal_at)),
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise _public_error(PublicErrorCode.STORAGE_CORRUPT) from exc
+                self._state.jobs[job.job_id] = job
+                self._state.job_by_case[(job.writer_id, job.operation_id, job.case_digest)] = (
+                    job.job_id
+                )
+
+            for attempt_row in self._db.execute(
+                "SELECT attempt_id,job_id,attempt_ordinal,provider_request_id,owner_generation,"
+                "lease_owner_id,lease_generation,state,result_object_id,terminal_code "
+                "FROM semantic_attempts WHERE job_id IN ("
+                "SELECT job_id FROM semantic_jobs AS jobs WHERE EXISTS ("
+                "SELECT 1 FROM operations AS operations "
+                "WHERE operations.writer_id=jobs.writer_id "
+                "AND operations.operation_id=jobs.operation_id "
+                "AND operations.state='pending'))"
+            ):
+                (
+                    attempt_id_value,
+                    attempt_job_id,
+                    attempt_ordinal,
+                    provider_request_id,
+                    attempt_owner_generation,
+                    attempt_lease_owner,
+                    attempt_lease_generation,
+                    attempt_state,
+                    attempt_result_object_id,
+                    attempt_terminal_code,
+                ) = attempt_row
+                try:
+                    job = self._state.jobs[cast(str, attempt_job_id)]
+                    operation = self._state.operations[(job.writer_id, job.operation_id)][0]
+                    case = self._state.frozen_cases[(job.writer_id, job.operation_id)]
+                    if operation.lease_expires_at is None:
+                        raise ValueError("semantic_attempt_operation_lease_missing")
+                    result_ref = (
+                        None
+                        if attempt_result_object_id is None
+                        else self._object_ref_from_inventory(
+                            cast(str, attempt_result_object_id),
+                            self._task_id,
+                            "application/vnd.yoetz.semantic-response+json",
+                        )
+                    )
+                    handle = SemanticAttemptHandle(
+                        job.job_id,
+                        cast(str, attempt_id_value),
+                        cast(int, attempt_ordinal),
+                        cast(str, provider_request_id),
+                        job.writer_id,
+                        job.operation_id,
+                        cast(str, attempt_owner_generation),
+                        cast(str, attempt_lease_owner),
+                        cast(int, attempt_lease_generation),
+                        operation.lease_expires_at,
+                        case.frontier,
+                        _case_dependency_digest(case),
+                    )
+                    attempt = _AttemptState(
+                        handle,
+                        cast(str, attempt_state),
+                        result_ref,
+                        None
+                        if attempt_terminal_code is None
+                        else SemanticReason(cast(str, attempt_terminal_code)),
+                    )
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise _public_error(PublicErrorCode.STORAGE_CORRUPT) from exc
+                self._state.attempts[handle.attempt_id] = attempt
+
             # Disclosure waits are durable but the oracle is in-memory, so a restart would
             # otherwise answer "no continuation" for a check that is genuinely still suspended —
             # exactly the unrecoverable state this work exists to remove.
             for wait_row in self._db.execute(
                 "SELECT job_id,attempt_id,writer_id,operation_id,pending_id,"
-                "pending_expires_at,state,resolved_at FROM semantic_disclosure_waits"
+                "pending_expires_at,state,resolved_at FROM semantic_disclosure_waits "
+                "WHERE job_id IN (SELECT job_id FROM semantic_jobs AS jobs WHERE EXISTS ("
+                "SELECT 1 FROM operations AS operations "
+                "WHERE operations.writer_id=jobs.writer_id "
+                "AND operations.operation_id=jobs.operation_id "
+                "AND operations.state='pending'))"
             ):
                 (
                     job_value,

--- a/src/yoetz/application/egress.py
+++ b/src/yoetz/application/egress.py
@@ -647,23 +647,43 @@ class PrivacyCoordinator:
                 PrivacyReason.AUDIT_FAILED,
             )
         status = state.status
-        if status == "awaiting_human":
+        if status in {"reserved", "awaiting_human"}:
+            try:
+                pending = await self._audit.load_disclosure_proposal(
+                    state.reservation.privacy_proposal_id
+                )
+            except Exception:
+                pending = None
+            if pending is None or pending.prepared_case_digest != case_digest:
+                return SemanticEgressBlocked(
+                    request_id,
+                    PrivacyOutcome.AUDIT_FAILED,
+                    PrivacyReason.AUDIT_FAILED,
+                    privacy_proposal_id=state.reservation.privacy_proposal_id,
+                )
+            if pending.expires_at <= self._clock.now_utc():
+                return SemanticEgressBlocked(
+                    request_id,
+                    PrivacyOutcome.APPROVAL_EXPIRED,
+                    PrivacyReason.AUTHORIZATION_EXPIRED,
+                    privacy_proposal_id=state.reservation.privacy_proposal_id,
+                )
             return SemanticEgressAwaitingHuman(
                 request_id,
                 state.reservation.privacy_proposal_id,
                 state.reservation.subject_digest,
-                state.reservation.reserved_at + timedelta(seconds=60),
+                pending.expires_at,
             )
-        if status in {"denied", "expired", "decision_completed"}:
+        if status in {"denied", "decision_receipt_pending", "expired", "decision_completed"}:
             return SemanticEgressBlocked(
                 request_id,
                 PrivacyOutcome.HUMAN_DENIED
-                if status == "denied"
+                if status in {"denied", "decision_receipt_pending"}
                 else PrivacyOutcome.APPROVAL_EXPIRED
                 if status == "expired"
                 else PrivacyOutcome.BLOCKED_BY_POLICY,
                 PrivacyReason.HUMAN_DENIED
-                if status == "denied"
+                if status in {"denied", "decision_receipt_pending"}
                 else PrivacyReason.AUTHORIZATION_EXPIRED
                 if status == "expired"
                 else PrivacyReason.POLICY_DENIED,
@@ -791,7 +811,7 @@ class PrivacyCoordinator:
                 effective,
                 proposal,
                 minimized,
-                ConsentSource.BASELINE_POLICY,
+                ConsentSource.PER_REQUEST_LOCAL_HUMAN,
                 deadline,
                 subject_digest=state.reservation.subject_digest,
                 authorization=authorization,
@@ -802,7 +822,7 @@ class PrivacyCoordinator:
             effective,
             proposal,
             minimized,
-            ConsentSource.BASELINE_POLICY,
+            ConsentSource.PER_REQUEST_LOCAL_HUMAN,
             deadline,
             subject_digest=state.reservation.subject_digest,
             authority_digest=authority_digest,

--- a/src/yoetz/application/semantic_attempts.py
+++ b/src/yoetz/application/semantic_attempts.py
@@ -330,7 +330,51 @@ class _SemanticAttemptLedger(Protocol):
         pending_expires_at: datetime,
     ) -> object: ...
 
+    async def load_disclosure_wait(self, writer_id: str, operation_id: str) -> object | None: ...
+
+    async def resolve_disclosure_wait(self, job_id: str) -> object: ...
+
     async def renew_leases(self, lease: OperationLease) -> OperationLease: ...
+
+
+async def _resolve_disclosure_wait_after_terminal(
+    ledger: _SemanticAttemptLedger,
+    lease: OperationLease,
+    job_id: str,
+    attempt_id: str | None = None,
+) -> None:
+    """Close an exact one-use wait only after its bound attempt is terminal.
+
+    The attempt write is the authoritative transition. Resolving the side-table wait afterwards
+    keeps crash recovery safe: a crash before this cleanup still recovers the terminal attempt,
+    while resolving first could expose a started attempt as though it were no longer waiting. The
+    job may itself be terminal or queued for a separately authorized physical retry.
+    """
+
+    try:
+        wait = await ledger.load_disclosure_wait(lease.writer_id, lease.operation_id)
+    except Exception as exc:
+        record_unexpected_exception_without_raising(
+            exc,
+            component="semantic_attempts",
+            operation="semantic_disclosure_wait_load_after_terminal_failed",
+        )
+        return
+    if (
+        wait is None
+        or getattr(wait, "job_id", None) != job_id
+        or getattr(wait, "state", None) != "awaiting"
+        or (attempt_id is not None and getattr(wait, "attempt_id", None) != attempt_id)
+    ):
+        return
+    try:
+        await ledger.resolve_disclosure_wait(job_id)
+    except Exception as exc:
+        record_unexpected_exception_without_raising(
+            exc,
+            component="semantic_attempts",
+            operation="semantic_disclosure_wait_resolve_after_terminal_failed",
+        )
 
 
 class _AttemptEvaluation(Protocol):
@@ -379,6 +423,7 @@ async def _recover_terminal_job(
 ) -> object:
     """Rebuild the final evaluation from a durable terminal job without re-claiming."""
 
+    await _resolve_disclosure_wait_after_terminal(ledger, lease, job.job_id)
     accounting = await _accounting_for(ledger, lease, job.job_id, max_retries=max_retries)
     if job.state == "succeeded":
         evaluation: _AttemptEvaluation | None = None
@@ -458,6 +503,12 @@ async def _terminalize_after_failure(
                 component="semantic_attempts",
                 operation="semantic_terminalize_job_failed",
             )
+    await _resolve_disclosure_wait_after_terminal(
+        ledger,
+        lease_holder(),
+        job_id,
+        None if handle is None else handle.attempt_id,
+    )
     try:
         return await _accounting_for(ledger, lease_holder(), job_id, max_retries=max_retries)
     except Exception as exc:
@@ -589,6 +640,7 @@ async def run_durable_semantic_attempts(
                     job.job_id,
                     SemanticReason.PROVIDER_TIMEOUT,
                 )
+                await _resolve_disclosure_wait_after_terminal(ledger, current_lease, job.job_id)
                 accounting = await _accounting_for(
                     ledger, current_lease, job.job_id, max_retries=max_retries
                 )
@@ -605,6 +657,7 @@ async def run_durable_semantic_attempts(
                 max_retries=max_retries,
             )
             await ledger.fail_semantic_job(current_lease, job.job_id, reason)
+            await _resolve_disclosure_wait_after_terminal(ledger, current_lease, job.job_id)
             accounting = await _accounting_for(
                 ledger, current_lease, job.job_id, max_retries=max_retries
             )
@@ -671,6 +724,9 @@ async def run_durable_semantic_attempts(
                 handle, AttemptOutcome.RESPONSE_DURABLE, response_ref
             )
             await ledger.select_attempt(current_lease, handle, response_ref)
+            await _resolve_disclosure_wait_after_terminal(
+                ledger, current_lease, job.job_id, handle.attempt_id
+            )
             accounting = await _accounting_for(
                 ledger, current_lease, job.job_id, max_retries=max_retries
             )
@@ -734,6 +790,9 @@ async def run_durable_semantic_attempts(
                 AttemptOutcome.EXPIRED,
                 terminal_code=evaluation.reason,
             )
+            await _resolve_disclosure_wait_after_terminal(
+                ledger, current_lease, job.job_id, handle.attempt_id
+            )
             # A repair is not waiting out a transport fault; resubmit without backoff.
             repair = is_repairable_semantic_outcome(evaluation.status, evaluation.reason)
             delay = backoff_seconds(handle.attempt_ordinal, kind="none" if repair else "transient")
@@ -752,6 +811,9 @@ async def run_durable_semantic_attempts(
             AttemptOutcome.FAILED,
             terminal_code=terminal_reason,
         )
+        await _resolve_disclosure_wait_after_terminal(
+            ledger, current_lease, job.job_id, handle.attempt_id
+        )
         accounting = await _accounting_for(
             ledger, current_lease, job.job_id, max_retries=max_retries
         )
@@ -763,6 +825,7 @@ async def run_durable_semantic_attempts(
             job.job_id,
             SemanticReason.RETRY_BUDGET_EXHAUSTED,
         )
+        await _resolve_disclosure_wait_after_terminal(ledger, current_lease, job.job_id)
         accounting = await _accounting_for(
             ledger, current_lease, job.job_id, max_retries=max_retries
         )
@@ -779,5 +842,6 @@ async def run_durable_semantic_attempts(
         max_retries=max_retries,
     )
     await ledger.fail_semantic_job(current_lease, job.job_id, reason)
+    await _resolve_disclosure_wait_after_terminal(ledger, current_lease, job.job_id)
     accounting = await _accounting_for(ledger, current_lease, job.job_id, max_retries=max_retries)
     return build_final(status, reason, last, accounting)

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -2108,7 +2108,25 @@ def _privacy_gated_semantic_evaluator(
                     scope=scope,
                     provider_binding=provider,
                 )
-                result = await privacy.evaluate_semantic(candidate, attempt_deadline)
+                wait = await runtime.ledger.load_disclosure_wait(
+                    handle.writer_id, handle.operation_id
+                )
+                if (
+                    wait is not None
+                    and wait.job_id == handle.job_id
+                    and wait.attempt_id == handle.attempt_id
+                    and wait.state == "awaiting"
+                ):
+                    # Exact replay after a trusted local decision resumes the already-prepared
+                    # proposal. Starting the semantic pipeline again would mint a replacement
+                    # proposal and could never observe the decision bound to this attempt.
+                    result = await privacy.resume(
+                        handle.provider_request_id,
+                        semantic_case.case_digest,
+                        attempt_deadline,
+                    )
+                else:
+                    result = await privacy.evaluate_semantic(candidate, attempt_deadline)
                 return _map_egress_to_final(
                     result,
                     ids,

--- a/tests/integration/application/test_check.py
+++ b/tests/integration/application/test_check.py
@@ -51,11 +51,12 @@ from yoetz.domain.receipts import (
     COMPLETION_SCOPE_DECLARED_NONE_GAP,
     COMPLETION_SCOPE_UNDECLARED_GAP,
 )
-from yoetz.domain.values import Frontier
+from yoetz.domain.values import Frontier, disclosure_continuation
 from yoetz.kernel import deterministic_checks as deterministic_checks_module
 from yoetz.ports.diagnostics import RuntimeCapability
 from yoetz.ports.ids import IdPort
 from yoetz.ports.ledger import (
+    CheckAwaitingHuman,
     CheckCommitResult,
     CheckPhase,
     CheckPolicyExecution,
@@ -658,6 +659,61 @@ async def test_check_replay_skips_policy_ids_and_second_commit() -> None:
     assert replayed is first
     assert app.id_source.count == allocated
     assert app.ledger.commit_count == 1
+
+
+@pytest.mark.anyio
+async def test_awaiting_human_replay_commits_only_after_a_terminal_decision() -> None:
+    app = _App(semantic=True)
+    objects = cast(MemoryObjects, cast(_Runtime, app.runtime).task.objects)
+    prior = ObjectRef(
+        "obj_30000000-0000-4000-8000-00000000aaaa",
+        1,
+        "hmac-sha256:" + "a" * 64,
+        "sha256:" + "b" * 64,
+        "yoetz-object/1",
+        "bmk-1",
+        ObjectMetadata(
+            ObjectKind.CHECK_RESUME,
+            "application/vnd.yoetz.check-resume+json",
+            _TASK,
+            datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+    )
+    objects._refs[prior.object_id] = prior  # pyright: ignore[reportPrivateUsage]
+    objects._data[prior.object_id] = b"{}"  # pyright: ignore[reportPrivateUsage]
+    app.semantic_result = FinalSemanticEvaluation(
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+        continuation=disclosure_continuation(
+            pending_id="ppr_30000000-0000-4000-8000-000000000009",
+            expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+            request_id=_REQUEST,
+        ),
+    )
+
+    suspended = await _execute_check_commit(app, _request("semantic_if_configured"))
+
+    assert type(suspended) is CheckAwaitingHuman
+    assert app.ledger.commit_count == 0
+    assert app.ledger.operation is not None
+    assert app.ledger.operation.state is OperationState.PENDING
+    assert app.ledger.operation.phase is CheckPhase.SEMANTIC_WAIT
+
+    app.semantic_result = FinalSemanticEvaluation(
+        SemanticStatus.HUMAN_DENIED,
+        SemanticReason.HUMAN_DENIED,
+    )
+    committed = await _execute_check_commit(app, _request("semantic_if_configured"))
+
+    assert type(committed) is CheckCommitResult
+    assert committed.semantic_status is SemanticStatus.HUMAN_DENIED
+    assert committed.semantic_reason is SemanticReason.HUMAN_DENIED
+    assert app.ledger.commit_count == 1
+    assert app.ledger.phase_transitions == [
+        (CheckPhase.RESERVED, CheckPhase.LOCAL_READY),
+        (CheckPhase.LOCAL_READY, CheckPhase.SEMANTIC_WAIT),
+        (CheckPhase.SEMANTIC_WAIT, CheckPhase.READY_TO_FINALIZE),
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/integration/service/test_semantic_non_dispatch.py
+++ b/tests/integration/service/test_semantic_non_dispatch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import replace
@@ -11,13 +12,22 @@ import pytest
 
 import yoetz.observability.diagnostics as diagnostics_module
 import yoetz.service.ready_composition as ready_composition_module
-from builders.ledger_adapters import FixedClock
+from builders.ledger_adapters import (
+    FixedClock,
+    append_command,
+    memory_adapter,
+    ownership_fence,
+    sqlite_adapter,
+)
 from builders.policy_cases import FRONTIER, make_case
+from yoetz.adapters.memory.ledger import MemoryLedgerAdapter
+from yoetz.adapters.sqlite.repository import SqliteLedger
 from yoetz.application.check import FinalSemanticEvaluation, semantic_coverage_gap_code
 from yoetz.application.egress import (
     PrivacyCoordinator,
     RepositoryGrantAdmission,
     SemanticEgressAwaitingHuman,
+    SemanticEgressBlocked,
     SemanticEgressProviderOutcome,
 )
 from yoetz.domain.findings import SamplingParams, SemanticDispatchKind, SemanticFailureClass
@@ -27,8 +37,10 @@ from yoetz.domain.privacy import (
     ChannelPolicy,
     DataClass,
     EgressChannel,
+    PrivacyOutcome,
     PrivacyPolicy,
     PrivacyProfile,
+    PrivacyReason,
     ProviderBinding,
     ReviewContextProfile,
     ReviewSelectionPolicy,
@@ -37,7 +49,10 @@ from yoetz.domain.receipts import (
     SEMANTIC_RELEVANCE_REVIEW_NOT_RUN_GAP,
     SEMANTIC_REVIEW_NOT_CONFIGURED_GAP,
 )
+from yoetz.ports.diagnostics import RuntimeCapability
+from yoetz.ports.importer import ImporterPort
 from yoetz.ports.ledger import CheckPhase, FrozenCase, OperationLease
+from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectSource, ObjectStorePort
 from yoetz.ports.privacy import (
     EffectivePrivacyPolicy,
     OutboundGatewayPort,
@@ -46,6 +61,7 @@ from yoetz.ports.privacy import (
     PrivacyPolicyStorePort,
     RepositoryPrivacyAuthority,
 )
+from yoetz.ports.runtime import TaskRuntime
 from yoetz.ports.semantic import ProviderAttemptProvenance, SemanticResultUnavailable
 from yoetz.ports.start_catalog import (
     SessionBinding,
@@ -53,7 +69,7 @@ from yoetz.ports.start_catalog import (
     TaskRoute,
     TaskRouteState,
 )
-from yoetz.protocol.canonical import canonical_digest
+from yoetz.protocol.canonical import canonical_digest, canonical_encode
 from yoetz.protocol.models import DataCategory, SemanticReason, SemanticStatus
 
 _TASK = "tsk_53000000-0000-4000-8000-000000000001"
@@ -175,21 +191,25 @@ class _PolicyApplication:
 
 
 class _Privacy:
-    def __init__(self, *, repository_granted: bool = True) -> None:
+    def __init__(self, *, repository_granted: bool = True, task_id: str = _TASK) -> None:
         self.calls = 0
+        self.resume_calls = 0
         self.repository_granted = repository_granted
+        self.task_id = task_id
         # Real policy path is required for dispatch; never mint synthetic policy identity.
         self.policy_application = _PolicyApplication(
             _test_effective_policy(), repository_granted=repository_granted
         )
         self.terminal_provider_result = False
+        self.resume_terminal: tuple[PrivacyOutcome, PrivacyReason] | None = None
+        self.cancel_on_resume = False
 
     async def activate_repository(self, scope: AuthorizationScope) -> bool:
         assert scope == AuthorizationScope(
             AuthorizationScopeKind.TASK,
             _INSTALLATION,
             _REPOSITORY,
-            _TASK,
+            self.task_id,
         )
         return self.repository_granted
 
@@ -259,13 +279,27 @@ class _Privacy:
             datetime(2030, 1, 1, tzinfo=UTC),
         )
 
+    async def resume(self, request_id: str, case_digest: str, deadline: object) -> object:
+        del case_digest, deadline
+        self.resume_calls += 1
+        if self.cancel_on_resume:
+            raise asyncio.CancelledError
+        assert self.resume_terminal is not None
+        outcome, reason = self.resume_terminal
+        return SemanticEgressBlocked(
+            request_id,
+            outcome,
+            reason,
+            privacy_proposal_id="ppr_53000000-0000-4000-8000-000000000001",
+        )
+
 
 class _Catalog:
     def __init__(self, route: TaskRoute | None) -> None:
         self.route = route
 
     async def resolve_route(self, session: str) -> TaskRoute | None:
-        assert session == _SESSION
+        assert self.route is None or session == self.route.session_id
         return self.route
 
     async def session_binding(self, session: str) -> SessionBinding | None:
@@ -310,6 +344,107 @@ def _frozen() -> FrozenCase:
             "sha256:" + "d" * 64,
         ),
     )
+
+
+def _route_for(task_id: str, session_id: str) -> TaskRoute:
+    route_generation = 1
+    bundle_relpath = f"tasks/{task_id}"
+    return TaskRoute(
+        task_id,
+        session_id,
+        bundle_relpath,
+        route_generation,
+        TaskRouteState.ACTIVE,
+        canonical_digest(
+            {
+                "task_id": task_id,
+                "bundle_relpath": bundle_relpath,
+                "route_generation": route_generation,
+            }
+        ),
+        _REPOSITORY,
+    )
+
+
+async def _durable_semantic_case(
+    adapter: MemoryLedgerAdapter | SqliteLedger,
+) -> tuple[FrozenCase, TaskRuntime]:
+    command = append_command()
+    await adapter.append_batch(command)
+    frozen = await adapter.freeze_case(
+        command.session_id,
+        command.writer_id,
+        1,
+        _REQUEST,
+        "sha256:" + "7" * 64,
+    )
+    assert type(frozen) is FrozenCase
+    operation = await adapter.lookup_operation(command.writer_id, _REQUEST)
+    assert operation is not None and operation.resume_object_ref is not None
+    prior = operation.resume_object_ref
+    local_canonical = canonical_encode(
+        {
+            "schema_version": "1.0.0",
+            "request_id": _REQUEST,
+            "request_digest": "sha256:" + "7" * 64,
+            "task_id": command.task_id,
+            "session_id": command.session_id,
+            "writer_id": command.writer_id,
+            "subject_frontier": frozen.case.frontier.as_wire(),
+            "dependency_digest": frozen.lease.dependency_digest,
+            "prior_resume": {
+                "object_id": prior.object_id,
+                "envelope_digest": prior.envelope_digest,
+                "commitment": prior.commitment,
+            },
+            "policy_executions": (),
+            "assessments": (),
+        }
+    )
+    objects = cast(ObjectStorePort, adapter._objects)  # pyright: ignore[reportPrivateUsage]
+    staged = await objects.stage(
+        ObjectSource(data=local_canonical, declared_size=len(local_canonical)),
+        ObjectMetadata(
+            ObjectKind.DETERMINISTIC_RESULT,
+            "application/vnd.yoetz.deterministic-result+json",
+            command.task_id,
+            datetime(2026, 7, 19, 12, 0, tzinfo=UTC),
+        ),
+    )
+    local_result = await objects.finalize(staged)
+    lease = await adapter.advance_check_phase(
+        frozen.lease,
+        CheckPhase.RESERVED,
+        CheckPhase.LOCAL_READY,
+        local_result,
+    )
+    lease = await adapter.advance_check_phase(
+        lease,
+        CheckPhase.LOCAL_READY,
+        CheckPhase.SEMANTIC_WAIT,
+    )
+    runtime = TaskRuntime(
+        command.task_id,
+        command.session_id,
+        command.writer_id,
+        frozenset(
+            {
+                RuntimeCapability.WRITE,
+                RuntimeCapability.STRUCTURAL_READ,
+                RuntimeCapability.PAYLOAD_READ,
+                RuntimeCapability.SEMANTIC,
+            }
+        ),
+        adapter,
+        objects,
+        cast(ImporterPort, object()),
+        "0.1.0",
+        "0.1.0",
+        "0.1",
+        "1.0.0",
+        ownership_fence(),
+    )
+    return FrozenCase(frozen.case, lease), runtime
 
 
 def _evaluator(
@@ -427,6 +562,216 @@ async def test_exact_same_request_resumes_after_trusted_grant_to_terminal_provid
     )
     assert resumed.continuation is None
     assert provider_resolutions == privacy.calls == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "adapter_factory",
+    (memory_adapter, sqlite_adapter),
+    ids=("memory", "sqlite"),
+)
+@pytest.mark.parametrize(
+    ("terminal", "expected"),
+    (
+        (
+            (PrivacyOutcome.HUMAN_DENIED, PrivacyReason.HUMAN_DENIED),
+            (SemanticStatus.HUMAN_DENIED, SemanticReason.HUMAN_DENIED),
+        ),
+        (
+            (PrivacyOutcome.APPROVAL_EXPIRED, PrivacyReason.AUTHORIZATION_EXPIRED),
+            (SemanticStatus.APPROVAL_EXPIRED, SemanticReason.HUMAN_APPROVAL_EXPIRED),
+        ),
+        (
+            (PrivacyOutcome.BLOCKED_BY_POLICY, PrivacyReason.SCOPE_MISMATCH),
+            (SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.SCOPE_NOT_AUTHORIZED),
+        ),
+    ),
+)
+async def test_disclosure_wait_replay_uses_resume_and_terminalizes_one_exact_attempt(
+    adapter_factory: Callable[[object], MemoryLedgerAdapter | SqliteLedger],
+    terminal: tuple[PrivacyOutcome, PrivacyReason],
+    expected: tuple[SemanticStatus, SemanticReason],
+) -> None:
+    command = append_command()
+    adapter = adapter_factory(command)
+    frozen, runtime = await _durable_semantic_case(adapter)
+    privacy = _Privacy(task_id=runtime.task_id)
+    evaluator = cast(
+        Callable[[FrozenCase, tuple[object, ...], TaskRuntime], Awaitable[FinalSemanticEvaluation]],
+        _evaluator(
+            privacy,
+            lambda: _PROVIDER,
+            _route_for(runtime.task_id, runtime.session_id),
+        ),
+    )
+
+    waiting = await evaluator(frozen, (), runtime)
+    assert waiting.status is SemanticStatus.AWAITING_HUMAN
+    assert waiting.operation_lease is not None
+    job = await adapter.load_semantic_job(runtime.writer_id or "", _REQUEST)
+    assert job is not None
+    attempts = await adapter.list_semantic_attempts(job.job_id)
+    assert len(attempts) == 1 and attempts[0].state == "started"
+    original_attempt = attempts[0]
+
+    privacy.resume_terminal = terminal
+    resumed = await evaluator(
+        FrozenCase(frozen.case, waiting.operation_lease),
+        (),
+        runtime,
+    )
+
+    assert (resumed.status, resumed.reason) == expected
+    assert privacy.calls == 1
+    assert privacy.resume_calls == 1
+    terminal_job = await adapter.load_semantic_job(runtime.writer_id or "", _REQUEST)
+    assert terminal_job is not None and terminal_job.state == "failed"
+    terminal_attempts = await adapter.list_semantic_attempts(terminal_job.job_id)
+    assert len(terminal_attempts) == 1
+    assert terminal_attempts[0].attempt_id == original_attempt.attempt_id
+    assert terminal_attempts[0].provider_request_id == original_attempt.provider_request_id
+    assert terminal_attempts[0].state == "failed"
+    wait = await adapter.load_disclosure_wait(runtime.writer_id or "", _REQUEST)
+    assert wait is not None and wait.state == "resolved"
+
+
+@pytest.mark.anyio
+async def test_cancellation_while_resuming_a_wait_terminalizes_before_propagating() -> None:
+    command = append_command()
+    adapter = memory_adapter(command)
+    frozen, runtime = await _durable_semantic_case(adapter)
+    privacy = _Privacy(task_id=runtime.task_id)
+    evaluator = cast(
+        Callable[[FrozenCase, tuple[object, ...], TaskRuntime], Awaitable[FinalSemanticEvaluation]],
+        _evaluator(
+            privacy,
+            lambda: _PROVIDER,
+            _route_for(runtime.task_id, runtime.session_id),
+        ),
+    )
+    waiting = await evaluator(frozen, (), runtime)
+    assert waiting.operation_lease is not None
+    privacy.cancel_on_resume = True
+
+    with pytest.raises(asyncio.CancelledError):
+        await evaluator(FrozenCase(frozen.case, waiting.operation_lease), (), runtime)
+
+    job = await adapter.load_semantic_job(runtime.writer_id or "", _REQUEST)
+    assert job is not None and job.state == "failed"
+    assert job.terminal_code is SemanticReason.COORDINATOR_FAILURE
+    attempts = await adapter.list_semantic_attempts(job.job_id)
+    assert len(attempts) == 1 and attempts[0].state == "failed"
+    wait = await adapter.load_disclosure_wait(runtime.writer_id or "", _REQUEST)
+    assert wait is not None and wait.state == "resolved"
+    assert privacy.calls == privacy.resume_calls == 1
+
+
+@pytest.mark.anyio
+async def test_sqlite_restart_mid_wait_recovers_the_same_attempt_and_resume_route() -> None:
+    command = append_command()
+    original = sqlite_adapter(command)
+    frozen, runtime = await _durable_semantic_case(original)
+    privacy = _Privacy(task_id=runtime.task_id)
+    evaluator = cast(
+        Callable[[FrozenCase, tuple[object, ...], TaskRuntime], Awaitable[FinalSemanticEvaluation]],
+        _evaluator(
+            privacy,
+            lambda: _PROVIDER,
+            _route_for(runtime.task_id, runtime.session_id),
+        ),
+    )
+    waiting = await evaluator(frozen, (), runtime)
+    assert waiting.operation_lease is not None
+
+    original._db.execute(  # pyright: ignore[reportPrivateUsage]
+        "UPDATE bundle_meta SET value='2' WHERE key='owner_generation'"
+    )
+    restarted = SqliteLedger(
+        db=original._db,  # pyright: ignore[reportPrivateUsage]
+        task_id=runtime.task_id,
+        ownership_fence=ownership_fence(generation=2),
+        clock=FixedClock(),
+        ids=original._ids,  # pyright: ignore[reportPrivateUsage]
+        objects=original._objects,  # pyright: ignore[reportPrivateUsage]
+    )
+    restarted_runtime = replace(
+        runtime,
+        ledger=restarted,
+        fence=ownership_fence(generation=2),
+    )
+    recovered = await restarted.load_semantic_job(runtime.writer_id or "", _REQUEST)
+    assert recovered is not None and recovered.state == "leased"
+    recovered_attempts = await restarted.list_semantic_attempts(recovered.job_id)
+    assert len(recovered_attempts) == 1 and recovered_attempts[0].state == "started"
+    recovered_wait = await restarted.load_disclosure_wait(runtime.writer_id or "", _REQUEST)
+    assert recovered_wait is not None and recovered_wait.state == "awaiting"
+    reclaimed = await restarted.freeze_case(
+        runtime.session_id,
+        runtime.writer_id or "",
+        1,
+        _REQUEST,
+        "sha256:" + "7" * 64,
+    )
+    assert type(reclaimed) is FrozenCase
+
+    privacy.resume_terminal = (PrivacyOutcome.HUMAN_DENIED, PrivacyReason.HUMAN_DENIED)
+    result = await evaluator(
+        reclaimed,
+        (),
+        restarted_runtime,
+    )
+
+    assert (result.status, result.reason) == (
+        SemanticStatus.HUMAN_DENIED,
+        SemanticReason.HUMAN_DENIED,
+    )
+    terminal = await restarted.load_semantic_job(runtime.writer_id or "", _REQUEST)
+    assert terminal is not None and terminal.state == "failed"
+    attempts = await restarted.list_semantic_attempts(terminal.job_id)
+    assert len(attempts) == 1
+    assert attempts[0].attempt_id == recovered_attempts[0].attempt_id
+    assert attempts[0].provider_request_id == recovered_attempts[0].provider_request_id
+    assert privacy.calls == privacy.resume_calls == 1
+
+    # A second crash after the terminal semantic write but before the outer check commit must
+    # recover that terminal answer without calling either privacy entrypoint again.
+    assert result.operation_lease is not None
+    original._db.execute(  # pyright: ignore[reportPrivateUsage]
+        "UPDATE bundle_meta SET value='3' WHERE key='owner_generation'"
+    )
+    recovered_terminal = SqliteLedger(
+        db=original._db,  # pyright: ignore[reportPrivateUsage]
+        task_id=runtime.task_id,
+        ownership_fence=ownership_fence(generation=3),
+        clock=FixedClock(),
+        ids=original._ids,  # pyright: ignore[reportPrivateUsage]
+        objects=original._objects,  # pyright: ignore[reportPrivateUsage]
+    )
+    terminal_runtime = replace(
+        runtime,
+        ledger=recovered_terminal,
+        fence=ownership_fence(generation=3),
+    )
+    terminal_reclaimed = await recovered_terminal.freeze_case(
+        runtime.session_id,
+        runtime.writer_id or "",
+        1,
+        _REQUEST,
+        "sha256:" + "7" * 64,
+    )
+    assert type(terminal_reclaimed) is FrozenCase
+    replayed = await evaluator(
+        terminal_reclaimed,
+        (),
+        terminal_runtime,
+    )
+    assert (replayed.status, replayed.reason) == (
+        SemanticStatus.HUMAN_DENIED,
+        SemanticReason.HUMAN_DENIED,
+    )
+    replayed_wait = await recovered_terminal.load_disclosure_wait(runtime.writer_id or "", _REQUEST)
+    assert replayed_wait is not None and replayed_wait.state == "resolved"
+    assert privacy.calls == privacy.resume_calls == 1
 
 
 class _ClosingGateway:

--- a/tests/unit/application/test_semantic_attempts.py
+++ b/tests/unit/application/test_semantic_attempts.py
@@ -29,6 +29,7 @@ from yoetz.ports.ledger import (
     OperationLease,
     SemanticAttemptHandle,
     SemanticAttemptRecord,
+    SemanticDisclosureWait,
     SemanticJobRecord,
 )
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef
@@ -256,9 +257,11 @@ class _FakeLedger:
     renew_count: int = 0
     claim_calls: int = 0
     disclosure_waits: list[tuple[str, str, datetime]] | None = None
+    resolved_disclosure_waits: set[str] | None = None
 
     def __post_init__(self) -> None:
         self.disclosure_waits = []
+        self.resolved_disclosure_waits = set()
         self.outcomes = []
         self.dispatches = []
         self.attempt_ids = []
@@ -285,6 +288,30 @@ class _FakeLedger:
         assert lease == self.lease
         assert job_id == self.job.job_id
         self.claim_calls += 1
+        assert self.attempts is not None
+        assert self.disclosure_waits is not None
+        assert self.resolved_disclosure_waits is not None
+        if (
+            self.job.state == "leased"
+            and self.job.active_attempt_id is not None
+            and self.disclosure_waits
+            and self.job.job_id not in self.resolved_disclosure_waits
+        ):
+            current = self.attempts[self.job.active_attempt_id]
+            return SemanticAttemptHandle(
+                job_id,
+                current.attempt_id,
+                current.attempt_ordinal,
+                current.provider_request_id,
+                lease.writer_id,
+                lease.operation_id,
+                lease.owner_generation,
+                lease.lease_owner_id,
+                current.attempt_ordinal,
+                lease.lease_expires_at,
+                lease.frontier,
+                lease.dependency_digest,
+            )
         ordinal = self.job.attempt_count + 1
         att = f"att_40000000-0000-4000-8000-{ordinal:012x}"
         req = f"req_40000000-0000-4000-8000-{ordinal:012x}"
@@ -313,7 +340,6 @@ class _FakeLedger:
         )
         assert self.attempt_ids is not None
         assert self.provider_ids is not None
-        assert self.attempts is not None
         self.attempt_ids.append(att)
         self.provider_ids.append(req)
         self.attempts[att] = SemanticAttemptRecord(job_id, att, ordinal, req, "started", None, None)
@@ -426,8 +452,39 @@ class _FakeLedger:
         pending_expires_at: datetime,
     ) -> object:
         assert self.disclosure_waits is not None
+        assert self.resolved_disclosure_waits is not None
         self.disclosure_waits.append((handle.attempt_id, pending_id, pending_expires_at))
+        self.resolved_disclosure_waits.discard(handle.job_id)
         return None
+
+    async def load_disclosure_wait(
+        self, writer_id: str, operation_id: str
+    ) -> SemanticDisclosureWait | None:
+        assert (writer_id, operation_id) == (_WRITER, _OP)
+        assert self.disclosure_waits is not None
+        assert self.resolved_disclosure_waits is not None
+        if not self.disclosure_waits:
+            return None
+        attempt_id, pending_id, pending_expires_at = self.disclosure_waits[-1]
+        resolved = _JOB in self.resolved_disclosure_waits
+        return SemanticDisclosureWait(
+            _JOB,
+            attempt_id,
+            writer_id,
+            operation_id,
+            pending_id,
+            pending_expires_at,
+            "resolved" if resolved else "awaiting",
+            datetime(2026, 1, 1, tzinfo=UTC) if resolved else None,
+        )
+
+    async def resolve_disclosure_wait(self, job_id: str) -> SemanticDisclosureWait:
+        assert job_id == _JOB
+        assert self.resolved_disclosure_waits is not None
+        self.resolved_disclosure_waits.add(job_id)
+        resolved = await self.load_disclosure_wait(_WRITER, _OP)
+        assert resolved is not None
+        return resolved
 
 
 @pytest.mark.anyio
@@ -1704,19 +1761,46 @@ async def test_confirm_every_request_repair_waits_for_a_fresh_decision() -> None
     # proposal. The repair attempt therefore surfaces a second awaiting_human wait bound to the
     # new attempt; the first decision is never reused and nothing is dispatched on its authority.
     ledger = _FakeLedger(_queued_job(), _lease())
+    first_wait = _AwaitingEval(
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+        _Continuation(
+            "ppr_40000000-0000-4000-8000-000000000003",
+            _ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC)),
+        ),
+    )
     second_wait = _AwaitingEval(
         SemanticStatus.AWAITING_HUMAN,
         SemanticReason.HUMAN_APPROVAL_REQUIRED,
-        _Continuation("pnd_repair", _ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC))),
+        _Continuation(
+            "ppr_40000000-0000-4000-8000-000000000004",
+            _ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC)),
+        ),
+    )
+    first = await _run(ledger, [first_wait], max_retries=1)
+    assert first[:2] == (
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
     )
     status, reason, accounting = await _run(ledger, [_INVALID, second_wait], max_retries=1)
-    assert ledger.dispatches is not None and len(ledger.dispatches) == 2
+    assert ledger.dispatches is not None and len(ledger.dispatches) == 3
     assert len(set(ledger.dispatches)) == 2
     assert (status, reason) == (
         SemanticStatus.AWAITING_HUMAN,
         SemanticReason.HUMAN_APPROVAL_REQUIRED,
     )
-    assert ledger.disclosure_waits == [(_ATT2, "pnd_repair", datetime(2030, 1, 1, tzinfo=UTC))]
+    assert ledger.disclosure_waits == [
+        (
+            _ATT1,
+            "ppr_40000000-0000-4000-8000-000000000003",
+            datetime(2030, 1, 1, tzinfo=UTC),
+        ),
+        (
+            _ATT2,
+            "ppr_40000000-0000-4000-8000-000000000004",
+            datetime(2030, 1, 1, tzinfo=UTC),
+        ),
+    ]
     # The repair attempt stays started and the job leased: an open wait, not a finished check.
     assert ledger.outcomes == [
         (_ATT1, AttemptOutcome.EXPIRED, SemanticReason.RESPONSE_CONTENT_INVALID)
@@ -1724,6 +1808,104 @@ async def test_confirm_every_request_repair_waits_for_a_fresh_decision() -> None
     assert ledger.attempts is not None and ledger.attempts[_ATT2].state == "started"
     assert ledger.job.state == "leased"
     assert accounting.attempted_count == 2
+    active_wait = await ledger.load_disclosure_wait(_WRITER, _OP)
+    assert active_wait is not None
+    assert active_wait.state == "awaiting"
+    assert active_wait.attempt_id == _ATT2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("terminal", "expected"),
+    (
+        (
+            _Eval(SemanticStatus.HUMAN_DENIED, SemanticReason.HUMAN_DENIED),
+            (SemanticStatus.HUMAN_DENIED, SemanticReason.HUMAN_DENIED),
+        ),
+        (
+            _Eval(
+                SemanticStatus.APPROVAL_EXPIRED,
+                SemanticReason.HUMAN_APPROVAL_EXPIRED,
+            ),
+            (SemanticStatus.APPROVAL_EXPIRED, SemanticReason.HUMAN_APPROVAL_EXPIRED),
+        ),
+        (
+            _Eval(
+                SemanticStatus.BLOCKED_BY_POLICY,
+                SemanticReason.POLICY_GENERATION_REVOKED,
+            ),
+            (SemanticStatus.BLOCKED_BY_POLICY, SemanticReason.POLICY_GENERATION_REVOKED),
+        ),
+    ),
+)
+async def test_wait_replay_terminalizes_the_same_attempt_and_resolves_one_use_state(
+    terminal: _Eval,
+    expected: tuple[SemanticStatus, SemanticReason],
+) -> None:
+    ledger = _FakeLedger(_queued_job(), _lease())
+    waiting = _AwaitingEval(
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+        _Continuation(
+            "ppr_40000000-0000-4000-8000-000000000005",
+            _ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC)),
+        ),
+    )
+
+    first = await _run(ledger, [waiting], max_retries=2)
+    provider_request_id = ledger.provider_ids[0] if ledger.provider_ids is not None else None
+    assert first[:2] == (
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+    )
+
+    second = await _run(ledger, [terminal], max_retries=2)
+
+    assert second[:2] == expected
+    assert ledger.provider_ids == [provider_request_id]
+    assert ledger.attempt_ids == [_ATT1]
+    assert ledger.outcomes == [(_ATT1, AttemptOutcome.FAILED, terminal.reason)]
+    assert ledger.job.state == "failed"
+    resolved = await ledger.load_disclosure_wait(_WRITER, _OP)
+    assert resolved is not None and resolved.state == "resolved"
+
+
+@pytest.mark.anyio
+async def test_cancellation_after_wait_terminalizes_before_propagating_and_resolves_wait() -> None:
+    ledger = _FakeLedger(_queued_job(), _lease())
+    waiting = _AwaitingEval(
+        SemanticStatus.AWAITING_HUMAN,
+        SemanticReason.HUMAN_APPROVAL_REQUIRED,
+        _Continuation(
+            "ppr_40000000-0000-4000-8000-000000000006",
+            _ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC)),
+        ),
+    )
+    await _run(ledger, [waiting], max_retries=0)
+
+    async def cancel_dispatch(handle: SemanticAttemptHandle, attempt_deadline: Deadline) -> _Eval:
+        del handle, attempt_deadline
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_durable_semantic_attempts(
+            ledger=ledger,
+            lease=ledger.lease,
+            job=ledger.job,
+            deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1000.0),
+            max_retries=0,
+            now_monotonic=lambda: 0.0,
+            dispatch=cancel_dispatch,
+            publish_success_response=_publish_response,
+            sleep=lambda _: _async_noop(),
+            build_final=_build_tuple,
+        )
+
+    assert ledger.attempt_ids == [_ATT1]
+    assert ledger.outcomes == [(_ATT1, AttemptOutcome.FAILED, SemanticReason.COORDINATOR_FAILURE)]
+    assert ledger.job.state == "failed"
+    resolved = await ledger.load_disclosure_wait(_WRITER, _OP)
+    assert resolved is not None and resolved.state == "resolved"
 
 
 @pytest.mark.anyio

--- a/tests/unit/application/test_semantic_authorization_resume.py
+++ b/tests/unit/application/test_semantic_authorization_resume.py
@@ -1,0 +1,306 @@
+"""Failure-matrix coverage for resuming one-use semantic disclosure authority."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+
+from builders.privacy_policies import minimal_external_policy
+from yoetz.application.egress import (
+    PrivacyCoordinator,
+    SemanticEgressAwaitingHuman,
+    SemanticEgressBlocked,
+)
+from yoetz.domain.privacy import (
+    AuthorizationScope,
+    AuthorizationScopeKind,
+    ConsentSource,
+    DisclosureProposal,
+    PrivacyOutcome,
+    PrivacyProfile,
+    PrivacyReason,
+    ProviderBinding,
+)
+from yoetz.ports.clock import ClockPort
+from yoetz.ports.ids import IdPort
+from yoetz.ports.privacy import (
+    EffectivePrivacyPolicy,
+    HumanAuthorityCapability,
+    OutboundGatewayPort,
+    PrivacyAuditPort,
+    PrivacyAuditReservation,
+    PrivacyAuditState,
+    PrivacyClassifierPort,
+    PrivacyPolicyStorePort,
+    RepositoryPrivacyAuthority,
+)
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.ids import IdKind
+
+_NOW = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+_INSTALLATION = "ins_54000000-0000-4000-8000-000000000001"
+_TASK = "tsk_54000000-0000-4000-8000-000000000002"
+_REQUEST = "req_54000000-0000-4000-8000-000000000003"
+_PROPOSAL = "ppr_54000000-0000-4000-8000-000000000004"
+_WORKSPACE = "hmac-sha256:" + "5" * 64
+_CASE_DIGEST = "sha256:" + "6" * 64
+_AUTHORITY_DIGEST = "sha256:" + "8" * 64
+
+
+class _Clock:
+    def __init__(self, now: datetime = _NOW) -> None:
+        self.now = now
+
+    def now_utc(self) -> datetime:
+        return self.now
+
+    def monotonic_seconds(self) -> float:
+        return 1.0
+
+
+class _Ids:
+    def __init__(self) -> None:
+        self.next_value = 0
+
+    def new(self, kind: IdKind) -> str:
+        self.next_value += 1
+        prefix = "out_" if kind is IdKind.OUTBOUND_CASE else "egr_"
+        return f"{prefix}54000000-0000-4000-8000-{self.next_value:012x}"
+
+
+def _scope() -> AuthorizationScope:
+    return AuthorizationScope(
+        AuthorizationScopeKind.TASK,
+        _INSTALLATION,
+        _WORKSPACE,
+        _TASK,
+    )
+
+
+def _binding() -> ProviderBinding:
+    policy = minimal_external_policy()
+    binding = next(
+        channel.provider_binding
+        for channel in policy.channel_policies
+        if channel.provider_binding is not None
+    )
+    return binding
+
+
+def _effective() -> EffectivePrivacyPolicy:
+    base = minimal_external_policy()
+    channels = tuple(
+        replace(channel, preview_required=True) if channel.provider_binding is not None else channel
+        for channel in base.channel_policies
+    )
+    policy = replace(
+        base,
+        profile=PrivacyProfile.CONFIRM_EVERY_REQUEST,
+        effective_scope=_scope(),
+        channel_policies=channels,
+    )
+    return EffectivePrivacyPolicy(policy, 2, policy.policy_digest)
+
+
+def _proposal(*, expires_at: datetime) -> DisclosureProposal:
+    policy = _effective().policy
+    return DisclosureProposal(
+        _PROPOSAL,
+        _REQUEST,
+        _TASK,
+        ("sha256:" + "9" * 64,),
+        b"{}",
+        (),
+        (),
+        (),
+        _CASE_DIGEST,
+        _binding(),
+        None,
+        "semantic-review",
+        _scope(),
+        policy.version,
+        policy.policy_digest,
+        2,
+        1,
+        expires_at,
+        "hmac-sha256:" + "a" * 64,
+    )
+
+
+class _Audit:
+    def __init__(self, status: str, proposal: DisclosureProposal) -> None:
+        self.status = status
+        self.proposal = proposal
+
+    async def load(self, request_id: str, subject_digest: str) -> PrivacyAuditState | None:
+        assert (request_id, subject_digest) == (_REQUEST, _CASE_DIGEST)
+        reservation = PrivacyAuditReservation(
+            _PROPOSAL,
+            _REQUEST,
+            _CASE_DIGEST,
+            self.status,
+            2,
+            _NOW,
+        )
+        return PrivacyAuditState(reservation, self.status)
+
+    async def load_disclosure_proposal(self, proposal_id: str) -> DisclosureProposal | None:
+        assert proposal_id == _PROPOSAL
+        return self.proposal
+
+
+class _Policies:
+    def __init__(self, *, granted: bool) -> None:
+        self.granted = granted
+        self.effective = _effective()
+
+    async def effective_policy(self, scope: AuthorizationScope) -> EffectivePrivacyPolicy:
+        assert scope == _scope()
+        return self.effective
+
+    async def repository_authority(self, scope: AuthorizationScope) -> RepositoryPrivacyAuthority:
+        assert scope == _scope()
+        policy = self.effective.policy
+        grant_policy = replace(
+            policy,
+            effective_scope=AuthorizationScope(
+                AuthorizationScopeKind.WORKSPACE,
+                _INSTALLATION,
+                _WORKSPACE,
+            ),
+        )
+        return RepositoryPrivacyAuthority(
+            scope,
+            self.effective,
+            _WORKSPACE,
+            "granted" if self.granted else "missing",
+            "not_applicable",
+            _AUTHORITY_DIGEST,
+            (),
+            2 if self.granted else None,
+            grant_policy.policy_digest if self.granted else None,
+            grant_policy if self.granted else None,
+        )
+
+
+class _Gateway:
+    def __init__(self) -> None:
+        self.reconciliations = 0
+
+    async def reconcile_repository_policy(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        self.reconciliations += 1
+        return object()
+
+    async def close(self) -> None:
+        return None
+
+
+def _coordinator(
+    status: str,
+    *,
+    expires_at: datetime,
+    granted: bool = True,
+    clock: _Clock | None = None,
+) -> PrivacyCoordinator:
+    return PrivacyCoordinator(
+        cast(PrivacyPolicyStorePort, _Policies(granted=granted)),
+        cast(PrivacyClassifierPort, object()),
+        cast(PrivacyAuditPort, _Audit(status, _proposal(expires_at=expires_at))),
+        cast(OutboundGatewayPort, _Gateway()),
+        cast(ClockPort, clock or _Clock()),
+        cast(IdPort, _Ids()),
+        human_authority=HumanAuthorityCapability(
+            "established_passphrase",
+            "sha256:" + "b" * 64,
+            1,
+            "passphrase",
+            1,
+            True,
+        ),
+    )
+
+
+def _deadline() -> Deadline:
+    return Deadline(_NOW + timedelta(minutes=10), 600.0)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status", ("reserved", "awaiting_human"))
+async def test_unanswered_or_crash_before_wait_marking_remains_nonterminal(status: str) -> None:
+    coordinator = _coordinator(status, expires_at=_NOW + timedelta(minutes=5))
+
+    result = await coordinator.resume(_REQUEST, _CASE_DIGEST, _deadline())
+
+    assert isinstance(result, SemanticEgressAwaitingHuman)
+    assert result.privacy_proposal_id == _PROPOSAL
+    assert result.expires_at == _NOW + timedelta(minutes=5)
+
+
+@pytest.mark.anyio
+async def test_expired_wait_terminalizes_without_dispatch() -> None:
+    coordinator = _coordinator(
+        "awaiting_human",
+        expires_at=_NOW - timedelta(seconds=1),
+    )
+
+    result = await coordinator.resume(_REQUEST, _CASE_DIGEST, _deadline())
+
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.APPROVAL_EXPIRED
+    assert result.reason is PrivacyReason.AUTHORIZATION_EXPIRED
+
+
+@pytest.mark.anyio
+async def test_recorded_denial_terminalizes_without_dispatch() -> None:
+    coordinator = _coordinator(
+        "decision_receipt_pending",
+        expires_at=_NOW + timedelta(minutes=5),
+    )
+
+    result = await coordinator.resume(_REQUEST, _CASE_DIGEST, _deadline())
+
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.HUMAN_DENIED
+    assert result.reason is PrivacyReason.HUMAN_DENIED
+
+
+@pytest.mark.anyio
+async def test_stale_repository_authority_fails_closed_before_dispatch() -> None:
+    coordinator = _coordinator(
+        "approved",
+        expires_at=_NOW + timedelta(minutes=5),
+        granted=False,
+    )
+
+    result = await coordinator.resume(_REQUEST, _CASE_DIGEST, _deadline())
+
+    assert isinstance(result, SemanticEgressBlocked)
+    assert result.outcome is PrivacyOutcome.BLOCKED_BY_POLICY
+    assert result.reason is PrivacyReason.SCOPE_MISMATCH
+
+
+@pytest.mark.anyio
+async def test_approved_resume_preserves_per_request_human_consent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _coordinator(
+        "approved",
+        expires_at=_NOW + timedelta(minutes=5),
+    )
+    captured: list[ConsentSource] = []
+
+    async def dispatch(self: PrivacyCoordinator, *args: object, **kwargs: object) -> object:
+        del self, kwargs
+        captured.append(cast(ConsentSource, args[4]))
+        return object()
+
+    monkeypatch.setattr(PrivacyCoordinator, "_dispatch_approved", dispatch)
+
+    result = await coordinator.resume(_REQUEST, _CASE_DIGEST, _deadline())
+
+    assert result is not None
+    assert captured == [ConsentSource.PER_REQUEST_LOCAL_HUMAN]


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #141
- I searched existing issues and PRs for duplicates before opening this PR. The related implementation PRs #142 and #163 are merged; no open PR owns the remaining matrix.
- The original design gate was acknowledged on the issue. The maintainer's current scope comment narrows this PR to the automated failure matrix and says the remaining test work is not design-gated.

## Documentation

- Behavior change? `yes`
- Updated `docs/INTERFACES.md` with the restart and terminal-write ordering invariant for an awaiting-human semantic operation.

## Verification

Commands run (paste):

```text
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue141 uv run pytest tests/unit/application/test_semantic_attempts.py tests/unit/application/test_semantic_authorization_resume.py tests/unit/service/test_daemon_disclosure_effects.py tests/integration/application/test_check.py tests/integration/application/test_status_operation_view.py tests/integration/application/test_full_workflow.py tests/integration/service/test_semantic_non_dispatch.py tests/conformance/adapters/test_ledger_port.py tests/integration/storage tests/unit/adapters/test_runtime_read_facade.py
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue141 uv run ruff format --check .
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue141 uv run ruff check .
/Users/shayb/yoetz-core/node_modules/.bin/pyright
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue141 uv run python scripts/sync_resource_ripple.py --check
UV_CACHE_DIR=/private/tmp/yoetz-uv-cache-issue141 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Focused result: `231 passed`; Ruff, Pyright, resource fixed-point, public-boundary scan, and diff checks passed.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Awaiting-human semantic checks now resume the exact durable provider request after a local decision instead of rebuilding the privacy pipeline. Denial, expiry, stale authority, and cancellation terminalize that exact attempt before resolving its one-use wait, preserving the no-dispatch boundary.

SQLite restart recovery now reconstructs the pending semantic job and physical attempt together with the disclosure wait. The matrix covers memory and SQLite adapters, crash recovery before and after the semantic terminal write, cancellation, public check replay, and per-request consent provenance.

Implemented with GPT-5.6 through the Codex desktop harness.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores durable resumption of awaiting-human semantic checks while preserving the original provider request and terminal-write ordering.
- Reconstructs semantic jobs and attempts during SQLite restart recovery.
- Resumes matching disclosure waits rather than rebuilding the privacy pipeline.
- Resolves one-use waits only after attempt or job terminalization.
- Records per-request human consent provenance and expands restart, cancellation, denial, expiry, and replay coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

The changed recovery, identifier preservation, resume routing, and terminal cleanup paths are mutually consistent and are covered across memory, SQLite restart, cancellation, denial, expiry, and replay scenarios.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/sqlite/repository.py | Restores semantic jobs, attempts, and matching disclosure waits for pending operations during SQLite startup. |
| src/yoetz/application/egress.py | Validates persisted proposals during resume and attributes resumed authorization to per-request human consent. |
| src/yoetz/application/semantic_attempts.py | Resolves disclosure waits after durable terminal transitions across success, failure, cancellation, expiry, and recovery paths. |
| src/yoetz/service/ready_composition.py | Routes matching awaiting attempts through privacy resume while retaining fresh evaluation for other attempts. |
| docs/INTERFACES.md | Documents restart reconstruction and terminal-write-before-wait-resolution invariants. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Check
    participant Ledger
    participant Privacy
    participant Provider
    Check->>Ledger: Claim semantic attempt
    Ledger-->>Check: Existing attempt and provider request ID
    Check->>Ledger: Load disclosure wait
    alt Matching awaiting wait
        Check->>Privacy: Resume original provider request
    else No matching wait
        Check->>Privacy: Evaluate semantic candidate
    end
    Privacy-->>Check: Terminal result or awaiting-human
    alt Terminal result
        Check->>Ledger: Terminalize attempt and job
        Check->>Ledger: Resolve one-use disclosure wait
    else Awaiting-human
        Check->>Ledger: Persist disclosure wait
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(semantic): recover awaiting-human ch..."](https://github.com/thegaysupreme123/yoetz/commit/7e2c2a530d428cb28176f871f42d6604584682b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58430567)</sub>

<!-- /greptile_comment -->