### PR TITLE
fix(cli): resolve machine scope through configured installation bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- `yoetz privacy show` — and every other local machine-scope privacy read: the empty-request CLI
+  body, `privacy export-desired`, `privacy apply-desired`, the prompt-loop menu's effective-policy
+  view, and setup's update-policy probe — now resolves the installation marker through the
+  configured storage bundle, the same root the service uses, instead of the fixed platform state
+  directory, so an explicit `[storage].data_dir` no longer breaks machine-scope construction. A
+  missing or malformed marker (or an unresolvable bundle) stops locally with one bounded
+  actionable diagnostic (`machine_scope_unavailable: <reason>: <next command>`, exit 2) before
+  any service request, instead of an inadmissible error construction the CLI masked as generic
+  `internal_error` exit 70. The diagnostic names no paths, marker content, or secrets
+  (issue #517).
+
 - Receipt creation now abandons both exact caller-owned object stages when the payload object's
   stage/finalize fails before ledger submission, and equally when the commit boundary refuses the
   append ahead of submission because cancellation is already pending. This removes a receipt file

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -411,6 +411,23 @@ def _usage_failure() -> int:
     return 2
 
 
+def _machine_scope_request_or_none() -> JsonObject | None:
+    """Build the machine-scope privacy body locally, or emit one bounded diagnostic.
+
+    Machine-scope construction is a local read of the configured installation bundle. When it
+    fails, the bounded reason and its remediation are reported here and ``None`` is returned so
+    the caller stops before any service request is sent (issue #517).
+    """
+
+    from yoetz.cli.provider_status import MachineScopeError, machine_scope_request
+
+    try:
+        return machine_scope_request()
+    except MachineScopeError as error:
+        _stderr(f"machine_scope_unavailable: {error.reason}: {error.remediation}")
+        return None
+
+
 def _bounded_failure_line(reason: str, *, prefix: str | None = None) -> str:
     """Render one bounded token with its remediation; the token itself stays first."""
 
@@ -1080,15 +1097,17 @@ async def _call_support(
 ) -> int:
     try:
         if input_path is None and inline is None and method == "privacy_get_effective":
-            from yoetz.cli.provider_status import machine_scope_request
-
-            request = machine_scope_request()
+            scoped = _machine_scope_request_or_none()
+            if scoped is None:
+                return 2
+            request = scoped
         else:
             request = _json_object(input_path, inline)
             if method == "privacy_get_effective" and len(request) == 0:
-                from yoetz.cli.provider_status import machine_scope_request
-
-                request = machine_scope_request()
+                scoped = _machine_scope_request_or_none()
+                if scoped is None:
+                    return 2
+                request = scoped
         # Every support body passes through here, whichever branch built it, so the normalization
         # is one step rather than a property of one path.
         request = with_body_schema_version(method, request)
@@ -2979,12 +2998,15 @@ def privacy_export_desired(
         from yoetz.adapters.privacy.catalog import decode_privacy_policy_canonical
         from yoetz.config.privacy_desired import write_privacy_desired_toml
 
+        # Machine scope is a local construction; resolve it before connecting so a broken
+        # installation marker stops here without any service request (issue #517).
+        scoped = _machine_scope_request_or_none()
+        if scoped is None:
+            return 2
         try:
             client = await build_service_client()
             try:
-                from yoetz.cli.provider_status import machine_scope_request
-
-                effective = await client.privacy_get_effective(machine_scope_request())
+                effective = await client.privacy_get_effective(scoped)
             finally:
                 await client.close()
         except ControlError as error:
@@ -3025,12 +3047,15 @@ def privacy_apply_desired(
         except ConfigError as error:
             typer.echo(f"invalid_request: {error.reason_code}", err=True)
             return 2
+        # Machine scope is a local construction; resolve it before connecting so a broken
+        # installation marker stops here without any service request (issue #517).
+        scoped = _machine_scope_request_or_none()
+        if scoped is None:
+            return 2
         try:
             client = await build_service_client()
             try:
-                from yoetz.cli.provider_status import machine_scope_request
-
-                effective = await client.privacy_get_effective(machine_scope_request())
+                effective = await client.privacy_get_effective(scoped)
             finally:
                 await client.close()
         except ControlError as error:

--- a/src/yoetz/cli/menu.py
+++ b/src/yoetz/cli/menu.py
@@ -432,9 +432,20 @@ def _provider_menu() -> None:
 async def _privacy_show(method: str) -> None:
     from yoetz.cli.app import build_service_client
 
+    request = JsonObject({})
+    if method == "privacy_get_effective":
+        from yoetz.cli.provider_status import MachineScopeError, machine_scope_request
+
+        # The frozen request schema requires a machine scope; it is a local construction, so a
+        # broken installation marker is reported here without any service request (issue #517).
+        try:
+            request = machine_scope_request()
+        except MachineScopeError as error:
+            typer.echo(f"machine_scope_unavailable: {error.reason}: {error.remediation}", err=True)
+            return
     client = await build_service_client()
     try:
-        result = await getattr(client, method)(JsonObject({}))
+        result = await getattr(client, method)(request)
     finally:
         await client.close()
     _show(result)

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -8,8 +8,10 @@ when every installation condition holds.
 
 from __future__ import annotations
 
-import json
+import hashlib
+import hmac
 import os
+import stat
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -20,7 +22,8 @@ from yoetz.config.models import ConfigError
 from yoetz.config.paths import PathSafetyError, bundle_root
 from yoetz.domain.values import JsonObject
 from yoetz.ports.control import ControlClientKind, ControlError, WorkspaceLocator
-from yoetz.protocol.canonical import JsonValue, canonical_encode
+from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
+from yoetz.protocol.ids import IdKind, validate_id
 from yoetz.service.client import connect_service
 
 __all__ = [
@@ -38,6 +41,18 @@ _CREDENTIAL_MASK: Final = "********"
 # This report probes the persistent user service over the fixed endpoint only. It never starts
 # one, unlike the MCP bridge's connect-on-demand path.
 _PROBED_LIFECYCLE: Final = "user_service_no_autostart"
+_INSTALLATION_MARKER_DOMAIN: Final = b"yoetz/installation-state/v1\x00"
+_MAX_INSTALLATION_MARKER_BYTES: Final = 65_536
+_INSTALLATION_MARKER_KEYS: Final = frozenset(
+    {
+        "schema_version",
+        "installation_id",
+        "vault_mode",
+        "root_envelope_base64",
+        "mode_binding_digest",
+        "record_digest",
+    }
+)
 
 
 def _stdout_json(value: JsonValue) -> None:
@@ -370,21 +385,51 @@ def machine_scope_request() -> JsonObject:
         root = bundle_root(_data_dir=config.storage.data_dir)
     except (ConfigError, OSError, PathSafetyError) as exc:
         raise MachineScopeError("installation_bundle_unavailable") from exc
+    marker = root / "installation-state.json"
     try:
-        text = (root / "installation-state.json").read_text()
+        facts = marker.lstat()
+        encoded = marker.read_bytes()
     except FileNotFoundError as exc:
         raise MachineScopeError("installation_marker_missing") from exc
     except OSError as exc:
         raise MachineScopeError("installation_marker_invalid") from exc
     try:
-        state: object = json.loads(text)
-    except ValueError as exc:
+        if (
+            not stat.S_ISREG(facts.st_mode)
+            or stat.S_ISLNK(facts.st_mode)
+            or facts.st_nlink != 1
+            or len(encoded) > _MAX_INSTALLATION_MARKER_BYTES
+            or not encoded.endswith(b"\n")
+            or encoded.endswith(b"\n\n")
+        ):
+            raise ValueError
+        if os.name == "posix" and stat.S_IMODE(facts.st_mode) & 0o077:
+            raise ValueError
+        state: object = strict_json_parse(encoded[:-1])
+        if type(state) is not dict or canonical_encode(cast(JsonValue, state)) != encoded[:-1]:
+            raise ValueError
+        source = cast("dict[str, JsonValue]", state)
+        if frozenset(source) != _INSTALLATION_MARKER_KEYS or source["schema_version"] != "1":
+            raise ValueError
+        body = dict(source)
+        record_digest = body.pop("record_digest")
+        if type(record_digest) is not str:
+            raise ValueError
+        expected = (
+            "sha256:"
+            + hashlib.sha256(_INSTALLATION_MARKER_DOMAIN + canonical_encode(body)).hexdigest()
+        )
+        if not hmac.compare_digest(record_digest, expected):
+            raise ValueError
+    except (TypeError, ValueError) as exc:
         raise MachineScopeError("installation_marker_invalid") from exc
-    installation_id: object = (
-        cast("dict[str, object]", state).get("installation_id") if type(state) is dict else None
-    )
-    if type(installation_id) is not str or not installation_id:
+    installation_id: object = source["installation_id"]
+    if type(installation_id) is not str:
         raise MachineScopeError("installation_marker_invalid")
+    try:
+        validate_id(IdKind.INSTALLATION, installation_id)
+    except (TypeError, ValueError) as exc:
+        raise MachineScopeError("installation_marker_invalid") from exc
     body: dict[str, JsonValue] = {
         "schema_version": "1.0.0",
         "scope": {"kind": "machine", "installation_id": installation_id},

--- a/src/yoetz/cli/provider_status.py
+++ b/src/yoetz/cli/provider_status.py
@@ -16,13 +16,15 @@ from pathlib import Path
 from typing import Final, Literal, cast
 
 from yoetz.config.load import load_config
-from yoetz.config.paths import state_dir
+from yoetz.config.models import ConfigError
+from yoetz.config.paths import PathSafetyError, bundle_root
 from yoetz.domain.values import JsonObject
 from yoetz.ports.control import ControlClientKind, ControlError, WorkspaceLocator
 from yoetz.protocol.canonical import JsonValue, canonical_encode
 from yoetz.service.client import connect_service
 
 __all__ = [
+    "MachineScopeError",
     "credential_human_display",
     "host_admission_observation",
     "machine_scope_request",
@@ -309,20 +311,80 @@ def host_admission_observation(
     return report
 
 
+# Closed remediation set: each machine-scope construction failure names exactly one trusted next
+# command. Values are fixed strings — no paths, no marker content, no user-controlled text.
+_MACHINE_SCOPE_REMEDIATIONS: Final[Mapping[str, str]] = {
+    "installation_bundle_unavailable": (
+        "the configured storage bundle could not be resolved; "
+        "fix [storage].data_dir in config.toml, then retry"
+    ),
+    "installation_marker_invalid": (
+        "the installation marker could not be read; "
+        "run 'yoetz service recovery status' for the trusted repair path, then retry"
+    ),
+    "installation_marker_missing": (
+        "this installation is not initialized; run 'yoetz setup', then retry"
+    ),
+}
+
+
+class MachineScopeError(Exception):
+    """A bounded local machine-scope construction failure; never a service result.
+
+    Raised before any service request when this installation's identity cannot be resolved from
+    the configured storage bundle. The reason set is closed so every caller renders one valid
+    actionable diagnostic instead of constructing an error the control vocabulary does not admit
+    (issue #517: an inadmissible ``ControlError`` reason surfaced as generic ``internal_error``).
+    """
+
+    __slots__ = ("reason",)
+
+    reason: str
+
+    def __init__(self, reason: str) -> None:
+        if type(reason) is not str or reason not in _MACHINE_SCOPE_REMEDIATIONS:
+            raise ValueError("machine_scope_reason_invalid")
+        self.reason = reason
+        super().__init__(reason)
+
+    @property
+    def remediation(self) -> str:
+        """One fixed actionable next step for this reason; safe for human stderr output."""
+
+        return _MACHINE_SCOPE_REMEDIATIONS[self.reason]
+
+
 def machine_scope_request() -> JsonObject:
     """Build the ``privacy_get_effective`` body for this installation's machine scope.
 
-    ``scope`` is required by the frozen request schema, so an unreadable installation id is
-    reported as a caller error here rather than sent as a body the service must reject.
+    The installation marker lives in the configured storage bundle — the same root the service
+    resolves via ``bundle_root(_data_dir=config.storage.data_dir)`` — not the fixed platform
+    state directory, so an explicit ``storage.data_dir`` is honored here too (issue #517).
+    ``scope`` is required by the frozen request schema, so a scope that cannot be constructed
+    locally is reported as a bounded :class:`MachineScopeError` before any service request rather
+    than sent as a body the service must reject.
     """
 
     try:
-        state = json.loads((state_dir() / "installation-state.json").read_text())
-        installation_id = state["installation_id"]
-    except (OSError, KeyError, TypeError, ValueError) as exc:
-        raise ControlError("invalid_request") from exc
+        config = load_config({}, os.environ, None)
+        root = bundle_root(_data_dir=config.storage.data_dir)
+    except (ConfigError, OSError, PathSafetyError) as exc:
+        raise MachineScopeError("installation_bundle_unavailable") from exc
+    try:
+        text = (root / "installation-state.json").read_text()
+    except FileNotFoundError as exc:
+        raise MachineScopeError("installation_marker_missing") from exc
+    except OSError as exc:
+        raise MachineScopeError("installation_marker_invalid") from exc
+    try:
+        state: object = json.loads(text)
+    except ValueError as exc:
+        raise MachineScopeError("installation_marker_invalid") from exc
+    installation_id: object = (
+        cast("dict[str, object]", state).get("installation_id") if type(state) is dict else None
+    )
     if type(installation_id) is not str or not installation_id:
-        raise ControlError("invalid_request")
+        raise MachineScopeError("installation_marker_invalid")
     body: dict[str, JsonValue] = {
         "schema_version": "1.0.0",
         "scope": {"kind": "machine", "installation_id": installation_id},

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -2244,9 +2244,12 @@ async def _effective_update_policy_bits() -> tuple[bool | None, bool]:
         from yoetz.cli.app import build_service_client
         from yoetz.cli.provider_status import machine_scope_request
 
+        # Machine scope is a local construction; resolve it before connecting so a broken
+        # installation marker fails soft here without any service request (issue #517).
+        scoped = machine_scope_request()
         client = await build_service_client()
         try:
-            raw = await client.privacy_get_effective(machine_scope_request())
+            raw = await client.privacy_get_effective(scoped)
         finally:
             await client.close()
         raw_map = cast(Mapping[str, object], raw)

--- a/tests/subprocess/test_cli_invocations.py
+++ b/tests/subprocess/test_cli_invocations.py
@@ -138,6 +138,44 @@ def test_empty_privacy_show_request_uses_the_machine_scope(
     assert observed == [scoped]
 
 
+def test_privacy_show_machine_scope_failure_is_bounded_and_sends_no_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local machine-scope failure is one actionable diagnostic, never exit-70 masking.
+
+    Issue #517: an unreadable installation marker was converted into a ``ControlError`` reason
+    the closed control vocabulary does not admit, so the constructor's own failure surfaced as a
+    generic ``internal_error`` exit 70. The repaired contract stops before any service request
+    with one bounded line naming the reason and the next command.
+    """
+
+    from typing import NoReturn
+
+    from yoetz.cli.provider_status import MachineScopeError
+
+    connections: list[str] = []
+
+    async def build() -> object:
+        connections.append("connected")
+        raise AssertionError("no service request may be sent on local machine-scope failure")
+
+    monkeypatch.setattr(cli, "build_service_client", build)
+
+    def failing_scope() -> NoReturn:
+        raise MachineScopeError("installation_marker_missing")
+
+    monkeypatch.setattr("yoetz.cli.provider_status.machine_scope_request", failing_scope)
+
+    result = CliRunner().invoke(cli.app, ["privacy", "show", "--json"])
+
+    assert result.exit_code == 2
+    assert connections == []
+    assert "machine_scope_unavailable: installation_marker_missing" in result.stderr
+    assert "yoetz setup" in result.stderr
+    assert "internal_error" not in result.output
+    assert "Traceback" not in result.stderr
+
+
 def test_workflow_uses_service_client_and_preserves_failure_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/cli/test_machine_scope.py
+++ b/tests/unit/cli/test_machine_scope.py
@@ -11,6 +11,7 @@ raised before any service request.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import cast
@@ -21,6 +22,7 @@ from yoetz.cli import provider_status as module
 from yoetz.cli.provider_status import MachineScopeError, machine_scope_request
 from yoetz.config.models import ConfigError, StorageConfig, YoetzConfig
 from yoetz.config.paths import PathSafetyError
+from yoetz.protocol.canonical import JsonValue, canonical_encode
 
 _INSTALLATION_ID = "ins_50000000-0000-4000-8000-000000000001"
 
@@ -52,14 +54,35 @@ def _wire(
 
 
 def _write_marker(bundle: Path, text: str) -> None:
-    (bundle / "installation-state.json").write_text(text)
+    marker = bundle / "installation-state.json"
+    marker.write_text(text)
+    marker.chmod(0o600)
+
+
+def _valid_marker(*, installation_id: object = _INSTALLATION_ID) -> str:
+    body = {
+        "installation_id": installation_id,
+        "mode_binding_digest": "sha256:" + ("a" * 64),
+        "root_envelope_base64": None,
+        "schema_version": "1",
+        "vault_mode": "os_keyring",
+    }
+    record_digest = (
+        "sha256:"
+        + hashlib.sha256(
+            b"yoetz/installation-state/v1\x00" + canonical_encode(cast(JsonValue, body))
+        ).hexdigest()
+    )
+    return (
+        canonical_encode(cast(JsonValue, {**body, "record_digest": record_digest})).decode() + "\n"
+    )
 
 
 def test_default_configuration_reads_marker_from_default_bundle(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     bundle, observed = _wire(monkeypatch, tmp_path)
-    _write_marker(bundle, json.dumps({"installation_id": _INSTALLATION_ID}))
+    _write_marker(bundle, _valid_marker())
 
     request = machine_scope_request()
 
@@ -77,7 +100,7 @@ def test_explicit_data_dir_resolves_the_configured_bundle(
 
     configured = tmp_path / "configured-bundle"
     bundle, observed = _wire(monkeypatch, tmp_path, data_dir=configured)
-    _write_marker(bundle, json.dumps({"installation_id": _INSTALLATION_ID}))
+    _write_marker(bundle, _valid_marker())
 
     request = machine_scope_request()
 
@@ -103,10 +126,20 @@ def test_missing_marker_is_a_bounded_local_failure(
         "not json at all",
         json.dumps(["not", "an", "object"]),
         json.dumps({"schema_version": "1"}),
-        json.dumps({"installation_id": ""}),
-        json.dumps({"installation_id": 7}),
+        _valid_marker(installation_id=""),
+        _valid_marker(installation_id="not-an-installation-id"),
+        _valid_marker(installation_id=7),
+        _valid_marker().replace('"record_digest":"sha256:', '"record_digest":"sha256:0', 1),
     ],
-    ids=["not_json", "not_object", "id_absent", "id_empty", "id_not_string"],
+    ids=[
+        "not_json",
+        "not_object",
+        "id_absent",
+        "id_empty",
+        "id_malformed",
+        "id_not_string",
+        "digest_mismatch",
+    ],
 )
 def test_malformed_marker_is_a_bounded_local_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, marker: str

--- a/tests/unit/cli/test_machine_scope.py
+++ b/tests/unit/cli/test_machine_scope.py
@@ -1,0 +1,175 @@
+"""Machine-scope construction resolves the configured installation bundle (issue #517).
+
+``yoetz privacy show`` used to read the installation marker from the fixed platform state
+directory, so an explicit ``storage.data_dir`` bundle made the read miss, and the miss was
+converted into a ``ControlError`` reason the closed control vocabulary does not admit — the CLI
+then masked the constructor's own failure as a generic ``internal_error`` exit 70. These tests
+pin the repaired contract: the marker is resolved through the same canonical bundle the service
+uses, and every local construction failure is one bounded, actionable, pathless diagnostic
+raised before any service request.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from yoetz.cli import provider_status as module
+from yoetz.cli.provider_status import MachineScopeError, machine_scope_request
+from yoetz.config.models import ConfigError, StorageConfig, YoetzConfig
+from yoetz.config.paths import PathSafetyError
+
+_INSTALLATION_ID = "ins_50000000-0000-4000-8000-000000000001"
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    data_dir: Path | None = None,
+) -> tuple[Path, list[Path | None]]:
+    """Bind config and bundle resolution to a test cell; return (bundle, observed data dirs)."""
+
+    config = YoetzConfig(profile="strict-local", storage=StorageConfig(data_dir=data_dir))
+
+    def _load(*_args: object) -> YoetzConfig:
+        return config
+
+    monkeypatch.setattr(module, "load_config", _load)
+    bundle = tmp_path / "bundle"
+    bundle.mkdir(mode=0o700, exist_ok=True)
+    observed: list[Path | None] = []
+
+    def _bundle_root(*, _data_dir: Path | None = None) -> Path:
+        observed.append(_data_dir)
+        return bundle
+
+    monkeypatch.setattr(module, "bundle_root", _bundle_root)
+    return bundle, observed
+
+
+def _write_marker(bundle: Path, text: str) -> None:
+    (bundle / "installation-state.json").write_text(text)
+
+
+def test_default_configuration_reads_marker_from_default_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    bundle, observed = _wire(monkeypatch, tmp_path)
+    _write_marker(bundle, json.dumps({"installation_id": _INSTALLATION_ID}))
+
+    request = machine_scope_request()
+
+    assert observed == [None]
+    assert dict(request) == {
+        "schema_version": "1.0.0",
+        "scope": {"kind": "machine", "installation_id": _INSTALLATION_ID},
+    }
+
+
+def test_explicit_data_dir_resolves_the_configured_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit [storage].data_dir must reach bundle resolution exactly as configured."""
+
+    configured = tmp_path / "configured-bundle"
+    bundle, observed = _wire(monkeypatch, tmp_path, data_dir=configured)
+    _write_marker(bundle, json.dumps({"installation_id": _INSTALLATION_ID}))
+
+    request = machine_scope_request()
+
+    assert observed == [configured]
+    scope = cast(dict[str, object], dict(request)["scope"])
+    assert scope["installation_id"] == _INSTALLATION_ID
+
+
+def test_missing_marker_is_a_bounded_local_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _wire(monkeypatch, tmp_path)
+
+    with pytest.raises(MachineScopeError) as caught:
+        machine_scope_request()
+
+    assert caught.value.reason == "installation_marker_missing"
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "not json at all",
+        json.dumps(["not", "an", "object"]),
+        json.dumps({"schema_version": "1"}),
+        json.dumps({"installation_id": ""}),
+        json.dumps({"installation_id": 7}),
+    ],
+    ids=["not_json", "not_object", "id_absent", "id_empty", "id_not_string"],
+)
+def test_malformed_marker_is_a_bounded_local_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, marker: str
+) -> None:
+    bundle, _ = _wire(monkeypatch, tmp_path)
+    _write_marker(bundle, marker)
+
+    with pytest.raises(MachineScopeError) as caught:
+        machine_scope_request()
+
+    assert caught.value.reason == "installation_marker_invalid"
+
+
+def test_unsafe_bundle_is_a_bounded_local_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _wire(monkeypatch, tmp_path, data_dir=tmp_path / "unsafe")
+
+    def _refuse(*, _data_dir: Path | None = None) -> Path:
+        raise PathSafetyError("path_contains_symlink")
+
+    monkeypatch.setattr(module, "bundle_root", _refuse)
+
+    with pytest.raises(MachineScopeError) as caught:
+        machine_scope_request()
+
+    assert caught.value.reason == "installation_bundle_unavailable"
+
+
+def test_unloadable_config_is_a_bounded_local_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _refuse(*_args: object) -> YoetzConfig:
+        raise ConfigError("config_unreadable")
+
+    monkeypatch.setattr(module, "load_config", _refuse)
+
+    with pytest.raises(MachineScopeError) as caught:
+        machine_scope_request()
+
+    assert caught.value.reason == "installation_bundle_unavailable"
+
+
+def test_machine_scope_reason_set_is_closed() -> None:
+    with pytest.raises(ValueError):
+        MachineScopeError("some_new_reason")
+    with pytest.raises(ValueError):
+        MachineScopeError(cast(str, None))
+
+
+def test_failures_disclose_no_paths_and_carry_actionable_remediation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The diagnostic surface is the closed reason plus a fixed remediation — never a path."""
+
+    _wire(monkeypatch, tmp_path)
+
+    with pytest.raises(MachineScopeError) as caught:
+        machine_scope_request()
+
+    error = caught.value
+    assert str(error) == error.reason
+    assert str(tmp_path) not in str(error)
+    assert str(tmp_path) not in error.remediation
+    assert error.remediation
+    assert "yoetz" in error.remediation

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -98,19 +98,15 @@ class _Client:
         self.closed = True
 
 
-_INSTALLATION_ID = "ins_50000000-0000-4000-8000-000000000001"
-
-
 def _install(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
+    _tmp_path: Path,
     *,
     semantic: str = "optional",
     provider: ProviderProfileConfig | None = None,
     capabilities: tuple[str, ...] = ("external_provider",),
     llm_inference_enabled: bool = True,
     grant_state: str = "granted",
-    installation_state: str | None = None,
     service_state: str = "ready",
     service_state_reason: str = "none",
     mcp_route: dict[str, object] | None = None,
@@ -137,16 +133,6 @@ def _install(
         return client
 
     monkeypatch.setattr(module, "connect_service", _connect)
-
-    # privacy_get_effective requires a scope, which is read from installation state; without
-    # this the report degrades to "unknown" for every policy-derived condition.
-    state = tmp_path / "state"
-    state.mkdir(exist_ok=True)
-    if installation_state is None:
-        installation_state = json.dumps({"installation_id": _INSTALLATION_ID})
-    if installation_state:
-        (state / "installation-state.json").write_text(installation_state)
-    monkeypatch.setattr(module, "state_dir", lambda: state)
 
     # The route probe shells out to a discovered `codex`, so leaving it unpatched would make
     # every test in this module depend on the developer's own registration. The default is the
@@ -344,9 +330,13 @@ async def test_exit_code_is_zero_when_ready(
 async def test_repository_setup_does_not_trust_client_installation_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """The service binds repository and installation; client state cannot choose either."""
+    """The service binds repository and installation; client state cannot choose either.
 
-    _install(monkeypatch, tmp_path, provider=_provider(), installation_state="")
+    No installation marker exists anywhere in this cell, so a report that read one — instead of
+    letting the service bind the installation — could not produce these policy-derived facts.
+    """
+
+    _install(monkeypatch, tmp_path, provider=_provider())
 
     report = await module.provider_status_report()
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #517
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated.

## Documentation

- Behavior change? `yes`
- Docs updated: n/a — CLI defect fix; no interface/ADR change (no wire, schema, or safe_details changes).

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/cli -q                                   # 639 passed
uv run pytest tests/unit/cli/test_machine_scope.py tests/unit/cli/test_provider_status.py \
  tests/subprocess/test_cli_invocations.py tests/subprocess/test_cli_menu.py \
  tests/unit/cli/test_privacy_setup.py -q                         # 109 passed
uv run ruff check / uv run ruff format --check (touched files)    # clean
node_modules/.bin/pyright (pinned npm pyright, touched files)     # 0 errors
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

`yoetz privacy show` read the installation marker from the fixed platform state directory, so an explicit `[storage].data_dir` bundle made the read miss; the miss was converted to `ControlError("invalid_request")` — a reason the closed control vocabulary does not admit — and the constructor's own `TypeError` surfaced as generic `internal_error` exit 70.

`machine_scope_request` now resolves the marker through the same canonical bundle the service uses (`bundle_root` with `config.storage.data_dir`) and raises a bounded `MachineScopeError` with a closed reason set (`installation_bundle_unavailable` / `installation_marker_missing` / `installation_marker_invalid`), each carrying one fixed pathless remediation. Every machine-scope caller (privacy show, `export-desired`/`apply-desired`, setup's update-policy probe, the prompt-loop menu's effective-policy view) stops locally with one actionable diagnostic (exit 2) before any service request. Tests cover default bundle, explicit `data_dir`, missing marker, malformed-marker shapes, no-path-disclosure, and zero service connections on local failure.

Implemented by Claude Fable 5 running in Claude Code (parallel worktree agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes machine-scoped privacy operations resolve installation identity from the configured storage bundle and converts local resolution failures into bounded diagnostics before connecting to the service.
- Introduces a closed `MachineScopeError` reason and remediation contract.
- Updates direct CLI, prompt-menu, export/apply, and setup probe paths to resolve machine scope before service access.
- Adds coverage for configured data directories, malformed or missing markers, pathless diagnostics, and zero service connections after local failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code defect remains after checking bundle equivalence, caller coverage, and setup failure handling.

Machine-scope resolution now follows the daemon's canonical configuration and bundle path, and every current caller either emits the intended bounded diagnostic before connecting or preserves an established fail-soft result.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/cli/provider_status.py | Resolves machine scope through the canonical configured bundle and exposes bounded, pathless local failure reasons. |
| src/yoetz/cli/app.py | Handles machine-scope construction failures before service connection across direct privacy, export, and apply commands. |
| src/yoetz/cli/menu.py | Supplies the required machine scope for effective-policy menu reads and stops locally when scope resolution fails. |
| src/yoetz/cli/setup.py | Moves scope resolution ahead of client construction while preserving the existing fail-soft probe behavior. |
| tests/unit/cli/test_machine_scope.py | Covers configured and default bundles, marker validation, bounded reasons, and pathless remediation. |
| tests/subprocess/test_cli_invocations.py | Verifies that local machine-scope failure exits with an actionable diagnostic and makes no service connection. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Machine-scoped CLI operation] --> B[Load canonical configuration]
    B --> C[Resolve configured bundle root]
    C --> D[Read installation-state marker]
    D -->|Valid installation ID| E[Construct machine scope request]
    E --> F[Connect to service]
    F --> G[Request effective privacy policy]
    C -->|Resolution failure| H[Bounded MachineScopeError]
    D -->|Missing or invalid marker| H
    H --> I[Emit diagnostic or fail soft]
    I --> J[No service connection]
```

<sub>Reviews (1): Last reviewed commit: ["fix(cli): resolve machine scope through ..."](https://github.com/thegaysupreme123/yoetz/commit/3831719466caab0308d8fc8176e6d0be0bb5da68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59048837)</sub>

<!-- /greptile_comment -->

## Independent review follow-up (2026-09-01)

Codex independently reviewed the issue scope, complete diff, callers, tests, and bot state. Beyond the original patch, the marker reader still accepted partial JSON and any non-empty installation ID. Commit `6d580c5d` now validates the exact canonical marker shape, record digest, private file shape, and installation-ID grammar before any service request.

Verification: 59 focused tests passed; Ruff and pinned Pyright passed.
