### PR TITLE
fix(consent): commit-aware repository grant result with stored-terminal recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- An authorized `repository_privacy_grant` no longer reports `repository_privacy_grant_failed`
+  after the durable grant already committed. The service records the policy transition before it
+  sends the ceremony result, so when only the trailing close confirmation is missing, wrong, or
+  lost with the connection, the confidential client now carries the already-validated result
+  instead of discarding it, and authorize recovers that stored terminal outcome exactly once,
+  read-only — a committed grant completes as `granted` with a consumed approved review, a carried
+  denied or stale result stays a bounded failure with no grant, and the privacy expansion is never
+  replayed as a new decision. A post-decision transport outcome that is unprovable either way now
+  reports the typed `elevated_bootstrap: repository_privacy_grant_unconfirmed` with remediation
+  pointing at `yoetz provider status`, while genuine pre-commit proposal/decision failures keep
+  `repository_privacy_grant_failed` (issue #519).
+
 - Receipt creation now abandons both exact caller-owned object stages when the payload object's
   stage/finalize fails before ledger submission, and equally when the commit boundary refuses the
   append ahead of submission because cancellation is already pending. This removes a receipt file

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2193,6 +2193,19 @@ as a typed orphan that `yoetz service auto-unlock status` distinguishes
 resolves by proof, so retry never fails on `auto_unlock_entry_exists` from an abandoned
 same-attempt entry.
 
+A `repository_privacy_grant` result is commit-aware (issue #519). The service records the
+durable policy transition before it sends the correlated ceremony result, so when only the
+trailing close confirmation is missing, wrong, or lost with the connection, the confidential
+client carries the already-validated result instead of discarding it, and authorize recovers
+that stored terminal outcome exactly once, read-only — a committed grant completes as `granted`
+with a consumed approved review, and a carried denied or stale result stays a bounded failure
+with no grant. The privacy expansion is never replayed as a new decision. When the decision was
+submitted but no result is in hand and the transport outcome is unprovable, authorize reports
+the typed `elevated_bootstrap: repository_privacy_grant_unconfirmed` instead of claiming
+failure, and `yoetz provider status` remains the authoritative read of the repository grant
+state. A genuine pre-commit proposal or decision failure still reports
+`repository_privacy_grant_failed` with no grant.
+
 The current public JSON Schema contracts are `catalog`, `pending-agent`, `prepare-result`,
 `review-result`, and `status`, each at version `5.0.0` under `schemas/consent/`; frozen versions
 `2.0.0` through `4.0.0` remain shipped for compatibility. The current version report is

--- a/src/yoetz/cli/elevated.py
+++ b/src/yoetz/cli/elevated.py
@@ -26,7 +26,10 @@ from yoetz.protocol.consent import (
     ConsentReviewResultModel,
     RepositoryPrivacyRecipe,
 )
-from yoetz.service.confidential_client import ConfidentialClientError
+from yoetz.service.confidential_client import (
+    ConfidentialClientError,
+    ConfidentialResultUnconfirmed,
+)
 from yoetz.service.confidential_protocol import (
     EmptyVaultTarget,
     HumanCeremonyKind,
@@ -724,11 +727,24 @@ async def _complete_repository_privacy_grant(
     passphrase = _load_auto_unlock_passphrase()
     if passphrase is None:
         raise ElevatedBootstrapError("chat_user_reauthentication_unavailable")
+    decision_result: object
     try:
         decision_result = await decide_policy(
             proposal_id, decision="approve", passphrase=passphrase
         )
-    except (HumanCeremonyCliError, ConfidentialClientError, OSError, ValueError) as exc:
+    except ConfidentialResultUnconfirmed as exc:
+        # Commit-aware recovery (issue #519): the server records the durable transition before
+        # it sends the result, so a validated result whose close confirmation was lost is the
+        # stored terminal outcome. Consume it exactly once, read-only — never by replaying the
+        # privacy expansion as a new decision — and let the shared validation below decide.
+        decision_result = exc.result
+    except ConfidentialClientError as exc:
+        if exc.reason == "ambiguous":
+            # No result in hand and the transport outcome is unprovable either way: the durable
+            # grant may already be effective, so reporting failure here would be untruthful.
+            raise ElevatedBootstrapError("repository_privacy_grant_unconfirmed") from exc
+        raise ElevatedBootstrapError("repository_privacy_grant_failed") from exc
+    except (HumanCeremonyCliError, OSError, ValueError) as exc:
         raise ElevatedBootstrapError("repository_privacy_grant_failed") from exc
     from yoetz.service.confidential_protocol import PrivacyDecisionResult
 

--- a/src/yoetz/cli/elevated.py
+++ b/src/yoetz/cli/elevated.py
@@ -692,7 +692,7 @@ async def _complete_repository_privacy_grant(
     recipe = pending.grant_binding["recipe"]
     expected_commitment = pending.grant_binding["repository_privacy_commitment"]
     expected_authority_digest = pending.grant_binding["authority_digest"]
-    from yoetz.cli.privacy_control import decide_policy
+    from yoetz.cli.privacy_control import PrivacyDecisionUnconfirmed, decide_policy
     from yoetz.cli.privacy_setup import (
         build_candidate_policy,
         configured_bindings,
@@ -738,11 +738,11 @@ async def _complete_repository_privacy_grant(
         # stored terminal outcome. Consume it exactly once, read-only — never by replaying the
         # privacy expansion as a new decision — and let the shared validation below decide.
         decision_result = exc.result
+    except PrivacyDecisionUnconfirmed as exc:
+        # The client began sending an approval action but never received an authoritative result.
+        # It is therefore unsafe to report failure or to invite an immediate replay.
+        raise ElevatedBootstrapError("repository_privacy_grant_unconfirmed") from exc
     except ConfidentialClientError as exc:
-        if exc.reason == "ambiguous":
-            # No result in hand and the transport outcome is unprovable either way: the durable
-            # grant may already be effective, so reporting failure here would be untruthful.
-            raise ElevatedBootstrapError("repository_privacy_grant_unconfirmed") from exc
         raise ElevatedBootstrapError("repository_privacy_grant_failed") from exc
     except (HumanCeremonyCliError, OSError, ValueError) as exc:
         raise ElevatedBootstrapError("repository_privacy_grant_failed") from exc

--- a/src/yoetz/cli/exits.py
+++ b/src/yoetz/cli/exits.py
@@ -239,6 +239,12 @@ REMEDIATION_MESSAGES: Final = MappingProxyType(
             "approval was recorded as failed and nothing was approved; run "
             "'yoetz consent prepare <operation>' again, and report a defect if this recurs"
         ),
+        "repository_privacy_grant_unconfirmed": (
+            "the grant decision was submitted but its outcome could not be confirmed over the "
+            "confidential channel, so it may already be effective; check 'yoetz provider status' "
+            "for the repository grant state before preparing a new consent — do not assume it "
+            "failed"
+        ),
         "workspace_unresolvable": (
             "the --workspace locator is empty, missing, symlinked, foreign-owned, or otherwise "
             "unsafe; pass the resolved path of a directory owned by the current user (host hooks "

--- a/src/yoetz/cli/privacy_control.py
+++ b/src/yoetz/cli/privacy_control.py
@@ -15,7 +15,11 @@ from yoetz.cli.unlock import (
     _verify_preview,  # pyright: ignore[reportPrivateUsage]
     overwrite_secret_buffer,
 )
-from yoetz.service.confidential_client import HumanControlClient
+from yoetz.service.confidential_client import (
+    ConfidentialClientError,
+    ConfidentialResultUnconfirmed,
+    HumanControlClient,
+)
 from yoetz.service.confidential_protocol import (
     DecisionAction,
     DecisionRequiredPhase,
@@ -28,10 +32,20 @@ from yoetz.service.confidential_protocol import (
 
 __all__ = [
     "PrivacyLocalEditResult",
+    "PrivacyDecisionUnconfirmed",
     "decide_disclosure",
     "decide_policy",
     "decide_policy_with_local_reauthentication",
 ]
+
+
+class PrivacyDecisionUnconfirmed(ConfidentialClientError):
+    """A privacy decision was attempted but no authoritative result was received."""
+
+
+_UNCONFIRMED_AFTER_DECISION_REASONS = frozenset(
+    {"ambiguous", "correlation_mismatch", "protocol_error", "service_unavailable", "timeout"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,6 +171,7 @@ async def _decide_policy_supplied(
     kind = HumanCeremonyKind.PRIVACY_POLICY_DECISION
     client = HumanControlClient()
     terminal = _SuppliedSecretTerminal()
+    session = None
     try:
         session = await client.open(kind, target)
         async with session:
@@ -177,6 +192,14 @@ async def _decide_policy_supplied(
                     passphrase=passphrase,
                 )
                 return cast(PrivacyDecisionResult, result)
+            except ConfidentialResultUnconfirmed:
+                await _cancel_quietly(session)
+                raise
+            except ConfidentialClientError as exc:
+                await _cancel_quietly(session)
+                if session.decision_attempted and exc.reason in _UNCONFIRMED_AFTER_DECISION_REASONS:
+                    raise PrivacyDecisionUnconfirmed("ambiguous") from exc
+                raise
             except BaseException:
                 await _cancel_quietly(session)
                 raise

--- a/src/yoetz/service/confidential_client.py
+++ b/src/yoetz/service/confidential_client.py
@@ -345,6 +345,7 @@ class HumanControlSession:
         "_awaiting_server",
         "_closed",
         "_connect_secret",
+        "_decision_attempted",
         "_next_step",
         "_opened",
         "_stream",
@@ -372,6 +373,7 @@ class HumanControlSession:
         self._next_step = opened.step + 1
         self._closed = False
         self._awaiting_server = isinstance(opened.phase, SecretRequiredPhase)
+        self._decision_attempted = False
         self._token: ConfidentialSessionToken | None = None
         self._replace_token(opened.phase)
 
@@ -420,6 +422,17 @@ class HumanControlSession:
             _token=_SECRET_CLIENT_CONSTRUCTOR,
         )
 
+    @property
+    def decision_attempted(self) -> bool:
+        """Whether this session began sending an approve/deny action.
+
+        The flag is set before the transport write because a failed send may still have delivered
+        the complete frame. Callers use it only to distinguish failures that happened before any
+        decision attempt from genuinely ambiguous post-attempt outcomes.
+        """
+
+        return self._decision_attempted
+
     async def send_action(self, action: HumanAction) -> None:
         self._ensure_open()
         if self._awaiting_server:
@@ -436,6 +449,8 @@ class HumanControlSession:
             step=self._next_step,
             action=action,
         )
+        if type(action) is DecisionAction:
+            self._decision_attempted = True
         await _write_human_frame(self._stream, envelope)
         self._replace_token(None)
         self._next_step += 1

--- a/src/yoetz/service/confidential_client.py
+++ b/src/yoetz/service/confidential_client.py
@@ -52,6 +52,7 @@ from yoetz.service.confidential_protocol import (
 
 __all__ = [
     "ConfidentialClientError",
+    "ConfidentialResultUnconfirmed",
     "ConfidentialSecretClient",
     "HumanControlClient",
     "HumanControlSession",
@@ -158,6 +159,25 @@ class ConfidentialClientError(Exception):
             raise ValueError("confidential_client_reason_invalid")
         self.reason = reason
         super().__init__(reason)
+
+
+class ConfidentialResultUnconfirmed(ConfidentialClientError):
+    """The correlated terminal result arrived; only the close confirmation did not.
+
+    The server records its durable terminal transition before it writes the result frame, so a
+    result that already passed correlation on the authenticated stream is authoritative even when
+    the trailing close frame is missing, wrong, or lost with the connection. The validated result
+    rides on the exception so a caller that can act on it recovers the stored terminal outcome
+    exactly once, read-only; every other caller observes the unchanged bounded reason token.
+    """
+
+    __slots__ = ("result",)
+
+    result: HumanResult
+
+    def __init__(self, reason: str, result: HumanResult) -> None:
+        super().__init__(reason)
+        self.result = result
 
 
 def _mapped_error(error: BaseException) -> ConfidentialClientError:
@@ -459,7 +479,13 @@ class HumanControlSession:
             return frame.phase
         if type(frame) is ServerResultEnvelope:
             self._replace_token(None)
-            await self._require_close("completed")
+            try:
+                await self._require_close("completed")
+            except ConfidentialClientError as exc:
+                # The durable terminal transition committed before this result frame was sent
+                # (issue #519): losing only the close confirmation must not discard the
+                # validated result in hand.
+                raise ConfidentialResultUnconfirmed(exc.reason, frame.result) from exc
             return frame.result
         if type(frame) is ServerErrorEnvelope:
             self._replace_token(None)

--- a/tests/integration/service/test_repository_grant_authorize_composition.py
+++ b/tests/integration/service/test_repository_grant_authorize_composition.py
@@ -1,0 +1,180 @@
+"""Positive repository-privacy-grant authorization over the real composition (#519).
+
+The defect this locks against: an exact prepared `repository_privacy_grant` was authorized, the
+durable policy transition committed, the real confidential server sent the terminal result — and
+a lost close confirmation collapsed the whole ceremony to
+`elevated_bootstrap: repository_privacy_grant_failed` while `yoetz provider status` already
+reported the grant effective. These tests run real agent attestation, the real ordinary-control
+propose path, and the real YZH1/YZS1 decide ceremony against the production daemon composition,
+mocking only the OS keyring backend and the configured provider binding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+import yoetz.service.daemon as daemon_module
+from integration.service.test_consent_vault_initialize_composition import (
+    _approve_attestation,  # pyright: ignore[reportPrivateUsage]
+    _approved_store,  # pyright: ignore[reportPrivateUsage]
+    _MemoryKeyring,  # pyright: ignore[reportPrivateUsage]
+    _production_daemon,  # pyright: ignore[reportPrivateUsage]
+    runtime_directory,  # noqa: F401 - imported pytest fixture  # pyright: ignore[reportUnusedImport]
+)
+from yoetz.cli import elevated
+from yoetz.cli.privacy_setup import PrivacySetupSnapshot, get_privacy_setup_snapshot
+from yoetz.domain.privacy import ProviderBinding
+from yoetz.service.confidential_protocol import ServerCloseEnvelope
+from yoetz.service.daemon import ServiceDaemon
+from yoetz.service.elevated_bootstrap import load_pending
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+_EXTERNAL_BINDING = ProviderBinding(
+    "fireworks",
+    "accounts/fireworks/models/minimax-m3",
+    "fireworks-responses",
+    "1.0.0",
+    "external",
+)
+
+
+async def _authorize_current_pending(consent_state: Path) -> dict[str, Any]:
+    pending = load_pending(_state=consent_state)
+    assert pending is not None
+    return cast(
+        dict[str, Any],
+        await asyncio.wait_for(
+            elevated.authorize_elevated(_approve_attestation(pending)), timeout=30
+        ),
+    )
+
+
+async def _initialize_vault(consent_state: Path) -> None:
+    elevated.prepare_elevated("vault_initialize")
+    result = await _authorize_current_pending(consent_state)
+    assert result["result"] == {"state": "ready", "reason": "succeeded"}
+
+
+async def _prepared_grant_snapshot(consent_state: Path) -> PrivacySetupSnapshot:
+    snapshot = await get_privacy_setup_snapshot()
+    commitment = snapshot.bound_scope.get("workspace_ref_commitment")
+    assert type(commitment) is str
+    assert snapshot.grant_state == "missing"
+    elevated.prepare_elevated(
+        "repository_privacy_grant",
+        grant_binding={
+            "recipe": "assisted_review",
+            "repository_privacy_commitment": commitment,
+            "authority_digest": snapshot.authority_digest,
+        },
+    )
+    return snapshot
+
+
+def _audit_lines(consent_state: Path) -> list[str]:
+    return (
+        (consent_state / "elevated-bootstrap" / "elevated-bootstrap-audit.jsonl")
+        .read_text("utf-8")
+        .splitlines()
+    )
+
+
+def _assert_granted_once(consent_state: Path, snapshot_after: PrivacySetupSnapshot) -> None:
+    assert snapshot_after.grant_state == "granted"
+    assert load_pending(_state=consent_state) is None
+    audit = _audit_lines(consent_state)
+    approved = [line for line in audit if '"outcome":"approved"' in line]
+    # Vault initialization plus exactly one grant approval; nothing was applied twice.
+    assert len(approved) == 2
+    assert not any('"outcome":"failed"' in line for line in audit)
+
+
+async def _run_grant_flow(
+    tmp_path: Path,
+    *,
+    authorize_patches: Any = None,
+) -> None:
+    tmp_path.chmod(0o700)
+    consent_state = tmp_path / "consent"
+    consent_state.mkdir(mode=0o700)
+    backend = _MemoryKeyring()
+    store = _approved_store(tmp_path / "data", backend)
+
+    daemon: ServiceDaemon = await _production_daemon(tmp_path, pristine=True)
+    await daemon.start()
+    serving = asyncio.create_task(daemon.serve())
+    try:
+        with (
+            patch("yoetz.service.elevated_bootstrap.state_dir", return_value=consent_state),
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch(
+                "yoetz.cli.elevated._load_auto_unlock_passphrase",
+                side_effect=lambda: store.load(),
+            ),
+            patch(
+                "yoetz.cli.privacy_setup.configured_bindings",
+                return_value=(_EXTERNAL_BINDING, None),
+            ),
+        ):
+            await _initialize_vault(consent_state)
+            await _prepared_grant_snapshot(consent_state)
+            if authorize_patches is None:
+                result = await _authorize_current_pending(consent_state)
+            else:
+                with authorize_patches:
+                    result = await _authorize_current_pending(consent_state)
+
+            assert result["outcome"] == "completed"
+            assert result["authority_channel"] == "agent_attested_chat_instruction"
+            assert result["result"] == {"recipe": "assisted_review", "outcome": "granted"}
+            snapshot_after = await get_privacy_setup_snapshot()
+            _assert_granted_once(consent_state, snapshot_after)
+    finally:
+        await daemon.stop()
+        await asyncio.wait_for(serving, timeout=10)
+
+
+@pytest.mark.anyio
+async def test_agent_authorized_repository_grant_completes_with_truthful_result(
+    tmp_path: Path,
+    runtime_directory: Path,  # noqa: F811 - imported pytest fixture
+) -> None:
+    """#519 acceptance: prepare, exact agent authorize, real client/server, truthful result."""
+
+    await _run_grant_flow(tmp_path)
+
+
+@pytest.mark.anyio
+async def test_lost_close_confirmation_after_committed_grant_recovers_the_stored_result(
+    tmp_path: Path,
+    runtime_directory: Path,  # noqa: F811 - imported pytest fixture
+) -> None:
+    """#519 acceptance: the close frame is lost after the durable commit and the sent result;
+    authorize recovers the stored terminal result exactly once instead of reporting failure."""
+
+    original_write = daemon_module._write_human_envelope  # pyright: ignore[reportPrivateUsage]
+
+    async def drop_completed_close(stream: object, envelope: object) -> None:
+        # The exact injection: the durable transition committed, the result frame was written,
+        # and the correlated "completed" close never reaches the client (the daemon then closes
+        # the connection, so the client observes the ambiguous end-of-stream).
+        if type(envelope) is ServerCloseEnvelope and envelope.outcome == "completed":
+            return
+        await original_write(cast(Any, stream), envelope)
+
+    await _run_grant_flow(
+        tmp_path,
+        authorize_patches=patch.object(
+            daemon_module, "_write_human_envelope", drop_completed_close
+        ),
+    )

--- a/tests/unit/cli/test_ceremony_refusal_reporting.py
+++ b/tests/unit/cli/test_ceremony_refusal_reporting.py
@@ -177,6 +177,16 @@ def test_vault_result_family_names_the_failed_approval_and_the_retry() -> None:
     assert remediation_message("result_invalid") is not None
 
 
+def test_grant_unconfirmed_remediation_points_at_status_not_a_blind_retry() -> None:
+    """#519: an unprovable grant outcome must send the owner to the authoritative state read."""
+
+    message = remediation_message("repository_privacy_grant_unconfirmed")
+
+    assert message is not None
+    assert "yoetz provider status" in message
+    assert "may already be effective" in message
+
+
 def test_resource_count_remediation_names_the_owning_sync_script() -> None:
     message = remediation_message("resource_counts_invalid")
 

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -24,7 +24,15 @@ from yoetz.protocol.canonical import canonical_digest
 from yoetz.protocol.chat_user_authority import ChatUserAttestationModel
 from yoetz.protocol.consent import ConsentReviewResultModel
 from yoetz.protocol.schemas import SchemaInstanceInvalid, validate_schema_instance
-from yoetz.service.confidential_protocol import ProviderCredentialResult, VaultStateResult
+from yoetz.service.confidential_client import (
+    ConfidentialClientError,
+    ConfidentialResultUnconfirmed,
+)
+from yoetz.service.confidential_protocol import (
+    PrivacyDecisionResult,
+    ProviderCredentialResult,
+    VaultStateResult,
+)
 from yoetz.service.elevated_bootstrap import (
     ElevatedBootstrapError,
     audit_path,
@@ -380,6 +388,174 @@ def test_chat_user_authorize_denial_is_single_shot_for_repository_grant(tmp_path
     assert result["outcome"] == "denied"
     assert result["authority_channel"] == "agent_attested_chat_instruction"
     assert load_pending(_state=tmp_path) is None
+
+
+_GRANT_BINDING = {
+    "recipe": "assisted_review",
+    "repository_privacy_commitment": "hmac-sha256:" + ("d" * 64),
+    "authority_digest": "sha256:" + ("e" * 64),
+}
+
+
+@contextmanager
+def _repository_grant_patches(
+    decide: Callable[..., object],
+    propose: Callable[..., object] | None = None,
+) -> Generator[Any]:
+    """Patch everything around the decide ceremony so its outcome handling is under test."""
+
+    async def snapshot() -> SimpleNamespace:
+        return SimpleNamespace(
+            bound_scope={
+                "workspace_ref_commitment": _GRANT_BINDING["repository_privacy_commitment"]
+            },
+            authority_digest=_GRANT_BINDING["authority_digest"],
+            composed_policy=object(),
+        )
+
+    async def default_propose(candidate: object, authority_digest: str) -> str:
+        del candidate, authority_digest
+        return "ppr_00000000-0000-4000-8000-000000000519"
+
+    with (
+        patch("yoetz.cli.privacy_setup.get_privacy_setup_snapshot", side_effect=snapshot),
+        patch("yoetz.cli.privacy_setup.configured_bindings", return_value=(None, None)),
+        patch("yoetz.cli.privacy_setup.recipe_answers", return_value=object()),
+        patch("yoetz.cli.privacy_setup.build_candidate_policy", return_value=object()),
+        patch(
+            "yoetz.cli.privacy_setup.propose_privacy_candidate",
+            side_effect=default_propose if propose is None else propose,
+        ),
+        patch(
+            "yoetz.cli.elevated._load_auto_unlock_passphrase",
+            return_value=bytearray(b"scoped-reauth"),
+        ),
+        patch("yoetz.cli.privacy_control.decide_policy", side_effect=decide) as decide_mock,
+    ):
+        yield decide_mock
+
+
+def _audit_lines(tmp_path: Path) -> list[str]:
+    return (
+        (tmp_path / "elevated-bootstrap" / "elevated-bootstrap-audit.jsonl")
+        .read_text("utf-8")
+        .splitlines()
+    )
+
+
+def test_repository_grant_recovers_committed_result_when_close_confirmation_lost(
+    tmp_path: Path,
+) -> None:
+    """#519: the durable grant committed; losing only the close frame must not report failure."""
+
+    committed = PrivacyDecisionResult("committed", "sha256:" + ("f" * 64))
+
+    async def decide(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialResultUnconfirmed("ambiguous", committed)
+
+    async def run() -> dict[str, Any]:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with _repository_grant_patches(decide) as decide_mock:
+                result = cast(
+                    dict[str, Any],
+                    await elevated.authorize_elevated(_chat_attestation(pending)),
+                )
+            # One-shot recovery: the carried result is consumed read-only, never by replaying
+            # the privacy expansion as a new decision.
+            decide_mock.assert_awaited_once()
+            return result
+
+    result = anyio.run(run)
+    assert result["outcome"] == "completed"
+    assert result["result"] == {"recipe": "assisted_review", "outcome": "granted"}
+    validate_schema_instance("review-result", "5.0.0", result)
+    assert load_pending(_state=tmp_path) is None
+    audit = _audit_lines(tmp_path)
+    assert any('"outcome":"approved"' in line for line in audit)
+    assert not any('"outcome":"failed"' in line for line in audit)
+
+
+def test_repository_grant_carried_denied_result_stays_a_bounded_failure(tmp_path: Path) -> None:
+    denied = PrivacyDecisionResult("denied", "sha256:" + ("f" * 64))
+
+    async def decide(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialResultUnconfirmed("ambiguous", denied)
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with _repository_grant_patches(decide):
+                with pytest.raises(ElevatedBootstrapError) as caught:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert caught.value.reason == "repository_privacy_grant_failed"
+
+    anyio.run(run)
+    assert load_pending(_state=tmp_path) is None
+    audit = _audit_lines(tmp_path)
+    assert not any('"outcome":"approved"' in line for line in audit)
+    assert any('"failure_reason":"repository_privacy_grant_failed"' in line for line in audit)
+
+
+def test_repository_grant_ambiguity_without_a_result_is_typed_unconfirmed(tmp_path: Path) -> None:
+    """A post-decision outcome that is unprovable either way must not claim failure."""
+
+    async def decide(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialClientError("ambiguous")
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with _repository_grant_patches(decide):
+                with pytest.raises(ElevatedBootstrapError) as caught:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert caught.value.reason == "repository_privacy_grant_unconfirmed"
+
+    anyio.run(run)
+    assert load_pending(_state=tmp_path) is None
+    audit = _audit_lines(tmp_path)
+    assert not any('"outcome":"approved"' in line for line in audit)
+    assert any('"failure_reason":"repository_privacy_grant_unconfirmed"' in line for line in audit)
+
+
+def test_repository_grant_pre_commit_failures_stay_bounded_with_no_grant(tmp_path: Path) -> None:
+    async def cancelled_decide(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialClientError("cancelled")
+
+    async def failing_propose(*_args: object, **_kwargs: object) -> object:
+        raise OSError("proposal channel down")
+
+    async def run() -> None:
+        decision_state = tmp_path / "decision"
+        with _patch_state(decision_state):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=decision_state)
+            assert pending is not None
+            with _repository_grant_patches(cancelled_decide):
+                with pytest.raises(ElevatedBootstrapError) as caught:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert caught.value.reason == "repository_privacy_grant_failed"
+            assert load_pending(_state=decision_state) is None
+
+        proposal_state = tmp_path / "proposal"
+        with _patch_state(proposal_state):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=proposal_state)
+            assert pending is not None
+            with _repository_grant_patches(cancelled_decide, propose=failing_propose) as decided:
+                with pytest.raises(ElevatedBootstrapError) as caught:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+                decided.assert_not_awaited()
+            assert caught.value.reason == "repository_privacy_grant_failed"
+            assert load_pending(_state=proposal_state) is None
+
+    anyio.run(run)
 
 
 def test_chat_user_authorize_requires_advertised_capability_before_claim(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -501,11 +501,13 @@ def test_repository_grant_carried_denied_result_stays_a_bounded_failure(tmp_path
     assert any('"failure_reason":"repository_privacy_grant_failed"' in line for line in audit)
 
 
-def test_repository_grant_ambiguity_without_a_result_is_typed_unconfirmed(tmp_path: Path) -> None:
-    """A post-decision outcome that is unprovable either way must not claim failure."""
+def test_repository_grant_post_decision_ambiguity_is_typed_unconfirmed(tmp_path: Path) -> None:
+    """A submitted decision with no result must not be reported as a failed grant."""
+
+    from yoetz.cli.privacy_control import PrivacyDecisionUnconfirmed
 
     async def decide(*_args: object, **_kwargs: object) -> object:
-        raise ConfidentialClientError("ambiguous")
+        raise PrivacyDecisionUnconfirmed("ambiguous")
 
     async def run() -> None:
         with _patch_state(tmp_path):
@@ -522,6 +524,33 @@ def test_repository_grant_ambiguity_without_a_result_is_typed_unconfirmed(tmp_pa
     audit = _audit_lines(tmp_path)
     assert not any('"outcome":"approved"' in line for line in audit)
     assert any('"failure_reason":"repository_privacy_grant_unconfirmed"' in line for line in audit)
+
+
+def test_repository_grant_pre_decision_ambiguity_is_a_retryable_failed_review(
+    tmp_path: Path,
+) -> None:
+    """An open/read failure sent no decision and must not claim the grant may be effective."""
+
+    async def decide(*_args: object, **_kwargs: object) -> object:
+        raise ConfidentialClientError("ambiguous")
+
+    async def run() -> None:
+        with _patch_state(tmp_path):
+            elevated.prepare_elevated("repository_privacy_grant", grant_binding=_GRANT_BINDING)
+            pending = load_pending(_state=tmp_path)
+            assert pending is not None
+            with _repository_grant_patches(decide):
+                with pytest.raises(ElevatedBootstrapError) as caught:
+                    await elevated.authorize_elevated(_chat_attestation(pending))
+            assert caught.value.reason == "repository_privacy_grant_failed"
+
+    anyio.run(run)
+    assert load_pending(_state=tmp_path) is None
+    audit = _audit_lines(tmp_path)
+    assert any('"failure_reason":"repository_privacy_grant_failed"' in line for line in audit)
+    assert not any(
+        '"failure_reason":"repository_privacy_grant_unconfirmed"' in line for line in audit
+    )
 
 
 def test_repository_grant_pre_commit_failures_stay_bounded_with_no_grant(tmp_path: Path) -> None:

--- a/tests/unit/service/test_confidential_client.py
+++ b/tests/unit/service/test_confidential_client.py
@@ -14,6 +14,7 @@ from yoetz.adapters.control.unix_socket import AuthenticatedUnixStream
 from yoetz.service import confidential_protocol
 from yoetz.service.confidential_client import (
     ConfidentialClientError,
+    ConfidentialResultUnconfirmed,
     HumanControlClient,
 )
 from yoetz.service.confidential_protocol import (
@@ -246,6 +247,63 @@ def test_confidential_clients_have_no_raw_endpoint_or_secret_constructor() -> No
         )(lambda: None, object(), _token=None)
     assert not hasattr(HumanControlClient, "connect_secret")
     assert "HumanEnvelope" in confidential_protocol.__all__
+
+
+_READY_RESULT = VaultStateResult(state="ready", reason="succeeded")
+
+
+def _result_frame() -> bytes:
+    return encode_human_frame(
+        ServerResultEnvelope(ceremony_id=_CEREMONY_ID, step=2, result=_READY_RESULT)
+    )
+
+
+@pytest.mark.anyio
+async def test_missing_close_after_result_carries_the_validated_result() -> None:
+    """#519: a lost close confirmation must not discard a correlated terminal result."""
+
+    client, human_stream, session = await _open(_SecretStream())
+    await human_stream.feed(_result_frame())
+    await human_stream.aclose()
+    with pytest.raises(ConfidentialResultUnconfirmed) as caught:
+        await getattr(session, "wait_phase_or_result")()
+    assert caught.value.result == _READY_RESULT
+    assert caught.value.reason == "ambiguous"
+    # Callers that only understand the bounded error taxonomy observe it unchanged.
+    assert isinstance(caught.value, ConfidentialClientError)
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_wrong_close_outcome_after_result_carries_the_validated_result() -> None:
+    client, human_stream, session = await _open(_SecretStream())
+    await human_stream.feed(
+        _result_frame()
+        + encode_human_frame(
+            ServerCloseEnvelope(ceremony_id=_CEREMONY_ID, step=3, outcome="failed")
+        )
+    )
+    with pytest.raises(ConfidentialResultUnconfirmed) as caught:
+        await getattr(session, "wait_phase_or_result")()
+    assert caught.value.result == _READY_RESULT
+    assert caught.value.reason == "ambiguous"
+    await client.close()
+
+
+@pytest.mark.anyio
+async def test_miscorrelated_close_after_result_keeps_its_exact_reason() -> None:
+    client, human_stream, session = await _open(_SecretStream())
+    await human_stream.feed(
+        _result_frame()
+        + encode_human_frame(
+            ServerCloseEnvelope(ceremony_id=_CEREMONY_ID, step=9, outcome="completed")
+        )
+    )
+    with pytest.raises(ConfidentialResultUnconfirmed) as caught:
+        await getattr(session, "wait_phase_or_result")()
+    assert caught.value.result == _READY_RESULT
+    assert caught.value.reason == "correlation_mismatch"
+    await client.close()
 
 
 class _RecoveryStream:


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #519
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: no protocol/wire change (the granted payload is already schema-admitted; `failure_reason` is a bounded string, not an enum).

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` paragraph on the commit-aware result contract.

## Verification

Commands run (paste):

```text
uv run pytest on the touched/neighboring slices: confidential client, elevated,
  ceremony refusal reporting, protocol errors, the three consent/initialization
  composition families, human_control                              # 143 passed
uv run pytest secret_ingress, encrypted_vault, installation_recovery_flow  # 21 passed
uv run ruff check / uv run ruff format --check                     # clean
node_modules/.bin/pyright (pinned npm pyright, touched files)      # 0 errors
Mutation check: with recovery disabled, the injected close-frame-loss composition test fails.
```

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

A prepared `repository_privacy_grant` could durably commit (grant `granted`, migration `consumed`, pending consumed) while the CLI reported `elevated_bootstrap: repository_privacy_grant_failed`: the catalog records the terminal transition before the result frame, and a post-result close/transport failure became `ConfidentialClientError("ambiguous")`, collapsed to a false failure.

The confidential client now exploits the proven ordering (durable transition → result frame → close frame): when a correlated, validated result is in hand and only the close confirmation fails, `wait_phase_or_result` raises `ConfidentialResultUnconfirmed` — a subclass preserving the bounded reason and carrying the validated result, so every existing caller is unchanged. `_complete_repository_privacy_grant` consumes that carried result exactly once, read-only, through the same `PrivacyDecisionResult`/`status=="committed"` validation gate — recovery never touches the wire again and never replays the privacy decision, so double-apply is impossible and a carried denied/stale result stays a bounded failure with no grant. A post-decision bare `ambiguous` with no result in hand becomes the typed `repository_privacy_grant_unconfirmed` (remediation → `yoetz provider status`) instead of an untruthful failure; genuine pre-commit failures keep `repository_privacy_grant_failed`.

Tests add missing/wrong-outcome/miscorrelated close-frame coverage on the client, recovery/unconfirmed/pre-commit CLI coverage, and a new composition test driving a positive repository grant through the real daemon with injected loss of the completed close frame.

The post-decision unconfirmed classification covers bounded ambiguous, timeout, service-unavailable, protocol, and correlation failures after a decision attempt. Pre-decision/open failures remain ordinary failed reviews. Server-side post-commit `reconcile_policy` failure and the interactive `yoetz --privacy` decide path remain outside this PR.

Implemented by Claude Fable 5 running in Claude Code (parallel worktree agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves validated confidential-ceremony results when only the trailing close confirmation fails and uses that result to recover committed repository privacy grants.
- Adds `ConfidentialResultUnconfirmed` with the validated terminal result.
- Adds grant-specific recovery and an unconfirmed outcome with operator remediation.
- Documents the commit-aware contract and adds unit and integration coverage for lost or invalid close frames.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until pre-decision transport ambiguity is distinguished from a decision that may have committed.

A connection failure while opening the ceremony occurs before approval is sent, but the new broad catch consumes the pending consent and reports that the grant may already be effective.

**Files Needing Attention:** src/yoetz/cli/elevated.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/service/confidential_client.py | Preserves a correlated terminal result when the subsequent completed-close confirmation cannot be validated. |
| src/yoetz/cli/elevated.py | Recovers committed grant results correctly, but over-classifies pre-decision open failures as potentially committed grants. |
| src/yoetz/cli/exits.py | Adds focused remediation for genuinely unconfirmed repository grant outcomes. |
| tests/unit/service/test_confidential_client.py | Covers missing, wrong-outcome, and miscorrelated close frames after a validated result. |
| tests/integration/service/test_repository_grant_authorize_composition.py | Exercises successful authorization and recovery from a dropped completed-close frame through the production daemon composition. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as Consent CLI
    participant Client as Confidential client
    participant Service as Privacy service
    CLI->>Client: open privacy-decision ceremony
    alt Open succeeds
        Client->>Service: approve decision
        Service->>Service: commit policy transition
        Service-->>Client: validated result
        Service--xClient: close confirmation lost
        Client-->>CLI: ConfidentialResultUnconfirmed(result)
        CLI->>CLI: validate and recover committed result
    else Connection fails while opening
        Service--xClient: EOF before opened frame
        Client-->>CLI: ConfidentialClientError(ambiguous)
        CLI->>CLI: incorrectly classify as grant_unconfirmed
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(consent): commit-aware repository gr..."](https://github.com/thegaysupreme123/yoetz/commit/96ea8f3fa84899d7be6fe93a7e6a09d077cc8c2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59048967)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## Independent review follow-up (2026-09-01)

Codex verified Greptile's pre-decision ambiguity finding as valid. Commit `8a1e71bc` latches whether an approve/deny action was actually attempted and emits `repository_privacy_grant_unconfirmed` only for bounded ambiguous transport outcomes after that point. Initial-frame/open failures remain ordinary failed reviews and can be safely prepared again; a correlated committed result remains recoverable without replay.

Verification: 83 focused unit/integration tests passed; Ruff and pinned Pyright passed.