### PR TITLE
fix(vault): stage generated initialization credential until proven

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1935,8 +1935,12 @@ discards each strictly by proof against the vault envelope. No MCP method, ordin
 config value, environment value, argv value, stdin path, or log field can carry the secret.
 Active-slot deletion is not exposed until it can be atomically coupled to a human-known passphrase
 rewrap; a staged slot is deleted, with verified read-back, only after proof that no vault envelope
-depends on it (the accepting unlock disproved it, or the live service reports the vault
-uninitialized), so generated-passphrase installations cannot be stranded.
+depends on it (the accepting unlock disproved it, or the live service reports a locked,
+uninitialized vault). CLI-side staging, promotion, and proof-based discard serialize on a
+bundle-scoped advisory lock held by the initializing process for its whole
+stage→ceremony→promote span and re-checked by discard-only callers while held, so a stale status
+read can never delete a credential whose vault commit is in flight, and generated-passphrase
+installations cannot be stranded.
 
 `SecretMemoryPort` exposes `capability`, `capture`, `allocate`, and `close` over opaque one-shot
 `SecretHandle` values. `SecretPurpose` is exactly `vault_initialize`, `vault_unlock`,

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1919,17 +1919,24 @@ reveals credential or policy state.
 
 `AutoUnlockPassphraseStore` is a trusted-service/setup adapter, not an ordinary control port. Its
 credential-store service name is `yoetz.auto-unlock.v1`; its account identity is
