### PR TITLE
fix(consent): validate vault result before consuming approval

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2142,6 +2142,17 @@ helper generates and scoped-credential-store-verifies it before confidential sub
 unlock an already-locked vault. The six MCP tools (ADR-011) are unchanged; authorize is local
 CLI control.
 
+A consent action is recorded approved only after its operation result is validated as the exact
+success the review-result schema admits (issue #510). A ceremony that ends in any other state —
+for example a locked vault reporting `throttle_record_exists` — consumes the pending decision
+with audit outcome `failed` and a bounded `failure_reason`, prints
+`elevated_bootstrap: vault_result_<reason>` (`result_invalid` for a result outside the schema),
+and leaves no durable claim of approval, so failed execution stays distinguishable from denial,
+expiry, and completion. Retry is one new `yoetz consent prepare`, which rebinds the identical
+target digest for vault operations. A failed generated rotation never promotes the staged
+scoped-credential replacement; startup reconciliation still owns the staged slot. Recovery of a
+generated auto-unlock credential left behind by a failed initialization is owned by issue #511.
+
 The current public JSON Schema contracts are `catalog`, `pending-agent`, `prepare-result`,
 `review-result`, and `status`, each at version `5.0.0` under `schemas/consent/`; frozen versions
 `2.0.0` through `4.0.0` remain shipped for compatibility. The current version report is

--- a/src/yoetz/cli/elevated.py
+++ b/src/yoetz/cli/elevated.py
@@ -129,19 +129,32 @@ def _review_result(
         "trusted_console_presence", "agent_attested_chat_instruction"
     ] = "trusted_console_presence",
 ) -> dict[str, JsonValue]:
-    model = ConsentReviewResultModel.model_validate(
-        {
-            "schema": "yoetz.elevated-bootstrap.result/5",
-            "pending_id": pending.pending_id,
-            "operation": pending.operation,
-            "risk_class": pending.risk_class,
-            "outcome": outcome,
-            "danger_digest": pending.danger_digest,
-            "authority_channel": authority_channel,
-            "result": dict(result),
-        }
-    )
+    try:
+        model = ConsentReviewResultModel.model_validate(
+            {
+                "schema": "yoetz.elevated-bootstrap.result/5",
+                "pending_id": pending.pending_id,
+                "operation": pending.operation,
+                "risk_class": pending.risk_class,
+                "outcome": outcome,
+                "danger_digest": pending.danger_digest,
+                "authority_channel": authority_channel,
+                "result": dict(result),
+            }
+        )
+    except (TypeError, ValueError) as exc:
+        raise ElevatedBootstrapError("result_invalid") from exc
     return model.model_dump(mode="json", by_alias=True)
+
+
+def _validated_vault_success(result: object) -> dict[str, JsonValue]:
+    """Admit only the exact schema-admitted success; project a bounded failure otherwise."""
+
+    if type(result) is not VaultStateResult:
+        raise ElevatedBootstrapError("result_invalid")
+    if result.state != "ready" or result.reason != "succeeded":
+        raise ElevatedBootstrapError(f"vault_result_{result.reason}")
+    return {"state": result.state, "reason": result.reason}
 
 
 def _require_action_bound_user_presence() -> None:
@@ -177,9 +190,12 @@ async def review_elevated() -> dict[str, JsonValue]:
                 consumed = True
                 raise ElevatedBootstrapError("pending_expired")
             result = await _complete_approved(console, pending)
+            # Validate the projected result before the durable approval record exists: a
+            # result the schema does not admit must consume this review as failed.
+            payload = _review_result(pending, outcome="completed", result=result)
             complete_review(pending, outcome="approved")
             consumed = True
-            return _review_result(pending, outcome="completed", result=result)
+            return payload
     except TrustedConsoleError as exc:
         if pending is not None and not consumed:
             _consume_failed_review(pending, "cancelled")
@@ -190,15 +206,21 @@ async def review_elevated() -> dict[str, JsonValue]:
         if pending is not None and not consumed:
             _consume_failed_review(pending, "cancelled")
         raise ElevatedBootstrapError("review_cancelled") from exc
-    except BaseException:
+    except BaseException as exc:
         if pending is not None and not consumed:
-            _consume_failed_review(pending, "failed")
+            _consume_failed_review(pending, "failed", _bounded_failure_reason(exc))
         raise
 
 
