### PR TITLE
fix(providers): demultiplex reviewed notifications during Codex login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ reverse-chronological released versions.
   leave no partial Yoetz binding, while any Codex-owned authentication remains under Codex's control
   (issue #525).
 
+- Fresh Codex subscription login now demultiplexes only the reviewed pre-disclosure notifications
+  from the pinned 0.150.1 app-server cell, including its mandatory `remoteControl/status/changed`
+  notice, while retaining exact `loginId`/success completion matching and fail-closed handling for
+  unknown or unallowlisted notifications. Notification payloads remain unread and do not cross the
+  adapter (issue #530).
+
 - Codex subscription semantic attempts now record which closed stage stopped them. A
   `response_schema_invalid` result stays terminal and non-retryable, but its
   `semantic_provenance.runtime_evidence.failure_stage` names one registered token — malformed or

--- a/docs/runbooks/codex-subscription-evaluator.md
+++ b/docs/runbooks/codex-subscription-evaluator.md
@@ -63,6 +63,16 @@ device-code login are the only accepted methods. The browser window is 600 secon
 window is 900 seconds. Cancellation and timeout use bounded process-group termination, pipe close,
 and task cleanup before returning one terminal diagnostic.
 
+Codex 0.150.1 emits `remoteControl/status/changed` immediately after initialization, so either
+login method may receive that notification while `account/login/start` is outstanding. The login
+waiter follows the same reviewed pre-disclosure method allowlist as the evaluator: accepted
+structural notifications are demultiplexed and discarded unread, with the remote-control and rate
+limit shapes validated; warnings remain fail-closed. `account/login/completed` remains the only
+terminal login event and must carry the exact `loginId` with `success: true`. Unknown, tool, or
+otherwise unallowlisted notifications still fail closed. This mirrors the official SDK's separate
+login waiter/global-notification routing without introducing a broad ignore or carrying notification
+payload content across the adapter.
+
 No partial Yoetz binding is written. A timeout, denial, malformed completion, process exit,
 cancellation, or later configuration-write failure leaves a new or replacement Yoetz binding
 uncommitted. If Codex completed its own login before the failure, its OAuth state may remain in the

--- a/src/yoetz/adapters/providers/codex_app_server.py
+++ b/src/yoetz/adapters/providers/codex_app_server.py
@@ -870,16 +870,51 @@ def _login_challenge(result: Mapping[str, object]) -> CodexLoginChallenge:
     return CodexLoginChallenge(mode, url, user_code)
 
 
+def _validate_predisclosure_notification(
+    message: Mapping[str, object],
+    *,
+    invalid_token: str = "codex_app_server_predisclosure_event_forbidden",
+) -> bool:
+    """Validate one reviewed pre-disclosure notification and retain no native payload."""
+
+    if "method" in message and "id" in message:
+        raise ValueError("codex_app_server_tool_request_forbidden")
+    method = message.get("method")
+    if type(method) is not str or method not in _PREDISCLOSURE_NOTIFICATION_METHODS:
+        raise ValueError(invalid_token)
+    if method == "account/updated":
+        return True
+    if method == "account/rateLimits/updated":
+        _discard_rate_limits_notification(message)
+    elif method == "warning":
+        raise _runtime_warning(message)
+    elif method == "remoteControl/status/changed":
+        params = _object(message.get("params"))
+        if set(params) != {"environmentId", "installationId", "serverName", "status"}:
+            raise ValueError("codex_app_server_remote_control_state_invalid")
+        if params.get("status") != "disabled":
+            raise ValueError("codex_app_server_remote_control_not_disabled")
+    return False
+
+
 def _login_notification(
     message: Mapping[str, object], login_id: str
-) -> Literal["account_updated", "completed"]:
+) -> Literal["account_updated", "completed", "predisclosure"]:
     """Validate one login notification without retaining any native payload text."""
 
     if "method" in message and "id" in message:
         raise ValueError("codex_app_server_tool_request_forbidden")
     method = message.get("method")
-    if method == "account/updated":
-        return "account_updated"
+    if type(method) is str and method in _PREDISCLOSURE_NOTIFICATION_METHODS:
+        try:
+            updated = _validate_predisclosure_notification(
+                message, invalid_token="codex_login_event_invalid"
+            )
+        except _CodexRuntimeWarning as warning:
+            # A native warning is not a login event. It ends the login with the bounded login
+            # token; its free-form body never leaves the adapter.
+            raise ValueError("codex_login_event_invalid") from warning
+        return "account_updated" if updated else "predisclosure"
     if method != "account/login/completed":
         raise ValueError("codex_login_event_invalid")
     params = _object(message.get("params"))
@@ -917,9 +952,12 @@ def _take_account_updated(runtime: _CodexProcess) -> bool:
     pending = runtime.pending_notifications
     runtime.pending_notifications = []
     for message in pending:
-        if message.get("method") != "account/updated":
+        notification = _login_notification(message, "")
+        if notification == "account_updated":
+            updated = True
+            continue
+        if notification != "predisclosure":
             raise ValueError("codex_login_event_invalid")
-        updated = True
     return updated
 
 
@@ -932,9 +970,12 @@ async def _wait_for_account_updated(runtime: _CodexProcess, deadline: float) -> 
             if remaining <= 0.0:
                 return False
             message = await runtime.read(remaining)
-            if _login_notification(message, "") != "account_updated":
-                raise ValueError("codex_login_event_invalid")
-            return True
+            notification = _login_notification(message, "")
+            if notification == "account_updated":
+                return True
+            if notification == "predisclosure":
+                continue
+            raise ValueError("codex_login_event_invalid")
     except TimeoutError:
         return False
 
@@ -1024,8 +1065,11 @@ async def codex_login(
                 except TimeoutError:
                     break
                 events_seen += 1
-                if _login_notification(message, login_id) == "account_updated":
+                notification = _login_notification(message, login_id)
+                if notification == "account_updated":
                     account_updated_seen = True
+                    continue
+                if notification == "predisclosure":
                     continue
                 completion_seen = True
                 completion_succeeded = True
@@ -1052,8 +1096,11 @@ async def codex_login(
                     except TimeoutError as error:
                         raise TimeoutError from error
                     events_seen += 1
-                    if _login_notification(message, login_id) == "account_updated":
+                    notification = _login_notification(message, login_id)
+                    if notification == "account_updated":
                         account_updated_seen = True
+                        continue
+                    if notification == "predisclosure":
                         continue
                     completion_seen = True
                     completion_succeeded = True
@@ -1290,22 +1337,7 @@ def _turn_failure(error: object) -> _CodexTurnFailure:
 
 def _validate_predisclosure_notifications(runtime: _CodexProcess) -> None:
     for message in runtime.pending_notifications:
-        if "method" in message and "id" in message:
-            raise ValueError("codex_app_server_tool_request_forbidden")
-        method = message.get("method")
-        if method not in _PREDISCLOSURE_NOTIFICATION_METHODS:
-            raise ValueError("codex_app_server_predisclosure_event_forbidden")
-        if method == "account/rateLimits/updated":
-            _discard_rate_limits_notification(message)
-            continue
-        if method == "warning":
-            raise _runtime_warning(message)
-        if method == "remoteControl/status/changed":
-            params = _object(message.get("params"))
-            if set(params) != {"environmentId", "installationId", "serverName", "status"}:
-                raise ValueError("codex_app_server_remote_control_state_invalid")
-            if params.get("status") != "disabled":
-                raise ValueError("codex_app_server_remote_control_not_disabled")
+        _validate_predisclosure_notification(message)
     runtime.pending_notifications.clear()
 
 

--- a/tests/unit/adapters/providers/test_codex_app_server.py
+++ b/tests/unit/adapters/providers/test_codex_app_server.py
@@ -306,6 +306,7 @@ class _LoginRuntime:
         *,
         account_results: list[Mapping[str, object]] | None = None,
         login_result: Mapping[str, object] | None = None,
+        login_notifications: list[dict[str, object]] | None = None,
         cancel_error: BaseException | None = None,
         block_read: bool = False,
     ) -> None:
@@ -316,6 +317,7 @@ class _LoginRuntime:
             account_results or [{"account": {"type": "chatgpt", "planType": "plus"}}]
         )
         self.login_result = login_result
+        self.login_notifications = list(login_notifications or [])
         self.cancel_error = cancel_error
         self.block_read = block_read
         self.pending_notifications: list[dict[str, object]] = []
@@ -342,6 +344,7 @@ class _LoginRuntime:
             }
         if method == "account/login/start":
             assert isinstance(params, dict)
