### PR TITLE
fix(protocol): keep const-free oneOf branches live

### DIFF
--- a/src/yoetz/mcp/errors.py
+++ b/src/yoetz/mcp/errors.py
@@ -814,7 +814,9 @@ def _selected_branch_requirement_text(
             continue
         branch_required = source.get("required")
         if isinstance(branch_required, list) and required in cast(list[object], branch_required):
-            return f"{condition_field} {condition_value} requires {required}"
+            required_names = _format_required_list(branch_required, prop_names)
+            if required_names:
+                return f"{condition_field} {condition_value} requires {required_names}"
         alternatives = source.get("anyOf")
         if not isinstance(alternatives, list):
             continue

--- a/src/yoetz/protocol/schemas.py
+++ b/src/yoetz/protocol/schemas.py
@@ -1061,37 +1061,16 @@ def _project_selected_one_of_required_locations_impl(
     if base_path is None:
         return None
     for field in sorted(root_properties):
-        rejected: set[int] = set()
-        candidates: list[tuple[int, str]] = []
-        for index, errors in branches.items():
-            if not 0 <= index < len(option_values) or not isinstance(option_values[index], Mapping):
-                return None
-            properties = cast(Mapping[str, JsonValue], option_values[index]).get("properties")
-            if not isinstance(properties, Mapping):
-                continue
-            condition = cast(Mapping[str, JsonValue], properties).get(field)
-            if not isinstance(condition, Mapping):
-                continue
-            value = cast(Mapping[str, JsonValue], condition).get("const")
-            if type(value) is not str or not value.isascii() or not 1 <= len(value) <= 64:
-                continue
-            candidates.append((index, value))
-            if any(
-                error.validator == "const"
-                and tuple((_path_items_from(error) or ())[-1:]) == (field,)
-                for error in errors
-            ):
-                rejected.add(index)
-        survivors = [(index, value) for index, value in candidates if index not in rejected]
-        if (
-            len(candidates) < _MIN_DISCRIMINATED_BRANCHES
-            or len(rejected) < _MIN_DISCRIMINATED_BRANCHES
-        ):
+        selected = _const_discriminator_selected_branch(exc, branches, field=field)
+        if selected is None:
             continue
-        if len(survivors) != 1:
+        selected_index, selected_errors, selected_value = selected
+        if selected_value is None:
+            # A const-free branch can be the sole survivor, but it supplies no safe condition text
+            # for a selected-branch repair. The recursive path below may still project an inner
+            # schema-authored conditional rule from that branch.
             continue
-        selected_index, selected_value = survivors[0]
-        ordered = _missing_required_locations(branches[selected_index], base_path, root_properties)
+        ordered = _missing_required_locations(selected_errors, base_path, root_properties)
         if ordered:
             return (tuple(ordered), field, selected_value, _selected_family_for(exc))
     # Descend only into a branch the discriminator proved selected. Recursing into
@@ -1516,19 +1495,65 @@ def _discriminator_selected_branch(exc: ValidationError) -> tuple[ValidationErro
     # top-level const properties such as evidence strength. Select those only when const failures
     # rule out every sibling but one; the selected branch then exposes its real required peer.
     for field in _const_discriminator_fields(exc, branches):
-        rejected = {
-            index
-            for index, errors in branches.items()
-            if any(
-                error.validator == "const"
-                and tuple((_path_items_from(error) or ())[-1:]) == (field,)
-                for error in errors
-            )
-        }
-        selected = [errors for index, errors in branches.items() if index not in rejected]
-        if len(rejected) >= _MIN_DISCRIMINATED_BRANCHES and len(selected) == 1:
-            return tuple(selected[0])
+        selected = _const_discriminator_selected_branch(exc, branches, field=field)
+        if selected is not None:
+            return tuple(selected[1])
     return None
+
+
+def _const_discriminator_selected_branch(
+    exc: ValidationError,
+    branches: Mapping[int, Sequence[ValidationError]],
+    *,
+    field: str,
+) -> tuple[int, Sequence[ValidationError], str | None] | None:
+    """Select one branch only when every other branch has a proven const rejection.
+
+    Branches without a const for ``field`` are always survivors. Returning the selected const
+    value separately lets required-peer projection name a condition only when the sole survivor
+    actually declares one, while ordinary branch scoring can still select a const-free fallback.
+    """
+
+    validator_value = cast(object, exc.validator_value)
+    if not isinstance(validator_value, list):
+        return None
+    options = cast(list[object], validator_value)
+    const_values: dict[int, str] = {}
+    rejected: set[int] = set()
+    for index, errors in branches.items():
+        if not 0 <= index < len(options):
+            return None
+        branch = options[index]
+        if not isinstance(branch, Mapping):
+            return None
+        properties = cast(Mapping[str, JsonValue], branch).get("properties")
+        condition = (
+            cast(Mapping[str, JsonValue], properties).get(field)
+            if isinstance(properties, Mapping)
+            else None
+        )
+        value = (
+            cast(Mapping[str, JsonValue], condition).get("const")
+            if isinstance(condition, Mapping)
+            else None
+        )
+        if type(value) is not str or not value.isascii() or not 1 <= len(value) <= 64:
+            continue
+        const_values[index] = value
+        if any(
+            error.validator == "const" and tuple((_path_items_from(error) or ())[-1:]) == (field,)
+            for error in errors
+        ):
+            rejected.add(index)
+    survivors = [index for index in branches if index not in rejected]
+    if (
+        len(const_values) < _MIN_DISCRIMINATED_BRANCHES
+        or len(rejected) < _MIN_DISCRIMINATED_BRANCHES
+        or len(survivors) != 1
+    ):
+        return None
+    selected_index = survivors[0]
+    return selected_index, branches[selected_index], const_values.get(selected_index)
 
 
 def _const_discriminator_fields(

--- a/tests/unit/mcp/test_root_object_rule_locations.py
+++ b/tests/unit/mcp/test_root_object_rule_locations.py
@@ -196,6 +196,28 @@ def test_selected_payload_any_of_required_names_metadata_only_alternatives() -> 
     assert "strength admits" not in message
 
 
+def test_selected_payload_required_peers_share_one_complete_hint_part() -> None:
+    """One selected branch's peers must not consume the global three-part hint budget."""
+
+    base = deepcopy(cast(dict[str, object], cast(list[object], _PUBLISH_SCHEMA["examples"])[0]))
+    draft = cast(dict[str, object], cast(list[object], base["event_drafts"])[0])
+    draft["schema"] = {"name": "evidence_recorded", "version": "1.1.0"}
+    draft["payload"] = {
+        "evidence_id": "evd_00000000-0000-4000-8000-000000000001",
+        "evidence_kind": "artifact",
+        "strength": "independently_reproduced",
+        "observed_at": "2026-01-01T00:00:00.000Z",
+        "description": "bounded evidence description",
+    }
+    with pytest.raises(ValidationError) as captured:
+        PublishWorkRequest.model_validate(base)
+
+    locations = safe_validation_locations(captured.value)
+    message = invalid_request_message("publish_work", locations)
+    assert message.count("strength independently_reproduced requires") == 1
+    assert "captured_object_id, content_digest, and subject_state" in message
+
+
 def test_selected_payload_all_of_requires_digest_binding_with_content_digest() -> None:
     """A content_digest draft missing digest_binding must name the allOf peer (#335)."""
 

--- a/tests/unit/protocol/test_schema_instance_reasons.py
+++ b/tests/unit/protocol/test_schema_instance_reasons.py
@@ -17,6 +17,7 @@ from jsonschema.exceptions import ValidationError
 from yoetz.protocol.schemas import (
     SchemaInstanceInvalid,
     _best_schema_instance_error,  # pyright: ignore[reportPrivateUsage]
+    _project_selected_one_of_required_locations,  # pyright: ignore[reportPrivateUsage]
 )
 
 _DISCRIMINATED_UNION: dict[str, Any] = {
@@ -156,3 +157,46 @@ def test_an_undiscriminated_union_keeps_whole_tree_scoring() -> None:
     best = _best_schema_instance_error(captured.value)
 
     assert best.validator in {"oneOf", "type", "required"}
+
+
+def test_const_free_branch_remains_live_beside_matching_const_branch() -> None:
+    """Projection must not select a const branch while a const-free alternative also survives."""
+
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string"},
+            "alpha_peer": {"type": "string"},
+            "fallback_peer": {"type": "string"},
+        },
+        "oneOf": [
+            {"properties": {"kind": {"const": "alpha"}}, "required": ["alpha_peer"]},
+            {"properties": {"kind": {"const": "beta"}}, "required": ["beta_peer"]},
+            {"properties": {"kind": {"const": "gamma"}}, "required": ["gamma_peer"]},
+            {"required": ["fallback_peer"]},
+        ],
+    }
+    validator = Draft202012Validator(cast(Any, schema))
+    with pytest.raises(ValidationError) as captured:
+        cast(Any, validator).validate({"kind": "alpha"})
+
+    assert _project_selected_one_of_required_locations(captured.value) is None
+
+
+def test_fully_const_discriminated_union_still_projects_the_selected_peer() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"kind": {"type": "string"}, "alpha_peer": {"type": "string"}},
+        "oneOf": [
+            {"properties": {"kind": {"const": "alpha"}}, "required": ["alpha_peer"]},
+            {"properties": {"kind": {"const": "beta"}}, "required": ["beta_peer"]},
+            {"properties": {"kind": {"const": "gamma"}}, "required": ["gamma_peer"]},
+        ],
+    }
+    validator = Draft202012Validator(cast(Any, schema))
+    with pytest.raises(ValidationError) as captured:
+        cast(Any, validator).validate({"kind": "alpha"})
+
+    projected = _project_selected_one_of_required_locations(captured.value)
+    assert projected is not None
+    assert projected[:3] == (((("alpha_peer",), "conditional_field_required"),), "kind", "alpha")


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #334
- I searched existing issues and PRs for duplicates before opening this PR; no open duplicate PR was found.
- Maintainer acknowledgement: #334 is maintainer-authored, and the maintainer explicitly requested that the ready worktree be sent as a PR.

## Documentation

- Behavior change? yes
- Docs updated: n/a — this corrects internal selector and hint projection behavior while preserving the existing public schemas, registered names, and wire shapes; focused tests lock the corrected behavior.

## Verification

Commands run:

```text
git diff --check
uv run pytest tests/unit/protocol/test_schema_instance_reasons.py tests/unit/mcp/test_root_object_rule_locations.py
uv run pytest tests/unit/protocol tests/unit/mcp/test_root_object_rule_locations.py
uv run ruff check src/yoetz/protocol/schemas.py src/yoetz/mcp/errors.py tests/unit/protocol/test_schema_instance_reasons.py tests/unit/mcp/test_root_object_rule_locations.py
uv run ruff format --check src/yoetz/protocol/schemas.py src/yoetz/mcp/errors.py tests/unit/protocol/test_schema_instance_reasons.py tests/unit/mcp/test_root_object_rule_locations.py
/Users/shayb/yoetz-core/node_modules/.bin/pyright src/yoetz/protocol/schemas.py src/yoetz/mcp/errors.py tests/unit/protocol/test_schema_instance_reasons.py tests/unit/mcp/test_root_object_rule_locations.py
uv run python scripts/scan_public_boundary.py --source-tree .
```

Results: 33 focused tests passed; 329 protocol/root-location tests passed; Ruff format and lint passed; Pyright reported zero errors; the public-boundary scan passed across 1,192 files.

Harness: Codex desktop. Model: Codex; the exact model identifier was not exposed to this task.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Use one const-discriminator survivor helper for both branch selection paths so a const-free alternative remains live instead of allowing the projection to assert a sibling's required peer. A const-free branch can still be selected when it is the sole survivor, but it cannot fabricate condition text.

The related hint fix renders all required peers from one selected branch as one complete hint part, preventing the global three-part cap from silently dropping a fourth peer.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes const-discriminator branch selection so const-free `oneOf` alternatives remain viable and updates selected-branch hints to keep all required peers in one hint part.

- Reuses one discriminator-selection helper across direct projection and recursive error scoring.
- Prevents const-free survivors from allowing unsafe condition text.
- Formats a selected branch’s required peers as one complete hint.
- Adds focused regression coverage for const-free alternatives, fully discriminated unions, and multi-peer hints.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed behavior.

The shared selector correctly keeps const-free branches live, avoids fabricating discriminator text for them, and retains the expected projection and complete-hint behavior for current schemas.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/protocol/schemas.py | Centralizes discriminator selection, preserves const-free survivors, and safely suppresses condition text when the selected branch has no usable const. |
| src/yoetz/mcp/errors.py | Formats all safe required peers from a selected branch into one hint part, avoiding truncation by the global hint-part limit. |
| tests/unit/protocol/test_schema_instance_reasons.py | Adds regression tests for const-free survivor handling and continued projection for fully const-discriminated unions. |
| tests/unit/mcp/test_root_object_rule_locations.py | Verifies that all required peers from one selected branch remain visible in the generated hint. |

<sub>Reviews (1): Last reviewed commit: ["fix(protocol): keep const-free oneOf bra..."](https://github.com/thegaysupreme123/yoetz/commit/4bee50ebe10d6cf187d92c1bc31a3e8562fcffe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59493656)</sub>

<!-- /greptile_comment -->