### PR TITLE
feat(config): supported isolated-root contract for dogfood/test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ reverse-chronological released versions.
   root from it — config, storage bundle, state directory (service singleton lock and generation),
   control endpoints, cache, and logs — so an isolated runtime structurally cannot reach the
   normal Yoetz service. A set but unusable root fails closed instead of falling back to ambient
-  platform directories. `yoetz service isolation --json` proves the resolved mode with
-  digest-only identity comparisons and no service connection, and the Codex dogfood parity gate
-  (schema `yoetz.codex-dogfood-parity/2`) gains a `service_isolation` preflight facet that
-  rejects shared, ambient, or unknown Yoetz service/state identity before launch (issue #518).
+  platform directories. `yoetz service isolation --json` reports one exact target's digest-only
+  identities without a service connection; the Codex dogfood parity gate compares separate exact
+  normal and candidate snapshots (including relocated storage and the Yoetz executable) and
+  rejects shared, ambient, or unknown identity before launch (issue #518).
 
 - `claim_recorded/1.1.0` adds append-only completion-claim correction: a fresh replacement names
   prior effective claims in `supersedes_claim_refs` and records partial or failed results in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ reverse-chronological released versions.
 
 ### Added
 
+- One supported exact-target isolation contract for test and dogfood runtimes (ADR-026): setting
+  `YOETZ_ISOLATED_ROOT` to a pre-provisioned owner-only private directory derives every identity
+  root from it — config, storage bundle, state directory (service singleton lock and generation),
+  control endpoints, cache, and logs — so an isolated runtime structurally cannot reach the
+  normal Yoetz service. A set but unusable root fails closed instead of falling back to ambient
+  platform directories. `yoetz service isolation --json` proves the resolved mode with
+  digest-only identity comparisons and no service connection, and the Codex dogfood parity gate
+  (schema `yoetz.codex-dogfood-parity/2`) gains a `service_isolation` preflight facet that
+  rejects shared, ambient, or unknown Yoetz service/state identity before launch (issue #518).
+
 - `claim_recorded/1.1.0` adds append-only completion-claim correction: a fresh replacement names
   prior effective claims in `supersedes_claim_refs` and records partial or failed results in
   `limitation_refs` instead of treating them as support. Dry-run rejects missing, stale, disjoint,

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -4173,7 +4173,15 @@ facade and are never MCP tools.
 - `config/write.py` / `config/privacy_desired.py`: atomic nonsecret TOML writers and privacy
   desired-state export/apply classification (widen never silent).
 - `config/paths.py`: platformdirs-based `bundle_root()`, `catalog_path()`, path safety checks
-  (rejects repo/sync/network/world-readable locations).
+  (rejects repo/sync/network/world-readable locations). Owns the one exact-target isolation
+  contract (`ISOLATED_ROOT_ENV` = `YOETZ_ISOLATED_ROOT`, ADR-026, issue #518): when set, every
+  identity root — `config_file_path()`, default `bundle_root()`, `state_dir()` (service
+  lock/generation), `runtime_dir()` (control/secret/human-control endpoints), `cache_dir()`,
+  `log_dir()` — derives from the validated `isolated_root()`; a set but unusable root fails
+  closed as `PathSafetyError("isolation_root_invalid")` or the precise existing path-safety
+  reason, never by falling back to ambient platform directories. `YOETZ_STORAGE_DATA_DIR` and
+  `storage.data_dir` alone are storage relocation, not isolation. The connection-free proof
+  surface is `yoetz service isolation --json` (`cli/isolation_status.py`), digest-only.
 - `observability/logging.py`: structured stderr logging, allowlisted fields only; shared `LogMode`
   is exactly `service|cli|mcp_stdio|confidential_helper` so each process installs only its bounded
   sink/filter profile.

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -1,0 +1,92 @@
+# ADR-026 — Exact-target isolated-root runtime identity
+
+**Status:** Accepted (2026-09-01), maintainer-authorized in
+[issue #518](https://github.com/TheGaySupreme123/yoetz/issues/518).
+**Implemented by:** `src/yoetz/config/paths.py` (`isolated_root()`, `runtime_dir()`,
+`ISOLATED_ROOT_ENV`), `src/yoetz/adapters/control/unix_socket.py`, `src/yoetz/config/load.py`,
+`src/yoetz/service/client.py`, `src/yoetz/cli/isolation_status.py`, the
+`yoetz service isolation` CLI command, `scripts/check_codex_dogfood_parity.py`
+(`yoetz.codex-dogfood-parity/2`), and `tests/packaging/test_isolated_root_boundary.py`.
+**Relates to:** ADR-001 (single service/writer authority), ADR-003 (durable storage), and the
+[Codex dogfood parity runbook](../runbooks/codex-dogfood.md).
+
+## Context
+
+Every Yoetz identity root previously resolved independently: `storage.data_dir` (and
+`YOETZ_STORAGE_DATA_DIR`) relocated only the storage bundle, while the platform `state_dir()` kept
+owning the service singleton lock, service generation, and setup markers, and the platform runtime
+directory kept owning the control endpoints. A dogfood or test environment could therefore hold an
+isolated Codex home, candidate wheel, plugin tree, and storage bundle and still transparently
+connect to — and write through — the live user's Yoetz singleton. In a real run, a repository
+privacy grant intended for a disposable dogfood environment committed into the normal Yoetz
+state, and the parity preflight had no facet that could expose the shared service identity.
+
+Internal test isolation existed only as unsupported mechanisms: monkeypatched path functions in
+unit tests and whole-`HOME` overrides in packaging tests. A `HOME` override is not an exact-target
+contract — it drags the host's Codex home, keychain-adjacent state, and every other `HOME`-derived
+identity along with it, and nothing validates or proves it.
+
+## Decisions
+
+1. **One isolation contract, one variable.** `YOETZ_ISOLATED_ROOT` (owned by
+   `yoetz.config.paths`) is the sole supported way to isolate a Yoetz runtime. When set, every
+   identity root derives from the single root: config `<root>/config/config.toml`, default
+   storage bundle `<root>/data`, state `<root>/state` (service lock, generation, setup markers),
+   runtime endpoints `<root>/run` (control, secret-ingress, human-control sockets), cache
+   `<root>/cache`, and logs `<root>/log`. There is deliberately no pile of per-subsystem
+   overrides: partial mechanisms (`YOETZ_STORAGE_DATA_DIR`, `storage.data_dir`) remain storage
+   relocation, never isolation.
+2. **Fail closed, never fall back.** A set but unusable root raises
+   `PathSafetyError("isolation_root_invalid")` (empty, relative, missing, or not a directory) or
+   the precise existing path-safety reason (symlink component, shared temp, repository, sync
+   folder, network filesystem, foreign owner, broad permissions) from the same
+   `verify_private_local_bundle` gate that guards every private directory. No code path resolves
+   to an ambient platform directory while the variable is set. At the endpoint layer this
+   surfaces as the bounded `runtime_directory_unsafe` transport reason.
+3. **The endpoint follows the root.** `runtime_dir()` in `config/paths.py` now owns the runtime
+   endpoint directory and `adapters/control/unix_socket.py` consumes it, so an isolated runtime
+   binds and connects only beneath its root. Not sharing an endpoint (or lock, which already
+   derives from `state_dir()`) is what makes reaching the ambient singleton structurally
+   impossible rather than merely discouraged.
+4. **The variable is paths authority, not configuration.** `config/load.py` recognizes
+   `YOETZ_ISOLATED_ROOT` as mapping to no configuration leaf (like `YOETZ_TUI`), and
+   `service/client.py` forwards it to the detached service process it spawns, so an isolated
+   client can never start a service whose state lands in the ambient install. An explicit
+   `storage.data_dir` still wins over the isolated default `<root>/data`; the parity gate, not
+   silent rejection, is what exposes an override that reaches shared storage.
+5. **Isolation is provable, not assumed.** `yoetz service isolation [--json]` resolves — locally,
+   without connecting to any service or opening any ledger — the exact identity roots this
+   environment would use and reports each as a digest over the canonical resolved path identity
+   (never a raw path), beside the ambient platform-default identities and a `distinct`
+   conclusion. Ambient identities are the normal target's *default* identities: the command never
+   reads the ambient install's config file, so a normal target relocated by its own config is
+   compared against its platform default. The command is CLI-only by design; MCP tools and hook
+   events inherit isolation transparently through the process environment and expose no
+   isolation surface of their own.
+6. **The dogfood parity gate fails closed on shared identity.** Report schema
+   `yoetz.codex-dogfood-parity/2` adds the `service_isolation` preflight facet, the
+   `identity.yoetz_isolation` digest block, and the `observed.yoetz_isolation_state` closed state
+   (`isolated|shared|ambient|unknown`). The facet can pass only when the observed state is
+   `isolated`, the identity mode is `isolated`, and every resolved state/endpoint/storage/config
+   digest differs from its normal-target counterpart; any equality, ambient mode, or unknown
+   state is rejected or fails preflight, and a non-pass row must carry the
+   `provision_isolated_yoetz_root` continuation. Version 1 reports are no longer accepted.
+
+## Reverse states and rollback
+
+Unsetting `YOETZ_ISOLATED_ROOT` restores ambient resolution with no residue: every artifact an
+isolated runtime creates lives beneath the root, so deleting the root is complete rollback and
+cannot touch unrelated user state. The packaged regression
+(`tests/packaging/test_isolated_root_boundary.py`) locks this: an isolated service run leaves the
+ambient home tree byte-identical before/after, an ambient client cannot reach the isolated
+singleton, and removing the root removes every trace.
+
+## Consequences
+
+- Dogfood and test environments get a natively separate temporary Yoetz whose service singleton,
+  storage, config, and endpoints cannot reach the live install, with a preflight that proves it.
+- The isolation root must be provisioned deliberately (existing, owner-only, symlink-free,
+  outside shared temp and repositories) before launch; there is no auto-creation, so a typoed
+  root is an error instead of a silently different target.
+- Existing unsupported isolation mechanisms remain internal test details; new tooling must use
+  this contract.

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -54,21 +54,20 @@ identity along with it, and nothing validates or proves it.
    client can never start a service whose state lands in the ambient install. An explicit
    `storage.data_dir` still wins over the isolated default `<root>/data`; the parity gate, not
    silent rejection, is what exposes an override that reaches shared storage.
-5. **Isolation is provable, not assumed.** `yoetz service isolation [--json]` resolves — locally,
-   without connecting to any service or opening any ledger — the exact identity roots this
-   environment would use and reports each as a digest over the canonical resolved path identity
-   (never a raw path), beside the ambient platform-default identities and a `distinct`
-   conclusion. Ambient identities are the normal target's *default* identities: the command never
-   reads the ambient install's config file, so a normal target relocated by its own config is
-   compared against its platform default. The command is CLI-only by design; MCP tools and hook
-   events inherit isolation transparently through the process environment and expose no
-   isolation surface of their own.
+5. **Isolation is proved from two exact target snapshots.** `yoetz service isolation [--json]`
+   resolves — locally, without connecting to a service or opening a ledger — only the identity
+   roots of the executable and environment that invoked it. Dogfood captures one report from the
+   exact normal executable/config environment and one from the exact isolated candidate. The gate
+   compares those reports; it never substitutes platform defaults for the normal target, because
+   its config or storage may be relocated. Each report contains canonical path-identity digests,
+   never raw paths. The command is CLI-only; MCP and hooks inherit isolation through environment.
 6. **The dogfood parity gate fails closed on shared identity.** Report schema
    `yoetz.codex-dogfood-parity/2` adds the `service_isolation` preflight facet, the
    `identity.yoetz_isolation` digest block, and the `observed.yoetz_isolation_state` closed state
    (`isolated|shared|ambient|unknown`). The facet can pass only when the observed state is
-   `isolated`, the identity mode is `isolated`, and every resolved state/endpoint/storage/config
-   digest differs from its normal-target counterpart; any equality, ambient mode, or unknown
+   `isolated`, the candidate mode is `isolated`, the normal mode is `ambient`, and every resolved
+   state/endpoint/storage/config/executable digest differs from its exact normal-target counterpart;
+   any equality, wrong mode, or unknown
    state is rejected or fails preflight, and a non-pass row must carry the
    `provision_isolated_yoetz_root` continuation. Version 1 reports are no longer accepted.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@ ADR wins; when an ADR and the code disagree, that is a bug in one of them and wo
 | [022](ADR-022-harness-observation-writer-identity-and-observation-tolerant-concurrency.md) | Harness observation writer identity and observation-tolerant concurrency |
 | [023](ADR-023-portable-plugin-carrier-host-activation.md) | Portable plugin carrier and host activation |
 | [025](ADR-025-versioned-claim-correction.md) | Versioned append-only claim correction |
+| [026](ADR-026-isolated-root-runtime-identity.md) | Exact-target isolated-root runtime identity |
 
 Unresolved gates are centralized in [`docs/OPEN_QUESTIONS.md`](../OPEN_QUESTIONS.md), not scattered
 through individual ADRs.

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -89,6 +89,12 @@ status never mistakes it for the marketplace-installed cell, and `preview` refus
 session proves skill delivery, MCP binding/runtime, hooks, model use, semantic dispatch, and receipts
 for the exact bytes, but never marketplace installation, discovery, enablement, or host activation.
 
+An isolated `CLAUDE_CONFIG_DIR` isolates only Claude Code. When the session's Yoetz must not touch
+the live install, also export `YOETZ_ISOLATED_ROOT` (ADR-026) into the session environment so the
+plugin's MCP bridge, hook commands, and any service they spawn derive config, storage, state, and
+endpoints from the isolated root; prove it beforehand with `yoetz service isolation --json` run
+under the same environment.
+
 ## Upgrading Yoetz under a running service
 
 The local-control handshake pins the exact schema-manifest digest, so after installing a new Yoetz

--- a/docs/runbooks/codex-dogfood.md
+++ b/docs/runbooks/codex-dogfood.md
@@ -13,6 +13,21 @@ the machine on its own, authenticate the report author, or upgrade a digest into
 
 - Use a disposable worktree, an isolated Codex executable/home, an isolated Yoetz installation and
   state directory, and a candidate wheel built from the recorded source ref.
+- Yoetz isolation uses exactly one supported contract (ADR-026, issue #518): provision one
+  owner-only (0700), symlink-free private directory outside shared temp and any repository, and
+  export `YOETZ_ISOLATED_ROOT` to it for **every** tested process — the launcher, the MCP server
+  entry, hook commands, and every `yoetz` control command the run executes. Config, storage
+  bundle, state (service lock/generation), control endpoints, cache, and logs all derive from
+  that root, so the isolated runtime structurally cannot reach the normal singleton. Do not treat
+  `YOETZ_STORAGE_DATA_DIR` alone as isolation (it relocates only storage), and do not rely on a
+  bare `yoetz` child command resolving ambient identity. A set but unusable root fails closed
+  (`isolation_root_invalid` or the precise path-safety reason) instead of falling back to the
+  normal install.
+- Prove, never assume, the isolation mode: `yoetz service isolation --json` (run with the exact
+  launch environment) reports the resolved state/endpoint/storage/config identity digests beside
+  the normal-target defaults and a `distinct` conclusion, without connecting to any service.
+- Rollback of Yoetz state is deleting the isolation root: every artifact of the isolated runtime
+  lives beneath it. Stop only processes the runner started, then remove the root.
 - The exact worktree passed to Codex is also passed to plugin status, observation status, consent,
   mapping, drain, and session-stream reconciliation. Never substitute the primary checkout.
 - Observation consent is independent trusted-local authority. Do not copy its database row, reuse
@@ -40,6 +55,7 @@ Resolve and verify, rather than merely accept, these inputs:
 | `launcher_digest` | Exact launcher bytes that start the tested Codex process. |
 | `route_profile` | Registered `strict` or `policy` route actually observed for that isolated target. |
 | `worktree_digest` | SHA-256 over the canonical tested Git-root identity; do not publish the path. |
+| `yoetz_isolation` | The verbatim `mode`, resolved identity digests, and normal-target digests from `yoetz service isolation --json` run in the exact launch environment: `state_digest`, `endpoint_digest`, `storage_digest`, `config_digest`, `executable_digest`, and the four `normal_*` counterparts. |
 
 The source ref, wheel digest, executable digest/version, and launcher digest must agree with the
 actual launch inputs. A clean working tree is not a substitute for the exact source ref, and an
@@ -50,6 +66,7 @@ installed package version is not a substitute for the wheel digest.
 Run each status command from the isolated runtime, with the exact selectors filled in:
 
 ```text
+yoetz service isolation --json
 yoetz recommend list --codex-path <exact-executable> --codex-home <exact-home> --json
 yoetz integrate codex plugin status --project-root <exact-worktree> --codex-path <exact-executable> --codex-home <exact-home> --json
 CODEX_HOME=<exact-home> CODEX_TESTING_HOME=<exact-home> yoetz integrate codex mcp status --codex-path <exact-executable> --json
@@ -64,6 +81,7 @@ bounded reason token, an optional evidence digest, and a closed next action.
 |---|---|
 | `source_identity` | Worktree HEAD equals `source_ref`. |
 | `package_identity` | Installed candidate is the recorded package digest. |
+| `service_isolation` | The launch environment's `yoetz service isolation` reports mode `isolated` with every state/endpoint/storage/config digest distinct from its normal-target counterpart. Shared, ambient, or unknown Yoetz service/state identity cannot pass. |
 | `workspace_binding` | Codex and every Yoetz control use the same exact worktree. |
 | `observation_consent` | Consent is `active` for that worktree commitment. |
 | `plugin_source` | Exact managed source is present in that worktree. |
@@ -75,6 +93,12 @@ bounded reason token, an optional evidence digest, and a closed next action.
 | `plugin_cache` | The versioned cache matches the intended rendered digest. |
 | `plugin_activation` | Exact target state is `active`; presence or enablement alone is insufficient. |
 | `normal_target_snapshot` | A digest-only before-run snapshot exists. |
+
+If isolation is not proven — the command fails, reports `ambient`, or any identity digest equals
+its normal-target counterpart — record the non-pass `service_isolation` row with the
+`provision_isolated_yoetz_root` continuation, provision a fresh isolation root, re-export
+`YOETZ_ISOLATED_ROOT`, and rebuild the report from fresh status. Never launch over shared,
+ambient, or unknown Yoetz identity.
 
 If consent is missing, record `blocked / observation_consent_missing /
 yoetz_observe_grant_exact_worktree`, show the trusted local command, and stop. If activation is
@@ -154,9 +178,13 @@ an out-of-scope pass, failure, or block is inconsistent evidence and invalidates
 ## 7. Report shape and statuses
 
 The top-level keys are exactly `schema`, `identity`, `scope`, `observed`, and `facets`; the current
-schema is `yoetz.codex-dogfood-parity/1`. `observed` retains only closed states/counts:
-activation state, exact/primary consent states, workspace-match boolean, mapping presence, accepted
-envelope count, undelivered count, drain success, hook coverage, and stream coverage.
+schema is `yoetz.codex-dogfood-parity/2` (version 1 reports, which carried no Yoetz isolation
+identity, are no longer accepted). `observed` retains only closed states/counts:
+activation state, Yoetz isolation state (`isolated|shared|ambient|unknown`), exact/primary consent
+states, workspace-match boolean, mapping presence, accepted envelope count, undelivered count,
+drain success, hook coverage, and stream coverage. The validator rejects a passing
+`service_isolation` row whose observed state is not `isolated`, whose identity mode is not
+`isolated`, or whose digests show any shared identity root.
 
 Every facet is reported even when unsupported or not run. The validator rejects extra top-level,
 identity, scope, observed, or facet-row fields; this is the privacy boundary that keeps paths and

--- a/docs/runbooks/codex-dogfood.md
+++ b/docs/runbooks/codex-dogfood.md
@@ -23,9 +23,10 @@ the machine on its own, authenticate the report author, or upgrade a digest into
   bare `yoetz` child command resolving ambient identity. A set but unusable root fails closed
   (`isolation_root_invalid` or the precise path-safety reason) instead of falling back to the
   normal install.
-- Prove, never assume, the isolation mode: `yoetz service isolation --json` (run with the exact
-  launch environment) reports the resolved state/endpoint/storage/config identity digests beside
-  the normal-target defaults and a `distinct` conclusion, without connecting to any service.
+- Prove, never assume, the isolation mode with two connection-free snapshots. First run the normal
+  target's exact `yoetz service isolation --json` without the isolation variable; then run the
+  candidate executable with the exact launch environment. Compare the two exact reports. Platform
+  defaults are not a substitute because the normal target may relocate its config or storage.
 - Rollback of Yoetz state is deleting the isolation root: every artifact of the isolated runtime
   lives beneath it. Stop only processes the runner started, then remove the root.
 - The exact worktree passed to Codex is also passed to plugin status, observation status, consent,
@@ -55,7 +56,7 @@ Resolve and verify, rather than merely accept, these inputs:
 | `launcher_digest` | Exact launcher bytes that start the tested Codex process. |
 | `route_profile` | Registered `strict` or `policy` route actually observed for that isolated target. |
 | `worktree_digest` | SHA-256 over the canonical tested Git-root identity; do not publish the path. |
-| `yoetz_isolation` | The verbatim `mode`, resolved identity digests, and normal-target digests from `yoetz service isolation --json` run in the exact launch environment: `state_digest`, `endpoint_digest`, `storage_digest`, `config_digest`, `executable_digest`, and the four `normal_*` counterparts. |
+| `yoetz_isolation` | `mode` and candidate identity digests from the exact launch report, plus `normal_mode` and the five `normal_*` digests copied from the exact normal-target report: state, endpoint, storage, config, and Yoetz executable. |
 
 The source ref, wheel digest, executable digest/version, and launcher digest must agree with the
 actual launch inputs. A clean working tree is not a substitute for the exact source ref, and an
@@ -66,7 +67,8 @@ installed package version is not a substitute for the wheel digest.
 Run each status command from the isolated runtime, with the exact selectors filled in:
 
 ```text
-yoetz service isolation --json
+<normal-yoetz> service isolation --json
+YOETZ_ISOLATED_ROOT=<exact-root> <candidate-yoetz> service isolation --json
 yoetz recommend list --codex-path <exact-executable> --codex-home <exact-home> --json
 yoetz integrate codex plugin status --project-root <exact-worktree> --codex-path <exact-executable> --codex-home <exact-home> --json
 CODEX_HOME=<exact-home> CODEX_TESTING_HOME=<exact-home> yoetz integrate codex mcp status --codex-path <exact-executable> --json
@@ -81,7 +83,7 @@ bounded reason token, an optional evidence digest, and a closed next action.
 |---|---|
 | `source_identity` | Worktree HEAD equals `source_ref`. |
 | `package_identity` | Installed candidate is the recorded package digest. |
-| `service_isolation` | The launch environment's `yoetz service isolation` reports mode `isolated` with every state/endpoint/storage/config digest distinct from its normal-target counterpart. Shared, ambient, or unknown Yoetz service/state identity cannot pass. |
+| `service_isolation` | The exact normal report has mode `ambient`, the exact launch report has mode `isolated`, and every state/endpoint/storage/config/executable digest differs. Shared, relocated, ambient, or unknown identity cannot pass. |
 | `workspace_binding` | Codex and every Yoetz control use the same exact worktree. |
 | `observation_consent` | Consent is `active` for that worktree commitment. |
 | `plugin_source` | Exact managed source is present in that worktree. |

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -510,7 +510,11 @@ state, source/installed/preview digests, the bounded reason token, and file-stat
 For a disposable-worktree integration run, use the [Codex dogfood parity
 runbook](codex-dogfood.md). The ordinary setup/semantic checks above are necessary but do not prove
 exact-worktree activation, consent, host delivery, observation, rollback, or normal-target
-isolation.
+isolation. In particular, an isolated Codex home (`CODEX_TESTING_HOME`) does not isolate Yoetz:
+without `YOETZ_ISOLATED_ROOT` (ADR-026) exported to every tested process, the run's Yoetz clients
+and any service they spawn resolve the normal singleton, state directory, and storage. Prove the
+mode with `yoetz service isolation --json` before launch; the parity gate's `service_isolation`
+facet fails closed on shared, ambient, or unknown identity.
 
 ## Subscription evaluator is a separate Codex role
 

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -25,7 +25,11 @@ release line at `1.0.24`. Nearby versions are untested, not implicitly compatibl
 
 ## Preview and install
 
-Use an explicit isolated root; never point a test at regular `~/.cursor`. The Cursor plugin
+Use an explicit isolated root; never point a test at regular `~/.cursor`. An isolated Cursor
+home isolates only Cursor: an isolated-Yoetz test cell must also export `YOETZ_ISOLATED_ROOT`
+(ADR-026) into the cell's `mcp.json` `env` and hook commands, or the plugin's Yoetz children
+resolve the live service singleton and state; prove the mode with
+`yoetz service isolation --json` from the cell environment. The Cursor plugin
 command surface is `preview`, `install`, `status`, and `remove` (`--action replace` previews a
 replacement); the generic `update`, `enable`, `disable`, and `export` commands listed by the shared
 group are Claude Code lifecycles and refuse for Cursor with

--- a/scripts/check_codex_dogfood_parity.py
+++ b/scripts/check_codex_dogfood_parity.py
@@ -97,6 +97,7 @@ class DogfoodScope(TypedDict):
 
 class DogfoodYoetzIsolation(TypedDict):
     mode: Literal["isolated", "ambient", "unknown"]
+    normal_mode: Literal["isolated", "ambient", "unknown"]
     state_digest: str
     endpoint_digest: str
     storage_digest: str
@@ -106,6 +107,7 @@ class DogfoodYoetzIsolation(TypedDict):
     normal_endpoint_digest: str
     normal_storage_digest: str
     normal_config_digest: str
+    normal_executable_digest: str
 
 
 class DogfoodIdentity(TypedDict):
@@ -176,17 +178,22 @@ def _parse_yoetz_isolation(value: object) -> DogfoodYoetzIsolation:
         "normal_endpoint_digest",
         "normal_storage_digest",
         "normal_config_digest",
+        "normal_executable_digest",
     )
-    if set(row) != {"mode", *digest_fields}:
+    if set(row) != {"mode", "normal_mode", *digest_fields}:
         raise _error("yoetz_isolation_fields_invalid")
     mode = row["mode"]
+    normal_mode = row["normal_mode"]
     if mode not in {"isolated", "ambient", "unknown"}:
         raise _error("yoetz_isolation_mode_invalid")
+    if normal_mode not in {"isolated", "ambient", "unknown"}:
+        raise _error("yoetz_isolation_normal_mode_invalid")
     digests = {
         name: _require_digest(row[name], "yoetz_isolation_digest_invalid") for name in digest_fields
     }
     return DogfoodYoetzIsolation(
         mode=cast(Literal["isolated", "ambient", "unknown"], mode),
+        normal_mode=cast(Literal["isolated", "ambient", "unknown"], normal_mode),
         state_digest=digests["state_digest"],
         endpoint_digest=digests["endpoint_digest"],
         storage_digest=digests["storage_digest"],
@@ -196,6 +203,7 @@ def _parse_yoetz_isolation(value: object) -> DogfoodYoetzIsolation:
         normal_endpoint_digest=digests["normal_endpoint_digest"],
         normal_storage_digest=digests["normal_storage_digest"],
         normal_config_digest=digests["normal_config_digest"],
+        normal_executable_digest=digests["normal_executable_digest"],
     )
 
 
@@ -443,13 +451,14 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
     ):
         raise _error("service_isolation_state_mismatch")
     if facets["service_isolation"]["status"] == "pass":
-        if isolation["mode"] != "isolated":
+        if isolation["mode"] != "isolated" or isolation["normal_mode"] != "ambient":
             raise _error("service_isolation_identity_mismatch")
         shared_identity_pairs = (
             (isolation["state_digest"], isolation["normal_state_digest"]),
             (isolation["endpoint_digest"], isolation["normal_endpoint_digest"]),
             (isolation["storage_digest"], isolation["normal_storage_digest"]),
             (isolation["config_digest"], isolation["normal_config_digest"]),
+            (isolation["executable_digest"], isolation["normal_executable_digest"]),
         )
         if any(resolved == normal for resolved, normal in shared_identity_pairs):
             raise _error("service_isolation_identity_shared")

--- a/scripts/check_codex_dogfood_parity.py
+++ b/scripts/check_codex_dogfood_parity.py
@@ -1,4 +1,4 @@
-"""Validate the retained exact-worktree Codex dogfood parity gate (issues #463/#464).
+"""Validate the retained exact-worktree Codex dogfood parity gate (issues #463/#464/#518).
 
 The input is a bounded structural report assembled from the runbook's named commands. It carries
 digests and closed states only: no paths, prompts, transcripts, credentials, or provider payloads.
@@ -18,7 +18,7 @@ from typing import Final, Literal, TypedDict, cast
 
 GateStatus = Literal["pass", "fail", "unsupported", "blocked", "not_run"]
 
-_SCHEMA: Final = "yoetz.codex-dogfood-parity/1"
+_SCHEMA: Final = "yoetz.codex-dogfood-parity/2"
 _MAX_REPORT_BYTES: Final = 131_072
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$", re.ASCII)
 _SOURCE_REF = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$", re.ASCII)
@@ -28,6 +28,7 @@ _VERSION = re.compile(r"^[0-9A-Za-z][0-9A-Za-z.+-]{0,127}$", re.ASCII)
 PREFLIGHT_FACETS: Final = (
     "source_identity",
     "package_identity",
+    "service_isolation",
     "workspace_binding",
     "observation_consent",
     "plugin_source",
@@ -67,6 +68,7 @@ _NEXT_ACTIONS: Final = frozenset(
     {
         "none",
         "do_not_launch",
+        "provision_isolated_yoetz_root",
         "yoetz_observe_grant_exact_worktree",
         "yoetz_recommend_list_exact_target",
         "manual_activation_review",
@@ -93,6 +95,19 @@ class DogfoodScope(TypedDict):
     influence_required: bool
 
 
+class DogfoodYoetzIsolation(TypedDict):
+    mode: Literal["isolated", "ambient", "unknown"]
+    state_digest: str
+    endpoint_digest: str
+    storage_digest: str
+    config_digest: str
+    executable_digest: str
+    normal_state_digest: str
+    normal_endpoint_digest: str
+    normal_storage_digest: str
+    normal_config_digest: str
+
+
 class DogfoodIdentity(TypedDict):
     source_ref: str
     package_digest: str
@@ -102,10 +117,12 @@ class DogfoodIdentity(TypedDict):
     launcher_digest: str
     route_profile: Literal["strict", "policy"]
     worktree_digest: str
+    yoetz_isolation: DogfoodYoetzIsolation
 
 
 class DogfoodObserved(TypedDict):
     activation_state: str
+    yoetz_isolation_state: str
     exact_worktree_consent: str
     primary_checkout_consent: str
     controls_workspace_match: bool
@@ -145,6 +162,43 @@ def _require_bool(value: object, reason: str) -> bool:
     return value
 
 
+def _parse_yoetz_isolation(value: object) -> DogfoodYoetzIsolation:
+    if type(value) is not dict:
+        raise _error("yoetz_isolation_invalid")
+    row = cast(dict[str, object], value)
+    digest_fields = (
+        "state_digest",
+        "endpoint_digest",
+        "storage_digest",
+        "config_digest",
+        "executable_digest",
+        "normal_state_digest",
+        "normal_endpoint_digest",
+        "normal_storage_digest",
+        "normal_config_digest",
+    )
+    if set(row) != {"mode", *digest_fields}:
+        raise _error("yoetz_isolation_fields_invalid")
+    mode = row["mode"]
+    if mode not in {"isolated", "ambient", "unknown"}:
+        raise _error("yoetz_isolation_mode_invalid")
+    digests = {
+        name: _require_digest(row[name], "yoetz_isolation_digest_invalid") for name in digest_fields
+    }
+    return DogfoodYoetzIsolation(
+        mode=cast(Literal["isolated", "ambient", "unknown"], mode),
+        state_digest=digests["state_digest"],
+        endpoint_digest=digests["endpoint_digest"],
+        storage_digest=digests["storage_digest"],
+        config_digest=digests["config_digest"],
+        executable_digest=digests["executable_digest"],
+        normal_state_digest=digests["normal_state_digest"],
+        normal_endpoint_digest=digests["normal_endpoint_digest"],
+        normal_storage_digest=digests["normal_storage_digest"],
+        normal_config_digest=digests["normal_config_digest"],
+    )
+
+
 def _parse_identity(value: object) -> DogfoodIdentity:
     if type(value) is not dict:
         raise _error("identity_invalid")
@@ -158,6 +212,7 @@ def _parse_identity(value: object) -> DogfoodIdentity:
         "launcher_digest",
         "route_profile",
         "worktree_digest",
+        "yoetz_isolation",
     }
     if set(row) != expected:
         raise _error("identity_fields_invalid")
@@ -181,6 +236,7 @@ def _parse_identity(value: object) -> DogfoodIdentity:
         launcher_digest=_require_digest(row["launcher_digest"], "launcher_digest_invalid"),
         route_profile=cast(Literal["strict", "policy"], route),
         worktree_digest=_require_digest(row["worktree_digest"], "worktree_digest_invalid"),
+        yoetz_isolation=_parse_yoetz_isolation(row["yoetz_isolation"]),
     )
 
 
@@ -212,6 +268,7 @@ def _parse_observed(value: object) -> DogfoodObserved:
     row = cast(dict[str, object], value)
     expected = {
         "activation_state",
+        "yoetz_isolation_state",
         "exact_worktree_consent",
         "primary_checkout_consent",
         "controls_workspace_match",
@@ -225,6 +282,7 @@ def _parse_observed(value: object) -> DogfoodObserved:
     if set(row) != expected:
         raise _error("observed_fields_invalid")
     activation = row["activation_state"]
+    isolation_state = row["yoetz_isolation_state"]
     exact_consent = row["exact_worktree_consent"]
     primary_consent = row["primary_checkout_consent"]
     if activation not in {
@@ -235,6 +293,8 @@ def _parse_observed(value: object) -> DogfoodObserved:
         "unknown",
     }:
         raise _error("activation_state_invalid")
+    if isolation_state not in {"isolated", "shared", "ambient", "unknown"}:
+        raise _error("yoetz_isolation_state_invalid")
     consent_states = {"active", "missing", "paused", "revoked", "unknown"}
     if exact_consent not in consent_states or primary_consent not in consent_states:
         raise _error("consent_state_invalid")
@@ -246,6 +306,7 @@ def _parse_observed(value: object) -> DogfoodObserved:
             raise _error(f"{name}_invalid")
     return DogfoodObserved(
         activation_state=cast(str, activation),
+        yoetz_isolation_state=cast(str, isolation_state),
         exact_worktree_consent=cast(str, exact_consent),
         primary_checkout_consent=cast(str, primary_consent),
         controls_workspace_match=_require_bool(
@@ -355,7 +416,7 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
         or report["schema"] != _SCHEMA
     ):
         raise _error("report_fields_invalid")
-    _parse_identity(report["identity"])
+    identity = _parse_identity(report["identity"])
     scope = _parse_scope(report["scope"])
     observed = _parse_observed(report["observed"])
     raw_facets = report["facets"]
@@ -376,6 +437,22 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
         observed["activation_state"] == "active"
     ):
         raise _error("activation_state_mismatch")
+    isolation = identity["yoetz_isolation"]
+    if (facets["service_isolation"]["status"] == "pass") != (
+        observed["yoetz_isolation_state"] == "isolated"
+    ):
+        raise _error("service_isolation_state_mismatch")
+    if facets["service_isolation"]["status"] == "pass":
+        if isolation["mode"] != "isolated":
+            raise _error("service_isolation_identity_mismatch")
+        shared_identity_pairs = (
+            (isolation["state_digest"], isolation["normal_state_digest"]),
+            (isolation["endpoint_digest"], isolation["normal_endpoint_digest"]),
+            (isolation["storage_digest"], isolation["normal_storage_digest"]),
+            (isolation["config_digest"], isolation["normal_config_digest"]),
+        )
+        if any(resolved == normal for resolved, normal in shared_identity_pairs):
+            raise _error("service_isolation_identity_shared")
     if facets["mapping"]["status"] == "pass" and not observed["mapping_present"]:
         raise _error("mapping_observation_missing")
     if (
@@ -397,6 +474,11 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
         "yoetz_observe_grant_exact_worktree"
     ):
         raise _error("observation_consent_continuation_missing")
+    isolation_row = facets["service_isolation"]
+    if isolation_row["status"] != "pass" and isolation_row["next_action"] != (
+        "provision_isolated_yoetz_root"
+    ):
+        raise _error("service_isolation_continuation_missing")
     activation = facets["plugin_activation"]
     if activation["reason"] == "installed_not_activated" and activation["next_action"] != (
         "yoetz_recommend_list_exact_target"

--- a/src/yoetz/adapters/control/unix_socket.py
+++ b/src/yoetz/adapters/control/unix_socket.py
@@ -14,9 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Final, NoReturn, Protocol, Self
 
-from platformdirs import PlatformDirs
-
-from yoetz.config.paths import PathSafetyError, ensure_owner_only_dir
+from yoetz.config.paths import PathSafetyError, ensure_owner_only_dir, runtime_dir
 
 __all__ = [
     "CONTROL_ENDPOINT_BASENAME",
@@ -363,7 +361,13 @@ def authenticate_peer(
 
 
 def _runtime_directory() -> Path:
-    return PlatformDirs(appname="yoetz", appauthor=False, roaming=False).user_runtime_path
+    # Derives from the one isolation contract in yoetz.config.paths: an isolated runtime binds
+    # and connects beneath its isolation root, never at the ambient platform endpoint. A set but
+    # unusable isolation root fails closed as the bounded transport reason.
+    try:
+        return runtime_dir()
+    except PathSafetyError as exc:
+        raise LocalControlTransportError("runtime_directory_unsafe") from exc
 
 
 def _endpoint_path(kind: EndpointKind) -> Path:

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1281,6 +1281,32 @@ def service_run() -> None:
         _finish(_lifecycle_failure(error))
 
 
+@service_app.command("isolation")
+def service_isolation(json_output: _JSON = False) -> None:
+    """Report the resolved identity roots and isolation mode without connecting to a service.
+
+    Digest-only output: each root is a digest over its canonical resolved path identity so the
+    dogfood parity preflight (issue #518) can prove an isolated runtime shares no state
+    directory, endpoint, storage bundle, or config with the ambient target.
+    """
+
+    from yoetz.cli.isolation_status import isolation_report
+    from yoetz.config.models import ConfigError
+    from yoetz.config.paths import PathSafetyError
+
+    try:
+        report = isolation_report()
+    except PathSafetyError as error:
+        _stderr(f"isolation_invalid: {error.reason_code}")
+        _finish(2)
+    except ConfigError as error:
+        _stderr(f"isolation_unprovable: {error.reason_code}")
+        _finish(2)
+    else:
+        _human_or_json(cast(JsonValue, dict(report)), json_output=json_output)
+        _finish(0)
+
+
 @service_app.command("diagnostics")
 def service_diagnostics(
     correlation_id: Annotated[

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -1285,9 +1285,9 @@ def service_run() -> None:
 def service_isolation(json_output: _JSON = False) -> None:
     """Report the resolved identity roots and isolation mode without connecting to a service.
 
-    Digest-only output: each root is a digest over its canonical resolved path identity so the
-    dogfood parity preflight (issue #518) can prove an isolated runtime shares no state
-    directory, endpoint, storage bundle, or config with the ambient target.
+    Digest-only output: each root is a digest over its canonical resolved path identity. The
+    dogfood parity preflight compares one report from the exact normal target with another from
+    the isolated launch environment; platform defaults cannot stand in for a relocated target.
     """
 
     from yoetz.cli.isolation_status import isolation_report

--- a/src/yoetz/cli/isolation_status.py
+++ b/src/yoetz/cli/isolation_status.py
@@ -1,0 +1,124 @@
+"""Connection-free proof of the runtime's resolved Yoetz identity roots (issue #518).
+
+``yoetz service isolation`` resolves — locally, without touching any service, lock, or ledger —
+which identity roots this exact process environment would use: state directory (service lock and
+generation), runtime endpoint directory, effective storage bundle, selected config file, and the
+runtime executable. It reports each as a digest over the canonical resolved path identity, never
+as a raw path, next to the ambient platform-default identities, so a dogfood preflight can PROVE
+that an isolated runtime shares nothing with the normal Yoetz target instead of assuming it.
+
+A set but unusable ``YOETZ_ISOLATED_ROOT`` propagates as the bounded ``PathSafetyError`` — the
+mode is then unprovable and callers must fail closed, never report ``ambient``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Final, Literal, TypedDict
+
+from platformdirs import PlatformDirs
+
+from yoetz.config.load import parse_minimal_safe_config
+from yoetz.config.paths import (
+    bundle_root,
+    config_file_path,
+    isolated_root,
+    runtime_dir,
+    state_dir,
+)
+
+__all__ = ["IsolationReport", "isolation_report"]
+
+_APP_NAME: Final = "yoetz"
+
+
+class ResolvedIdentity(TypedDict):
+    state_digest: str
+    endpoint_digest: str
+    storage_digest: str
+    config_digest: str
+    executable_digest: str
+
+
+class AmbientIdentity(TypedDict):
+    state_digest: str
+    endpoint_digest: str
+    storage_digest: str
+    config_digest: str
+
+
+class IsolationReport(TypedDict):
+    mode: Literal["isolated", "ambient"]
+    distinct: bool
+    identity: ResolvedIdentity
+    ambient_identity: AmbientIdentity
+
+
+def _identity_digest(path: Path) -> str:
+    """Digest over the canonical resolved path identity; never publishes the path itself."""
+
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:
+        resolved = path
+    return "sha256:" + hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()
+
+
+def _selected_config_path() -> Path:
+    explicit = os.environ.get("YOETZ_CONFIG", "")
+    return Path(explicit) if explicit else config_file_path()
+
+
+def _effective_storage_dir() -> Path:
+    """The storage bundle the runtime would actually open, honoring config and env overrides."""
+
+    minimal = parse_minimal_safe_config(os.environ, {})
+    if minimal.data_dir is not None:
+        return minimal.data_dir
+    return bundle_root()
+
+
+def isolation_report() -> IsolationReport:
+    """Resolve the exact-environment identity roots and the ambient-default counterparts.
+
+    Raises ``PathSafetyError`` when ``YOETZ_ISOLATED_ROOT`` is set but unusable and
+    ``ConfigError`` when the selected configuration cannot be minimally parsed; both mean the
+    isolation state is unprovable and the caller must fail closed.
+    """
+
+    ambient_dirs = PlatformDirs(appname=_APP_NAME, appauthor=False, roaming=False)
+    ambient = AmbientIdentity(
+        state_digest=_identity_digest(Path(ambient_dirs.user_state_dir)),
+        endpoint_digest=_identity_digest(Path(ambient_dirs.user_runtime_path)),
+        # Ambient storage/config are the normal target's DEFAULT identities. The normal
+        # install's config file is deliberately not read here: an isolated runtime must not
+        # touch the ambient install even read-only, so a normal target relocated by its own
+        # config is compared against its platform default identity instead.
+        storage_digest=_identity_digest(Path(ambient_dirs.user_data_dir)),
+        config_digest=_identity_digest(Path(ambient_dirs.user_config_dir) / "config.toml"),
+    )
+    root = isolated_root()
+    mode: Literal["isolated", "ambient"] = "ambient" if root is None else "isolated"
+    identity = ResolvedIdentity(
+        state_digest=_identity_digest(state_dir()),
+        endpoint_digest=_identity_digest(runtime_dir()),
+        storage_digest=_identity_digest(_effective_storage_dir()),
+        config_digest=_identity_digest(_selected_config_path()),
+        executable_digest=_identity_digest(Path(sys.executable)),
+    )
+    pairs = (
+        (identity["state_digest"], ambient["state_digest"]),
+        (identity["endpoint_digest"], ambient["endpoint_digest"]),
+        (identity["storage_digest"], ambient["storage_digest"]),
+        (identity["config_digest"], ambient["config_digest"]),
+    )
+    distinct = mode == "isolated" and all(resolved != normal for resolved, normal in pairs)
+    return IsolationReport(
+        mode=mode,
+        distinct=distinct,
+        identity=identity,
+        ambient_identity=ambient,
+    )

--- a/src/yoetz/cli/isolation_status.py
+++ b/src/yoetz/cli/isolation_status.py
@@ -3,9 +3,9 @@
 ``yoetz service isolation`` resolves — locally, without touching any service, lock, or ledger —
 which identity roots this exact process environment would use: state directory (service lock and
 generation), runtime endpoint directory, effective storage bundle, selected config file, and the
-runtime executable. It reports each as a digest over the canonical resolved path identity, never
-as a raw path, next to the ambient platform-default identities, so a dogfood preflight can PROVE
-that an isolated runtime shares nothing with the normal Yoetz target instead of assuming it.
+Yoetz launcher. It reports each as a digest over the canonical resolved path identity, never as a
+raw path. A dogfood preflight combines one exact normal-target report with one exact isolated
+report, so relocated normal storage cannot be mistaken for separation.
 
 A set but unusable ``YOETZ_ISOLATED_ROOT`` propagates as the bounded ``PathSafetyError`` — the
 mode is then unprovable and callers must fail closed, never report ``ambient``.
@@ -17,9 +17,7 @@ import hashlib
 import os
 import sys
 from pathlib import Path
-from typing import Final, Literal, TypedDict
-
-from platformdirs import PlatformDirs
+from typing import Literal, TypedDict
 
 from yoetz.config.load import parse_minimal_safe_config
 from yoetz.config.paths import (
@@ -32,8 +30,6 @@ from yoetz.config.paths import (
 
 __all__ = ["IsolationReport", "isolation_report"]
 
-_APP_NAME: Final = "yoetz"
-
 
 class ResolvedIdentity(TypedDict):
     state_digest: str
@@ -43,18 +39,9 @@ class ResolvedIdentity(TypedDict):
     executable_digest: str
 
 
-class AmbientIdentity(TypedDict):
-    state_digest: str
-    endpoint_digest: str
-    storage_digest: str
-    config_digest: str
-
-
 class IsolationReport(TypedDict):
     mode: Literal["isolated", "ambient"]
-    distinct: bool
     identity: ResolvedIdentity
-    ambient_identity: AmbientIdentity
 
 
 def _identity_digest(path: Path) -> str:
@@ -82,24 +69,15 @@ def _effective_storage_dir() -> Path:
 
 
 def isolation_report() -> IsolationReport:
-    """Resolve the exact-environment identity roots and the ambient-default counterparts.
+    """Resolve only this exact environment's identity roots.
 
     Raises ``PathSafetyError`` when ``YOETZ_ISOLATED_ROOT`` is set but unusable and
     ``ConfigError`` when the selected configuration cannot be minimally parsed; both mean the
-    isolation state is unprovable and the caller must fail closed.
+    isolation state is unprovable and the caller must fail closed. A dogfood preflight compares
+    this report with a second report captured from the exact normal target; platform defaults are
+    not a substitute because that target may use relocated config or storage.
     """
 
-    ambient_dirs = PlatformDirs(appname=_APP_NAME, appauthor=False, roaming=False)
-    ambient = AmbientIdentity(
-        state_digest=_identity_digest(Path(ambient_dirs.user_state_dir)),
-        endpoint_digest=_identity_digest(Path(ambient_dirs.user_runtime_path)),
-        # Ambient storage/config are the normal target's DEFAULT identities. The normal
-        # install's config file is deliberately not read here: an isolated runtime must not
-        # touch the ambient install even read-only, so a normal target relocated by its own
-        # config is compared against its platform default identity instead.
-        storage_digest=_identity_digest(Path(ambient_dirs.user_data_dir)),
-        config_digest=_identity_digest(Path(ambient_dirs.user_config_dir) / "config.toml"),
-    )
     root = isolated_root()
     mode: Literal["isolated", "ambient"] = "ambient" if root is None else "isolated"
     identity = ResolvedIdentity(
@@ -107,18 +85,9 @@ def isolation_report() -> IsolationReport:
         endpoint_digest=_identity_digest(runtime_dir()),
         storage_digest=_identity_digest(_effective_storage_dir()),
         config_digest=_identity_digest(_selected_config_path()),
-        executable_digest=_identity_digest(Path(sys.executable)),
+        # ``sys.argv[0]`` is the exact selected Yoetz launcher. ``sys.executable`` would identify
+        # only the shared Python interpreter and could make two distinct installed targets look
+        # identical (or the reverse when wrappers share one interpreter).
+        executable_digest=_identity_digest(Path(sys.argv[0])),
     )
-    pairs = (
-        (identity["state_digest"], ambient["state_digest"]),
-        (identity["endpoint_digest"], ambient["endpoint_digest"]),
-        (identity["storage_digest"], ambient["storage_digest"]),
-        (identity["config_digest"], ambient["config_digest"]),
-    )
-    distinct = mode == "isolated" and all(resolved != normal for resolved, normal in pairs)
-    return IsolationReport(
-        mode=mode,
-        distinct=distinct,
-        identity=identity,
-        ambient_identity=ambient,
-    )
+    return IsolationReport(mode=mode, identity=identity)

--- a/src/yoetz/config/load.py
+++ b/src/yoetz/config/load.py
@@ -36,6 +36,12 @@ _ENV_TO_LEAF: Final[dict[str, _LeafPath | None]] = {
     # Documented presentation control, recognized here so strict config loading cannot mistake
     # the prompt-loop opt-out for a service setting. It maps to no configuration leaf.
     "YOETZ_TUI": None,
+    # The one supported exact-target isolation contract (issue #518). It is consumed and
+    # fail-closed validated by yoetz.config.paths, which rebases every identity root (config,
+    # storage bundle, state, runtime endpoints, cache, logs) onto the isolation root. It maps to
+    # no configuration leaf; recognizing it here keeps strict config loading from rejecting an
+    # isolated runtime as carrying an unknown YOETZ_ variable.
+    "YOETZ_ISOLATED_ROOT": None,
     "YOETZ_PROFILE": ("profile",),
     "YOETZ_STORAGE_DATA_DIR": ("storage", "data_dir"),
     "YOETZ_STORAGE_DURABILITY": ("storage", "durability"),

--- a/src/yoetz/config/paths.py
+++ b/src/yoetz/config/paths.py
@@ -15,13 +15,16 @@ from typing import Final
 from platformdirs import PlatformDirs
 
 __all__ = [
+    "ISOLATED_ROOT_ENV",
     "PathSafetyError",
     "bundle_root",
     "cache_dir",
     "catalog_path",
     "config_file_path",
     "ensure_owner_only_dir",
+    "isolated_root",
     "log_dir",
+    "runtime_dir",
     "service_generation_path",
     "setup_marker_path",
     "state_dir",
@@ -31,6 +34,7 @@ __all__ = [
 ]
 
 _APP_NAME: Final = "yoetz"
+ISOLATED_ROOT_ENV: Final = "YOETZ_ISOLATED_ROOT"
 _PRIVATE_DIR_MODE: Final = 0o700
 _VCS_MARKERS: Final = frozenset({".git", ".hg", ".svn", ".jj"})
 _NETWORK_FILESYSTEMS_LINUX: Final = frozenset(
@@ -57,6 +61,7 @@ _LINUX_SYNC_COMPONENTS: Final = frozenset(
 _SYNC_METADATA_NAMES: Final = frozenset({".dropbox", ".dropbox.cache", ".stfolder", ".sync"})
 _PATH_SAFETY_REASONS: Final = frozenset(
     {
+        "isolation_root_invalid",
         "path_contains_symlink",
         "path_in_repository",
         "path_in_sync_folder",
@@ -158,11 +163,45 @@ def _probe_or_default(probe: _PathProbe | None) -> _PathProbe:
     return _default_probe() if probe is None else probe
 
 
+def isolated_root(*, _probe: _PathProbe | None = None) -> Path | None:
+    """Return the validated exact-target isolation root, or ``None`` in ambient mode.
+
+    ``YOETZ_ISOLATED_ROOT`` is the one supported isolation contract (issue #518): when it is
+    set, every identity root — config, storage bundle, state directory (service lock and
+    generation), runtime endpoint directory, cache, and logs — derives from this single root, so
+    an isolated runtime can never share the ambient platform singleton. Validation fails closed:
+    a set-but-unusable root raises instead of falling back to the ambient platform directories.
+    The root must already exist as an absolute, owner-only, symlink-free private directory
+    outside shared temp, repositories, and sync folders.
+    """
+
+    raw = os.environ.get(ISOLATED_ROOT_ENV)
+    if raw is None:
+        return None
+    if not raw:
+        raise PathSafetyError("isolation_root_invalid")
+    root = Path(raw)
+    if not root.is_absolute():
+        raise PathSafetyError("isolation_root_invalid")
+    probe = _probe_or_default(_probe)
+    verify_private_local_bundle(root, _probe=probe)
+    try:
+        facts = root.lstat()
+    except OSError as exc:
+        raise PathSafetyError("isolation_root_invalid") from exc
+    if not stat.S_ISDIR(facts.st_mode):
+        raise PathSafetyError("isolation_root_invalid")
+    return root
+
+
 def bundle_root(*, _data_dir: Path | None = None, _probe: _PathProbe | None = None) -> Path:
     """Return the default bundle root or a safety-verified explicit override."""
 
     probe = _probe_or_default(_probe)
     if _data_dir is None:
+        isolated = isolated_root(_probe=probe)
+        if isolated is not None:
+            return isolated / "data"
         return Path(probe.platform_dirs.user_data_dir)
     verify_private_local_bundle(_data_dir, _probe=probe)
     return _data_dir
@@ -186,25 +225,55 @@ def config_file_path(*, _probe: _PathProbe | None = None) -> Path:
     """Return the sole default user configuration file path."""
 
     probe = _probe_or_default(_probe)
+    isolated = isolated_root(_probe=probe)
+    if isolated is not None:
+        return isolated / "config" / "config.toml"
     return Path(probe.platform_dirs.user_config_dir) / "config.toml"
 
 
 def cache_dir(*, _probe: _PathProbe | None = None) -> Path:
-    """Return the platform-native user cache directory."""
+    """Return the platform-native or isolated user cache directory."""
 
-    return Path(_probe_or_default(_probe).platform_dirs.user_cache_dir)
+    probe = _probe_or_default(_probe)
+    isolated = isolated_root(_probe=probe)
+    if isolated is not None:
+        return isolated / "cache"
+    return Path(probe.platform_dirs.user_cache_dir)
 
 
 def state_dir(*, _probe: _PathProbe | None = None) -> Path:
-    """Return the platform-native user state directory."""
+    """Return the platform-native or isolated user state directory."""
 
-    return Path(_probe_or_default(_probe).platform_dirs.user_state_dir)
+    probe = _probe_or_default(_probe)
+    isolated = isolated_root(_probe=probe)
+    if isolated is not None:
+        return isolated / "state"
+    return Path(probe.platform_dirs.user_state_dir)
 
 
 def log_dir(*, _probe: _PathProbe | None = None) -> Path:
-    """Return the platform-native user log directory."""
+    """Return the platform-native or isolated user log directory."""
 
-    return Path(_probe_or_default(_probe).platform_dirs.user_log_dir)
+    probe = _probe_or_default(_probe)
+    isolated = isolated_root(_probe=probe)
+    if isolated is not None:
+        return isolated / "log"
+    return Path(probe.platform_dirs.user_log_dir)
+
+
+def runtime_dir(*, _probe: _PathProbe | None = None) -> Path:
+    """Return the platform-native or isolated runtime endpoint directory.
+
+    The service control, secret-ingress, and human-control endpoints bind beneath this
+    directory, so deriving it from the isolation root is what makes an isolated runtime unable
+    to reach — or be reached by — the ambient service singleton.
+    """
+
+    probe = _probe_or_default(_probe)
+    isolated = isolated_root(_probe=probe)
+    if isolated is not None:
+        return isolated / "run"
+    return Path(probe.platform_dirs.user_runtime_path)
 
 
 def service_generation_path(*, _probe: _PathProbe | None = None) -> Path:

--- a/src/yoetz/service/client.py
+++ b/src/yoetz/service/client.py
@@ -149,6 +149,10 @@ _SECRET_ENV_MARKERS: Final = (
 _SERVICE_CONFIG_ENV_NAMES: Final = frozenset(
     {
         "YOETZ_CONFIG",
+        # The exact-target isolation root must reach the detached service process, or an
+        # isolated client would spawn a service whose state, storage, and endpoints silently
+        # land in the ambient install (issue #518).
+        "YOETZ_ISOLATED_ROOT",
         "YOETZ_LOG_LEVEL",
         "YOETZ_PROFILE",
         "YOETZ_PROVIDER_ENDPOINT_PROFILE_ID",

--- a/tests/packaging/test_isolated_root_boundary.py
+++ b/tests/packaging/test_isolated_root_boundary.py
@@ -1,0 +1,241 @@
+"""Isolated-root runtime boundary against the real installed launcher (issue #518).
+
+Proves the one supported exact-target isolation contract end to end: with
+``YOETZ_ISOLATED_ROOT`` set, a real installed ``yoetz`` runtime places its service singleton
+(lock, generation), control endpoint, storage bundle, config, cache, and logs beneath the
+isolated root; an ambient client of the same installation cannot reach that service; the
+ambient home tree is byte-identical before and after the isolated run; and removing the root
+removes every trace of the test-owned runtime.
+
+Like the rest of ``tests/packaging``, this spawns real CLIs against install roots under
+``~/.yz-*`` and must run from the primary checkout, never concurrently with another pytest run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+
+
+def _is_advertised_host() -> bool:
+    if sys.platform == "darwin":
+        return platform.machine() == "arm64"
+    if sys.platform.startswith("linux"):
+        return platform.machine() in {"x86_64", "amd64"}
+    return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_advertised_host(),
+    reason="only the v0.1 advertised macOS arm64 / manylinux_2_28 x86-64 cells are certified",
+)
+
+
+def _real_cache_dir() -> str:
+    result = subprocess.run(["uv", "cache", "dir"], capture_output=True, timeout=15, check=False)
+    return result.stdout.decode("utf-8").strip()
+
+
+def _short_home(tag: str) -> Path:
+    # AF_UNIX socket paths derived from the isolation root must stay well under the ~104-byte
+    # sockaddr_un limit, contain no symlink component, and avoid shared temp directories; the
+    # real user home is the only location on this host satisfying all of that. Fully disposable.
+    base = Path.home() / f".yz-{tag}"
+    base.mkdir(mode=0o700, exist_ok=True)
+    root = base / secrets.token_hex(3)
+    root.mkdir(mode=0o700)
+    (root / "h").mkdir(mode=0o700)
+    return root
+
+
+def _tool_install(dist_dir: Path, root: Path, home: Path) -> tuple[Path, dict[str, str]]:
+    tool_dir = root / "tool"
+    bin_dir = root / "bin"
+    spec = "yoetz==0.1.0"
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "UV_TOOL_DIR": str(tool_dir),
+        "UV_TOOL_BIN_DIR": str(bin_dir),
+        "UV_CACHE_DIR": _real_cache_dir(),
+    }
+
+    def _install(offline: bool) -> subprocess.CompletedProcess[bytes]:
+        args = ["uv", "tool", "install", "--python", "3.14.6"]
+        if offline:
+            args.append("--offline")
+        args += ["--find-links", str(dist_dir), spec]
+        return subprocess.run(args, capture_output=True, timeout=180, env=env, check=False)
+
+    result = _install(offline=True)
+    if result.returncode != 0:
+        result = _install(offline=False)
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    return bin_dir / "yoetz", env
+
+
+@pytest.fixture(scope="module")
+def built_dist(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    dist_dir = tmp_path_factory.mktemp("isolated-root-dist")
+    result = subprocess.run(
+        ["uv", "build", "--no-sources", "-o", str(dist_dir), str(_REPO_ROOT)],
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    return dist_dir
+
+
+def _home_tree_digest(home: Path) -> dict[str, str]:
+    snapshot: dict[str, str] = {}
+    for path in sorted(home.rglob("*")):
+        relative = str(path.relative_to(home))
+        if path.is_symlink():
+            snapshot[relative] = "symlink:" + str(path.readlink())
+        elif path.is_file():
+            snapshot[relative] = hashlib.sha256(path.read_bytes()).hexdigest()
+        elif path.is_dir():
+            snapshot[relative] = "dir"
+    return snapshot
+
+
+def _stop_service(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_isolation_report_modes_and_fail_closed_root(built_dist: Path) -> None:
+    root = _short_home("iso-report")
+    try:
+        home = root / "h"
+        yoetz_exe, env = _tool_install(built_dist, root, home)
+
+        ambient = subprocess.run(
+            [str(yoetz_exe), "service", "isolation", "--json"],
+            capture_output=True,
+            timeout=20,
+            env=env,
+            check=False,
+        )
+        assert ambient.returncode == 0, ambient.stderr
+        ambient_report = json.loads(ambient.stdout)
+        assert ambient_report["mode"] == "ambient"
+        assert ambient_report["distinct"] is False
+
+        iso = root / "iso"
+        iso.mkdir(mode=0o700)
+        isolated = subprocess.run(
+            [str(yoetz_exe), "service", "isolation", "--json"],
+            capture_output=True,
+            timeout=20,
+            env={**env, "YOETZ_ISOLATED_ROOT": str(iso)},
+            check=False,
+        )
+        assert isolated.returncode == 0, isolated.stderr
+        isolated_report = json.loads(isolated.stdout)
+        assert isolated_report["mode"] == "isolated"
+        assert isolated_report["distinct"] is True
+        for key in ("state_digest", "endpoint_digest", "storage_digest", "config_digest"):
+            assert isolated_report["identity"][key] != ambient_report["identity"][key]
+        # Digest-only privacy boundary: the report publishes no raw path.
+        assert str(iso) not in isolated.stdout.decode("utf-8")
+
+        unusable = subprocess.run(
+            [str(yoetz_exe), "service", "isolation", "--json"],
+            capture_output=True,
+            timeout=20,
+            env={**env, "YOETZ_ISOLATED_ROOT": str(root / "never-created")},
+            check=False,
+        )
+        assert unusable.returncode == 2
+        assert b"isolation_invalid: isolation_root_invalid" in unusable.stderr
+    finally:
+        shutil.rmtree(root.parent, ignore_errors=True)
+
+
+def test_isolated_service_singleton_cannot_be_reached_ambiently_and_leaves_no_trace(
+    built_dist: Path,
+) -> None:
+    root = _short_home("iso-boundary")
+    try:
+        home = root / "h"
+        yoetz_exe, env = _tool_install(built_dist, root, home)
+        iso = root / "iso"
+        iso.mkdir(mode=0o700)
+        env_iso = {**env, "YOETZ_ISOLATED_ROOT": str(iso)}
+
+        before = _home_tree_digest(home)
+
+        service = subprocess.Popen(
+            [str(yoetz_exe), "service", "run"],
+            env=env_iso,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            deadline = time.monotonic() + 15
+            reachable = False
+            while time.monotonic() < deadline:
+                if service.poll() is not None:
+                    raise AssertionError("isolated service exited during startup")
+                status = subprocess.run(
+                    [str(yoetz_exe), "service", "status", "--json"],
+                    capture_output=True,
+                    timeout=10,
+                    env=env_iso,
+                    check=False,
+                )
+                if status.returncode == 0:
+                    reachable = True
+                    break
+                time.sleep(0.2)
+            assert reachable, "isolated client never reached the isolated service"
+
+            # Every singleton identity artifact lives beneath the isolated root.
+            assert (iso / "state" / "service.lock").is_file()
+            assert (iso / "run" / "control.sock").is_socket()
+
+            # The same installation without the isolation root resolves the ambient endpoint
+            # and must NOT reach the isolated singleton (`service status` never spawns).
+            ambient_status = subprocess.run(
+                [str(yoetz_exe), "service", "status", "--json"],
+                capture_output=True,
+                timeout=10,
+                env=env,
+                check=False,
+            )
+            assert ambient_status.returncode != 0
+            assert b"Traceback (most recent call last)" not in ambient_status.stderr
+        finally:
+            _stop_service(service)
+
+        # Before/after: the isolated run wrote nothing into the ambient home tree.
+        assert _home_tree_digest(home) == before
+
+        # Rollback removes only test-owned state: everything the run created is under the root.
+        shutil.rmtree(iso)
+        assert _home_tree_digest(home) == before
+    finally:
+        shutil.rmtree(root.parent, ignore_errors=True)

--- a/tests/packaging/test_isolated_root_boundary.py
+++ b/tests/packaging/test_isolated_root_boundary.py
@@ -141,7 +141,6 @@ def test_isolation_report_modes_and_fail_closed_root(built_dist: Path) -> None:
         assert ambient.returncode == 0, ambient.stderr
         ambient_report = json.loads(ambient.stdout)
         assert ambient_report["mode"] == "ambient"
-        assert ambient_report["distinct"] is False
 
         iso = root / "iso"
         iso.mkdir(mode=0o700)
@@ -155,7 +154,6 @@ def test_isolation_report_modes_and_fail_closed_root(built_dist: Path) -> None:
         assert isolated.returncode == 0, isolated.stderr
         isolated_report = json.loads(isolated.stdout)
         assert isolated_report["mode"] == "isolated"
-        assert isolated_report["distinct"] is True
         for key in ("state_digest", "endpoint_digest", "storage_digest", "config_digest"):
             assert isolated_report["identity"][key] != ambient_report["identity"][key]
         # Digest-only privacy boundary: the report publishes no raw path.

--- a/tests/unit/cli/test_service_isolation.py
+++ b/tests/unit/cli/test_service_isolation.py
@@ -1,0 +1,103 @@
+"""Connection-free isolation proof for the dogfood preflight (issue #518).
+
+The report must prove — with digests over canonical resolved path identities, never raw paths —
+which identity roots this exact environment would use, so a parity preflight can reject shared,
+ambient, or unprovable Yoetz service/state identity before any launch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from yoetz.cli.isolation_status import isolation_report
+from yoetz.config.paths import ISOLATED_ROOT_ENV, PathSafetyError
+
+_DIGEST_KEYS = ("state_digest", "endpoint_digest", "storage_digest", "config_digest")
+
+
+def _scrub_yoetz_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    for name in [name for name in os.environ if name.startswith("YOETZ_")]:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _expected_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(str(path.resolve(strict=False)).encode("utf-8")).hexdigest()
+
+
+def test_ambient_mode_reports_identical_platform_identities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _scrub_yoetz_env(monkeypatch)
+    # A hermetic explicit config keeps the probe away from the live user config file.
+    monkeypatch.setenv("YOETZ_CONFIG", str(tmp_path / "missing.toml"))
+
+    report = isolation_report()
+
+    assert report["mode"] == "ambient"
+    assert report["distinct"] is False
+    identity = cast(dict[str, str], report["identity"])
+    ambient = cast(dict[str, str], report["ambient_identity"])
+    for key in ("state_digest", "endpoint_digest", "storage_digest"):
+        assert identity[key] == ambient[key]
+    assert set(identity) == {*_DIGEST_KEYS, "executable_digest"}
+    assert set(ambient) == set(_DIGEST_KEYS)
+
+
+def test_isolated_mode_proves_every_identity_root_distinct(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _scrub_yoetz_env(monkeypatch)
+    root = tmp_path / "iso"
+    root.mkdir(mode=0o700)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
+
+    report = isolation_report()
+
+    assert report["mode"] == "isolated"
+    assert report["distinct"] is True
+    identity = cast(dict[str, str], report["identity"])
+    ambient = cast(dict[str, str], report["ambient_identity"])
+    for key in _DIGEST_KEYS:
+        assert identity[key] != ambient[key]
+    assert report["identity"]["state_digest"] == _expected_digest(root / "state")
+    assert report["identity"]["endpoint_digest"] == _expected_digest(root / "run")
+    assert report["identity"]["storage_digest"] == _expected_digest(root / "data")
+    assert report["identity"]["config_digest"] == _expected_digest(root / "config" / "config.toml")
+    # Digest-only privacy boundary: no raw path may appear anywhere in the report.
+    assert str(root) not in repr(report)
+
+
+def test_isolated_storage_pointed_at_ambient_data_is_not_distinct(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """YOETZ_STORAGE_DATA_DIR alone is not isolation; the report must expose the overlap."""
+
+    from platformdirs import PlatformDirs
+
+    _scrub_yoetz_env(monkeypatch)
+    root = tmp_path / "iso"
+    root.mkdir(mode=0o700)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
+    ambient_data = PlatformDirs(appname="yoetz", appauthor=False, roaming=False).user_data_dir
+    monkeypatch.setenv("YOETZ_STORAGE_DATA_DIR", str(ambient_data))
+
+    report = isolation_report()
+
+    assert report["mode"] == "isolated"
+    assert report["distinct"] is False
+    assert report["identity"]["storage_digest"] == report["ambient_identity"]["storage_digest"]
+
+
+def test_unusable_root_is_unprovable_never_ambient(monkeypatch: pytest.MonkeyPatch) -> None:
+    _scrub_yoetz_env(monkeypatch)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, "relative/never-valid")
+
+    with pytest.raises(PathSafetyError) as caught:
+        isolation_report()
+    assert caught.value.reason_code == "isolation_root_invalid"

--- a/tests/unit/cli/test_service_isolation.py
+++ b/tests/unit/cli/test_service_isolation.py
@@ -8,6 +8,9 @@ ambient, or unprovable Yoetz service/state identity before any launch.
 from __future__ import annotations
 
 import hashlib
+import shutil
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import cast
 
@@ -17,6 +20,16 @@ from yoetz.cli.isolation_status import isolation_report
 from yoetz.config.paths import ISOLATED_ROOT_ENV, PathSafetyError
 
 _DIGEST_KEYS = ("state_digest", "endpoint_digest", "storage_digest", "config_digest")
+
+
+@pytest.fixture
+def private_root() -> Iterator[Path]:
+    root = Path(tempfile.mkdtemp(prefix=".yz-isolation-test-", dir=Path.home()))
+    root.chmod(0o700)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
 
 
 def _scrub_yoetz_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,7 +43,7 @@ def _expected_digest(path: Path) -> str:
     return "sha256:" + hashlib.sha256(str(path.resolve(strict=False)).encode("utf-8")).hexdigest()
 
 
-def test_ambient_mode_reports_identical_platform_identities(
+def test_ambient_mode_reports_the_exact_platform_identity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _scrub_yoetz_env(monkeypatch)
@@ -40,31 +53,21 @@ def test_ambient_mode_reports_identical_platform_identities(
     report = isolation_report()
 
     assert report["mode"] == "ambient"
-    assert report["distinct"] is False
     identity = cast(dict[str, str], report["identity"])
-    ambient = cast(dict[str, str], report["ambient_identity"])
-    for key in ("state_digest", "endpoint_digest", "storage_digest"):
-        assert identity[key] == ambient[key]
     assert set(identity) == {*_DIGEST_KEYS, "executable_digest"}
-    assert set(ambient) == set(_DIGEST_KEYS)
 
 
-def test_isolated_mode_proves_every_identity_root_distinct(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_isolated_mode_reports_every_identity_beneath_the_exact_root(
+    private_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _scrub_yoetz_env(monkeypatch)
-    root = tmp_path / "iso"
+    root = private_root / "iso"
     root.mkdir(mode=0o700)
     monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
 
     report = isolation_report()
 
     assert report["mode"] == "isolated"
-    assert report["distinct"] is True
-    identity = cast(dict[str, str], report["identity"])
-    ambient = cast(dict[str, str], report["ambient_identity"])
-    for key in _DIGEST_KEYS:
-        assert identity[key] != ambient[key]
     assert report["identity"]["state_digest"] == _expected_digest(root / "state")
     assert report["identity"]["endpoint_digest"] == _expected_digest(root / "run")
     assert report["identity"]["storage_digest"] == _expected_digest(root / "data")
@@ -73,25 +76,26 @@ def test_isolated_mode_proves_every_identity_root_distinct(
     assert str(root) not in repr(report)
 
 
-def test_isolated_storage_pointed_at_ambient_data_is_not_distinct(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_two_target_reports_expose_shared_relocated_storage(
+    private_root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """YOETZ_STORAGE_DATA_DIR alone is not isolation; the report must expose the overlap."""
-
-    from platformdirs import PlatformDirs
+    """The exact normal target, not platform defaults, supplies the comparison identity."""
 
     _scrub_yoetz_env(monkeypatch)
-    root = tmp_path / "iso"
+    relocated = private_root / "relocated-data"
+    relocated.mkdir(mode=0o700)
+    monkeypatch.setenv("YOETZ_STORAGE_DATA_DIR", str(relocated))
+
+    normal = isolation_report()
+
+    root = private_root / "iso"
     root.mkdir(mode=0o700)
     monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
-    ambient_data = PlatformDirs(appname="yoetz", appauthor=False, roaming=False).user_data_dir
-    monkeypatch.setenv("YOETZ_STORAGE_DATA_DIR", str(ambient_data))
+    isolated = isolation_report()
 
-    report = isolation_report()
-
-    assert report["mode"] == "isolated"
-    assert report["distinct"] is False
-    assert report["identity"]["storage_digest"] == report["ambient_identity"]["storage_digest"]
+    assert normal["mode"] == "ambient"
+    assert isolated["mode"] == "isolated"
+    assert isolated["identity"]["storage_digest"] == normal["identity"]["storage_digest"]
 
 
 def test_unusable_root_is_unprovable_never_ambient(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/config/test_isolated_root.py
+++ b/tests/unit/config/test_isolated_root.py
@@ -1,0 +1,207 @@
+"""Exact-target isolation-root contract for every identity root (issue #518).
+
+``YOETZ_ISOLATED_ROOT`` must rebase config, storage bundle, state (service lock/generation),
+runtime endpoints, cache, and logs onto one validated private root — and must fail closed rather
+than fall back to the ambient platform directories when the root is set but unusable. These are
+the locks that keep a dogfood/test runtime from ever reaching the live singleton.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from platformdirs import PlatformDirs
+
+from yoetz.adapters.control import unix_socket
+from yoetz.config import paths as paths_module
+from yoetz.config.paths import (
+    ISOLATED_ROOT_ENV,
+    PathSafetyError,
+    _PathProbe,  # pyright: ignore[reportPrivateUsage]
+    bundle_root,
+    cache_dir,
+    config_file_path,
+    isolated_root,
+    log_dir,
+    runtime_dir,
+    service_generation_path,
+    state_dir,
+)
+
+
+def _probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fixed_shared_temps: tuple[Path, ...] = (),
+) -> _PathProbe:  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+    private_temp = tmp_path / "private-temp"
+    private_temp.mkdir(mode=0o700, exist_ok=True)
+    return _PathProbe(  # pyright: ignore[reportPrivateUsage]
+        platform="linux",
+        effective_uid=os.geteuid(),
+        home=tmp_path,
+        shared_temp=private_temp,
+        fixed_shared_temps=fixed_shared_temps,
+        platform_dirs=PlatformDirs(appname="yoetz", appauthor=False, roaming=False),
+        mount_table=lambda: "rootfs / ext4 rw 0 0",
+        macos_fstype=lambda _path: None,
+        diagnostic=lambda _reason: None,
+    )
+
+
+def _isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "iso"
+    root.mkdir(mode=0o700)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
+    return root
+
+
+def test_ambient_mode_is_unchanged_when_the_variable_is_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ISOLATED_ROOT_ENV, raising=False)
+    probe = _probe(tmp_path, monkeypatch)
+
+    assert isolated_root(_probe=probe) is None
+    assert state_dir(_probe=probe) == Path(probe.platform_dirs.user_state_dir)
+    assert cache_dir(_probe=probe) == Path(probe.platform_dirs.user_cache_dir)
+    assert log_dir(_probe=probe) == Path(probe.platform_dirs.user_log_dir)
+    assert runtime_dir(_probe=probe) == Path(probe.platform_dirs.user_runtime_path)
+    assert bundle_root(_probe=probe) == Path(probe.platform_dirs.user_data_dir)
+    assert config_file_path(_probe=probe) == (
+        Path(probe.platform_dirs.user_config_dir) / "config.toml"
+    )
+
+
+def test_one_isolated_root_derives_every_identity_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _isolation(tmp_path, monkeypatch)
+    probe = _probe(tmp_path, monkeypatch)
+
+    assert isolated_root(_probe=probe) == root
+    assert state_dir(_probe=probe) == root / "state"
+    assert cache_dir(_probe=probe) == root / "cache"
+    assert log_dir(_probe=probe) == root / "log"
+    assert runtime_dir(_probe=probe) == root / "run"
+    assert bundle_root(_probe=probe) == root / "data"
+    assert config_file_path(_probe=probe) == root / "config" / "config.toml"
+
+    # The service singleton (lock, generation) derives from the isolated state directory: the
+    # locked-state metadata lands beneath the root, so an isolated service can never contend
+    # for — or accidentally supersede — the ambient install's singleton.
+    generation = service_generation_path(_probe=probe)
+    assert generation == root / "state" / "service-generation.json"
+    assert generation.parent.is_dir()
+
+
+def test_explicit_data_dir_override_still_wins_over_the_isolated_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolation(tmp_path, monkeypatch)
+    probe = _probe(tmp_path, monkeypatch)
+    explicit = tmp_path / "explicit-bundle"
+    explicit.mkdir(mode=0o700)
+
+    assert bundle_root(_data_dir=explicit, _probe=probe) == explicit
+
+
+@pytest.mark.parametrize("raw", ["", "relative/root"])
+def test_empty_or_relative_root_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, raw)
+    probe = _probe(tmp_path, monkeypatch)
+
+    with pytest.raises(PathSafetyError) as caught:
+        state_dir(_probe=probe)
+    assert caught.value.reason_code == "isolation_root_invalid"
+
+
+def test_missing_root_and_nondirectory_root_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probe = _probe(tmp_path, monkeypatch)
+
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(tmp_path / "never-created"))
+    with pytest.raises(PathSafetyError) as missing:
+        isolated_root(_probe=probe)
+    assert missing.value.reason_code == "isolation_root_invalid"
+
+    plain_file = tmp_path / "a-file"
+    plain_file.touch()
+    os.chmod(plain_file, 0o600)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(plain_file))
+    with pytest.raises(PathSafetyError) as nondir:
+        isolated_root(_probe=probe)
+    assert nondir.value.reason_code == "isolation_root_invalid"
+
+
+def test_unsafe_roots_keep_their_precise_bounded_reasons(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probe = _probe(tmp_path, monkeypatch)
+
+    broad = tmp_path / "broad"
+    broad.mkdir(mode=0o750)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(broad))
+    with pytest.raises(PathSafetyError) as permissions:
+        runtime_dir(_probe=probe)
+    assert permissions.value.reason_code == "permissions_too_broad"
+
+    real = tmp_path / "real"
+    real.mkdir(mode=0o700)
+    linked = tmp_path / "linked"
+    linked.symlink_to(real, target_is_directory=True)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(linked))
+    with pytest.raises(PathSafetyError) as symlink:
+        state_dir(_probe=probe)
+    assert symlink.value.reason_code == "path_contains_symlink"
+
+    repo = tmp_path / "checkout" / "root"
+    repo.mkdir(parents=True, mode=0o700)
+    (repo.parent / ".git").mkdir(mode=0o700)
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(repo))
+    with pytest.raises(PathSafetyError) as repository:
+        bundle_root(_probe=probe)
+    assert repository.value.reason_code == "path_in_repository"
+
+
+def test_shared_temp_root_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    shared = tmp_path / "shared-temp"
+    shared.mkdir(mode=0o700)
+    root = shared / "root"
+    root.mkdir(mode=0o700)
+    probe = _probe(tmp_path, monkeypatch, fixed_shared_temps=(shared,))
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, str(root))
+
+    with pytest.raises(PathSafetyError) as caught:
+        config_file_path(_probe=probe)
+    assert caught.value.reason_code == "path_shared_temp"
+
+
+def test_endpoint_layer_fails_closed_as_the_bounded_transport_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ISOLATED_ROOT_ENV, "")
+
+    with pytest.raises(unix_socket.LocalControlTransportError) as caught:
+        unix_socket._runtime_directory()  # pyright: ignore[reportPrivateUsage]
+    assert caught.value.reason == "runtime_directory_unsafe"
+
+
+def test_endpoint_layer_binds_beneath_the_isolated_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _isolation(tmp_path, monkeypatch)
+    probe = _probe(tmp_path, monkeypatch)
+    monkeypatch.setattr(paths_module, "_default_probe", lambda: probe)
+
+    assert unix_socket._runtime_directory() == root / "run"  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/config/test_load_precedence.py
+++ b/tests/unit/config/test_load_precedence.py
@@ -142,6 +142,21 @@ def test_tui_opt_out_is_known_process_control_not_a_config_override(tmp_path: Pa
     assert config.profile == "strict-local"
 
 
+def test_isolated_root_is_known_paths_control_not_a_config_override(tmp_path: Path) -> None:
+    """The isolation root (issue #518) belongs to yoetz.config.paths, not to config leaves.
+
+    Strict loading must recognize it (an isolated service start would otherwise refuse with
+    ``unknown_config_env_var``) while leaving every configuration value untouched.
+    """
+
+    config = load_config(
+        {}, {"YOETZ_ISOLATED_ROOT": str(tmp_path / "iso")}, tmp_path / "missing.toml"
+    )
+
+    assert config.profile == "strict-local"
+    assert config.storage.data_dir is None
+
+
 def test_minimal_parse_ignores_nonminimal_provider_shape(tmp_path: Path) -> None:
     config_path = tmp_path / "minimal.toml"
     config_path.write_text(

--- a/tests/unit/dogfood/test_codex_dogfood_parity.py
+++ b/tests/unit/dogfood/test_codex_dogfood_parity.py
@@ -55,6 +55,7 @@ def _report() -> dict[str, object]:
             "worktree_digest": _DIGEST,
             "yoetz_isolation": {
                 "mode": "isolated",
+                "normal_mode": "ambient",
                 "state_digest": _DIGEST,
                 "endpoint_digest": _DIGEST,
                 "storage_digest": _DIGEST,
@@ -64,6 +65,7 @@ def _report() -> dict[str, object]:
                 "normal_endpoint_digest": _NORMAL_DIGEST,
                 "normal_storage_digest": _NORMAL_DIGEST,
                 "normal_config_digest": _NORMAL_DIGEST,
+                "normal_executable_digest": _NORMAL_DIGEST,
             },
         },
         "scope": {
@@ -215,6 +217,14 @@ def test_shared_yoetz_identity_cannot_pass_the_isolation_facet() -> None:
         classify_codex_dogfood_report(report)
 
 
+def test_shared_yoetz_executable_cannot_pass_the_isolation_facet() -> None:
+    report = _report()
+    _isolation(report)["executable_digest"] = _NORMAL_DIGEST
+
+    with pytest.raises(DogfoodGateError, match="service_isolation_identity_shared"):
+        classify_codex_dogfood_report(report)
+
+
 def test_ambient_or_unknown_isolation_state_contradicts_a_passing_facet() -> None:
     for state in ("ambient", "shared", "unknown"):
         report = _report()
@@ -226,6 +236,14 @@ def test_ambient_or_unknown_isolation_state_contradicts_a_passing_facet() -> Non
 def test_ambient_identity_mode_contradicts_a_passing_isolation_facet() -> None:
     report = _report()
     _isolation(report)["mode"] = "ambient"
+
+    with pytest.raises(DogfoodGateError, match="service_isolation_identity_mismatch"):
+        classify_codex_dogfood_report(report)
+
+
+def test_nonambient_normal_snapshot_contradicts_a_passing_isolation_facet() -> None:
+    report = _report()
+    _isolation(report)["normal_mode"] = "isolated"
 
     with pytest.raises(DogfoodGateError, match="service_isolation_identity_mismatch"):
         classify_codex_dogfood_report(report)

--- a/tests/unit/dogfood/test_codex_dogfood_parity.py
+++ b/tests/unit/dogfood/test_codex_dogfood_parity.py
@@ -1,4 +1,4 @@
-"""Executable classification locks for exact-worktree Codex dogfood parity (#464)."""
+"""Executable classification locks for exact-worktree Codex dogfood parity (#464, #518)."""
 
 from __future__ import annotations
 
@@ -22,6 +22,7 @@ PREFLIGHT_FACETS = _MODULE.PREFLIGHT_FACETS
 DogfoodGateError = _MODULE.DogfoodGateError
 classify_codex_dogfood_report = _MODULE.classify_codex_dogfood_report
 _DIGEST = "sha256:" + ("a" * 64)
+_NORMAL_DIGEST = "sha256:" + ("b" * 64)
 
 
 def _gate(status: str = "pass") -> dict[str, object]:
@@ -42,7 +43,7 @@ def _gate(status: str = "pass") -> dict[str, object]:
 
 def _report() -> dict[str, object]:
     return {
-        "schema": "yoetz.codex-dogfood-parity/1",
+        "schema": "yoetz.codex-dogfood-parity/2",
         "identity": {
             "source_ref": "a" * 40,
             "package_digest": _DIGEST,
@@ -52,6 +53,18 @@ def _report() -> dict[str, object]:
             "launcher_digest": _DIGEST,
             "route_profile": "policy",
             "worktree_digest": _DIGEST,
+            "yoetz_isolation": {
+                "mode": "isolated",
+                "state_digest": _DIGEST,
+                "endpoint_digest": _DIGEST,
+                "storage_digest": _DIGEST,
+                "config_digest": _DIGEST,
+                "executable_digest": _DIGEST,
+                "normal_state_digest": _NORMAL_DIGEST,
+                "normal_endpoint_digest": _NORMAL_DIGEST,
+                "normal_storage_digest": _NORMAL_DIGEST,
+                "normal_config_digest": _NORMAL_DIGEST,
+            },
         },
         "scope": {
             "hooks_advertised": True,
@@ -61,6 +74,7 @@ def _report() -> dict[str, object]:
         },
         "observed": {
             "activation_state": "active",
+            "yoetz_isolation_state": "isolated",
             "exact_worktree_consent": "active",
             "primary_checkout_consent": "active",
             "controls_workspace_match": True,
@@ -182,6 +196,69 @@ def test_out_of_scope_failure_cannot_be_ignored_by_full_aggregation() -> None:
     }
 
     with pytest.raises(DogfoodGateError, match="out_of_scope_facet_not_not_run"):
+        classify_codex_dogfood_report(report)
+
+
+def _identity(report: dict[str, object]) -> dict[str, object]:
+    return cast(dict[str, object], report["identity"])
+
+
+def _isolation(report: dict[str, object]) -> dict[str, object]:
+    return cast(dict[str, object], _identity(report)["yoetz_isolation"])
+
+
+def test_shared_yoetz_identity_cannot_pass_the_isolation_facet() -> None:
+    report = _report()
+    _isolation(report)["state_digest"] = _NORMAL_DIGEST
+
+    with pytest.raises(DogfoodGateError, match="service_isolation_identity_shared"):
+        classify_codex_dogfood_report(report)
+
+
+def test_ambient_or_unknown_isolation_state_contradicts_a_passing_facet() -> None:
+    for state in ("ambient", "shared", "unknown"):
+        report = _report()
+        _observed(report)["yoetz_isolation_state"] = state
+        with pytest.raises(DogfoodGateError, match="service_isolation_state_mismatch"):
+            classify_codex_dogfood_report(report)
+
+
+def test_ambient_identity_mode_contradicts_a_passing_isolation_facet() -> None:
+    report = _report()
+    _isolation(report)["mode"] = "ambient"
+
+    with pytest.raises(DogfoodGateError, match="service_isolation_identity_mismatch"):
+        classify_codex_dogfood_report(report)
+
+
+def test_failed_isolation_refuses_launch_with_the_provisioning_continuation() -> None:
+    report = _report()
+    _observed(report)["yoetz_isolation_state"] = "shared"
+    _facets(report)["service_isolation"] = {
+        "status": "fail",
+        "reason": "yoetz_identity_shared",
+        "evidence_digest": _DIGEST,
+        "next_action": "provision_isolated_yoetz_root",
+    }
+
+    result = classify_codex_dogfood_report(report)
+
+    assert result["preflight_outcome"] == "fail"
+    assert result["launch_allowed"] is False
+    assert result["failed_facets"] == ["service_isolation"]
+
+
+def test_failed_isolation_without_the_provisioning_continuation_is_invalid() -> None:
+    report = _report()
+    _observed(report)["yoetz_isolation_state"] = "unknown"
+    _facets(report)["service_isolation"] = {
+        "status": "blocked",
+        "reason": "yoetz_identity_unknown",
+        "evidence_digest": None,
+        "next_action": "do_not_launch",
+    }
+
+    with pytest.raises(DogfoodGateError, match="service_isolation_continuation_missing"):
         classify_codex_dogfood_report(report)
 
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #518
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated (storage/durability, host isolation): the maintainer requested this work and the PR directly in-session on 2026-09-01, which is treated as the acknowledgement; flag if the gate should be handled differently.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/adr/ADR-026-isolated-root-runtime-identity.md` (+ index row), `docs/INTERFACES.md` §13 `config/paths.py` entry, `docs/runbooks/codex-dogfood.md` isolation section + parity schema/2, pointers in the Codex/Claude Code/Cursor integration runbooks.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/config tests/unit/dogfood tests/unit/cli/test_service_isolation.py  # 109 passed
uv run pytest tests/unit/cli tests/unit/service                   # 872 passed
uv run pytest tests/integration/service                           # 155 passed
uv run pytest tests/conformance                                   # 282 passed
uv run pytest tests/subprocess                                    # 294 passed
uv run pytest tests/packaging/test_isolated_root_boundary.py      # 2 passed (from primary checkout)
uv run ruff check / format --check (touched files); pinned npm pyright  # clean / 0 errors
Live smoke: yoetz service isolation --json in ambient, isolated, and unusable-root modes
(isolated roots under $HOME; live install untouched)
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

A disposable dogfood could isolate its Codex home, wheel, plugin tree, and storage bundle via `YOETZ_STORAGE_DATA_DIR` yet still connect to the live Yoetz singleton, because the platform `state_dir()` (service lock, generation, endpoints) stayed fixed — a repository privacy grant intended for a dogfood run committed into normal state.

This adds the one supported exact-target isolation contract: `YOETZ_ISOLATED_ROOT`, owned by `config/paths.py`. When set, every identity root derives from it — `config/`, `data/` (default bundle), `state/` (lock + generation + markers), `run/` (all three AF_UNIX endpoints via the new `runtime_dir()` consumed by `unix_socket.py`), `cache/`, `log/`. Validation fails closed (`isolation_root_invalid` plus the existing path-safety reasons; absolute, pre-existing, 0700, symlink-free, not `/tmp`, not in a repo) with no ambient fallback; `service/client.py` forwards it to the detached service it spawns. Explicit `storage.data_dir` still wins over the isolated default — the parity gate exposes that overlap rather than silently rejecting it.

Proof surface: `yoetz service isolation [--json]` now reports only the exact invoking target's mode and digest-only identities. Dogfood captures it once from the normal executable/config environment and once from the isolated candidate. The `yoetz.codex-dogfood-parity/2` gate requires normal mode `ambient`, candidate mode `isolated`, and distinct state, endpoint, storage, config, and Yoetz-executable identities; shared relocated storage therefore fails closed. Version 1 reports no longer validate. The packaged macOS regression exercises the real installed launcher: lock+socket land beneath the root, an ambient client cannot reach the isolated singleton, the ambient home tree is byte-identical before/after, and deleting the root is complete rollback.

Implemented by Claude Fable 5 running in Claude Code (parallel worktree agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a validated `YOETZ_ISOLATED_ROOT` contract that rebases Yoetz configuration, state, runtime endpoints, cache, logs, and default storage for dogfood and test targets.

- Adds isolated path derivation and forwards the root to detached services.
- Adds a digest-only service isolation report and schema-v2 Codex dogfood parity checks.
- Adds documentation and unit/packaging coverage for fail-closed roots and endpoint separation.
- The proof can still incorrectly pass when the normal target uses a relocated storage bundle.

<h3>Confidence Score: 4/5</h3>

The storage-identity proof must be fixed before merging because it can approve an isolated launch that shares a relocated bundle with the normal target.

Explicit storage configuration is reported as the effective isolated identity, but it is compared only with the platform-default ambient path, allowing a shared non-default normal storage directory to satisfy the parity gate.

**Files Needing Attention:** src/yoetz/cli/isolation_status.py, scripts/check_codex_dogfood_parity.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/config/paths.py | Adds fail-closed validation and isolated derivation for all principal identity roots. |
| src/yoetz/cli/isolation_status.py | Adds digest-only identity reporting, but its platform-default comparison cannot detect shared relocated storage. |
| scripts/check_codex_dogfood_parity.py | Adds schema-v2 service-isolation enforcement while relying on the incomplete normal-target identity supplied by the report. |
| src/yoetz/adapters/control/unix_socket.py | Rebinds all three Unix endpoint kinds to the centralized isolated runtime directory. |
| src/yoetz/service/client.py | Adds the isolation root to the detached service's forwarded configuration environment. |
| tests/packaging/test_isolated_root_boundary.py | Exercises installed-launcher isolation, ambient endpoint separation, and cleanup behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    E[YOETZ_ISOLATED_ROOT] --> V[Validate private root]
    V --> P[Derive config/state/run/cache/log]
    V --> D[Default isolated storage]
    C[Explicit storage.data_dir] --> S[Effective storage]
    D --> S
    P --> R[Digest-only isolation report]
    S --> R
    A[Platform-default ambient identities] --> R
    R --> G[Dogfood parity gate]
    G -->|all compared digests differ| L[Launch allowed]
    C -. relocated normal storage is not represented .-> A
```

<sub>Reviews (1): Last reviewed commit: ["feat(config): exact-target isolated-root..."](https://github.com/thegaysupreme123/yoetz/commit/f030e75373debb023a191402968d1e4e868d78f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59048907)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## Independent review follow-up (2026-09-01)

Codex verified Greptile's relocated-storage P1 as valid. Commit `f8bc436d` removes the platform-default comparison and requires two exact connection-free snapshots: one from the normal executable/config environment and one from the isolated candidate. Parity now requires normal mode `ambient`, candidate mode `isolated`, and distinct state, endpoint, storage, config, and Yoetz-executable identities. This supersedes the earlier PR-body limitation about not pair-comparing the executable.

Verification: 41 focused unit tests, Ruff, pinned Pyright, and the real installed-launcher packaging test (2 passed from the primary checkout).