-def _consume_failed_review(pending: PendingElevatedConsent, outcome: str) -> None:
+def _bounded_failure_reason(error: BaseException) -> str | None:
+    return error.reason if type(error) is ElevatedBootstrapError else None
+
+
+def _consume_failed_review(
+    pending: PendingElevatedConsent, outcome: str, failure_reason: str | None = None
+) -> None:
     try:
-        complete_review(pending, outcome=outcome)
+        complete_review(pending, outcome=outcome, failure_reason=failure_reason)
     except ElevatedBootstrapError:
         # Preserve the original bounded failure. A claim that could not be removed remains
         # fail-closed and prevents reuse or a second pending request.
@@ -305,17 +327,20 @@ async def authorize_elevated(
             }
         else:
             raise ElevatedBootstrapError("chat_user_operation_forbidden")
-        complete_review(pending, outcome="approved")
-        consumed = True
-        return _review_result(
+        # Validate the projected result before the durable approval record exists: a
+        # result the schema does not admit must consume this review as failed.
+        payload = _review_result(
             pending,
             outcome="completed",
             result=result,
             authority_channel="agent_attested_chat_instruction",
         )
-    except BaseException:
+        complete_review(pending, outcome="approved")
+        consumed = True
+        return payload
+    except BaseException as exc:
         if pending is not None and not consumed:
-            _consume_failed_review(pending, "failed")
+            _consume_failed_review(pending, "failed", _bounded_failure_reason(exc))
         raise
     finally:
         if provider_credential is not None:
@@ -366,9 +391,7 @@ async def _complete_vault_initialize(
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    if type(result) is not VaultStateResult:
-        raise ElevatedBootstrapError("result_invalid")
-    return {"state": result.state, "reason": result.reason}
+    return _validated_vault_success(result)
 
 
 async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
@@ -394,9 +417,7 @@ async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    if type(result) is not VaultStateResult:
-        raise ElevatedBootstrapError("result_invalid")
-    return {"state": result.state, "reason": result.reason}
+    return _validated_vault_success(result)
 
 
 async def _complete_vault_passphrase_rotate_generated() -> dict[str, JsonValue]:
@@ -421,12 +442,11 @@ async def _complete_vault_passphrase_rotate_generated() -> dict[str, JsonValue]:
             passphrase=bytearray(current),
             vault_rewrap_secret=bytearray(replacement),
         )
-        if type(result) is not VaultStateResult:
-            raise ElevatedBootstrapError("result_invalid")
-        # Promote only after the service reports a completed rewrap. On any ambiguous failure the
-        # staged slot intentionally remains for daemon restart reconciliation.
+        # Promote only after the service reports the exact completed rewrap. On any failed or
+        # ambiguous outcome the staged slot intentionally remains for restart reconciliation.
+        validated = _validated_vault_success(result)
         store.promote_staged_rotation()
-        return {"state": result.state, "reason": result.reason}
+        return validated
     except ConfidentialClientError as exc:
         raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
     except HumanCeremonyCliError as exc:

--- a/src/yoetz/cli/exits.py
+++ b/src/yoetz/cli/exits.py
@@ -234,6 +234,11 @@ REMEDIATION_MESSAGES: Final = MappingProxyType(
             "make the owner-only state directory accessible and writable from the supported host "
             "surface, then retry"
         ),
+        "result_invalid": (
+            "the operation produced a result the consent schema does not admit, so the "
+            "approval was recorded as failed and nothing was approved; run "
+            "'yoetz consent prepare <operation>' again, and report a defect if this recurs"
+        ),
         "workspace_unresolvable": (
             "the --workspace locator is empty, missing, symlinked, foreign-owned, or otherwise "
             "unsafe; pass the resolved path of a directory owned by the current user (host hooks "
@@ -247,4 +252,13 @@ REMEDIATION_MESSAGES: Final = MappingProxyType(
 def remediation_message(reason: str) -> str | None:
     """Return the next-step half of an operator-facing line for a bounded token, or None."""
 
-    return REMEDIATION_MESSAGES.get(reason)
+    message = REMEDIATION_MESSAGES.get(reason)
+    if message is None and reason.startswith("vault_result_"):
+        # One remediation for the whole family: the token names the exact service condition,
+        # and the consent approval was consumed as failed, never recorded as approved.
+        return (
+            "the vault ceremony finished without reaching its exact successful state, so the "
+            "approval was recorded as failed; inspect 'yoetz service status', resolve the "
+            "named condition, then run 'yoetz consent prepare <operation>' and authorize again"
+        )
+    return message

--- a/src/yoetz/service/elevated_bootstrap.py
+++ b/src/yoetz/service/elevated_bootstrap.py
@@ -1146,10 +1146,28 @@ def claim_pending_for_review(*, _state: Path | None = None) -> PendingElevatedCo
         return claimed
 
 
+_FAILURE_REASON_CHARACTERS: Final = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+def _validated_failure_reason(outcome: str, failure_reason: str | None) -> str | None:
+    if failure_reason is None:
+        return None
+    if outcome != "failed":
+        raise ElevatedBootstrapError("review_outcome_invalid")
+    if (
+        type(failure_reason) is not str
+        or not 0 < len(failure_reason) <= 128
+        or any(character not in _FAILURE_REASON_CHARACTERS for character in failure_reason)
+    ):
+        raise ElevatedBootstrapError("failure_reason_invalid")
+    return failure_reason
+
+
 def _complete_review_unlocked(
     pending: PendingElevatedConsent,
     *,
     outcome: str,
+    failure_reason: str | None = None,
     _state: Path | None = None,
 ) -> None:
     """Consume the claimed request exactly once for approval, denial, cancellation, or expiry."""
@@ -1158,6 +1176,7 @@ def _complete_review_unlocked(
         raise TypeError("pending_review_invalid")
     if outcome not in {"approved", "cancelled", "denied", "expired", "failed"}:
         raise ElevatedBootstrapError("review_outcome_invalid")
+    reason = _validated_failure_reason(outcome, failure_reason)
     claim = review_path(_state=_state)
     claimed = _load_pending_path(claim, _state=_state, expire=False)
     if claimed is None:
@@ -1168,27 +1187,30 @@ def _complete_review_unlocked(
         claim.unlink()
     except OSError as exc:
         raise ElevatedBootstrapError("pending_clear_failed") from exc
-    _audit(
-        {
-            "event": "review_consumed",
-            "pending_id": pending.pending_id,
-            "operation": pending.operation,
-            "outcome": outcome,
-        },
-        _state=_state,
-    )
+    event: dict[str, JsonValue] = {
+        "event": "review_consumed",
+        "pending_id": pending.pending_id,
+        "operation": pending.operation,
+        "outcome": outcome,
+    }
+    if reason is not None:
+        event["failure_reason"] = reason
+    _audit(event, _state=_state)
 
 
 def complete_review(
     pending: PendingElevatedConsent,
     *,
     outcome: str,
+    failure_reason: str | None = None,
     _state: Path | None = None,
 ) -> None:
     """Consume the claimed request exactly once for approval, denial, cancellation, or expiry."""
 
     with _PendingStateLock(_state):
-        _complete_review_unlocked(pending, outcome=outcome, _state=_state)
+        _complete_review_unlocked(
+            pending, outcome=outcome, failure_reason=failure_reason, _state=_state
+        )
 
 
 def projection_for_status(

--- a/tests/integration/service/test_consent_vault_initialize_composition.py
+++ b/tests/integration/service/test_consent_vault_initialize_composition.py
@@ -1,0 +1,238 @@
+"""Agent-authorized vault initialization over the real client/service composition (#510).
+
+The defect this locks against: `yoetz consent authorize` completed the real human-control
+ceremony, received a non-ready `VaultStateResult`, and still consumed the approval before the
+result was validated — collapsing the actionable service reason to `authorize_failed` while the
+audit said approved. These tests run real agent attestation, a generated local secret, the real
+YZH1/YZS1 client and service transport, and a real unlock throttle, mocking only the OS keyring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import yoetz.service.daemon as daemon_module
+from yoetz.adapters.control.unix_socket import (
+    bind_control_listener,
+    bind_human_control_listener,
+    bind_secret_listener,
+)
+from yoetz.cli import elevated
+from yoetz.config.load import YoetzConfig
+from yoetz.service.daemon import ServiceDaemon
+from yoetz.service.elevated_bootstrap import ElevatedBootstrapError, load_pending
+from yoetz.service.unlock import UnlockThrottleRecord
+
+_FOREIGN_INSTALLATION_ID = "ins_30000000-0000-4000-8000-000000000001"
+_FOREIGN_WRITER_ID = "svc_30000000-0000-4000-8000-000000000002"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def runtime_directory(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Short in-tree socket directory: AF_UNIX paths bound under tmp_path are too long."""
+
+    runtime = Path(tempfile.mkdtemp(prefix=".yctl-", dir=Path.cwd()))
+    runtime.chmod(0o700)
+    monkeypatch.setattr(
+        "yoetz.adapters.control.unix_socket._runtime_directory",
+        lambda: runtime,
+    )
+    try:
+        yield runtime
+    finally:
+        shutil.rmtree(runtime, ignore_errors=True)
+
+
+def _stage_non_pristine_throttle_record(path: Path) -> None:
+    """The exact repro state (#510): uninitialized bundle, non-pristine per-user throttle."""
+
+    import os
+
+    record = UnlockThrottleRecord.create(
+        installation_id=_FOREIGN_INSTALLATION_ID,
+        record_generation=1,
+        consecutive_failures=1,
+        attempt_in_progress=False,
+        last_failure_utc="2026-08-31T11:00:00.000Z",
+        last_writer_instance_id=_FOREIGN_WRITER_ID,
+    )
+    path.write_bytes(record.encode())
+    os.chmod(path, 0o600)
+
+
+async def _production_daemon(tmp_path: Path, *, pristine: bool) -> ServiceDaemon:
+    root = tmp_path / "data"
+    metadata = tmp_path / "state"
+    root.mkdir(mode=0o700, exist_ok=True)
+    metadata.mkdir(mode=0o700, exist_ok=True)
+    if not pristine:
+        _stage_non_pristine_throttle_record(metadata / "unlock-throttle.json")
+    paths = daemon_module._ProductionPaths(  # pyright: ignore[reportPrivateUsage]
+        root,
+        metadata / "service-generation.json",
+        metadata / "unlock-throttle.json",
+        metadata / "service.lock",
+        metadata,
+    )
+    binders = daemon_module._ListenerBinders(  # pyright: ignore[reportPrivateUsage]
+        bind_control_listener,
+        bind_secret_listener,
+        bind_human_control_listener,
+    )
+    composition = await daemon_module._production_composition(  # pyright: ignore[reportPrivateUsage]
+        _config=YoetzConfig(),
+        _paths=paths,
+        _binders=binders,
+    )
+    return ServiceDaemon(_composition=composition)
+
+
+def _assert_no_secret_bytes(tree: Path, secret: bytes) -> None:
+    for path in tree.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            assert secret not in path.read_bytes(), path
+
+
+@pytest.mark.anyio
+async def test_agent_authorized_initialize_non_ready_result_is_bounded_and_never_approved(
+    tmp_path: Path,
+    runtime_directory: Path,
+) -> None:
+    tmp_path.chmod(0o700)
+    consent_state = tmp_path / "consent"
+    consent_state.mkdir(mode=0o700)
+    generated = bytearray(b"g" * 64)
+    generated_copy = bytes(generated)
+
+    class _Store:
+        def create_for_initialization(self) -> bytearray:
+            return generated
+
+    daemon = await _production_daemon(tmp_path, pristine=False)
+    # Publish the endpoints before any client runs; serve() then only arms the accept loops.
+    await daemon.start()
+    serving = asyncio.create_task(daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+        ):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=consent_state)
+            assert pending is not None
+            attestation = {
+                "schema": "yoetz.chat-user-attestation/1",
+                "channel": "agent_attested_chat_instruction",
+                "client_kind": "codex",
+                "instruction_source": "explicit_current_chat_user",
+                "pending_id": pending.pending_id,
+                "operation": pending.operation,
+                "danger_digest": pending.danger_digest,
+                "target_digest": pending.target_digest,
+                "warning_acknowledged": True,
+                "decision": "approve",
+            }
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await asyncio.wait_for(elevated.authorize_elevated(attestation), timeout=30)
+
+            # The actionable service reason survives as a bounded token, never the generic
+            # authorize_failed collapse.
+            assert exc.value.reason == "vault_result_throttle_record_exists"
+            # The approval is consumed as failed with a stable correlation; nothing durable
+            # claims success and the audit never says approved.
+            assert load_pending(_state=consent_state) is None
+            audit_lines = (
+                (consent_state / "elevated-bootstrap" / "elevated-bootstrap-audit.jsonl")
+                .read_text("utf-8")
+                .splitlines()
+            )
+            assert not any('"outcome":"approved"' in line for line in audit_lines)
+            consumed = [line for line in audit_lines if '"event":"review_consumed"' in line]
+            assert len(consumed) == 1
+            assert '"outcome":"failed"' in consumed[0]
+            assert '"failure_reason":"vault_result_throttle_record_exists"' in consumed[0]
+            assert pending.pending_id in consumed[0]
+
+            # The daemon still reports the truthful vault state.
+            assert daemon.status().vault_mode == "uninitialized"
+            assert not (tmp_path / "data" / "vault").exists()
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(serving, timeout=10)
+
+    # The generated local secret was wiped and never persisted to any artifact.
+    assert bytes(generated) == b"\x00" * len(generated)
+    _assert_no_secret_bytes(tmp_path, generated_copy)
+    _assert_no_secret_bytes(runtime_directory, generated_copy)
+
+
+@pytest.mark.anyio
+async def test_agent_authorized_initialize_succeeds_on_pristine_state_without_secret_exposure(
+    tmp_path: Path,
+    runtime_directory: Path,
+) -> None:
+    tmp_path.chmod(0o700)
+    consent_state = tmp_path / "consent"
+    consent_state.mkdir(mode=0o700)
+    generated = bytearray(b"s" * 64)
+    generated_copy = bytes(generated)
+
+    class _Store:
+        def create_for_initialization(self) -> bytearray:
+            return generated
+
+    daemon = await _production_daemon(tmp_path, pristine=True)
+    await daemon.start()
+    serving = asyncio.create_task(daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+        ):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=consent_state)
+            assert pending is not None
+            attestation = {
+                "schema": "yoetz.chat-user-attestation/1",
+                "channel": "agent_attested_chat_instruction",
+                "client_kind": "codex",
+                "instruction_source": "explicit_current_chat_user",
+                "pending_id": pending.pending_id,
+                "operation": pending.operation,
+                "danger_digest": pending.danger_digest,
+                "target_digest": pending.target_digest,
+                "warning_acknowledged": True,
+                "decision": "approve",
+            }
+            result = await asyncio.wait_for(elevated.authorize_elevated(attestation), timeout=30)
+
+            assert result["outcome"] == "completed"
+            assert result["result"] == {"state": "ready", "reason": "succeeded"}
+            assert load_pending(_state=consent_state) is None
+            audit_lines = (
+                (consent_state / "elevated-bootstrap" / "elevated-bootstrap-audit.jsonl")
+                .read_text("utf-8")
+                .splitlines()
+            )
+            assert any('"outcome":"approved"' in line for line in audit_lines)
+            assert not any('"outcome":"failed"' in line for line in audit_lines)
+            assert daemon.status().vault_mode == "passphrase"
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(serving, timeout=10)
+
+    assert bytes(generated) == b"\x00" * len(generated)
+    _assert_no_secret_bytes(tmp_path, generated_copy)
+    _assert_no_secret_bytes(runtime_directory, generated_copy)

--- a/tests/unit/cli/test_ceremony_refusal_reporting.py
+++ b/tests/unit/cli/test_ceremony_refusal_reporting.py
@@ -165,6 +165,18 @@ def test_unmapped_tokens_have_no_remediation() -> None:
     assert remediation_message("authorize_failed") is None
 
 
+def test_vault_result_family_names_the_failed_approval_and_the_retry() -> None:
+    """Every bounded `vault_result_<reason>` projection shares one honest remediation."""
+
+    for reason in ("vault_result_throttle_record_exists", "vault_result_keyring_unavailable"):
+        message = remediation_message(reason)
+        assert message is not None, reason
+        assert "recorded as failed" in message, reason
+        assert "yoetz consent prepare" in message, reason
+    assert remediation_message("vault_result") is None
+    assert remediation_message("result_invalid") is not None
+
+
 def test_resource_count_remediation_names_the_owning_sync_script() -> None:
     message = remediation_message("resource_counts_invalid")
 

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -26,6 +26,7 @@ from yoetz.protocol.schemas import SchemaInstanceInvalid, validate_schema_instan
 from yoetz.service.confidential_protocol import ProviderCredentialResult, VaultStateResult
 from yoetz.service.elevated_bootstrap import (
     ElevatedBootstrapError,
+    audit_path,
     consume_import_publication_authorization,
     load_import_publication_authorization,
     load_pending,
@@ -644,12 +645,14 @@ def test_review_result_rejects_unknown_or_unbounded_result_fields(tmp_path: Path
         elevated.prepare_elevated("vault_initialize")
         pending = load_pending(_state=tmp_path)
     assert pending is not None
-    with pytest.raises(ValidationError):
+    with pytest.raises(ElevatedBootstrapError) as exc:
         elevated._review_result(  # pyright: ignore[reportPrivateUsage]
             pending,
             outcome="completed",
             result={"provider_text": "unbounded"},
         )
+    assert exc.value.reason == "result_invalid"
+    assert "unbounded" not in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -927,6 +930,188 @@ def test_agent_generated_rotation_uses_only_local_store_bytes_and_promotes() -> 
     assert result == {"state": "ready", "reason": "succeeded"}
     assert b"c" * 16 not in json.dumps(result).encode()
     assert b"r" * 16 not in json.dumps(result).encode()
+
+
+def _consumed_audit_events(tmp_path: Path) -> list[dict[str, Any]]:
+    lines = audit_path(_state=tmp_path).read_text("utf-8").splitlines()
+    events = [cast(dict[str, Any], json.loads(line)) for line in lines]
+    return [event for event in events if event["event"] == "review_consumed"]
+
+
+def test_agent_authorized_non_ready_vault_result_fails_before_approval(tmp_path: Path) -> None:
+    """Issue #510: a non-ready ceremony result must never leave an approved consent record."""
+
+    generated = bytearray(b"y" * 64)
+
+    class _Store:
+        def create_for_initialization(self) -> bytearray:
+            return generated
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("locked", "throttle_record_exists")
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            prepared = cast(dict[str, Any], elevated.prepare_elevated("vault_initialize"))
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with (
+                patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+                patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+            ):
+                with pytest.raises(ElevatedBootstrapError) as exc:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert exc.value.reason == "vault_result_throttle_record_exists"
+            assert bytes(generated) == b"\x00" * 64
+            assert load_pending(_state=tmp_path) is None
+            consumed = _consumed_audit_events(tmp_path)
+            assert [event["outcome"] for event in consumed] == ["failed"]
+            assert consumed[0]["pending_id"] == pending.pending_id
+            assert consumed[0]["failure_reason"] == "vault_result_throttle_record_exists"
+            # Retry is explicit and exact: a fresh prepare rebinds the identical target, so
+            # nothing about the originally authorized target needs reconstructing.
+            reprepared = cast(dict[str, Any], elevated.prepare_elevated("vault_initialize"))
+            assert reprepared["pending"]["target_digest"] == prepared["pending"]["target_digest"]
+
+    anyio.run(run)
+
+
+def test_non_ready_rotation_result_never_promotes_staged_secret() -> None:
+    current = bytearray(b"c" * 64)
+    replacement = bytearray(b"r" * 64)
+
+    class _Store:
+        promoted = False
+
+        def load(self) -> bytearray:
+            return current
+
+        def stage_for_rotation(self) -> bytearray:
+            return replacement
+
+        def promote_staged_rotation(self) -> None:
+            self.promoted = True
+
+    store = _Store()
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("locked", "credential_invalid")
+
+    async def run() -> None:
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+        ):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_passphrase_rotate_generated()  # pyright: ignore[reportPrivateUsage]
+            assert exc.value.reason == "vault_result_credential_invalid"
+
+    anyio.run(run)
+    assert store.promoted is False, "a failed rewrap must leave the staged slot for restart"
+    assert bytes(current) == b"\x00" * 64
+    assert bytes(replacement) == b"\x00" * 64
+
+
+def test_schema_rejected_result_is_bounded_and_never_recorded_approved(tmp_path: Path) -> None:
+    """Result validation runs before the approval record exists, and stays a bounded token."""
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with patch(
+                "yoetz.cli.elevated._complete_vault_initialize_generated",
+                return_value={"state": "locked", "reason": "throttle_record_exists"},
+            ):
+                with pytest.raises(ElevatedBootstrapError) as exc:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert exc.value.reason == "result_invalid"
+            assert load_pending(_state=tmp_path) is None
+            consumed = _consumed_audit_events(tmp_path)
+            assert [event["outcome"] for event in consumed] == ["failed"]
+            assert consumed[0]["failure_reason"] == "result_invalid"
+
+    anyio.run(run)
+
+
+def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: Path) -> None:
+    generated = bytearray(b"t" * 64)
+
+    class _Store:
+        def create_for_initialization(self) -> bytearray:
+            return generated
+
+    async def ceremony(
+        _console: object, _kind: object, _target: object, **_kwargs: object
+    ) -> VaultStateResult:
+        return VaultStateResult("locked", "keyring_unavailable")
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("vault_initialize")
+            with (
+                _patch_verified_presence(),
+                patch("yoetz.cli.elevated.TrustedForegroundConsole", return_value=_Console()),
+                patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+                patch(
+                    "yoetz.cli.elevated.run_human_ceremony_on_terminal",
+                    side_effect=ceremony,
+                ),
+            ):
+                with pytest.raises(ElevatedBootstrapError) as exc:
+                    await elevated.review_elevated()
+            assert exc.value.reason == "vault_result_keyring_unavailable"
+            assert load_pending(_state=tmp_path) is None
+            consumed = _consumed_audit_events(tmp_path)
+            assert [event["outcome"] for event in consumed] == ["failed"]
+            assert consumed[0]["failure_reason"] == "vault_result_keyring_unavailable"
+
+    anyio.run(run)
+
+
+def test_authorize_cli_projects_the_bounded_vault_failure_reason(tmp_path: Path) -> None:
+    generated = bytearray(b"q" * 64)
+
+    class _Store:
+        def create_for_initialization(self) -> bytearray:
+            return generated
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("locked", "throttle_record_exists")
+
+    with _patch_state(tmp_path):
+        elevated.prepare_elevated("vault_initialize")
+        pending = load_pending(_state=tmp_path)
+        assert pending is not None
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+        ):
+            result = CliRunner().invoke(
+                app,
+                [
+                    "consent",
+                    "authorize",
+                    "--pending-id",
+                    pending.pending_id,
+                    "--operation",
+                    "vault_initialize",
+                    "--danger-digest",
+                    pending.danger_digest,
+                    "--target-digest",
+                    pending.target_digest,
+                    "--client-kind",
+                    "codex",
+                    "--decision",
+                    "approve",
+                    "--warning-acknowledged",
+                ],
+            )
+    assert result.exit_code == 2
+    assert "elevated_bootstrap: vault_result_throttle_record_exists" in result.stderr
+    assert "yoetz consent prepare" in result.stderr
+    assert "authorize_failed" not in result.stderr
 
 
 def test_trusted_review_displays_exact_provider_binding(tmp_path: Path) -> None:


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #510
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated: consent/audit ordering; the maintainer filed #510 with these acceptance criteria and requested this PR.

## Documentation

- Behavior change? yes
- Docs updated: `docs/INTERFACES.md` — new paragraph in the consent authorize section describing validated-before-approval ordering, the bounded `vault_result_<reason>` / `result_invalid` failure projection, the `failed` audit outcome with `failure_reason`, explicit retry semantics, and the #511 hand-off for generated-credential recovery.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/cli tests/unit/service/test_elevated_bootstrap.py \
  tests/integration/service/test_consent_vault_initialize_composition.py \
  tests/integration/service/test_human_control.py \
  tests/conformance/surfaces/test_consent_public_boundary.py \
  tests/subprocess/test_consent_review_cli.py \
  tests/unit/adapters/test_portable_plugin.py tests/unit/adapters/test_codex_import_plan.py
  -> 617 + 190 passed (unit/cli family, and the targeted slice incl. the two new composition tests)
uv run ruff check / ruff format --check on all touched files -> clean
npx --no-install pyright on all touched files -> 0 errors
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

`authorize_elevated()` (and trusted `review_elevated()`) called `complete_review(outcome="approved")` before `_review_result()` validated the projected result, and `_complete_vault_initialize_generated()` returned any `VaultStateResult`. A non-ready ceremony outcome (`locked`/`throttle_record_exists`) therefore blew up in schema validation *after* the approval was consumed, and the CLI's generic handler collapsed it to `elevated_bootstrap: authorize_failed` — losing the actionable reason while durable audit said approved.

Now:

- The full review-result payload is built and validated **before** `complete_review(outcome="approved")` on both the agent-attested and trusted-console paths; a schema-inadmissible result raises bounded `result_invalid` and the review is consumed as `failed`, never `approved`.
- Vault initialize/rotate completions admit only the exact `ready`/`succeeded` result; anything else raises `vault_result_<reason>` where `<reason>` comes from the closed `_VAULT_STATE_RESULT_REASONS` set, so `elevated_bootstrap: vault_result_throttle_record_exists` reaches the caller with a family remediation line. Failed execution is distinguishable from denial (denied JSON), expiry (`pending_expired`), success (completed JSON), and ambiguous transport outcomes (`ceremony_*`).
- The failed consumption records a bounded `failure_reason` next to the pending id in the consent audit log for stable correlation.
- A failed generated passphrase rotation no longer promotes the staged scoped-credential replacement (validation now precedes `promote_staged_rotation()`), keeping the staged slot for restart reconciliation.
- Retry is explicit: one fresh `yoetz consent prepare`, which rebinds the identical vault target digest (locked by test).

Tests: new unit coverage for the non-ready authorize/review/rotation paths, the schema-rejection ordering, and the CLI stderr projection; plus a new production-composition integration test (`tests/integration/service/test_consent_vault_initialize_composition.py`) running real agent attestation → generated local secret → real YZH1/YZS1 client/service transport → real unlock throttle, in both the non-pristine failure and pristine success shapes, asserting no secret bytes reach argv, results, audit, or any on-disk artifact. Only the OS keyring is faked.

Scope note: cleanup/recovery of the generated auto-unlock credential after a failed ceremony stays with #511, per the issue.

Worked on by Claude Fable 5 (claude-fable-5) on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR validates consent operation results before recording approval and records bounded failure reasons when execution does not reach an admissible success state.
- Requires vault initialization and rotation to return the exact `ready`/`succeeded` result.
- Prevents promotion of a staged rotation credential after an unsuccessful ceremony.
- Adds bounded audit and CLI projections for failed review execution.
- Adds unit and production-composition coverage for success, non-ready results, schema rejection, audit ordering, retry behavior, and secret containment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue remains.

The changed paths validate every completed result before recording approval, preserve rotation recovery state on unsuccessful outcomes, and consume failures with bounded audit reasons; reachable production success results conform to the newly enforced contracts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/cli/elevated.py | Reorders result validation before approval consumption, enforces exact vault success, preserves staged rotation credentials on failure, and records bounded execution failures. |
| src/yoetz/service/elevated_bootstrap.py | Extends review consumption with validated, bounded failure reasons in audit events. |
| src/yoetz/cli/exits.py | Adds remediation for invalid result schemas and the bounded vault-result failure family. |
| tests/integration/service/test_consent_vault_initialize_composition.py | Exercises real consent-to-vault composition for pristine success and non-pristine failure while checking secret containment. |
| tests/unit/cli/test_elevated.py | Covers validation ordering, vault failures, failed audit consumption, retry target stability, and rotation promotion behavior. |
| tests/unit/cli/test_ceremony_refusal_reporting.py | Verifies operator-facing projection and remediation for the new bounded failure reasons. |
| docs/INTERFACES.md | Documents validated-before-approval ordering, failed audit semantics, rotation staging, and explicit retry behavior. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Consent as Consent CLI
    participant Operation as Vault/Operation Service
    participant Schema as Review Result Schema
    participant Audit as Consent Audit
    Caller->>Consent: authorize prepared consent
    Consent->>Operation: execute approved operation
    Operation-->>Consent: operation result
    Consent->>Schema: validate completed payload
    alt exact admissible success
        Schema-->>Consent: validated payload
        Consent->>Audit: consume as approved
        Consent-->>Caller: completed result
    else failure or invalid result
        Schema-->>Consent: bounded error
        Consent->>Audit: consume as failed + failure_reason
        Consent-->>Caller: bounded failure and retry guidance
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(consent): validate vault result befo..."](https://github.com/thegaysupreme123/yoetz/commit/c0314eeb8c922ff33b7e762fbd16377d86204d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58736374)</sub>

<!-- /greptile_comment -->