+            self.pending_notifications.extend(self.login_notifications)
             if self.login_result is not None:
                 return self.login_result
             if params["type"] == "chatgpt":
@@ -465,6 +468,150 @@ async def test_login_uses_the_native_method_window(
     assert result.model_available is True
     assert any(timeout >= expected_timeout - 0.1 for timeout in runtime.timeouts)
     assert runtime.methods.count("account/login/cancel") == 0
+
+
+@pytest.mark.parametrize("mode", ["browser", "device_code"])
+async def test_login_demultiplexes_exact_remote_control_notice_before_completion(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    runtime = _LoginRuntime(
+        _profile(),
+        [
+            {
+                "method": "account/login/completed",
+                "params": {"loginId": "login-1", "success": True},
+            }
+        ],
+        # Codex 0.150.1 emits this notification while account/login/start is in flight. The
+        # request buffers it before returning the login challenge, as the native process does.
+        login_notifications=[
+            {
+                "method": "remoteControl/status/changed",
+                "params": {
+                    "environmentId": None,
+                    "installationId": "discard-installation-canary",
+                    "serverName": "discard-server-canary",
+                    "status": "disabled",
+                },
+            }
+        ],
+    )
+
+    result = await _login(monkeypatch, runtime, mode=mode)
+
+    assert result.auth_mode == "chatgpt"
+    assert result.model_available is True
+    assert runtime.methods.count("account/login/cancel") == 0
+    assert runtime.pending_notifications == []
+    assert "discard-installation-canary" not in repr(result)
+    assert "discard-server-canary" not in repr(result)
+
+
+_RATE_LIMITS_NOTICE: dict[str, object] = {
+    "method": "account/rateLimits/updated",
+    "params": {
+        "rateLimits": {
+            "limitId": "codex",
+            "limitName": None,
+            "primary": {"usedPercent": 3, "windowDurationMins": 10080, "resetsAt": 1788698233},
+            "secondary": None,
+            "credits": {"hasCredits": False, "unlimited": False, "balance": "discard-balance"},
+            "individualLimit": None,
+            "spendControlReached": None,
+            "planType": "prolite",
+            "rateLimitReachedType": None,
+        }
+    },
+}
+_REMOTE_CONTROL_NOTICE: dict[str, object] = {
+    "method": "remoteControl/status/changed",
+    "params": {
+        "environmentId": None,
+        "installationId": "discard-installation-canary",
+        "serverName": "discard-server-canary",
+        "status": "disabled",
+    },
+}
+_LOGIN_COMPLETED: dict[str, object] = {
+    "method": "account/login/completed",
+    "params": {"loginId": "login-1", "success": True},
+}
+
+
+async def test_login_demultiplexes_every_reviewed_predisclosure_notice_in_the_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _LoginRuntime(
+        _profile(),
+        [_RATE_LIMITS_NOTICE, _REMOTE_CONTROL_NOTICE, _LOGIN_COMPLETED],
+        login_notifications=[_REMOTE_CONTROL_NOTICE],
+    )
+
+    result = await _login(monkeypatch, runtime)
+
+    assert result.auth_mode == "chatgpt"
+    assert result.model_available is True
+    assert runtime.methods.count("account/login/cancel") == 0
+    assert "discard-balance" not in repr(result)
+    assert "discard-installation-canary" not in repr(result)
+
+
+async def test_login_tolerates_predisclosure_notices_around_the_account_projection_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _LoginRuntime(
+        _profile(),
+        [
+            _LOGIN_COMPLETED,
+            _RATE_LIMITS_NOTICE,
+            {"method": "account/updated", "params": {"account": {"type": "chatgpt"}}},
+        ],
+        account_results=[
+            {"account": None},
+            {"account": {"type": "chatgpt", "planType": "plus"}},
+        ],
+    )
+
+    result = await _login(monkeypatch, runtime)
+
+    assert result.auth_mode == "chatgpt"
+    assert runtime.methods.count("account/read") == 2
+    assert runtime.methods.count("account/login/cancel") == 0
+
+
+@pytest.mark.parametrize(
+    "notice",
+    [
+        {"method": "warning", "params": {"message": "native-text-canary", "threadId": "t"}},
+        {
+            "method": "remoteControl/status/changed",
+            "params": {
+                "environmentId": None,
+                "installationId": "i",
+                "serverName": "s",
+                "status": "enabled-canary",
+            },
+        },
+        {"method": "thread/name/updated", "params": {"threadId": "t", "threadName": "canary"}},
+        {"method": "item/completed", "params": {"item": {"type": "commandExecution"}}},
+        {"method": "account/rateLimits/updated", "params": {"rateLimits": {"limitId": "x"}}},
+    ],
+)
+async def test_login_still_fails_closed_on_unallowlisted_or_malformed_notices(
+    monkeypatch: pytest.MonkeyPatch, notice: dict[str, object]
+) -> None:
+    runtime = _LoginRuntime(_profile(), [notice, _LOGIN_COMPLETED])
+
+    with pytest.raises(ValueError) as info:
+        await _login(monkeypatch, runtime)
+
+    assert str(info.value) in {
+        "codex_login_event_invalid",
+        "codex_app_server_remote_control_not_disabled",
+        "codex_app_server_rate_limits_invalid",
+    }
+    assert "canary" not in repr(info.value) and "canary" not in repr(info.value.__cause__)
+    assert runtime.methods.count("account/login/cancel") == 1
 
 
 async def test_login_accepts_terminal_event_in_bounded_grace_window(


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #530
- I searched existing issues and PRs for duplicates before opening this PR.
- If this change is design-gated (protocol, privacy/egress, storage/durability, release/packaging,
  ADR / `OPEN_QUESTIONS`), a maintainer acknowledged the issue before this PR was opened. — Maintainer requested the follow-up fix and PR in-session after the Codex dogfood filed #530.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/runbooks/codex-subscription-evaluator.md` (login-waiter demultiplexing paragraph), `CHANGELOG.md`. No schema or ADR change; the pre-disclosure allowlist is unchanged, it is now applied to the login waiter as well.

## Verification

Commands run (paste):

```text
uv run pytest -q tests/unit/adapters/providers/test_codex_app_server.py tests/unit/cli/test_codex_subscription.py   # 116 → 124 passed
uv run ruff format --check src tests && uv run ruff check src tests
node_modules/.bin/pyright src/yoetz/adapters/providers/codex_app_server.py tests/unit/adapters/providers/test_codex_app_server.py   # 0 errors
```

Live, isolated (adapter only, Codex-owned evaluator home in place, no Yoetz state dir, no config
write): `codex_account_status` → `runtime_ready=true auth_mode=chatgpt plan_type=prolite
model_available=true cleanup=terminated`; one `evaluate()` dispatch of a 9.8 KB test-built packet
returned a valid judgment with `turn_acknowledged=true`, `process_cleanup=terminated`; the
structural event tally showed two `remoteControl/status/changed` notices on the real stream being
validated and discarded by the shared pre-disclosure validator.

Fresh browser login with this patch was proven by the reporting Codex session (issue #530
evidence: fresh evaluator home, callback completed, `gpt-5.6-luna`/high discovered, binding
written, clean termination). I did not repeat it: a fresh OAuth ceremony needs the maintainer at
the browser or device-code prompt.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Codex 0.150.1 sends `remoteControl/status/changed` to every newly initialized client, and the
notice is buffered while `account/login/start` is outstanding. The login waiter accepted only
`account/updated` and `account/login/completed`, so it rejected the snapshot as
`codex_login_event_invalid`, cancelled the native login, and tore down the localhost callback
listener — the browser landed on an unavailable page and both login modes failed on a fresh home.

The login waiter now applies the same reviewed pre-disclosure allowlist the evaluator already uses,
through one shared `_validate_predisclosure_notification`: the remote-control snapshot and
rate-limit updates are validated for shape and discarded unread, `account/updated` still feeds the
readiness race, and completion still requires the exact `loginId` with `success: true`. A native
warning, a non-disabled remote-control state, a malformed rate-limit body, a tool item, or any
unallowlisted method still fails closed with a bounded token and cancels the native login. No
notification body crosses the adapter. Method-only demultiplexing was chosen over
`optOutNotificationMethods` because it keeps one allowlist for both pre-disclosure paths and keeps
the remote-control state check (must be `disabled`) in force during login.

New tests: remote-control notice buffered before the challenge (browser and device-code), every
reviewed notice interleaved before completion, notices around the account-projection race, and a
fail-closed matrix (warning, non-disabled remote control, unallowlisted method, tool item,
malformed rate limits) proving cancel-on-failure and no payload text in the error.

The first version of this patch and the root-cause analysis came from the Codex dogfood session
that filed #530; this PR adds the warning mapping and the interleaving/fail-closed tests. Work
finished by Claude Fable 5.1 in Claude Code (auto mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reuses the existing pre-disclosure notification validator in Codex login flows so reviewed structural notifications can be discarded while login completion remains strictly matched.
- Demultiplexes valid remote-control and rate-limit notifications during browser and device-code login.
- Preserves fail-closed handling for malformed, unsafe, tool, warning, and unallowlisted events.
- Adds coverage for buffered and interleaved notifications, account-projection races, cancellation, and payload non-disclosure.
- Documents the Codex 0.150.1 behavior and operational contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with reviewed notifications demultiplexed while strict login completion and fail-closed validation remain intact.

The shared validator preserves evaluator behavior, and the login loops now skip only structurally validated allowlisted notifications while continuing to reject unsafe events and require an exact successful completion.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/providers/codex_app_server.py | Extracts shared pre-disclosure validation and applies it throughout login notification handling without weakening terminal-event or fail-closed checks. |
| tests/unit/adapters/providers/test_codex_app_server.py | Adds focused coverage for both login modes, notification interleaving, readiness races, cancellation, malformed events, and payload redaction. |
| docs/runbooks/codex-subscription-evaluator.md | Documents the newly supported notification demultiplexing and retained validation boundaries. |
| CHANGELOG.md | Records the fresh-login compatibility fix and its security constraints. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Codex app-server
    participant A as Yoetz adapter
    participant L as Login flow
    C->>A: account/login/start response
    loop Until terminal event
        C-->>A: reviewed pre-disclosure notification
        A->>A: Validate shape and safety state
        A->>A: Discard payload
    end
    C-->>A: account/login/completed(loginId, success)
    A->>A: "Match exact loginId and success=true"
    A->>L: Continue account readiness checks
```

<sub>Reviews (1): Last reviewed commit: ["fix(providers): demultiplex reviewed not..."](https://github.com/thegaysupreme123/yoetz/commit/6aeb62ae20daa899ff4e8f645d701943dc475c8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59528222)</sub>

<!-- /greptile_comment -->