-`bundle-<sha256(os.fsencode(abspath(bundle_root)))>`. It accepts only exact vault-passphrase bytes,
-base64url-encodes them for the allowlisted platform backend, verifies writes by round trip, and
-returns only bounded structural load reasons. Setup, boot, and trusted-TTY repair overwrite mutable
-buffers best-effort. Setup and repair resolve the bundle through the same effective configuration
-and environment inputs as daemon startup. Setup falls back to a human-chosen passphrase only for a
-platform-store failure guaranteed to occur before any write. If a write may have committed but
-cannot be read back exactly, setup stops before vault initialization and requires recovery of
-platform-store access; it never initializes a different manual secret beside the ambiguous entry.
-No MCP method, ordinary control body, config value, environment value, argv value, stdin path, or
-log field can carry the secret. Deletion is not exposed until it can be atomically coupled to a
-human-known passphrase rewrap, so generated-passphrase installations cannot be stranded.
+`bundle-<sha256(os.fsencode(abspath(bundle_root)))>` for the active slot, with sibling
+`-staged-rotation` and `-staged-initialization` accounts for the two staged slots. It accepts only
+exact vault-passphrase bytes, base64url-encodes them for the allowlisted platform backend, verifies
+writes by round trip, and returns only bounded structural load reasons. Setup, boot, and
+trusted-TTY repair overwrite mutable buffers best-effort. Setup and repair resolve the bundle
+through the same effective configuration and environment inputs as daemon startup. Setup falls back
+to a human-chosen passphrase only for a platform-store failure guaranteed to occur before any
+write. If a write may have committed but cannot be read back exactly, setup stops before vault
+initialization and requires recovery of platform-store access; it never initializes a different
+manual secret beside the ambiguous entry. Generated initialization (issue #511) stages its fresh
+secret in the staged-initialization slot, never the active entry, and promotes it only after the
+validated ready result; restart unlock tries active then staged candidates and promotes or
+discards each strictly by proof against the vault envelope. No MCP method, ordinary control body,
+config value, environment value, argv value, stdin path, or log field can carry the secret.
+Active-slot deletion is not exposed until it can be atomically coupled to a human-known passphrase
+rewrap; a staged slot is deleted, with verified read-back, only after proof that no vault envelope
+depends on it (the accepting unlock disproved it, or the live service reports the vault
+uninitialized), so generated-passphrase installations cannot be stranded.
 
 `SecretMemoryPort` exposes `capability`, `capture`, `allocate`, and `close` over opaque one-shot
 `SecretHandle` values. `SecretPurpose` is exactly `vault_initialize`, `vault_unlock`,
@@ -2150,8 +2157,14 @@ with audit outcome `failed` and a bounded `failure_reason`, prints
 and leaves no durable claim of approval, so failed execution stays distinguishable from denial,
 expiry, and completion. Retry is one new `yoetz consent prepare`, which rebinds the identical
 target digest for vault operations. A failed generated rotation never promotes the staged
-scoped-credential replacement; startup reconciliation still owns the staged slot. Recovery of a
-generated auto-unlock credential left behind by a failed initialization is owned by issue #511.
+scoped-credential replacement; startup reconciliation still owns the staged slot. A failed
+generated initialization likewise never leaves the credential in the active slot (issue #511): the
+same-attempt staged entry is removed with proof when the vault is still uninitialized, or retained
+as a typed orphan that `yoetz service auto-unlock status` distinguishes
+(`initialization_orphaned`, `initialization_unreconciled`, `pre_existing_unadoptable`),
+`yoetz service auto-unlock repair` clears under the same proof, and restart reconciliation
+resolves by proof, so retry never fails on `auto_unlock_entry_exists` from an abandoned
+same-attempt entry.
 
 The current public JSON Schema contracts are `catalog`, `pending-agent`, `prepare-result`,
 `review-result`, and `status`, each at version `5.0.0` under `schemas/consent/`; frozen versions

--- a/docs/adr/ADR-015-elevated-bootstrap-consent.md
+++ b/docs/adr/ADR-015-elevated-bootstrap-consent.md
@@ -74,7 +74,15 @@ generate and store one locally without any secret-bearing agent channel.
    pending, catalog, result, log, error, or agent projection. For `vault_initialize`, agent-chat
    approval carries no secret: the helper generates the passphrase inside the local process,
    round-trips it through the scoped credential store, submits a mutable copy through YZS1, and
-   returns only structural vault state. `vault_passphrase_rotate` likewise carries no secret:
+   returns only structural vault state. **Staged initialization amendment (2026-08-31, issue
+   #511).** The helper writes the generated passphrase to a bundle-scoped staged-initialization
+   slot, never the active entry, and promotes it to the active slot only after the
+   schema-validated ready result. On a failed ceremony it removes exactly the same-attempt staged
+   entry, with verified read-back, only when the live service proves the vault is still
+   uninitialized; any unprovable outcome retains the entry as a typed orphan that
+   `yoetz service auto-unlock status` names and that restart reconciliation resolves by
+   cryptographic proof against the vault envelope, so a failed attempt never strands the
+   credential or blocks retry with `entry_exists`. `vault_passphrase_rotate` likewise carries no secret:
    the helper locally loads the active scoped secret, stages a generated replacement, completes
    reauthentication and rewrap, and then promotes the replacement. Trusted CLI/TUI remains the
    stronger recommended path.

--- a/src/yoetz/adapters/keys/os_keyring.py
+++ b/src/yoetz/adapters/keys/os_keyring.py
@@ -7,7 +7,8 @@ import binascii
 import hashlib
 import hmac
 import os
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Generator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -70,6 +71,7 @@ _ERRORS: Final = frozenset(
         "authority_mismatch",
         "entry_exists",
         "staged_entry_exists",
+        "initialization_in_progress",
         "entry_invalid",
         "correlation_mismatch",
         "migration_not_proven",
@@ -201,6 +203,7 @@ class AutoUnlockPassphraseStore:
     __slots__ = (
         "_backend",
         "_backend_id",
+        "_guard_path",
         "_staged_init_username",
         "_staged_username",
         "_username",
@@ -215,6 +218,36 @@ class AutoUnlockPassphraseStore:
         self._username = "bundle-" + hashlib.sha256(encoded).hexdigest()
         self._staged_username = self._username + "-staged-rotation"
         self._staged_init_username = self._username + "-staged-initialization"
+        self._guard_path = Path(os.path.abspath(bundle_path)) / "auto-unlock-init.lock"
+
+    @contextmanager
+    def staged_initialization_guard(self) -> Generator[None]:
+        """Serialize local staging, promotion, and proof-based discard of the staged slot.
+
+        A bundle-scoped advisory lock. The initializing process holds it across its whole
+        stage -> ceremony -> promote/cleanup span, so a concurrent repair or retry can never
+        delete the staged entry between a stale ``uninitialized`` status read and the vault
+        envelope commit; discard-only callers re-prove the vault state while holding it. The
+        lock releases automatically if its holder dies, and a held lock fails fast rather than
+        blocking behind a ceremony.
+        """
+
+        try:
+            import fcntl
+        except ImportError:
+            raise OSKeyringError("unsupported") from None
+        try:
+            fd = os.open(self._guard_path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+        except OSError:
+            raise OSKeyringError("unsupported") from None
+        try:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                raise OSKeyringError("initialization_in_progress") from None
+            yield
+        finally:
+            os.close(fd)
 
     @property
     def entry_identity(self) -> tuple[str, str]:

--- a/src/yoetz/adapters/keys/os_keyring.py
+++ b/src/yoetz/adapters/keys/os_keyring.py
@@ -69,6 +69,7 @@ _ERRORS: Final = frozenset(
         "human_authority_unavailable",
         "authority_mismatch",
         "entry_exists",
+        "staged_entry_exists",
         "entry_invalid",
         "correlation_mismatch",
         "migration_not_proven",
@@ -192,11 +193,18 @@ class AutoUnlockPassphraseStore:
 
     The keyring username is a digest of the absolute service bundle path, so independent Yoetz
     data roots never share an auto-unlock secret and the filesystem path is not disclosed to the
-    credential-store label. Fresh setup generates the value; trusted-TTY repair may store an
+    credential-store label. Fresh setup generates the value into a staged-initialization slot and
+    promotes it only after the vault ceremony proves success; trusted-TTY repair may store an
     existing passphrase only after the caller proves it unlocks the current vault envelope.
     """
 
-    __slots__ = ("_backend", "_backend_id", "_staged_username", "_username")
+    __slots__ = (
+        "_backend",
+        "_backend_id",
+        "_staged_init_username",
+        "_staged_username",
+        "_username",
+    )
 
     def __init__(self, bundle_path: object, *, backend: object | None = None) -> None:
         if not isinstance(bundle_path, Path) or not bundle_path.is_absolute():
@@ -206,6 +214,7 @@ class AutoUnlockPassphraseStore:
         encoded = os.fsencode(os.path.abspath(bundle_path))
         self._username = "bundle-" + hashlib.sha256(encoded).hexdigest()
         self._staged_username = self._username + "-staged-rotation"
+        self._staged_init_username = self._username + "-staged-initialization"
 
     @property
     def entry_identity(self) -> tuple[str, str]:
@@ -238,26 +247,37 @@ class AutoUnlockPassphraseStore:
 
     def load_candidates_with_reason(
         self,
-    ) -> tuple[tuple[tuple[bytearray, bool], ...], str]:
-        """Load active then crash-recovery staged candidates without exposing either value."""
+    ) -> tuple[tuple[tuple[bytearray, str], ...], str]:
+        """Load active then crash-recovery staged candidates without exposing any value.
+
+        Each candidate is tagged with its slot (``active``, ``staged_rotation``, or
+        ``staged_initialization``) so restart reconciliation can promote or discard exactly the
+        entry that cryptographic proof selected. Staged values identical to an earlier candidate
+        are dropped from the result but never deleted here.
+        """
 
         if not self.available:
             return (), "auto_unlock_backend_unavailable"
-        active, active_reason = self._load_username(self._username)
-        staged, staged_reason = self._load_username(self._staged_username)
-        candidates: list[tuple[bytearray, bool]] = []
-        if active is not None:
-            candidates.append((active, False))
-        if staged is not None:
-            if active is not None and hmac.compare_digest(active, staged):
-                _overwrite(staged)
-            else:
-                candidates.append((staged, True))
+        candidates: list[tuple[bytearray, str]] = []
+        reasons: list[str] = []
+        for username, slot in (
+            (self._username, "active"),
+            (self._staged_username, "staged_rotation"),
+            (self._staged_init_username, "staged_initialization"),
+        ):
+            value, reason = self._load_username(username)
+            reasons.append(reason)
+            if value is None:
+                continue
+            if any(hmac.compare_digest(existing, value) for existing, _slot in candidates):
+                _overwrite(value)
+                continue
+            candidates.append((value, slot))
         if candidates:
             return tuple(candidates), "none"
-        if active_reason == "auto_unlock_rejected" or staged_reason == "auto_unlock_rejected":
+        if "auto_unlock_rejected" in reasons:
             return (), "auto_unlock_rejected"
-        return (), active_reason
+        return (), reasons[0]
 
     def _load_username(self, username: str) -> tuple[bytearray | None, str]:
         try:
@@ -295,14 +315,71 @@ class AutoUnlockPassphraseStore:
             return existing
         return self._create_after_absent(load_reason)
 
-    def create_for_initialization(self) -> bytearray:
-        """Create a fresh secret; never initialize a vault from a pre-existing entry."""
+    def stage_for_initialization(self) -> bytearray:
+        """Create a fresh secret in the staged-initialization slot; never adopt an entry.
 
-        existing, load_reason = self.load_with_reason()
-        if existing is not None:
-            _overwrite(existing)
+        The active slot refuses any pre-existing entry (``entry_exists``): adopting one would
+        make an already known value the vault root passphrase. A leftover staged-initialization
+        entry (``staged_entry_exists``) belongs to an earlier authorized attempt whose outcome is
+        not yet reconciled; the caller must discard it with proof or let restart reconciliation
+        resolve it before staging again.
+        """
+
+        if not callable(getattr(self._backend, "delete_password", None)):
+            raise OSKeyringError("unsupported")
+        active, active_reason = self.load_with_reason()
+        if active is not None:
+            _overwrite(active)
             raise OSKeyringError("entry_exists")
-        return self._create_after_absent(load_reason)
+        if active_reason == "auto_unlock_backend_unavailable":
+            raise OSKeyringError("unsupported")
+        if active_reason != "auto_unlock_absent":
+            raise OSKeyringError("entry_invalid")
+        staged, staged_reason = self._load_username(self._staged_init_username)
+        if staged is not None:
+            _overwrite(staged)
+            raise OSKeyringError("staged_entry_exists")
+        return self._create_at(self._staged_init_username, staged_reason)
+
+    def promote_staged_initialization(self) -> None:
+        """Publish the proven staged-initialization secret as active, then clear the slot."""
+
+        value, reason = self._load_username(self._staged_init_username)
+        if value is None:
+            raise OSKeyringError("missing" if reason == "auto_unlock_absent" else "entry_invalid")
+        try:
+            self._save_at(self._username, value)
+            self._discard_slot(self._staged_init_username)
+        finally:
+            _overwrite(value)
+
+    def discard_staged_initialization(self) -> None:
+        """Remove a staged-initialization entry after proof that no vault envelope needs it."""
+
+        self._discard_slot(self._staged_init_username)
+
+    def slot_report(self) -> dict[str, str]:
+        """Report each slot as present/absent/invalid without exposing credential material."""
+
+        if not self.available:
+            return {
+                "active": "unavailable",
+                "staged_initialization": "unavailable",
+                "staged_rotation": "unavailable",
+            }
+        report: dict[str, str] = {}
+        for username, slot in (
+            (self._username, "active"),
+            (self._staged_init_username, "staged_initialization"),
+            (self._staged_username, "staged_rotation"),
+        ):
+            value, reason = self._load_username(username)
+            if value is not None:
+                _overwrite(value)
+                report[slot] = "present"
+            else:
+                report[slot] = "absent" if reason == "auto_unlock_absent" else "invalid"
+        return report
 
     def _create_after_absent(self, load_reason: str) -> bytearray:
         return self._create_at(self._username, load_reason)
@@ -351,19 +428,19 @@ class AutoUnlockPassphraseStore:
             raise OSKeyringError("missing" if reason == "auto_unlock_absent" else "entry_invalid")
         try:
             self._save_at(self._username, value)
-            self._delete_staged()
+            self._discard_slot(self._staged_username)
         finally:
             _overwrite(value)
 
     def discard_staged_rotation(self) -> None:
         """Remove a staged candidate after the vault proved it did not switch."""
 
-        self._delete_staged()
+        self._discard_slot(self._staged_username)
 
-    def _delete_staged(self) -> None:
+    def _discard_slot(self, username: str) -> None:
         if not callable(getattr(self._backend, "delete_password", None)):
             raise OSKeyringError("unsupported")
-        existing, reason = self._load_username(self._staged_username)
+        existing, reason = self._load_username(username)
         if existing is not None:
             _overwrite(existing)
         elif reason == "auto_unlock_absent":
@@ -372,11 +449,11 @@ class AutoUnlockPassphraseStore:
             raise OSKeyringError("entry_invalid")
         try:
             cast(AnyKeyringBackend, self._backend).delete_password(
-                _AUTO_UNLOCK_SERVICE_NAME, self._staged_username
+                _AUTO_UNLOCK_SERVICE_NAME, username
             )
         except Exception:
             raise OSKeyringError("ambiguous_write") from None
-        remaining, remaining_reason = self._load_username(self._staged_username)
+        remaining, remaining_reason = self._load_username(username)
         if remaining is not None:
             _overwrite(remaining)
             raise OSKeyringError("unverified")

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -2105,13 +2105,31 @@ async def _service_auto_unlock_repair(json_output: bool) -> int:
     except ControlError as error:
         return _control_failure(error)
     if status.vault_mode == "uninitialized":
-        # The service just proved no vault envelope exists that a staged-initialization secret
-        # could unlock, so an orphan left by a failed initialization attempt (#511) is removed
-        # here with verified read-back. Active entries are never deleted by this command.
+        # An orphan left by a failed initialization attempt (#511) is removed with verified
+        # read-back, but only under the bundle-scoped guard with the vault state re-proven
+        # while it is held: no initializer can stage, commit, or promote while the guard is
+        # taken, so the status cannot go stale between the read and the delete. Active entries
+        # are never deleted by this command.
         orphan_store = _auto_unlock_store()
         if orphan_store.slot_report().get("staged_initialization") == "present":
             try:
-                orphan_store.discard_staged_initialization()
+                with orphan_store.staged_initialization_guard():
+                    try:
+                        client = await build_service_client()
+                        try:
+                            proven = await client.service_status()
+                        finally:
+                            await client.close()
+                    except ControlError as error:
+                        return _control_failure(error)
+                    if proven.state.value != "locked" or proven.vault_mode != "uninitialized":
+                        _stderr(
+                            "auto_unlock_repair_unproven: the vault state changed; rerun "
+                            "'yoetz service auto-unlock status'"
+                        )
+                        return 20
+                    if orphan_store.slot_report().get("staged_initialization") == "present":
+                        orphan_store.discard_staged_initialization()
             except OSKeyringError as error:
                 _stderr(f"auto_unlock_{error.reason}")
                 return 20

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -2005,47 +2005,72 @@ def service_auto_unlock_status(json_output: _JSON = False) -> None:
 
 
 async def _service_auto_unlock_status(json_output: bool) -> int:
-    """Compose platform-entry and live-service evidence into one bounded report."""
+    """Compose platform-entry and live-service evidence into one bounded report.
+
+    The per-slot report distinguishes a genuinely pre-existing active entry, a same-attempt
+    staged or orphaned initialization entry, an established active entry, and an invalid entry
+    (#511) without exposing credential material.
+    """
 
     store = _auto_unlock_store()
     secret, reason = store.load_with_reason()
     if secret is not None:
         for index in range(len(secret)):
             secret[index] = 0
+    slots = store.slot_report()
     service_state: str | None = None
     service_reason: str | None = None
+    vault_mode: str | None = None
     try:
         client = await build_service_client()
         try:
             status = await client.service_status()
             service_state = status.state.value
             service_reason = status.state_reason
+            vault_mode = status.vault_mode
         finally:
             await client.close()
     except ControlError as error:
         service_state = error.reason
         service_reason = error.reason
-    state = (
-        "rejected"
-        if service_reason == "auto_unlock_rejected"
-        else "stale"
-        if service_reason == "auto_unlock_stale"
-        else "provisioned"
-        if reason == "none"
-        else "absent"
-        if reason == "auto_unlock_absent"
-        else "backend_unsupported"
-        if reason == "auto_unlock_backend_unavailable"
-        else "rejected"
-    )
+    staged_initialization = slots.get("staged_initialization")
+    if service_reason == "auto_unlock_rejected":
+        state = "rejected"
+    elif service_reason == "auto_unlock_stale":
+        state = "stale"
+    elif staged_initialization == "present":
+        # A staged-initialization entry exists only because an authorized initialization
+        # attempt has not been reconciled. With a provably uninitialized vault it is an
+        # orphan repair can discard; otherwise restart reconciliation resolves it by proof.
+        state = (
+            "initialization_orphaned"
+            if vault_mode == "uninitialized"
+            else "initialization_unreconciled"
+        )
+    elif reason == "none":
+        # An active entry beside an uninitialized vault predates initialization and is never
+        # adopted; it must be removed out of band before initialization can proceed.
+        state = "pre_existing_unadoptable" if vault_mode == "uninitialized" else "provisioned"
+    elif reason == "auto_unlock_absent":
+        state = "absent"
+    elif reason == "auto_unlock_backend_unavailable":
+        state = "backend_unsupported"
+    else:
+        state = "rejected"
+    if state in {"stale", "absent", "rejected", "initialization_orphaned"}:
+        next_command: str | None = "yoetz service auto-unlock repair"
+    elif state == "initialization_unreconciled":
+        next_command = "yoetz service restart"
+    else:
+        next_command = None
     report: JsonValue = {
-        "schema": "yoetz.auto-unlock-status/1",
+        "schema": "yoetz.auto-unlock-status/2",
         "state": state,
+        "slots": dict(slots),
         "service_state": service_state,
         "service_state_reason": service_reason,
-        "next_command": (
-            "yoetz service auto-unlock repair" if state in {"stale", "absent", "rejected"} else None
-        ),
+        "vault_mode": vault_mode,
+        "next_command": next_command,
     }
     _human_or_json(report, json_output=json_output)
     return 0 if state == "provisioned" else 20
@@ -2079,6 +2104,25 @@ async def _service_auto_unlock_repair(json_output: bool) -> int:
             await client.close()
     except ControlError as error:
         return _control_failure(error)
+    if status.vault_mode == "uninitialized":
+        # The service just proved no vault envelope exists that a staged-initialization secret
+        # could unlock, so an orphan left by a failed initialization attempt (#511) is removed
+        # here with verified read-back. Active entries are never deleted by this command.
+        orphan_store = _auto_unlock_store()
+        if orphan_store.slot_report().get("staged_initialization") == "present":
+            try:
+                orphan_store.discard_staged_initialization()
+            except OSKeyringError as error:
+                _stderr(f"auto_unlock_{error.reason}")
+                return 20
+            report = {
+                "schema": "yoetz.auto-unlock-repair/1",
+                "outcome": "initialization_orphan_cleared",
+                "service_state": status.state.value,
+                "next_command": "yoetz consent prepare vault_initialize",
+            }
+            _human_or_json(cast(JsonValue, report), json_output=json_output)
+            return 0
     if status.vault_mode != "passphrase":
         _stderr("auto_unlock_unavailable: the vault is not in passphrase mode")
         return 20

--- a/src/yoetz/cli/elevated.py
+++ b/src/yoetz/cli/elevated.py
@@ -60,7 +60,13 @@ __all__ = [
 
 
 class _AutoUnlockStore(Protocol):
-    def create_for_initialization(self) -> bytearray: ...
+    def stage_for_initialization(self) -> bytearray: ...
+
+    def promote_staged_initialization(self) -> None: ...
+
+    def discard_staged_initialization(self) -> None: ...
+
+    def slot_report(self) -> Mapping[str, str]: ...
 
     def load(self) -> bytearray | None: ...
 
@@ -356,42 +362,84 @@ def _auto_unlock_store() -> _AutoUnlockStore:
     return AutoUnlockPassphraseStore(bundle_root(_data_dir=config.storage.data_dir))
 
 
+async def _service_vault_mode() -> str | None:
+    """Return the live service vault mode, or ``None`` when it cannot be proven."""
+
+    from yoetz.ports.control import ControlClientKind, ControlError
+    from yoetz.service.client import connect_service
+
+    try:
+        client = await connect_service(ControlClientKind.CLI, workspace_locator=None)
+        try:
+            status = await client.service_status()
+        finally:
+            await client.close()
+    except ControlError, OSError, TypeError, ValueError:
+        return None
+    return status.vault_mode
+
+
+async def _discard_provably_orphaned_staged_initialization(store: _AutoUnlockStore) -> None:
+    """Remove a staged-initialization entry only with proof no vault envelope needs it.
+
+    An uninitialized vault has no envelope the staged secret could unlock, so the exact entry
+    created by an earlier authorized attempt is deleted with verified read-back. Any other or
+    unprovable service state keeps the entry for proof-based restart reconciliation; deleting
+    it there could destroy the only copy of a committed vault's passphrase.
+    """
+
+    if store.slot_report().get("staged_initialization") != "present":
+        return
+    if await _service_vault_mode() == "uninitialized":
+        store.discard_staged_initialization()
+
+
 async def _complete_vault_initialize(
     console: TrustedForegroundConsole,
 ) -> dict[str, JsonValue]:
     from yoetz.adapters.keys.os_keyring import OSKeyringError
 
     target = EmptyVaultTarget(expected_mode="uninitialized")
+    store = _auto_unlock_store()
     generated: bytearray | None = None
+    staged = False
     try:
-        store = _auto_unlock_store()
         try:
-            generated = store.create_for_initialization()
-        except OSKeyringError as exc:
-            if exc.reason != "unsupported":
-                raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
-            # The backend was known unavailable before any write. The existing local-human
-            # passphrase ceremony remains the only permitted fallback.
+            try:
+                await _discard_provably_orphaned_staged_initialization(store)
+                generated = store.stage_for_initialization()
+            except OSKeyringError as exc:
+                if exc.reason != "unsupported":
+                    raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
+                # The backend was known unavailable before any write. The existing local-human
+                # passphrase ceremony remains the only permitted fallback.
+                result = await run_human_ceremony_on_terminal(
+                    console,
+                    HumanCeremonyKind.VAULT_INITIALIZE,
+                    target,
+                )
+                return _validated_vault_success(result)
+            staged = True
             result = await run_human_ceremony_on_terminal(
                 console,
                 HumanCeremonyKind.VAULT_INITIALIZE,
                 target,
+                passphrase=bytearray(generated),
             )
-        else:
-            result = await run_human_ceremony_on_terminal(
-                console,
-                HumanCeremonyKind.VAULT_INITIALIZE,
-                target,
-                passphrase=generated,
-            )
-    except ConfidentialClientError as exc:
-        raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
-    except HumanCeremonyCliError as exc:
-        raise ElevatedBootstrapError(exc.reason) from exc
+            validated = _validated_vault_success(result)
+        except ConfidentialClientError as exc:
+            raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
+        except HumanCeremonyCliError as exc:
+            raise ElevatedBootstrapError(exc.reason) from exc
+    except BaseException:
+        if staged:
+            await _cleanup_failed_staged_initialization(store)
+        raise
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    return _validated_vault_success(result)
+    _promote_after_committed_initialization(store)
+    return validated
 
 
 async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
@@ -399,25 +447,66 @@ async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
 
     from yoetz.adapters.keys.os_keyring import OSKeyringError
 
+    store = _auto_unlock_store()
     generated: bytearray | None = None
+    staged = False
     try:
         try:
-            generated = _auto_unlock_store().create_for_initialization()
-        except OSKeyringError as exc:
-            raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
-        result = await run_human_ceremony(
-            HumanCeremonyKind.VAULT_INITIALIZE,
-            EmptyVaultTarget(expected_mode="uninitialized"),
-            passphrase=bytearray(generated),
-        )
-    except ConfidentialClientError as exc:
-        raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
-    except HumanCeremonyCliError as exc:
-        raise ElevatedBootstrapError(exc.reason) from exc
+            try:
+                await _discard_provably_orphaned_staged_initialization(store)
+                generated = store.stage_for_initialization()
+            except OSKeyringError as exc:
+                raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
+            staged = True
+            result = await run_human_ceremony(
+                HumanCeremonyKind.VAULT_INITIALIZE,
+                EmptyVaultTarget(expected_mode="uninitialized"),
+                passphrase=bytearray(generated),
+            )
+            validated = _validated_vault_success(result)
+        except ConfidentialClientError as exc:
+            raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
+        except HumanCeremonyCliError as exc:
+            raise ElevatedBootstrapError(exc.reason) from exc
+    except BaseException:
+        if staged:
+            await _cleanup_failed_staged_initialization(store)
+        raise
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    return _validated_vault_success(result)
+    _promote_after_committed_initialization(store)
+    return validated
+
+
+async def _cleanup_failed_staged_initialization(store: _AutoUnlockStore) -> None:
+    """Best-effort failure atomicity for the same-attempt staged credential.
+
+    Runs only under an already-propagating ceremony failure: discard the staged entry when the
+    service proves the vault is still uninitialized, and otherwise (ambiguous outcome, service
+    unreachable, or discard failure) keep it — the slot is durable, typed in
+    ``yoetz service auto-unlock status``, and reconciled by proof at the next unlock or retry.
+    Never masks the original failure.
+    """
+
+    try:
+        await _discard_provably_orphaned_staged_initialization(store)
+    except Exception:
+        pass
+
+
+def _promote_after_committed_initialization(store: _AutoUnlockStore) -> None:
+    """Promote the staged credential after the validated ready result.
+
+    The vault has committed and activated, so a promotion failure must not fail the completed
+    operation: the staged entry remains the sole candidate that unlocks the envelope and restart
+    reconciliation promotes it by proof.
+    """
+
+    try:
+        store.promote_staged_initialization()
+    except Exception:
+        pass
 
 
 async def _complete_vault_passphrase_rotate_generated() -> dict[str, JsonValue]:

--- a/src/yoetz/cli/elevated.py
+++ b/src/yoetz/cli/elevated.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import time
 from collections.abc import Mapping
+from contextlib import AbstractContextManager, ExitStack
 from datetime import UTC, datetime
 from typing import Literal, Protocol, cast
 
@@ -60,6 +61,8 @@ __all__ = [
 
 
 class _AutoUnlockStore(Protocol):
+    def staged_initialization_guard(self) -> AbstractContextManager[None]: ...
+
     def stage_for_initialization(self) -> bytearray: ...
 
     def promote_staged_initialization(self) -> None: ...
@@ -362,8 +365,8 @@ def _auto_unlock_store() -> _AutoUnlockStore:
     return AutoUnlockPassphraseStore(bundle_root(_data_dir=config.storage.data_dir))
 
 
-async def _service_vault_mode() -> str | None:
-    """Return the live service vault mode, or ``None`` when it cannot be proven."""
+async def _service_vault_state() -> tuple[str, str] | None:
+    """Return the live (service state, vault mode), or ``None`` when it cannot be proven."""
 
     from yoetz.ports.control import ControlClientKind, ControlError
     from yoetz.service.client import connect_service
@@ -376,21 +379,24 @@ async def _service_vault_mode() -> str | None:
             await client.close()
     except ControlError, OSError, TypeError, ValueError:
         return None
-    return status.vault_mode
+    return status.state.value, status.vault_mode
 
 
 async def _discard_provably_orphaned_staged_initialization(store: _AutoUnlockStore) -> None:
     """Remove a staged-initialization entry only with proof no vault envelope needs it.
 
-    An uninitialized vault has no envelope the staged secret could unlock, so the exact entry
-    created by an earlier authorized attempt is deleted with verified read-back. Any other or
-    unprovable service state keeps the entry for proof-based restart reconciliation; deleting
-    it there could destroy the only copy of a committed vault's passphrase.
+    Must be called with the store's staged-initialization guard held, so no other local actor
+    can stage, commit, or promote between the status read and the delete. A locked service with
+    an uninitialized vault has no envelope (and no in-flight ceremony) the staged secret could
+    unlock, so the exact entry created by an earlier authorized attempt is deleted with verified
+    read-back. Any other or unprovable service state keeps the entry for proof-based restart
+    reconciliation; deleting it there could destroy the only copy of a committed vault's
+    passphrase.
     """
 
     if store.slot_report().get("staged_initialization") != "present":
         return
-    if await _service_vault_mode() == "uninitialized":
+    if await _service_vault_state() == ("locked", "uninitialized"):
         store.discard_staged_initialization()
 
 
@@ -405,28 +411,31 @@ async def _complete_vault_initialize(
     staged = False
     try:
         try:
-            try:
-                await _discard_provably_orphaned_staged_initialization(store)
-                generated = store.stage_for_initialization()
-            except OSKeyringError as exc:
-                if exc.reason != "unsupported":
-                    raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
-                # The backend was known unavailable before any write. The existing local-human
-                # passphrase ceremony remains the only permitted fallback.
+            with ExitStack() as stack:
+                try:
+                    stack.enter_context(store.staged_initialization_guard())
+                    await _discard_provably_orphaned_staged_initialization(store)
+                    generated = store.stage_for_initialization()
+                except OSKeyringError as exc:
+                    if exc.reason != "unsupported":
+                        raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
+                    # The backend was known unavailable before any write. The existing
+                    # local-human passphrase ceremony remains the only permitted fallback.
+                    result = await run_human_ceremony_on_terminal(
+                        console,
+                        HumanCeremonyKind.VAULT_INITIALIZE,
+                        target,
+                    )
+                    return _validated_vault_success(result)
+                staged = True
                 result = await run_human_ceremony_on_terminal(
                     console,
                     HumanCeremonyKind.VAULT_INITIALIZE,
                     target,
+                    passphrase=bytearray(generated),
                 )
-                return _validated_vault_success(result)
-            staged = True
-            result = await run_human_ceremony_on_terminal(
-                console,
-                HumanCeremonyKind.VAULT_INITIALIZE,
-                target,
-                passphrase=bytearray(generated),
-            )
-            validated = _validated_vault_success(result)
+                validated = _validated_vault_success(result)
+                _promote_after_committed_initialization(store)
         except ConfidentialClientError as exc:
             raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
         except HumanCeremonyCliError as exc:
@@ -438,7 +447,6 @@ async def _complete_vault_initialize(
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    _promote_after_committed_initialization(store)
     return validated
 
 
@@ -452,18 +460,21 @@ async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
     staged = False
     try:
         try:
-            try:
-                await _discard_provably_orphaned_staged_initialization(store)
-                generated = store.stage_for_initialization()
-            except OSKeyringError as exc:
-                raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
-            staged = True
-            result = await run_human_ceremony(
-                HumanCeremonyKind.VAULT_INITIALIZE,
-                EmptyVaultTarget(expected_mode="uninitialized"),
-                passphrase=bytearray(generated),
-            )
-            validated = _validated_vault_success(result)
+            with ExitStack() as stack:
+                try:
+                    stack.enter_context(store.staged_initialization_guard())
+                    await _discard_provably_orphaned_staged_initialization(store)
+                    generated = store.stage_for_initialization()
+                except OSKeyringError as exc:
+                    raise ElevatedBootstrapError(f"auto_unlock_{exc.reason}") from exc
+                staged = True
+                result = await run_human_ceremony(
+                    HumanCeremonyKind.VAULT_INITIALIZE,
+                    EmptyVaultTarget(expected_mode="uninitialized"),
+                    passphrase=bytearray(generated),
+                )
+                validated = _validated_vault_success(result)
+                _promote_after_committed_initialization(store)
         except ConfidentialClientError as exc:
             raise ElevatedBootstrapError(f"ceremony_{exc.reason}") from exc
         except HumanCeremonyCliError as exc:
@@ -475,22 +486,23 @@ async def _complete_vault_initialize_generated() -> dict[str, JsonValue]:
     finally:
         if generated is not None:
             overwrite_secret_buffer(generated)
-    _promote_after_committed_initialization(store)
     return validated
 
 
 async def _cleanup_failed_staged_initialization(store: _AutoUnlockStore) -> None:
     """Best-effort failure atomicity for the same-attempt staged credential.
 
-    Runs only under an already-propagating ceremony failure: discard the staged entry when the
-    service proves the vault is still uninitialized, and otherwise (ambiguous outcome, service
-    unreachable, or discard failure) keep it — the slot is durable, typed in
+    Runs only under an already-propagating ceremony failure, after the initialization guard was
+    released: re-acquire it, then discard the staged entry when the service proves the vault is
+    still uninitialized. Otherwise (ambiguous outcome, unreachable service, contended guard, or
+    discard failure) keep it — the slot is durable, typed in
     ``yoetz service auto-unlock status``, and reconciled by proof at the next unlock or retry.
     Never masks the original failure.
     """
 
     try:
-        await _discard_provably_orphaned_staged_initialization(store)
+        with store.staged_initialization_guard():
+            await _discard_provably_orphaned_staged_initialization(store)
     except Exception:
         pass
 

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -178,6 +178,7 @@ _PROVIDER_SETUP_AUTO_UNLOCK_REASONS: Final = frozenset(
         "entry_exists",
         "entry_invalid",
         "human_authority_unavailable",
+        "initialization_in_progress",
         "locked",
         "migration_not_proven",
         "missing",
@@ -1784,19 +1785,58 @@ async def _interactive_provider_setup(
                 try:
                     # ADR-015 decision 5 / ADR-008: generate a fresh scoped secret for
                     # vault_initialize. Never adopt a pre-existing entry; the active slot stays
-                    # fail-closed on entry_exists. A leftover staged-initialization entry from
-                    # an earlier failed attempt is discarded only after a fresh service status
-                    # proves the vault is still uninitialized (#511) — any other state keeps it
-                    # for proof-based restart reconciliation.
-                    if auto_store.slot_report().get("staged_initialization") == "present":
-                        fresh = await _service_reachability()
-                        if fresh.get("vault_mode") == "uninitialized":
-                            auto_store.discard_staged_initialization()
-                    auto_passphrase = auto_store.stage_for_initialization()
+                    # fail-closed on entry_exists. The guard is held across stage, ceremony,
+                    # and promote so no concurrent repair or retry can act on a stale status.
+                    # A leftover staged-initialization entry from an earlier failed attempt is
+                    # discarded only after a fresh service status, read under the guard, proves
+                    # the vault is still uninitialized and idle (#511) — any other state keeps
+                    # it for proof-based restart reconciliation.
+                    with auto_store.staged_initialization_guard():
+                        if auto_store.slot_report().get("staged_initialization") == "present":
+                            fresh = await _service_reachability()
+                            if (
+                                fresh.get("state") == "locked"
+                                and fresh.get("vault_mode") == "uninitialized"
+                            ):
+                                auto_store.discard_staged_initialization()
+                        auto_passphrase = auto_store.stage_for_initialization()
+                        typer.echo("Secure vault setup (platform credential store auto-unlock)")
+                        init_result = await initialize_passphrase_vault(bytearray(auto_passphrase))
+                        if init_result.state == "ready" and init_result.reason == "succeeded":
+                            try:
+                                auto_store.promote_staged_initialization()
+                            except OSKeyringError:
+                                # The vault committed and activated; the staged entry remains
+                                # the proven candidate and restart reconciliation promotes it.
+                                pass
+                        else:
+                            # Failure atomicity (#511): remove the same-attempt staged
+                            # credential when the service proves no envelope was committed;
+                            # otherwise keep it for proof-based restart reconciliation.
+                            try:
+                                fresh = await _service_reachability()
+                                if (
+                                    fresh.get("state") == "locked"
+                                    and fresh.get("vault_mode") == "uninitialized"
+                                ):
+                                    auto_store.discard_staged_initialization()
+                            except OSKeyringError:
+                                pass
+                            provider_report["credential_reason"] = (
+                                f"vault_result_{init_result.reason}"
+                            )
+                            wipe_auto_passphrase()
+                            return _provider_setup_result(service, provider_report)
                 except OSKeyringError as error:
                     if error.reason != "unsupported":
                         provider_report["credential_reason"] = f"auto_unlock_{error.reason}"
-                        if error.reason == "staged_entry_exists":
+                        if error.reason == "initialization_in_progress":
+                            typer.echo(
+                                "Another Yoetz vault initialization is already in progress. "
+                                "Wait for it to finish, then rerun 'yoetz setup'.",
+                                err=True,
+                            )
+                        elif error.reason == "staged_entry_exists":
                             typer.echo(
                                 "A staged credential from an earlier vault-initialization "
                                 "attempt is not yet reconciled. Restart the service "
@@ -1832,29 +1872,6 @@ async def _interactive_provider_setup(
                     typer.echo("Platform credential store unavailable; choose a vault passphrase")
                     typer.echo("Secure vault setup (hidden local-terminal input)")
                     await initialize_passphrase_vault()
-                else:
-                    typer.echo("Secure vault setup (platform credential store auto-unlock)")
-                    init_result = await initialize_passphrase_vault(bytearray(auto_passphrase))
-                    if init_result.state == "ready" and init_result.reason == "succeeded":
-                        try:
-                            auto_store.promote_staged_initialization()
-                        except OSKeyringError:
-                            # The vault committed and activated; the staged entry remains the
-                            # proven candidate and restart reconciliation promotes it.
-                            pass
-                    else:
-                        # Failure atomicity (#511): remove the same-attempt staged credential
-                        # when the service proves no envelope was committed; otherwise keep it
-                        # for proof-based restart reconciliation.
-                        try:
-                            fresh = await _service_reachability()
-                            if fresh.get("vault_mode") == "uninitialized":
-                                auto_store.discard_staged_initialization()
-                        except OSKeyringError:
-                            pass
-                        provider_report["credential_reason"] = f"vault_result_{init_result.reason}"
-                        wipe_auto_passphrase()
-                        return _provider_setup_result(service, provider_report)
             elif service.get("vault_mode") == "passphrase":
                 typer.echo("")
                 current_config = load_config({}, os.environ, None)

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -182,6 +182,7 @@ _PROVIDER_SETUP_AUTO_UNLOCK_REASONS: Final = frozenset(
         "migration_not_proven",
         "missing",
         "readback_failed",
+        "staged_entry_exists",
         "unsupported",
         "unverified",
     }
@@ -227,6 +228,14 @@ def _allowlisted_provider_setup_reason(reason: object) -> str:
     if reason.startswith("auto_unlock_"):
         auto_unlock_reason = reason.removeprefix("auto_unlock_")
         if auto_unlock_reason in _PROVIDER_SETUP_AUTO_UNLOCK_REASONS:
+            return reason
+    if reason.startswith("vault_result_"):
+        # The suffix comes from a schema-validated VaultStateResult reason, never caller text;
+        # the structural bound here keeps the allowlist self-contained.
+        vault_reason = reason.removeprefix("vault_result_")
+        if 0 < len(vault_reason) <= 64 and all(
+            character in "abcdefghijklmnopqrstuvwxyz_" for character in vault_reason
+        ):
             return reason
     return "credential_setup_failed"
 
@@ -1774,13 +1783,28 @@ async def _interactive_provider_setup(
                 )
                 try:
                     # ADR-015 decision 5 / ADR-008: generate a fresh scoped secret for
-                    # vault_initialize. Never adopt a pre-existing entry (load_or_create).
-                    # Matches elevated create_for_initialization fail-closed on entry_exists.
-                    auto_passphrase = auto_store.create_for_initialization()
+                    # vault_initialize. Never adopt a pre-existing entry; the active slot stays
+                    # fail-closed on entry_exists. A leftover staged-initialization entry from
+                    # an earlier failed attempt is discarded only after a fresh service status
+                    # proves the vault is still uninitialized (#511) — any other state keeps it
+                    # for proof-based restart reconciliation.
+                    if auto_store.slot_report().get("staged_initialization") == "present":
+                        fresh = await _service_reachability()
+                        if fresh.get("vault_mode") == "uninitialized":
+                            auto_store.discard_staged_initialization()
+                    auto_passphrase = auto_store.stage_for_initialization()
                 except OSKeyringError as error:
                     if error.reason != "unsupported":
                         provider_report["credential_reason"] = f"auto_unlock_{error.reason}"
-                        if error.reason == "entry_exists":
+                        if error.reason == "staged_entry_exists":
+                            typer.echo(
+                                "A staged credential from an earlier vault-initialization "
+                                "attempt is not yet reconciled. Restart the service "
+                                "('yoetz service restart') so it can resolve the entry by "
+                                "proof, then rerun 'yoetz setup'.",
+                                err=True,
+                            )
+                        elif error.reason == "entry_exists":
                             entry_service, entry_account = auto_store.entry_identity
                             typer.echo(
                                 "A pre-existing platform credential entry blocks vault "
@@ -1810,7 +1834,27 @@ async def _interactive_provider_setup(
                     await initialize_passphrase_vault()
                 else:
                     typer.echo("Secure vault setup (platform credential store auto-unlock)")
-                    await initialize_passphrase_vault(bytearray(auto_passphrase))
+                    init_result = await initialize_passphrase_vault(bytearray(auto_passphrase))
+                    if init_result.state == "ready" and init_result.reason == "succeeded":
+                        try:
+                            auto_store.promote_staged_initialization()
+                        except OSKeyringError:
+                            # The vault committed and activated; the staged entry remains the
+                            # proven candidate and restart reconciliation promotes it.
+                            pass
+                    else:
+                        # Failure atomicity (#511): remove the same-attempt staged credential
+                        # when the service proves no envelope was committed; otherwise keep it
+                        # for proof-based restart reconciliation.
+                        try:
+                            fresh = await _service_reachability()
+                            if fresh.get("vault_mode") == "uninitialized":
+                                auto_store.discard_staged_initialization()
+                        except OSKeyringError:
+                            pass
+                        provider_report["credential_reason"] = f"vault_result_{init_result.reason}"
+                        wipe_auto_passphrase()
+                        return _provider_setup_result(service, provider_report)
             elif service.get("vault_mode") == "passphrase":
                 typer.echo("")
                 current_config = load_config({}, os.environ, None)

--- a/src/yoetz/service/daemon.py
+++ b/src/yoetz/service/daemon.py
@@ -1815,8 +1815,8 @@ class ServiceDaemon:
             )
             return False
         try:
-            accepted_staged: bool | None = None
-            for auto_passphrase, is_staged in candidates:
+            accepted_slot: str | None = None
+            for auto_passphrase, slot in candidates:
                 try:
                     handle = cast(LocalSecretMemory, memory).capture(
                         SecretPurpose.VAULT_UNLOCK, auto_passphrase
@@ -1824,9 +1824,9 @@ class ServiceDaemon:
                     await vault.unlock(handle)
                 except VaultError:
                     continue
-                accepted_staged = is_staged
+                accepted_slot = slot
                 break
-            if accepted_staged is None:
+            if accepted_slot is None:
                 raise VaultError("unlock_wrong")
         except VaultError:
             self._state_reason = "auto_unlock_stale"
@@ -1847,22 +1847,19 @@ class ServiceDaemon:
             )
             return False
         finally:
-            for candidate, _is_staged in candidates:
+            for candidate, _slot in candidates:
                 for index in range(len(candidate)):
                     candidate[index] = 0
-        # The vault is ready from here on. Reconciling the staged keyring rotation entry is
+        # The vault is ready from here on. Reconciling the staged keyring entries is
         # credential-store hygiene only: a promote/discard failure must never relock a ready
         # vault, so log it and continue activation (#492 review).
         try:
-            if accepted_staged:
-                await asyncio.to_thread(store.promote_staged_rotation)
-            elif any(staged for _value, staged in candidates):
-                await asyncio.to_thread(store.discard_staged_rotation)
+            await asyncio.to_thread(_reconcile_staged_slots, store, accepted_slot)
         except Exception:
             get_logger("service.daemon").warning(
                 "auto_unlock",
                 outcome="degraded",
-                reason="staged_rotation_reconcile_failed",
+                reason="staged_reconcile_failed",
             )
         if not vault.ready:
             self._state_reason = "unlock_failed"
@@ -1937,6 +1934,27 @@ class ServiceDaemon:
                 loop.add_signal_handler(signum, self._stop_event.set)
             except NotImplementedError, RuntimeError:
                 continue
+
+
+def _reconcile_staged_slots(store: AutoUnlockPassphraseStore, accepted_slot: str) -> None:
+    """Promote the proven staged entry, then discard staged entries the proof made stale.
+
+    Called only after one candidate unlocked the vault. The envelope authenticates exactly one
+    passphrase, so that success disproves every non-equal staged entry, and a staged entry
+    byte-equal to the now-active value is a redundant copy from an interrupted promotion.
+    Either way, any staged slot still present afterwards is safe to remove; invalid slots are
+    left in place for the status surface.
+    """
+
+    if accepted_slot == "staged_rotation":
+        store.promote_staged_rotation()
+    elif accepted_slot == "staged_initialization":
+        store.promote_staged_initialization()
+    report = store.slot_report()
+    if report.get("staged_rotation") == "present":
+        store.discard_staged_rotation()
+    if report.get("staged_initialization") == "present":
+        store.discard_staged_initialization()
 
 
 def _is_ready_application(value: object) -> bool:
@@ -3694,9 +3712,9 @@ async def _production_composition(
             auto_unlock_store = AutoUnlockPassphraseStore(paths.bundle)
             candidates, load_reason = auto_unlock_store.load_candidates_with_reason()
             if candidates:
-                accepted_staged: bool | None = None
+                accepted_slot: str | None = None
                 try:
-                    for auto_passphrase, is_staged in candidates:
+                    for auto_passphrase, slot in candidates:
                         try:
                             handle = secret_memory.capture(
                                 SecretPurpose.VAULT_UNLOCK, auto_passphrase
@@ -3704,31 +3722,28 @@ async def _production_composition(
                             await vault.unlock(handle)
                         except VaultError:
                             continue
-                        accepted_staged = is_staged
+                        accepted_slot = slot
                         break
-                    if accepted_staged is None:
+                    if accepted_slot is None:
                         auto_unlock_result = "failed"
                         auto_unlock_reason = "auto_unlock_stale"
                 except Exception:
                     auto_unlock_result = "failed"
                     auto_unlock_reason = "auto_unlock_rejected"
                 finally:
-                    for candidate, _is_staged in candidates:
+                    for candidate, _slot in candidates:
                         for index in range(len(candidate)):
                             candidate[index] = 0
-                if accepted_staged is not None:
-                    # Unlock succeeded; the staged keyring entry is hygiene only. A
+                if accepted_slot is not None:
+                    # Unlock succeeded; the staged keyring entries are hygiene only. A
                     # promote/discard failure must not degrade a ready vault (#492 review).
                     try:
-                        if accepted_staged:
-                            auto_unlock_store.promote_staged_rotation()
-                        elif any(staged for _value, staged in candidates):
-                            auto_unlock_store.discard_staged_rotation()
+                        _reconcile_staged_slots(auto_unlock_store, accepted_slot)
                     except Exception:
                         get_logger("service.daemon").warning(
                             "auto_unlock",
                             outcome="degraded",
-                            reason="staged_rotation_reconcile_failed",
+                            reason="staged_reconcile_failed",
                         )
             else:
                 auto_unlock_result = (

--- a/tests/integration/objects/test_key_backends.py
+++ b/tests/integration/objects/test_key_backends.py
@@ -190,6 +190,27 @@ def test_staged_initialization_leftover_refuses_a_second_staging(tmp_path: Path)
     assert base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)) == bytes(first)
 
 
+def test_staged_initialization_guard_is_exclusive_per_bundle(tmp_path: Path) -> None:
+    """#511 review: staging, promotion, and proof-based discard serialize on one bundle lock."""
+
+    backend = _AtomicBackend()
+    bundle = tmp_path.resolve()
+    holder = AutoUnlockPassphraseStore(bundle, backend=backend)
+    contender = AutoUnlockPassphraseStore(bundle, backend=backend)
+    holder._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+    contender._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    with holder.staged_initialization_guard():
+        with pytest.raises(OSKeyringError) as exc:
+            with contender.staged_initialization_guard():
+                pass
+        assert exc.value.reason == "initialization_in_progress"
+
+    # Released on exit: the contender can now take it.
+    with contender.staged_initialization_guard():
+        pass
+
+
 def test_staged_initialization_is_a_restart_unlock_candidate(tmp_path: Path) -> None:
     backend = _AtomicBackend()
     store = AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)

--- a/tests/integration/objects/test_key_backends.py
+++ b/tests/integration/objects/test_key_backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import inspect
 from pathlib import Path
@@ -120,11 +121,87 @@ def test_initialization_refuses_preexisting_auto_unlock_entry(
 
     monkeypatch.setattr(keyring_module, "_overwrite", observe_overwrite)
     with pytest.raises(OSKeyringError) as exc:
-        store.create_for_initialization()
+        store.stage_for_initialization()
 
     assert exc.value.reason == "entry_exists"
     assert backend.values == original_entry
     assert wiped and set(wiped[-1]) <= {0}
+
+
+def test_staged_initialization_promotes_only_after_explicit_promotion(tmp_path: Path) -> None:
+    """#511: staging never touches the active slot; promotion is a separate verified step."""
+
+    backend = _AtomicBackend()
+    store = AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    generated = store.stage_for_initialization()
+    assert 32 <= len(generated) <= 128
+    assert store.load() is None, "the active slot must stay empty until promotion"
+    assert store.slot_report() == {
+        "active": "absent",
+        "staged_initialization": "present",
+        "staged_rotation": "absent",
+    }
+
+    store.promote_staged_initialization()
+    assert store.load() == generated
+    assert store.slot_report() == {
+        "active": "present",
+        "staged_initialization": "absent",
+        "staged_rotation": "absent",
+    }
+    assert all("staged-initialization" not in account for _service, account in backend.values)
+
+
+def test_staged_initialization_discard_removes_exactly_the_staged_entry(tmp_path: Path) -> None:
+    backend = _AtomicBackend()
+    store = AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    store.stage_for_initialization()
+    store.discard_staged_initialization()
+
+    assert backend.values == {}
+    assert store.slot_report() == {
+        "active": "absent",
+        "staged_initialization": "absent",
+        "staged_rotation": "absent",
+    }
+
+
+def test_staged_initialization_leftover_refuses_a_second_staging(tmp_path: Path) -> None:
+    """#511: an unreconciled staged entry is never silently overwritten or adopted."""
+
+    backend = _AtomicBackend()
+    store = AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    first = store.stage_for_initialization()
+    with pytest.raises(OSKeyringError) as exc:
+        store.stage_for_initialization()
+
+    assert exc.value.reason == "staged_entry_exists"
+    staged_key = (
+        "yoetz.auto-unlock.v1",
+        store._staged_init_username,  # pyright: ignore[reportPrivateUsage]
+    )
+    encoded = backend.values[staged_key]
+    assert base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4)) == bytes(first)
+
+
+def test_staged_initialization_is_a_restart_unlock_candidate(tmp_path: Path) -> None:
+    backend = _AtomicBackend()
+    store = AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    generated = store.stage_for_initialization()
+    candidates, reason = store.load_candidates_with_reason()
+
+    assert reason == "none"
+    assert [(bytes(value), slot) for value, slot in candidates] == [
+        (bytes(generated), "staged_initialization")
+    ]
 
 
 def test_auto_unlock_rotation_stages_recovers_and_promotes_without_secret_output(
@@ -138,9 +215,9 @@ def test_auto_unlock_rotation_stages_recovers_and_promotes_without_secret_output
 
     candidates, reason = store.load_candidates_with_reason()
     assert reason == "none"
-    assert [(bytes(value), is_staged) for value, is_staged in candidates] == [
-        (bytes(active), False),
-        (bytes(staged), True),
+    assert [(bytes(value), slot) for value, slot in candidates] == [
+        (bytes(active), "active"),
+        (bytes(staged), "staged_rotation"),
     ]
 
     store.promote_staged_rotation()
@@ -148,7 +225,7 @@ def test_auto_unlock_rotation_stages_recovers_and_promotes_without_secret_output
     recovered, recovered_reason = store.load_candidates_with_reason()
     assert loaded == staged
     assert recovered_reason == "none"
-    assert [(bytes(value), is_staged) for value, is_staged in recovered] == [(bytes(staged), False)]
+    assert [(bytes(value), slot) for value, slot in recovered] == [(bytes(staged), "active")]
     assert all("staged-rotation" not in account for _service, account in backend.values)
 
 
@@ -177,9 +254,9 @@ def test_auto_unlock_rotation_can_stage_an_exact_user_selected_value(tmp_path: P
     candidates, reason = store.load_candidates_with_reason()
 
     assert reason == "none"
-    assert [(bytes(value), is_staged) for value, is_staged in candidates] == [
-        (bytes(active), False),
-        (bytes(selected), True),
+    assert [(bytes(value), slot) for value, slot in candidates] == [
+        (bytes(active), "active"),
+        (bytes(selected), "staged_rotation"),
     ]
 
 

--- a/tests/integration/service/test_consent_vault_initialize_composition.py
+++ b/tests/integration/service/test_consent_vault_initialize_composition.py
@@ -1,19 +1,24 @@
-"""Agent-authorized vault initialization over the real client/service composition (#510).
+"""Agent-authorized vault initialization over the real client/service composition (#510/#511).
 
-The defect this locks against: `yoetz consent authorize` completed the real human-control
+The defects these lock against: `yoetz consent authorize` completed the real human-control
 ceremony, received a non-ready `VaultStateResult`, and still consumed the approval before the
-result was validated — collapsing the actionable service reason to `authorize_failed` while the
-audit said approved. These tests run real agent attestation, a generated local secret, the real
-YZH1/YZS1 client and service transport, and a real unlock throttle, mocking only the OS keyring.
+result was validated (#510); and the generated auto-unlock credential was durably written before
+the ceremony, so a failed initialization stranded it with no recovery path — the retry refused
+the abandoned same-attempt entry as `auto_unlock_entry_exists` (#511). These tests run real agent
+attestation, the real staged-initialization keyring lifecycle over an in-memory backend, the real
+YZH1/YZS1 client and service transport, and a real unlock throttle, mocking only the OS keyring
+backend itself.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +29,7 @@ from yoetz.adapters.control.unix_socket import (
     bind_human_control_listener,
     bind_secret_listener,
 )
+from yoetz.adapters.keys.os_keyring import AutoUnlockPassphraseStore, OSKeyringError
 from yoetz.cli import elevated
 from yoetz.config.load import YoetzConfig
 from yoetz.service.daemon import ServiceDaemon
@@ -32,6 +38,7 @@ from yoetz.service.unlock import UnlockThrottleRecord
 
 _FOREIGN_INSTALLATION_ID = "ins_30000000-0000-4000-8000-000000000001"
 _FOREIGN_WRITER_ID = "svc_30000000-0000-4000-8000-000000000002"
+_SERVICE_NAME = "yoetz.auto-unlock.v1"
 
 
 @pytest.fixture
@@ -53,6 +60,39 @@ def runtime_directory(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
         yield runtime
     finally:
         shutil.rmtree(runtime, ignore_errors=True)
+
+
+class _MemoryKeyring:
+    """In-memory platform credential store standing in for the OS keyring backend."""
+
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.values.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.values[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        del self.values[(service, username)]
+
+
+def _approved_store(bundle: Path, backend: _MemoryKeyring) -> AutoUnlockPassphraseStore:
+    store = AutoUnlockPassphraseStore(bundle, backend=backend)
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+    return store
+
+
+def _entry_bytes(backend: _MemoryKeyring, account: str) -> bytes:
+    encoded = backend.values[(_SERVICE_NAME, account)]
+    return base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+
+
+def _slot_accounts(store: AutoUnlockPassphraseStore) -> tuple[str, str]:
+    active = store._username  # pyright: ignore[reportPrivateUsage]
+    staged = store._staged_init_username  # pyright: ignore[reportPrivateUsage]
+    return active, staged
 
 
 def _stage_non_pristine_throttle_record(path: Path) -> None:
@@ -99,10 +139,100 @@ async def _production_daemon(tmp_path: Path, *, pristine: bool) -> ServiceDaemon
     return ServiceDaemon(_composition=composition)
 
 
+def _approve_attestation(pending: object) -> dict[str, object]:
+    return {
+        "schema": "yoetz.chat-user-attestation/1",
+        "channel": "agent_attested_chat_instruction",
+        "client_kind": "codex",
+        "instruction_source": "explicit_current_chat_user",
+        "pending_id": getattr(pending, "pending_id"),
+        "operation": getattr(pending, "operation"),
+        "danger_digest": getattr(pending, "danger_digest"),
+        "target_digest": getattr(pending, "target_digest"),
+        "warning_acknowledged": True,
+        "decision": "approve",
+    }
+
+
 def _assert_no_secret_bytes(tree: Path, secret: bytes) -> None:
     for path in tree.rglob("*"):
         if path.is_file() and not path.is_symlink():
             assert secret not in path.read_bytes(), path
+
+
+@pytest.mark.anyio
+async def test_failed_initialize_discards_staged_credential_and_retry_succeeds(
+    tmp_path: Path,
+    runtime_directory: Path,
+) -> None:
+    """#511 acceptance: a definitive pre-commit failure leaves no orphan, and a fresh exact
+    consent attempt after restart succeeds without `auto_unlock_entry_exists`."""
+
+    tmp_path.chmod(0o700)
+    consent_state = tmp_path / "consent"
+    consent_state.mkdir(mode=0o700)
+    backend = _MemoryKeyring()
+    store = _approved_store(tmp_path / "data", backend)
+    active_account, staged_account = _slot_accounts(store)
+
+    daemon = await _production_daemon(tmp_path, pristine=False)
+    await daemon.start()
+    serving = asyncio.create_task(daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+        ):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=consent_state)
+            assert pending is not None
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await asyncio.wait_for(
+                    elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+                )
+
+            assert exc.value.reason == "vault_result_throttle_record_exists"
+            assert load_pending(_state=consent_state) is None
+            # Failure atomicity: the exact same-attempt staged credential was removed after
+            # the live service proved the vault is still uninitialized. Nothing is stranded.
+            assert backend.values == {}
+            assert daemon.status().vault_mode == "uninitialized"
+            assert not (tmp_path / "data" / "vault").exists()
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(serving, timeout=10)
+
+    # Operator repair of the unrelated foreign throttle record, then a sanctioned restart.
+    (tmp_path / "state" / "unlock-throttle.json").unlink()
+    retry_daemon = await _production_daemon(tmp_path, pristine=True)
+    await retry_daemon.start()
+    retry_serving = asyncio.create_task(retry_daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+        ):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=consent_state)
+            assert pending is not None
+            result = await asyncio.wait_for(
+                elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+            )
+
+            assert result["outcome"] == "completed"
+            assert result["result"] == {"state": "ready", "reason": "succeeded"}
+            assert retry_daemon.status().vault_mode == "passphrase"
+            # The credential is bundle-scoped, promoted to the active slot, and the staged
+            # slot is clear.
+            assert (_SERVICE_NAME, active_account) in backend.values
+            assert (_SERVICE_NAME, staged_account) not in backend.values
+    finally:
+        await retry_daemon.stop()
+        await asyncio.wait_for(retry_serving, timeout=10)
+
+    secret = _entry_bytes(backend, active_account)
+    _assert_no_secret_bytes(tmp_path, secret)
+    _assert_no_secret_bytes(runtime_directory, secret)
 
 
 @pytest.mark.anyio
@@ -113,12 +243,8 @@ async def test_agent_authorized_initialize_non_ready_result_is_bounded_and_never
     tmp_path.chmod(0o700)
     consent_state = tmp_path / "consent"
     consent_state.mkdir(mode=0o700)
-    generated = bytearray(b"g" * 64)
-    generated_copy = bytes(generated)
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    backend = _MemoryKeyring()
+    store = _approved_store(tmp_path / "data", backend)
 
     daemon = await _production_daemon(tmp_path, pristine=False)
     # Publish the endpoints before any client runs; serve() then only arms the accept loops.
@@ -127,25 +253,15 @@ async def test_agent_authorized_initialize_non_ready_result_is_bounded_and_never
     try:
         with (
             patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
-            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
         ):
             elevated.prepare_elevated("vault_initialize")
             pending = load_pending(_state=consent_state)
             assert pending is not None
-            attestation = {
-                "schema": "yoetz.chat-user-attestation/1",
-                "channel": "agent_attested_chat_instruction",
-                "client_kind": "codex",
-                "instruction_source": "explicit_current_chat_user",
-                "pending_id": pending.pending_id,
-                "operation": pending.operation,
-                "danger_digest": pending.danger_digest,
-                "target_digest": pending.target_digest,
-                "warning_acknowledged": True,
-                "decision": "approve",
-            }
             with pytest.raises(ElevatedBootstrapError) as exc:
-                await asyncio.wait_for(elevated.authorize_elevated(attestation), timeout=30)
+                await asyncio.wait_for(
+                    elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+                )
 
             # The actionable service reason survives as a bounded token, never the generic
             # authorize_failed collapse.
@@ -172,10 +288,8 @@ async def test_agent_authorized_initialize_non_ready_result_is_bounded_and_never
         await daemon.stop()
         await asyncio.wait_for(serving, timeout=10)
 
-    # The generated local secret was wiped and never persisted to any artifact.
-    assert bytes(generated) == b"\x00" * len(generated)
-    _assert_no_secret_bytes(tmp_path, generated_copy)
-    _assert_no_secret_bytes(runtime_directory, generated_copy)
+    # No credential entry survived the failed attempt.
+    assert backend.values == {}
 
 
 @pytest.mark.anyio
@@ -186,12 +300,9 @@ async def test_agent_authorized_initialize_succeeds_on_pristine_state_without_se
     tmp_path.chmod(0o700)
     consent_state = tmp_path / "consent"
     consent_state.mkdir(mode=0o700)
-    generated = bytearray(b"s" * 64)
-    generated_copy = bytes(generated)
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    backend = _MemoryKeyring()
+    store = _approved_store(tmp_path / "data", backend)
+    active_account, staged_account = _slot_accounts(store)
 
     daemon = await _production_daemon(tmp_path, pristine=True)
     await daemon.start()
@@ -199,24 +310,14 @@ async def test_agent_authorized_initialize_succeeds_on_pristine_state_without_se
     try:
         with (
             patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
-            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
         ):
             elevated.prepare_elevated("vault_initialize")
             pending = load_pending(_state=consent_state)
             assert pending is not None
-            attestation = {
-                "schema": "yoetz.chat-user-attestation/1",
-                "channel": "agent_attested_chat_instruction",
-                "client_kind": "codex",
-                "instruction_source": "explicit_current_chat_user",
-                "pending_id": pending.pending_id,
-                "operation": pending.operation,
-                "danger_digest": pending.danger_digest,
-                "target_digest": pending.target_digest,
-                "warning_acknowledged": True,
-                "decision": "approve",
-            }
-            result = await asyncio.wait_for(elevated.authorize_elevated(attestation), timeout=30)
+            result = await asyncio.wait_for(
+                elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+            )
 
             assert result["outcome"] == "completed"
             assert result["result"] == {"state": "ready", "reason": "succeeded"}
@@ -229,10 +330,84 @@ async def test_agent_authorized_initialize_succeeds_on_pristine_state_without_se
             assert any('"outcome":"approved"' in line for line in audit_lines)
             assert not any('"outcome":"failed"' in line for line in audit_lines)
             assert daemon.status().vault_mode == "passphrase"
+            assert (_SERVICE_NAME, active_account) in backend.values
+            assert (_SERVICE_NAME, staged_account) not in backend.values
     finally:
         await daemon.stop()
         await asyncio.wait_for(serving, timeout=10)
 
-    assert bytes(generated) == b"\x00" * len(generated)
-    _assert_no_secret_bytes(tmp_path, generated_copy)
-    _assert_no_secret_bytes(runtime_directory, generated_copy)
+    secret = _entry_bytes(backend, active_account)
+    _assert_no_secret_bytes(tmp_path, secret)
+    _assert_no_secret_bytes(runtime_directory, secret)
+
+
+@pytest.mark.anyio
+async def test_promotion_crash_is_reconciled_by_proof_at_restart(
+    tmp_path: Path,
+    runtime_directory: Path,
+) -> None:
+    """#511 acceptance: the vault commits, keyring promotion fails, the operation still
+    completes, and the next service start promotes the staged entry by cryptographic proof."""
+
+    tmp_path.chmod(0o700)
+    consent_state = tmp_path / "consent"
+    consent_state.mkdir(mode=0o700)
+    backend = _MemoryKeyring()
+    store = _approved_store(tmp_path / "data", backend)
+    active_account, staged_account = _slot_accounts(store)
+
+    daemon = await _production_daemon(tmp_path, pristine=True)
+    await daemon.start()
+    serving = asyncio.create_task(daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch.object(
+                AutoUnlockPassphraseStore,
+                "promote_staged_initialization",
+                side_effect=OSKeyringError("ambiguous_write"),
+            ),
+        ):
+            elevated.prepare_elevated("vault_initialize")
+            pending = load_pending(_state=consent_state)
+            assert pending is not None
+            result = await asyncio.wait_for(
+                elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+            )
+
+            # The vault committed and activated; the keyring hygiene failure does not turn a
+            # completed operation into a failure.
+            assert result["outcome"] == "completed"
+            assert result["result"] == {"state": "ready", "reason": "succeeded"}
+            assert daemon.status().vault_mode == "passphrase"
+            assert (_SERVICE_NAME, staged_account) in backend.values
+            assert (_SERVICE_NAME, active_account) not in backend.values
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(serving, timeout=10)
+
+    staged_secret = _entry_bytes(backend, staged_account)
+
+    def bound_store(bundle: Path) -> AutoUnlockPassphraseStore:
+        return _approved_store(Path(bundle), backend)
+
+    restart_daemon: ServiceDaemon | None = None
+    with patch.object(daemon_module, "AutoUnlockPassphraseStore", bound_store):
+        restart_daemon = await _production_daemon(tmp_path, pristine=True)
+        await restart_daemon.start()
+    restart_serving = asyncio.create_task(restart_daemon.serve())
+    try:
+        # Startup tried the active slot (absent), proved the staged-initialization candidate
+        # against the real envelope, and promoted exactly it.
+        assert restart_daemon.status().vault_mode == "passphrase"
+        assert cast(str, restart_daemon.status().state.value) == "ready"
+        assert (_SERVICE_NAME, active_account) in backend.values
+        assert (_SERVICE_NAME, staged_account) not in backend.values
+        assert _entry_bytes(backend, active_account) == staged_secret
+    finally:
+        await restart_daemon.stop()
+        await asyncio.wait_for(restart_serving, timeout=10)
+
+    _assert_no_secret_bytes(tmp_path, staged_secret)
+    _assert_no_secret_bytes(runtime_directory, staged_secret)

--- a/tests/integration/service/test_daemon_clients.py
+++ b/tests/integration/service/test_daemon_clients.py
@@ -1563,16 +1563,31 @@ def _patch_auto_unlock_store(
 
         def load_candidates_with_reason(
             self,
-        ) -> tuple[tuple[tuple[bytearray, bool], ...], str]:
+        ) -> tuple[tuple[tuple[bytearray, str], ...], str]:
             if secret is None:
                 return (), reason
-            return ((bytearray(secret), staged),), reason
+            slot = "staged_rotation" if staged else "active"
+            return ((bytearray(secret), slot),), reason
+
+        def slot_report(self) -> dict[str, str]:
+            return {
+                "active": "absent" if staged or secret is None else "present",
+                "staged_initialization": "absent",
+                "staged_rotation": "present" if staged and secret is not None else "absent",
+            }
 
         def promote_staged_rotation(self) -> None:
             if promote_error is not None:
                 raise promote_error
 
         def discard_staged_rotation(self) -> None:
+            return None
+
+        def promote_staged_initialization(self) -> None:
+            if promote_error is not None:
+                raise promote_error
+
+        def discard_staged_initialization(self) -> None:
             return None
 
     def _factory(_bundle: Path) -> _Store:

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -1887,13 +1887,23 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
     supplied: list[bytes] = []
     loaded_env: list[object] = []
 
-    def fake_create_for_initialization(_store: object) -> bytearray:
-        calls.append("create_for_initialization")
+    def fake_slot_report(_store: object) -> dict[str, str]:
+        return {
+            "active": "absent",
+            "staged_initialization": "absent",
+            "staged_rotation": "absent",
+        }
+
+    def fake_stage_for_initialization(_store: object) -> bytearray:
+        calls.append("stage_for_initialization")
         return bytearray(b"a" * 48)
+
+    def fake_promote(_store: object) -> None:
+        calls.append("promote_staged_initialization")
 
     async def fake_initialize(passphrase: bytearray | None = None) -> object:
         supplied.append(bytes(passphrase or b""))
-        return object()
+        return SimpleNamespace(state="ready", reason="succeeded")
 
     async def fake_reachability(*, start_if_absent: bool = False) -> dict[str, object]:
         del start_if_absent
@@ -1910,8 +1920,18 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
 
     monkeypatch.setattr(
         keyring_module.AutoUnlockPassphraseStore,
-        "create_for_initialization",
-        fake_create_for_initialization,
+        "slot_report",
+        fake_slot_report,
+    )
+    monkeypatch.setattr(
+        keyring_module.AutoUnlockPassphraseStore,
+        "stage_for_initialization",
+        fake_stage_for_initialization,
+    )
+    monkeypatch.setattr(
+        keyring_module.AutoUnlockPassphraseStore,
+        "promote_staged_initialization",
+        fake_promote,
     )
     monkeypatch.setattr(unlock_module, "initialize_passphrase_vault", fake_initialize)
     monkeypatch.setattr(binding_module, "prompt_provider_endpoint_binding", _skip_provider_binding)
@@ -1925,7 +1945,7 @@ def test_uninitialized_provider_setup_provisions_auto_unlock(
         )
     )
 
-    assert calls == ["create_for_initialization"]
+    assert calls == ["stage_for_initialization", "promote_staged_initialization"]
     assert loaded_env == [os.environ]
     assert supplied == [b"a" * 48]
     assert service["state"] == "ready"
@@ -1937,7 +1957,7 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
 ) -> None:
     """RT-vault-secrets-1 / ADR-015: pre-existing scoped entry must block vault init.
 
-    Interactive setup must use create_for_initialization (like elevated bootstrap)
+    Interactive setup must use stage_for_initialization (like elevated bootstrap)
     and must never submit a pre-planted auto-unlock secret to vault_initialize.
     """
 
@@ -1965,6 +1985,9 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
         def set_password(self, service: str, username: str, password: str) -> None:
             self.values[(service, username)] = password
 
+        def delete_password(self, service: str, username: str) -> None:
+            del self.values[(service, username)]
+
     backend = _AtomicBackend()
     store = keyring_module.AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)
     store._backend_id = (  # pyright: ignore[reportPrivateUsage]
@@ -1977,7 +2000,7 @@ def test_uninitialized_setup_refuses_preexisting_auto_unlock_entry(
     )
     assert backend.values[("yoetz.auto-unlock.v1", username)] == encoded
     with pytest.raises(keyring_module.OSKeyringError) as elevated_exc:
-        store.create_for_initialization()
+        store.stage_for_initialization()
     assert elevated_exc.value.reason == "entry_exists"
 
     supplied: list[bytes] = []
@@ -2052,6 +2075,9 @@ def test_uninitialized_setup_stops_after_write_with_failed_readback(
         def set_password(self, service: str, username: str, password: str) -> None:
             del service, username
             self.written = password
+
+        def delete_password(self, service: str, username: str) -> None:
+            del service, username
 
     backend = _WriteThenUnreadable()
     store = keyring_module.AutoUnlockPassphraseStore(tmp_path.resolve(), backend=backend)

--- a/tests/unit/cli/test_auto_unlock.py
+++ b/tests/unit/cli/test_auto_unlock.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -61,6 +63,11 @@ class _Store:
     def discard_staged_initialization(self) -> None:
         self.staged_initialization = "absent"
         self.discarded += 1
+
+    @contextmanager
+    def staged_initialization_guard(self) -> Generator[None]:
+        self.guard_acquisitions = getattr(self, "guard_acquisitions", 0) + 1
+        yield
 
     def save(self, value: bytearray) -> None:
         self.saved = bytes(value)
@@ -250,7 +257,32 @@ async def test_auto_unlock_repair_discards_initialization_orphan_with_proof(
     assert report["outcome"] == "initialization_orphan_cleared"
     assert report["next_command"] == "yoetz consent prepare vault_initialize"
     assert store.discarded == 1
+    assert store.guard_acquisitions == 1, "discard must happen under the exclusive guard"
     assert client.closed
+
+
+@pytest.mark.anyio
+async def test_auto_unlock_repair_refuses_orphan_discard_when_reproof_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#511 review: the vault state is re-proven under the guard; a change refuses deletion."""
+
+    store = _Store(None, "auto_unlock_absent", staged_initialization="present")
+    first = _Client(state="locked", reason="none", vault_mode="uninitialized")
+    second = _Client(state="unlocking", reason="none", vault_mode="uninitialized")
+    clients = iter([first, second])
+    monkeypatch.setattr(module, "_auto_unlock_store", lambda: store)
+    monkeypatch.setattr(module, "build_service_client", lambda: _async_value(next(clients)))
+
+    assert (
+        await module._service_auto_unlock_repair(  # pyright: ignore[reportPrivateUsage]
+            True
+        )
+        == 20
+    )
+
+    assert "auto_unlock_repair_unproven" in capsys.readouterr().err
+    assert store.discarded == 0
 
 
 @pytest.mark.anyio

--- a/tests/unit/cli/test_auto_unlock.py
+++ b/tests/unit/cli/test_auto_unlock.py
@@ -29,13 +29,38 @@ class _Client:
 
 
 class _Store:
-    def __init__(self, secret: bytearray | None, reason: str) -> None:
+    def __init__(
+        self,
+        secret: bytearray | None,
+        reason: str,
+        *,
+        staged_initialization: str = "absent",
+    ) -> None:
         self.secret = secret
         self.reason = reason
         self.saved: bytes | None = None
+        self.staged_initialization = staged_initialization
+        self.discarded = 0
 
     def load_with_reason(self) -> tuple[bytearray | None, str]:
         return self.secret, self.reason
+
+    def slot_report(self) -> dict[str, str]:
+        if self.reason == "auto_unlock_backend_unavailable":
+            return {
+                "active": "unavailable",
+                "staged_initialization": "unavailable",
+                "staged_rotation": "unavailable",
+            }
+        return {
+            "active": "present" if self.secret is not None else "absent",
+            "staged_initialization": self.staged_initialization,
+            "staged_rotation": "absent",
+        }
+
+    def discard_staged_initialization(self) -> None:
+        self.staged_initialization = "absent"
+        self.discarded += 1
 
     def save(self, value: bytearray) -> None:
         self.saved = bytes(value)
@@ -97,10 +122,16 @@ async def test_auto_unlock_status_reports_service_verified_stale_without_secret(
     report = json.loads(capsys.readouterr().out)
     assert report == {
         "next_command": "yoetz service auto-unlock repair",
-        "schema": "yoetz.auto-unlock-status/1",
+        "schema": "yoetz.auto-unlock-status/2",
         "service_state": "locked",
         "service_state_reason": "auto_unlock_stale",
+        "slots": {
+            "active": "present",
+            "staged_initialization": "absent",
+            "staged_rotation": "absent",
+        },
         "state": "stale",
+        "vault_mode": "passphrase",
     }
     assert secret == bytearray(len(secret))
     assert client.closed
@@ -125,6 +156,101 @@ async def test_auto_unlock_status_prioritizes_service_rejection(
     report = json.loads(capsys.readouterr().out)
     assert report["state"] == "rejected"
     assert report["next_command"] == "yoetz service auto-unlock repair"
+
+
+@pytest.mark.anyio
+async def test_auto_unlock_status_reports_initialization_orphan_with_repair_path(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#511: a staged entry beside an uninitialized vault is a typed, repairable orphan."""
+
+    store = _Store(None, "auto_unlock_absent", staged_initialization="present")
+    client = _Client(state="locked", reason="none", vault_mode="uninitialized")
+    monkeypatch.setattr(module, "_auto_unlock_store", lambda: store)
+    monkeypatch.setattr(module, "build_service_client", lambda: _async_value(client))
+
+    assert (
+        await module._service_auto_unlock_status(  # pyright: ignore[reportPrivateUsage]
+            True
+        )
+        == 20
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["state"] == "initialization_orphaned"
+    assert report["slots"]["staged_initialization"] == "present"
+    assert report["next_command"] == "yoetz service auto-unlock repair"
+
+
+@pytest.mark.anyio
+async def test_auto_unlock_status_reports_unreconciled_staged_initialization(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#511: with a committed vault the staged entry waits for proof-based reconciliation."""
+
+    store = _Store(None, "auto_unlock_absent", staged_initialization="present")
+    client = _Client(state="locked", reason="passphrase_required", vault_mode="passphrase")
+    monkeypatch.setattr(module, "_auto_unlock_store", lambda: store)
+    monkeypatch.setattr(module, "build_service_client", lambda: _async_value(client))
+
+    assert (
+        await module._service_auto_unlock_status(  # pyright: ignore[reportPrivateUsage]
+            True
+        )
+        == 20
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["state"] == "initialization_unreconciled"
+    assert report["next_command"] == "yoetz service restart"
+
+
+@pytest.mark.anyio
+async def test_auto_unlock_status_distinguishes_pre_existing_unadoptable_entry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#511: an active entry beside an uninitialized vault is named, not called provisioned."""
+
+    store = _Store(bytearray(b"a" * 48), "none")
+    client = _Client(state="locked", reason="none", vault_mode="uninitialized")
+    monkeypatch.setattr(module, "_auto_unlock_store", lambda: store)
+    monkeypatch.setattr(module, "build_service_client", lambda: _async_value(client))
+
+    assert (
+        await module._service_auto_unlock_status(  # pyright: ignore[reportPrivateUsage]
+            True
+        )
+        == 20
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["state"] == "pre_existing_unadoptable"
+    assert report["next_command"] is None
+
+
+@pytest.mark.anyio
+async def test_auto_unlock_repair_discards_initialization_orphan_with_proof(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """#511: repair removes the orphan only because the service proved no envelope exists."""
+
+    store = _Store(None, "auto_unlock_absent", staged_initialization="present")
+    client = _Client(state="locked", reason="none", vault_mode="uninitialized")
+    monkeypatch.setattr(module, "_auto_unlock_store", lambda: store)
+    monkeypatch.setattr(module, "build_service_client", lambda: _async_value(client))
+
+    assert (
+        await module._service_auto_unlock_repair(  # pyright: ignore[reportPrivateUsage]
+            True
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["outcome"] == "initialization_orphan_cleared"
+    assert report["next_command"] == "yoetz consent prepare vault_initialize"
+    assert store.discarded == 1
+    assert client.closed
 
 
 @pytest.mark.anyio

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -811,13 +811,53 @@ def test_forged_approval_arguments_fail_before_mutation(
         assert load_pending(_state=tmp_path) is not None
 
 
+class _StagedInitStore:
+    """Fake staged-initialization keyring lifecycle (#511) for elevated-flow tests."""
+
+    def __init__(self, generated: bytearray, *, staged_leftover: bool = False) -> None:
+        self._generated = generated
+        self.active = False
+        self.staged = staged_leftover
+        self.promoted = False
+        self.discarded = 0
+        self.staged_calls = 0
+
+    def slot_report(self) -> dict[str, str]:
+        return {
+            "active": "present" if self.active else "absent",
+            "staged_initialization": "present" if self.staged else "absent",
+            "staged_rotation": "absent",
+        }
+
+    def stage_for_initialization(self) -> bytearray:
+        from yoetz.adapters.keys.os_keyring import OSKeyringError
+
+        if self.active:
+            raise OSKeyringError("entry_exists")
+        if self.staged:
+            raise OSKeyringError("staged_entry_exists")
+        self.staged = True
+        self.staged_calls += 1
+        return self._generated
+
+    def promote_staged_initialization(self) -> None:
+        from yoetz.adapters.keys.os_keyring import OSKeyringError
+
+        if not self.staged:
+            raise OSKeyringError("missing")
+        self.staged = False
+        self.active = True
+        self.promoted = True
+
+    def discard_staged_initialization(self) -> None:
+        self.staged = False
+        self.discarded += 1
+
+
 def test_generated_initialization_secret_is_submitted_then_overwritten() -> None:
     generated = bytearray(b"g" * 64)
     observed: list[bytes] = []
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    store = _StagedInitStore(generated)
 
     async def ceremony(
         _console: object,
@@ -831,7 +871,7 @@ def test_generated_initialization_secret_is_submitted_then_overwritten() -> None
 
     async def run() -> dict[str, object]:
         with (
-            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
             patch(
                 "yoetz.cli.elevated.run_human_ceremony_on_terminal",
                 side_effect=ceremony,
@@ -848,15 +888,14 @@ def test_generated_initialization_secret_is_submitted_then_overwritten() -> None
     assert observed == [b"g" * 64]
     assert bytes(generated) == b"\x00" * 64
     assert result == {"state": "ready", "reason": "succeeded"}
+    assert store.promoted is True
+    assert store.discarded == 0
 
 
 def test_agent_generated_initialization_secret_never_enters_agent_result() -> None:
     generated = bytearray(b"z" * 64)
     observed: list[bytes] = []
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    store = _StagedInitStore(generated)
 
     async def ceremony(
         _kind: object,
@@ -869,7 +908,7 @@ def test_agent_generated_initialization_secret_never_enters_agent_result() -> No
 
     async def run() -> dict[str, object]:
         with (
-            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
             patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
         ):
             return cast(
@@ -882,6 +921,137 @@ def test_agent_generated_initialization_secret_never_enters_agent_result() -> No
     assert bytes(generated) == b"\x00" * 64
     assert result == {"state": "ready", "reason": "succeeded"}
     assert b"z" * 16 not in json.dumps(result).encode()
+    assert store.promoted is True
+
+
+def test_ambiguous_initialize_outcome_keeps_staged_credential(tmp_path: Path) -> None:
+    """#511: without proof the vault is uninitialized, the staged entry must survive."""
+
+    generated = bytearray(b"m" * 64)
+    store = _StagedInitStore(generated)
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("locked", "initialization_ambiguous")
+
+    async def unprovable() -> str | None:
+        return None
+
+    async def run() -> None:
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated._service_vault_mode", side_effect=unprovable),
+            patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+        ):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_initialize_generated()  # pyright: ignore[reportPrivateUsage]
+        assert exc.value.reason == "vault_result_initialization_ambiguous"
+
+    anyio.run(run)
+    assert store.discarded == 0, "an ambiguous outcome must never delete the staged credential"
+    assert store.staged is True
+    assert bytes(generated) == b"\x00" * 64
+
+
+def test_retry_reconciles_orphaned_staged_credential_before_staging() -> None:
+    """#511: a leftover staged entry with a provably uninitialized vault never blocks retry."""
+
+    generated = bytearray(b"n" * 64)
+    store = _StagedInitStore(generated, staged_leftover=True)
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("ready", "succeeded")
+
+    async def uninitialized() -> str | None:
+        return "uninitialized"
+
+    async def run() -> dict[str, object]:
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
+            patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+        ):
+            return cast(
+                dict[str, object],
+                await elevated._complete_vault_initialize_generated(),  # pyright: ignore[reportPrivateUsage]
+            )
+
+    result = anyio.run(run)
+    assert result == {"state": "ready", "reason": "succeeded"}
+    assert store.discarded == 1
+    assert store.staged_calls == 1
+    assert store.promoted is True
+
+
+def test_unprovable_staged_leftover_fails_closed_without_entry_exists() -> None:
+    """#511: an unreconcilable staged entry gets its own bounded reason, never a blind delete."""
+
+    generated = bytearray(b"p" * 64)
+    store = _StagedInitStore(generated, staged_leftover=True)
+
+    async def committed() -> str | None:
+        return "passphrase"
+
+    async def run() -> None:
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated._service_vault_mode", side_effect=committed),
+        ):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_initialize_generated()  # pyright: ignore[reportPrivateUsage]
+        assert exc.value.reason == "auto_unlock_staged_entry_exists"
+
+    anyio.run(run)
+    assert store.discarded == 0
+    assert store.staged is True
+
+
+def test_pre_existing_active_entry_is_still_refused() -> None:
+    """#111 preserved: an active entry that predates initialization is never adopted."""
+
+    generated = bytearray(b"x" * 64)
+    store = _StagedInitStore(generated)
+    store.active = True
+
+    async def run() -> None:
+        with patch("yoetz.cli.elevated._auto_unlock_store", return_value=store):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_initialize_generated()  # pyright: ignore[reportPrivateUsage]
+        assert exc.value.reason == "auto_unlock_entry_exists"
+
+    anyio.run(run)
+    assert store.discarded == 0
+
+
+def test_promotion_failure_after_committed_initialization_still_succeeds() -> None:
+    """#511: the vault committed and activated; a keyring promotion failure must not fail it."""
+
+    from yoetz.adapters.keys.os_keyring import OSKeyringError
+
+    generated = bytearray(b"w" * 64)
+    store = _StagedInitStore(generated)
+
+    def failing_promote() -> None:
+        raise OSKeyringError("ambiguous_write")
+
+    store.promote_staged_initialization = failing_promote  # type: ignore[method-assign]
+
+    async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
+        return VaultStateResult("ready", "succeeded")
+
+    async def run() -> dict[str, object]:
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
+        ):
+            return cast(
+                dict[str, object],
+                await elevated._complete_vault_initialize_generated(),  # pyright: ignore[reportPrivateUsage]
+            )
+
+    result = anyio.run(run)
+    assert result == {"state": "ready", "reason": "succeeded"}
+    assert store.staged is True, "the staged entry stays for proof-based restart promotion"
+    assert store.discarded == 0
 
 
 def test_agent_generated_rotation_uses_only_local_store_bytes_and_promotes() -> None:
@@ -942,13 +1112,13 @@ def test_agent_authorized_non_ready_vault_result_fails_before_approval(tmp_path:
     """Issue #510: a non-ready ceremony result must never leave an approved consent record."""
 
     generated = bytearray(b"y" * 64)
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    store = _StagedInitStore(generated)
 
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("locked", "throttle_record_exists")
+
+    async def uninitialized() -> str | None:
+        return "uninitialized"
 
     async def run() -> None:
         with _patch_state(tmp_path):
@@ -956,13 +1126,18 @@ def test_agent_authorized_non_ready_vault_result_fails_before_approval(tmp_path:
             pending = load_pending(_state=tmp_path)
             assert pending is not None
             with (
-                patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+                patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+                patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
                 patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
             ):
                 with pytest.raises(ElevatedBootstrapError) as exc:
                     await elevated.authorize_elevated(_chat_attestation(pending))
             assert exc.value.reason == "vault_result_throttle_record_exists"
             assert bytes(generated) == b"\x00" * 64
+            # #511: the same-attempt staged credential is removed once the service proves the
+            # vault is still uninitialized, so retry never hits auto_unlock_entry_exists.
+            assert store.discarded == 1
+            assert store.promoted is False
             assert load_pending(_state=tmp_path) is None
             consumed = _consumed_audit_events(tmp_path)
             assert [event["outcome"] for event in consumed] == ["failed"]
@@ -1037,15 +1212,15 @@ def test_schema_rejected_result_is_bounded_and_never_recorded_approved(tmp_path:
 
 def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: Path) -> None:
     generated = bytearray(b"t" * 64)
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    store = _StagedInitStore(generated)
 
     async def ceremony(
         _console: object, _kind: object, _target: object, **_kwargs: object
     ) -> VaultStateResult:
         return VaultStateResult("locked", "keyring_unavailable")
+
+    async def uninitialized() -> str | None:
+        return "uninitialized"
 
     async def run() -> None:
         with _patch_state(tmp_path):
@@ -1053,7 +1228,8 @@ def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: P
             with (
                 _patch_verified_presence(),
                 patch("yoetz.cli.elevated.TrustedForegroundConsole", return_value=_Console()),
-                patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+                patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+                patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
                 patch(
                     "yoetz.cli.elevated.run_human_ceremony_on_terminal",
                     side_effect=ceremony,
@@ -1066,26 +1242,29 @@ def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: P
             consumed = _consumed_audit_events(tmp_path)
             assert [event["outcome"] for event in consumed] == ["failed"]
             assert consumed[0]["failure_reason"] == "vault_result_keyring_unavailable"
+            assert store.discarded == 1
+            assert store.promoted is False
 
     anyio.run(run)
 
 
 def test_authorize_cli_projects_the_bounded_vault_failure_reason(tmp_path: Path) -> None:
     generated = bytearray(b"q" * 64)
-
-    class _Store:
-        def create_for_initialization(self) -> bytearray:
-            return generated
+    store = _StagedInitStore(generated)
 
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("locked", "throttle_record_exists")
+
+    async def uninitialized() -> str | None:
+        return "uninitialized"
 
     with _patch_state(tmp_path):
         elevated.prepare_elevated("vault_initialize")
         pending = load_pending(_state=tmp_path)
         assert pending is not None
         with (
-            patch("yoetz.cli.elevated._auto_unlock_store", return_value=_Store()),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
             patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
         ):
             result = CliRunner().invoke(

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import importlib
 import io
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -821,6 +822,18 @@ class _StagedInitStore:
         self.promoted = False
         self.discarded = 0
         self.staged_calls = 0
+        self.guard_acquisitions = 0
+        self.guard_held = False
+
+    @contextmanager
+    def staged_initialization_guard(self) -> Generator[None]:
+        assert not self.guard_held, "the guard is exclusive"
+        self.guard_held = True
+        self.guard_acquisitions += 1
+        try:
+            yield
+        finally:
+            self.guard_held = False
 
     def slot_report(self) -> dict[str, str]:
         return {
@@ -933,13 +946,13 @@ def test_ambiguous_initialize_outcome_keeps_staged_credential(tmp_path: Path) ->
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("locked", "initialization_ambiguous")
 
-    async def unprovable() -> str | None:
+    async def unprovable() -> tuple[str, str] | None:
         return None
 
     async def run() -> None:
         with (
             patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-            patch("yoetz.cli.elevated._service_vault_mode", side_effect=unprovable),
+            patch("yoetz.cli.elevated._service_vault_state", side_effect=unprovable),
             patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
         ):
             with pytest.raises(ElevatedBootstrapError) as exc:
@@ -961,13 +974,13 @@ def test_retry_reconciles_orphaned_staged_credential_before_staging() -> None:
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("ready", "succeeded")
 
-    async def uninitialized() -> str | None:
-        return "uninitialized"
+    async def uninitialized() -> tuple[str, str] | None:
+        return ("locked", "uninitialized")
 
     async def run() -> dict[str, object]:
         with (
             patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-            patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
+            patch("yoetz.cli.elevated._service_vault_state", side_effect=uninitialized),
             patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
         ):
             return cast(
@@ -988,13 +1001,13 @@ def test_unprovable_staged_leftover_fails_closed_without_entry_exists() -> None:
     generated = bytearray(b"p" * 64)
     store = _StagedInitStore(generated, staged_leftover=True)
 
-    async def committed() -> str | None:
-        return "passphrase"
+    async def committed() -> tuple[str, str] | None:
+        return ("locked", "passphrase")
 
     async def run() -> None:
         with (
             patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-            patch("yoetz.cli.elevated._service_vault_mode", side_effect=committed),
+            patch("yoetz.cli.elevated._service_vault_state", side_effect=committed),
         ):
             with pytest.raises(ElevatedBootstrapError) as exc:
                 await elevated._complete_vault_initialize_generated()  # pyright: ignore[reportPrivateUsage]
@@ -1117,8 +1130,8 @@ def test_agent_authorized_non_ready_vault_result_fails_before_approval(tmp_path:
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("locked", "throttle_record_exists")
 
-    async def uninitialized() -> str | None:
-        return "uninitialized"
+    async def uninitialized() -> tuple[str, str] | None:
+        return ("locked", "uninitialized")
 
     async def run() -> None:
         with _patch_state(tmp_path):
@@ -1127,7 +1140,7 @@ def test_agent_authorized_non_ready_vault_result_fails_before_approval(tmp_path:
             assert pending is not None
             with (
                 patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-                patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
+                patch("yoetz.cli.elevated._service_vault_state", side_effect=uninitialized),
                 patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
             ):
                 with pytest.raises(ElevatedBootstrapError) as exc:
@@ -1219,8 +1232,8 @@ def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: P
     ) -> VaultStateResult:
         return VaultStateResult("locked", "keyring_unavailable")
 
-    async def uninitialized() -> str | None:
-        return "uninitialized"
+    async def uninitialized() -> tuple[str, str] | None:
+        return ("locked", "uninitialized")
 
     async def run() -> None:
         with _patch_state(tmp_path):
@@ -1229,7 +1242,7 @@ def test_trusted_review_non_ready_vault_result_is_consumed_as_failed(tmp_path: P
                 _patch_verified_presence(),
                 patch("yoetz.cli.elevated.TrustedForegroundConsole", return_value=_Console()),
                 patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-                patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
+                patch("yoetz.cli.elevated._service_vault_state", side_effect=uninitialized),
                 patch(
                     "yoetz.cli.elevated.run_human_ceremony_on_terminal",
                     side_effect=ceremony,
@@ -1255,8 +1268,8 @@ def test_authorize_cli_projects_the_bounded_vault_failure_reason(tmp_path: Path)
     async def ceremony(_kind: object, _target: object, **_kwargs: object) -> VaultStateResult:
         return VaultStateResult("locked", "throttle_record_exists")
 
-    async def uninitialized() -> str | None:
-        return "uninitialized"
+    async def uninitialized() -> tuple[str, str] | None:
+        return ("locked", "uninitialized")
 
     with _patch_state(tmp_path):
         elevated.prepare_elevated("vault_initialize")
@@ -1264,7 +1277,7 @@ def test_authorize_cli_projects_the_bounded_vault_failure_reason(tmp_path: Path)
         assert pending is not None
         with (
             patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
-            patch("yoetz.cli.elevated._service_vault_mode", side_effect=uninitialized),
+            patch("yoetz.cli.elevated._service_vault_state", side_effect=uninitialized),
             patch("yoetz.cli.elevated.run_human_ceremony", side_effect=ceremony),
         ):
             result = CliRunner().invoke(


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #511
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated (storage/durability): the maintainer authored #511 and requested this fix directly.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (AutoUnlockPassphraseStore slot contract, consent
  failure/recovery paragraph) and `docs/adr/ADR-015` (staged initialization amendment,
  2026-08-31).

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/cli tests/unit/service tests/unit/tui/test_runtime.py \
  tests/integration/objects/test_key_backends.py \
  tests/integration/service/test_daemon_clients.py \
  tests/integration/service/test_consent_vault_initialize_composition.py \
  tests/integration/service/test_installation_recovery_flow.py -q
# 954 passed

uv run pytest tests/subprocess/test_setup_wizard_cli.py -q
# 82 passed

uv run ruff check src tests            # All checks passed
npx --no-install pyright <touched src and test files>   # 0 errors
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

The generated auto-unlock credential was durably written to the **active** keyring slot before
the vault initialization ceremony ran. A ceremony failure zeroized only the in-memory buffer, so
the entry was stranded: the next exact consent attempt refused it as `auto_unlock_entry_exists`
(indistinguishable from a genuinely pre-existing entry), and restart could not reconcile — a
one-way stuck state.

Initialization is now staged → vault committed → credential promoted:

- `AutoUnlockPassphraseStore` gains a `-staged-initialization` slot with
  `stage_for_initialization` / `promote_staged_initialization` / `discard_staged_initialization`
  and a bounded `slot_report`. The active slot still refuses pre-existing entries (#111
  preserved); a leftover staged entry gets its own `staged_entry_exists` reason, never
  `entry_exists`.
- Elevated authorize, trusted-console review, and the setup wizard all stage the fresh secret,
  submit a copy to the ceremony, and promote only after the schema-validated ready result. A
  promotion failure after the vault committed does not fail the completed operation — the staged
  entry remains the proven candidate.
- On failure, the exact same-attempt staged entry is discarded with verified read-back **only
  when the live service proves the vault is still uninitialized**; any unprovable outcome
  (ambiguous result, unreachable service, committed-but-unactivated vault) retains it as a
  durable typed orphan. Nothing is ever deleted or adopted blindly.
- Restart unlock (startup and soft-lock re-ready) treats the staged-initialization entry as a
  slot-tagged candidate and promotes or discards strictly by proof against the vault envelope:
  the envelope authenticates exactly one passphrase, so the accepting unlock disproves every
  non-equal staged entry.
- `yoetz service auto-unlock status` (schema `/2`) distinguishes `initialization_orphaned`,
  `initialization_unreconciled`, and `pre_existing_unadoptable` with per-slot presence and next
  commands; `yoetz service auto-unlock repair` clears the orphan under the same
  vault-uninitialized proof.

Production-composition tests (real daemon, real YZH1/YZS1 transport, real staged lifecycle over
an in-memory keyring backend) cover: definitive failure → no orphan → restart → retry succeeds
end-to-end without `auto_unlock_entry_exists`; promotion crash after commit → completed result →
restart promotes by proof; plus secrecy sweeps asserting no secret bytes reach any file in the
state or runtime trees. Unit tests cover the ambiguous-outcome retention, retry reconciliation,
fail-closed unreconcilable staging, and the preserved pre-existing-entry refusal.

Model/harness: Claude Fable 5 on Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a staged-initialization keyring slot so generated vault credentials are promoted only after successful initialization and can be reconciled after ambiguous outcomes.
- Adds staged credential creation, promotion, deletion, and per-slot status reporting.
- Extends setup and elevated initialization flows to retain or clean staged credentials according to live vault state.
- Extends daemon startup and soft-unlock reconciliation to test active, rotation, and initialization candidates.
- Adds operator-facing status and repair behavior for initialization orphans.

<h3>Confidence Score: 4/5</h3>

The concurrent status-then-delete race must be fixed before merging because it can remove the only durable credential for a vault that subsequently commits.

Repair and initialization cleanup delete a staged credential based on an earlier uninitialized status without serialization, while an in-flight ceremony can continue using its in-memory copy and commit afterward.

**Files Needing Attention:** src/yoetz/cli/app.py and src/yoetz/cli/elevated.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/keys/os_keyring.py | Adds an initialization staging slot, slot-tagged candidate loading, verified promotion/deletion, and structural slot reporting. |
| src/yoetz/cli/app.py | Adds versioned per-slot status and orphan repair, but repair can race an in-flight initialization and delete its credential. |
| src/yoetz/cli/elevated.py | Stages and reconciles generated initialization credentials, while its pre-attempt cleanup shares the non-atomic status-then-delete race. |
| src/yoetz/cli/setup.py | Moves setup initialization to the staged lifecycle and preserves ambiguous outcomes for restart reconciliation. |
| src/yoetz/service/daemon.py | Tries slot-tagged candidates and safely reconciles staged entries after cryptographically proven unlock. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant I as Initialization CLI
    participant K as Keyring
    participant S as Service
    participant R as Repair CLI
    I->>K: Stage generated credential
    I->>S: Begin initialization with in-memory copy
    R->>S: Read vault mode
    S-->>R: uninitialized
    R->>K: Delete staged credential
    I->>S: Commit passphrase envelope
    S-->>I: ready
    I->>K: Promote staged credential
    K-->>I: missing
    Note over S,K: Vault is committed but generated auto-unlock credential is gone
```

<sub>Reviews (1): Last reviewed commit: ["fix(vault): stage generated initializati..."](https://github.com/thegaysupreme123/yoetz/commit/3049a88ff348b6528f41d1606046de0f209c8770) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58760841)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->