### PR TITLE
fix(providers): reuse an already signed-in Codex evaluator home on setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ reverse-chronological released versions.
 
 ## Unreleased
 
+### Fixed
+
+- `yoetz provider codex-subscription setup` no longer forces a fresh Codex sign-in on a dedicated
+  evaluator home that Codex already reports signed in with the exact model available. Unless
+  `--switch-account` is passed, setup first runs the same structural app-server probe as `status`
+  (`account/read` with `refreshToken: false`, then `model/list`) and, on success, writes the
+  binding and reports `login_reused: true`; otherwise the existing login path runs and reports
+  `login_reused: false`. `--switch-account` (also the prompt-loop menu and `/provider` account
+  switch) always logs out and signs in again. Yoetz still never reads `auth.json`. A dedicated
+  evaluator home passed by path may live outside `YOETZ_ISOLATED_ROOT` and be reused across
+  dogfood runs; ADR-026 records that exemption (issue #534).
+
 ### Added
 
 - One supported exact-target isolation contract for test and dogfood runtimes (ADR-026): setting

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -1,7 +1,10 @@
 # ADR-026 — Exact-target isolated-root runtime identity
 
 **Status:** Accepted (2026-09-01), maintainer-authorized in
-[issue #518](https://github.com/TheGaySupreme123/yoetz/issues/518).
+[issue #518](https://github.com/TheGaySupreme123/yoetz/issues/518); amended 2026-09-03,
+maintainer-authorized in [issue #534](https://github.com/TheGaySupreme123/yoetz/issues/534), to
+exempt one explicitly passed dedicated Codex evaluator home from the "every artifact lives beneath
+the root" reverse state.
 **Implemented by:** `src/yoetz/config/paths.py` (`isolated_root()`, `runtime_dir()`,
 `ISOLATED_ROOT_ENV`), `src/yoetz/adapters/control/unix_socket.py`, `src/yoetz/config/load.py`,
 `src/yoetz/service/client.py`, `src/yoetz/cli/isolation_status.py`, the
@@ -78,10 +81,12 @@ isolated runtime creates lives beneath the root, so deleting the root is complet
 cannot touch unrelated user state. One explicit exemption (issue #534): a dedicated Codex
 evaluator home that the operator passes by path to `yoetz provider codex-subscription setup
 --codex-home` may live outside the root and be reused across runs. It holds Codex-owned OAuth
-state and no Yoetz identity, state, endpoint, or storage, so deleting the root still removes every
-Yoetz artifact; that home's reverse state is `yoetz provider codex-subscription disconnect`, and
-the parity gate still fails on any shared Yoetz identity. The default evaluator home (no explicit
-path) stays beneath the root. The packaged regression
+state plus the exact Codex `config.toml` Yoetz writes into it, and no Yoetz identity, state,
+endpoint, or storage, so deleting the root still removes every Yoetz identity artifact and the
+parity gate still fails on any shared Yoetz identity. That home is reverse-stated by
+`yoetz provider codex-subscription disconnect` — Codex logout plus binding removal — and then by
+the operator deleting the directory they provisioned; root deletion is not its rollback. The
+default evaluator home (no explicit path) stays beneath the root. The packaged regression
 (`tests/packaging/test_isolated_root_boundary.py`) locks this: an isolated service run leaves the
 ambient home tree byte-identical before/after, an ambient client cannot reach the isolated
 singleton, and removing the root removes every trace.

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -75,7 +75,13 @@ identity along with it, and nothing validates or proves it.
 
 Unsetting `YOETZ_ISOLATED_ROOT` restores ambient resolution with no residue: every artifact an
 isolated runtime creates lives beneath the root, so deleting the root is complete rollback and
-cannot touch unrelated user state. The packaged regression
+cannot touch unrelated user state. One explicit exemption (issue #534): a dedicated Codex
+evaluator home that the operator passes by path to `yoetz provider codex-subscription setup
+--codex-home` may live outside the root and be reused across runs. It holds Codex-owned OAuth
+state and no Yoetz identity, state, endpoint, or storage, so deleting the root still removes every
+Yoetz artifact; that home is reverse-stated by `yoetz provider codex-subscription disconnect`, and
+the parity gate still fails on any shared Yoetz identity. The default evaluator home (no explicit
+path) stays beneath the root. The packaged regression
 (`tests/packaging/test_isolated_root_boundary.py`) locks this: an isolated service run leaves the
 ambient home tree byte-identical before/after, an ambient client cannot reach the isolated
 singleton, and removing the root removes every trace.

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -79,7 +79,7 @@ cannot touch unrelated user state. One explicit exemption (issue #534): a dedica
 evaluator home that the operator passes by path to `yoetz provider codex-subscription setup
 --codex-home` may live outside the root and be reused across runs. It holds Codex-owned OAuth
 state and no Yoetz identity, state, endpoint, or storage, so deleting the root still removes every
-Yoetz artifact; that home is reverse-stated by `yoetz provider codex-subscription disconnect`, and
+Yoetz artifact; that home's reverse state is `yoetz provider codex-subscription disconnect`, and
 the parity gate still fails on any shared Yoetz identity. The default evaluator home (no explicit
 path) stays beneath the root. The packaged regression
 (`tests/packaging/test_isolated_root_boundary.py`) locks this: an isolated service run leaves the

--- a/docs/runbooks/codex-dogfood.md
+++ b/docs/runbooks/codex-dogfood.md
@@ -29,6 +29,16 @@ the machine on its own, authenticate the report author, or upgrade a digest into
   defaults are not a substitute because the normal target may relocate its config or storage.
 - Rollback of Yoetz state is deleting the isolation root: every artifact of the isolated runtime
   lives beneath it. Stop only processes the runner started, then remove the root.
+- Two Codex homes have different lifetimes. The **host** Codex home (the one carrying the plugin,
+  MCP activation, and hooks under test) is per run and lives beneath the run directory. The
+  **evaluator** home bound by `yoetz provider codex-subscription setup --codex-home <dir>` holds
+  Codex-owned ChatGPT OAuth state and no Yoetz identity, so it may be a stable owner-private
+  directory outside the isolation root that later runs pass again; `setup` then reuses the
+  existing sign-in (`login_reused: true`) instead of opening a new challenge. Record it through
+  its `codex_home_digest`; never use the ambient user Codex home or the host home for it, and log
+  it out with `yoetz provider codex-subscription disconnect`, not by deleting the root. Without an
+  explicit `--codex-home`, the default evaluator home resolves beneath the isolation root and is
+  therefore fresh — and asks for sign-in — on every run.
 - The exact worktree passed to Codex is also passed to plugin status, observation status, consent,
   mapping, drain, and session-stream reconciliation. Never substitute the primary checkout.
 - Observation consent is independent trusted-local authority. Do not copy its database row, reuse

--- a/docs/runbooks/codex-subscription-evaluator.md
+++ b/docs/runbooks/codex-subscription-evaluator.md
@@ -48,17 +48,25 @@ treats a sign-in as something to prove, not something to repeat (#534): after th
 and `prepare_codex_home`, it runs the same structural probe as `status` — app-server
 `account/read` with `refreshToken: false` followed by `model/list` — and, when Codex reports a
 ChatGPT account with the exact model/reasoning cell available, writes the binding and returns
-`login_reused: true` without issuing `account/login/start`. A logged-out home, a missing model, or
-an unproven cleanup still takes the ordinary login path or fails with its existing token; a
-dedicated home whose `config.toml` differs still fails `codex_runtime_config_conflict` before any
-process starts. `--switch-account` (the prompt-loop "switch ChatGPT account" confirmation and the
-`/provider` "Switch Codex ChatGPT account" choice) is the explicit override: it logs the home out through Codex and signs in again. Yoetz never reads,
-copies, or moves `auth.json`; readiness is only what Codex answers.
+`login_reused: true` without issuing `account/login/start`. The three non-reuse edges are distinct:
+a logged-out home or a home missing the exact model takes the ordinary login path, which still
+fails with its existing `codex_subscription_readiness_unproven` token when the login cannot prove
+the cell; a probe whose process-group cleanup is unconfirmed fails closed with that same token
+*before* any further child launch, never falling through to login; and a dedicated home whose
+`config.toml` differs still fails `codex_runtime_config_conflict` before any process starts. A
+probe that cannot complete at all — an unreachable or unanswering app-server, an expired
+capability cell — fails with its own bounded token rather than silently opening a login.
+`--switch-account` (the prompt-loop "switch ChatGPT account" confirmation and the `/provider`
+"Switch Codex ChatGPT account" choice) is the explicit override: it skips the probe, logs the home
+out through Codex, and signs in again. Yoetz never reads, copies, or moves `auth.json`; readiness
+is only what Codex answers.
 
 The dedicated evaluator home may be reused across runs, including isolated dogfood runs, by
 passing the same owner-private directory to `--codex-home`. The parity report identifies it by
 its existing `codex_home_digest`. It must remain a dedicated home — never the ambient user Codex
-home and never the per-run host home — and `disconnect` remains the way to log it out.
+home and never the per-run host home — and `disconnect` remains the way to log it out. Because a
+reused home outlives the isolation root, its full teardown is `disconnect` followed by the
+operator deleting that directory; deleting the isolation root does not remove it (ADR-026).
 
 ## Selected executable resolution
 

--- a/docs/runbooks/codex-subscription-evaluator.md
+++ b/docs/runbooks/codex-subscription-evaluator.md
@@ -51,8 +51,8 @@ ChatGPT account with the exact model/reasoning cell available, writes the bindin
 `login_reused: true` without issuing `account/login/start`. A logged-out home, a missing model, or
 an unproven cleanup still takes the ordinary login path or fails with its existing token; a
 dedicated home whose `config.toml` differs still fails `codex_runtime_config_conflict` before any
-process starts. `--switch-account` (the prompt-loop and `/provider` "switch account" choice) is
-the explicit override: it logs the home out through Codex and signs in again. Yoetz never reads,
+process starts. `--switch-account` (the prompt-loop "switch ChatGPT account" confirmation and the
+`/provider` "Switch Codex ChatGPT account" choice) is the explicit override: it logs the home out through Codex and signs in again. Yoetz never reads,
 copies, or moves `auth.json`; readiness is only what Codex answers.
 
 The dedicated evaluator home may be reused across runs, including isolated dogfood runs, by

--- a/docs/runbooks/codex-subscription-evaluator.md
+++ b/docs/runbooks/codex-subscription-evaluator.md
@@ -41,6 +41,25 @@ yoetz provider codex-subscription disconnect --accept
 yoetz provider codex-subscription rollback
 ```
 
+### Login lives once per dedicated home
+
+Codex owns the OAuth state of the dedicated home (`auth.json`, refresh, logout). `setup` therefore
+treats a sign-in as something to prove, not something to repeat (#534): after the local preflight
+and `prepare_codex_home`, it runs the same structural probe as `status` — app-server
+`account/read` with `refreshToken: false` followed by `model/list` — and, when Codex reports a
+ChatGPT account with the exact model/reasoning cell available, writes the binding and returns
+`login_reused: true` without issuing `account/login/start`. A logged-out home, a missing model, or
+an unproven cleanup still takes the ordinary login path or fails with its existing token; a
+dedicated home whose `config.toml` differs still fails `codex_runtime_config_conflict` before any
+process starts. `--switch-account` (the prompt-loop and `/provider` "switch account" choice) is
+the explicit override: it logs the home out through Codex and signs in again. Yoetz never reads,
+copies, or moves `auth.json`; readiness is only what Codex answers.
+
+The dedicated evaluator home may be reused across runs, including isolated dogfood runs, by
+passing the same owner-private directory to `--codex-home`. The parity report identifies it by
+its existing `codex_home_digest`. It must remain a dedicated home — never the ambient user Codex
+home and never the per-run host home — and `disconnect` remains the way to log it out.
+
 ## Selected executable resolution
 
 Pass one absolute selected path. The supported npm layouts are:

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -50,9 +50,12 @@ executable, and exact SHA-256 digest; a direct native path does not bypass those
 
 Before opening a browser, Yoetz shows the resolved native executable and SHA-256 digest, Codex
 version, dedicated evaluator home, model and reasoning effort, OpenAI destination, unknown
-plan-specific data-use posture, privacy implications, and the reverse commands. The explicit
-confirmation starts Codex's documented browser login, which may remain open for its full 600-second
-window. Add `--device-code --no-open-browser` to use Codex's device-code flow instead; that flow
+plan-specific data-use posture, privacy implications, and the reverse commands. After the explicit
+confirmation, Yoetz first asks Codex whether that dedicated home is already signed in with the
+selected model available; if it is, the binding is written without a new sign-in and the result
+reports `login_reused: true`. Otherwise the confirmation starts Codex's documented browser login,
+which may remain open for its full 600-second window. `--switch-account` always logs the
+dedicated home out and signs in again. Add `--device-code --no-open-browser` to use Codex's device-code flow instead; that flow
 may remain open for its full 900-second window. Cancellation and timeout use bounded process-group,
 pipe, and task cleanup and return one closed diagnostic. Codex owns the login, refresh, credential
 file, and logout; Yoetz neither receives nor stores the OAuth credential.

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -57,8 +57,9 @@ reports `login_reused: true`. Otherwise the confirmation starts Codex's document
 which may remain open for its full 600-second window. `--switch-account` always logs the
 dedicated home out and signs in again. Add `--device-code --no-open-browser` to use Codex's
 device-code flow instead; that flow may remain open for its full 900-second window. Cancellation
-and timeout use bounded process-group, pipe, and task cleanup and return one closed diagnostic. Codex owns the login, refresh, credential
-file, and logout; Yoetz neither receives nor stores the OAuth credential.
+and timeout use bounded process-group, pipe, and task cleanup and return one closed diagnostic.
+Codex owns the login, refresh, credential file, and logout; Yoetz neither receives nor stores the
+OAuth credential.
 
 A timeout, denial, malformed completion, process exit, cancellation, or later write failure never
 persists a partial Yoetz binding. If Codex completed login before a later failure, Codex may retain

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -55,9 +55,9 @@ confirmation, Yoetz first asks Codex whether that dedicated home is already sign
 selected model available; if it is, the binding is written without a new sign-in and the result
 reports `login_reused: true`. Otherwise the confirmation starts Codex's documented browser login,
 which may remain open for its full 600-second window. `--switch-account` always logs the
-dedicated home out and signs in again. Add `--device-code --no-open-browser` to use Codex's device-code flow instead; that flow
-may remain open for its full 900-second window. Cancellation and timeout use bounded process-group,
-pipe, and task cleanup and return one closed diagnostic. Codex owns the login, refresh, credential
+dedicated home out and signs in again. Add `--device-code --no-open-browser` to use Codex's
+device-code flow instead; that flow may remain open for its full 900-second window. Cancellation
+and timeout use bounded process-group, pipe, and task cleanup and return one closed diagnostic. Codex owns the login, refresh, credential
 file, and logout; Yoetz neither receives nor stores the OAuth credential.
 
 A timeout, denial, malformed completion, process exit, cancellation, or later write failure never

--- a/docs/usage/terminal-interface.md
+++ b/docs/usage/terminal-interface.md
@@ -187,8 +187,10 @@ review on.
 API-provider keys are entered through the secure prompt described under *Secrets* below. For a
 subscription, `/provider` asks for the exact Codex executable, dedicated evaluator home, model, and
 reasoning effort; validates the supported digest-bound cell; shows destination, plan/terms notice,
-privacy boundary, disconnect, rollback, and optional account switch; then suspends the UI for
-Codex's browser flow. OAuth credentials never pass through a widget or Yoetz vault. After setup,
+privacy boundary, disconnect, rollback, and optional account switch; then suspends the UI while
+Codex proves the existing sign-in or, when the home is not signed in, runs its browser flow. The
+result says which of the two happened. OAuth credentials never pass through a widget or Yoetz
+vault. After setup,
 disconnect, or rollback, the local service is recomposed so a running daemon cannot keep the old
 cell.
 

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -2764,7 +2764,10 @@ def provider_codex_subscription_setup(
         if switch_account:
             typer.echo("  existing sign-in: logged out first, then a new Codex sign-in")
         else:
-            typer.echo("  existing sign-in: reused when Codex reports the home already signed in")
+            typer.echo(
+                "  existing sign-in: reused when Codex reports the home already signed in;"
+                " pass --switch-account to sign in again"
+            )
         if not accept:
             if not (sys.stdin.isatty() and sys.stdout.isatty()) or not typer.confirm(
                 "Continue to Codex sign-in?", default=False

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -2723,7 +2723,11 @@ def provider_codex_subscription_setup(
         bool, typer.Option("--open-browser/--no-open-browser", help="Open Codex's returned URL.")
     ] = True,
     switch_account: Annotated[
-        bool, typer.Option("--switch-account", help="Log out the dedicated home before login.")
+        bool,
+        typer.Option(
+            "--switch-account",
+            help="Log out the dedicated home and sign in again, even if it is already signed in.",
+        ),
     ] = False,
     accept: Annotated[
         bool,
@@ -2757,6 +2761,10 @@ def provider_codex_subscription_setup(
         typer.echo("  Yoetz sends only a privacy-approved case; Codex owns the upstream body.")
         typer.echo("  disconnect: yoetz provider codex-subscription disconnect")
         typer.echo("  rollback only: yoetz provider codex-subscription rollback")
+        if switch_account:
+            typer.echo("  existing sign-in: logged out first, then a new Codex sign-in")
+        else:
+            typer.echo("  existing sign-in: reused when Codex reports the home already signed in")
         if not accept:
             if not (sys.stdin.isatty() and sys.stdout.isatty()) or not typer.confirm(
                 "Continue to Codex sign-in?", default=False

--- a/src/yoetz/cli/app.py
+++ b/src/yoetz/cli/app.py
@@ -2735,7 +2735,7 @@ def provider_codex_subscription_setup(
     ] = False,
     json_output: _JSON = False,
 ) -> None:
-    """Login via Codex app-server and bind the exact subscription runtime after readiness."""
+    """Prove an existing Codex login (or obtain one) via app-server, then bind the exact runtime."""
 
     from yoetz.cli.codex_subscription import (
         CODEX_EVALUATOR_CAPABILITY_CELL_SHA256,

--- a/src/yoetz/cli/codex_subscription.py
+++ b/src/yoetz/cli/codex_subscription.py
@@ -385,6 +385,12 @@ def _profile(binding: ExternalRuntimeProfileConfig) -> CodexAppServerProfile:
     return CodexAppServerProfile.from_config(binding)
 
 
+def _already_ready(status: CodexRuntimeStatus) -> bool:
+    """Codex proved a ChatGPT login and the exact model/reasoning cell for this home."""
+
+    return status.runtime_ready and status.auth_mode == "chatgpt" and status.model_available
+
+
 def _safe_status(
     binding: ExternalRuntimeProfileConfig, status: CodexRuntimeStatus
 ) -> dict[str, JsonValue]:
@@ -423,12 +429,20 @@ async def codex_subscription_setup(
     switch_account: bool,
     config_path: Path | None = None,
 ) -> dict[str, JsonValue]:
-    """Validate the binding and its persistence, login through Codex, then persist it.
+    """Validate the binding and its persistence, prove or obtain Codex login, then persist it.
 
     Every deterministic local requirement — the exact runtime cell, the canonical target
     configuration, and a render-validated, lock-probed write of the staged binding — is proven
-    before the Codex login flow opens, so a configuration failure can never follow login side
+    before any Codex process starts, so a configuration failure can never follow login side
     effects (#520).
+
+    Login is Codex-owned state that lives once per dedicated home. Unless the caller asked to
+    switch accounts, the same structural probe ``status`` uses (app-server ``account/read`` with
+    ``refreshToken: false`` and ``model/list``) runs first; a home Codex already reports as
+    signed in with the exact model cell available is bound without a new ``account/login/start``
+    challenge (#534). Yoetz still never reads or copies ``auth.json``: readiness is only ever what
+    Codex itself answers. ``switch_account`` remains the explicit override that logs the home out
+    and signs in again.
     """
 
     binding = _binding(
@@ -448,10 +462,25 @@ async def codex_subscription_setup(
     )
     prepare_codex_home(codex_home)
     profile = _profile(binding)
+    login_reused = False
     if switch_account:
         logout_status = await codex_logout(profile)
         if logout_status.cleanup == "failed":
             raise ValueError("codex_logout_unconfirmed")
+        status: CodexRuntimeStatus | None = None
+    else:
+        status = await codex_account_status(profile)
+        if status.cleanup == "failed":
+            raise ValueError("codex_subscription_readiness_unproven")
+        if _already_ready(status):
+            login_reused = True
+            typer.echo("")
+            typer.echo(
+                "Codex reports this dedicated home is already signed in with the exact model "
+                "available; reusing it without a new sign-in."
+            )
+        else:
+            status = None
 
     def present(challenge: CodexLoginChallenge) -> None:
         typer.echo("")
@@ -463,9 +492,10 @@ async def codex_subscription_setup(
             if not webbrowser.open(challenge.url):
                 raise ValueError("codex_login_browser_unavailable")
 
-    status = await codex_login(profile, mode=login_mode, present_challenge=present)
-    if status.auth_mode != "chatgpt" or not status.model_available or status.cleanup == "failed":
-        raise ValueError("codex_subscription_readiness_unproven")
+    if status is None:
+        status = await codex_login(profile, mode=login_mode, present_challenge=present)
+        if not _already_ready(status) or status.cleanup == "failed":
+            raise ValueError("codex_subscription_readiness_unproven")
     _bounded_config_operation(
         lambda: write_config_toml_if_unchanged(
             external_runtime_binding_config(binding, base=base),
@@ -473,7 +503,9 @@ async def codex_subscription_setup(
             path=target,
         )
     )
-    return _safe_status(binding, status)
+    result = _safe_status(binding, status)
+    result["login_reused"] = login_reused
+    return result
 
 
 async def prompt_codex_subscription_setup() -> dict[str, JsonValue]:
@@ -518,10 +550,11 @@ async def prompt_codex_subscription_setup() -> dict[str, JsonValue]:
     typer.echo("  Yoetz receives no OAuth credential and cannot observe the upstream body")
     typer.echo(f"  disconnect: {preview['disconnect_command']}")
     typer.echo(f"  rollback only: {preview['rollback_command']}")
+    typer.echo("  a dedicated home Codex already reports signed in is reused without a new sign-in")
     if not typer.confirm("Continue to Codex sign-in?", default=False):
         raise ValueError("cancelled")
     switch_account = typer.confirm(
-        "Log out the dedicated home first (switch ChatGPT account)?",
+        "Log out the dedicated home first and sign in again (switch ChatGPT account)?",
         default=False,
     )
     return await codex_subscription_setup(

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -1955,6 +1955,7 @@ async def _interactive_provider_setup(
                 "plan_type": status.get("plan_type"),
                 "model_available": status.get("model_available"),
                 "process_cleanup": status.get("process_cleanup"),
+                "login_reused": status.get("login_reused") is True,
             }
         )
         service = await _restart_service_for_semantic_composition()
@@ -2783,6 +2784,8 @@ def _emit_human_report(report: dict[str, JsonValue]) -> None:
         credential = provider.get("credential")
         if credential == "external_runtime_oauth":
             typer.echo("  Credential authority: Codex-managed ChatGPT login")
+            if provider.get("login_reused") is True:
+                typer.echo("  Sign-in: reused the existing Codex login")
         else:
             typer.echo(
                 "  Credential: "

--- a/src/yoetz/tui/app.py
+++ b/src/yoetz/tui/app.py
@@ -1355,6 +1355,11 @@ class YoetzTui(App[int]):
                 *body,
                 "This will log out the dedicated home first, then open Codex sign-in.",
             )
+        else:
+            body = (
+                *body,
+                "A home Codex already reports signed in is reused without a new sign-in.",
+            )
         confirmed = await self.ask(
             ApprovalView(
                 name="codex-subscription-confirm",
@@ -1387,10 +1392,16 @@ class YoetzTui(App[int]):
         except RuntimeError_ as error:
             self._report(error)
             return
+        sign_in = (
+            "reused the existing Codex login"
+            if status.get("login_reused") is True
+            else "completed through Codex"
+        )
         self.say(
             Level.VERIFIED,
             "Codex subscription binding is ready",
             (
+                f"Sign-in: {sign_in}",
                 f"Auth mode: {status.get('auth_mode')}",
                 f"Plan: {status.get('plan_type') or 'not reported'}",
                 f"Model available: {status.get('model_available')}",

--- a/src/yoetz/tui/app.py
+++ b/src/yoetz/tui/app.py
@@ -1359,6 +1359,7 @@ class YoetzTui(App[int]):
             body = (
                 *body,
                 "A home Codex already reports signed in is reused without a new sign-in.",
+                'Choose "Switch Codex ChatGPT account" instead to sign in as someone else.',
             )
         confirmed = await self.ask(
             ApprovalView(

--- a/tests/builders/tui_runtime.py
+++ b/tests/builders/tui_runtime.py
@@ -347,6 +347,8 @@ class FakeRuntime:
             "reasoning_effort": reasoning_effort,
         }
 
+    subscription_login_reused: bool = False
+
     async def setup_codex_subscription(
         self,
         executable: str,
@@ -364,6 +366,7 @@ class FakeRuntime:
             "plan_type": "plus",
             "model_available": True,
             "process_cleanup": "terminated",
+            "login_reused": self.subscription_login_reused and not switch_account,
         }
 
     async def codex_subscription_status(self) -> dict[str, object]:

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -2497,6 +2497,33 @@ def test_human_report_omits_a_credential_reason_once_the_credential_is_stored(
     assert "Credential reason:" not in _plain(capsys.readouterr().out)
 
 
+@pytest.mark.parametrize("login_reused", [True, False])
+def test_human_report_states_whether_the_codex_sign_in_was_reused(
+    capsys: pytest.CaptureFixture[str], login_reused: bool
+) -> None:
+    """First-run must say when setup reused the dedicated home's existing Codex login (#534)."""
+
+    import yoetz.cli.setup as setup_module
+
+    setup_module._emit_human_report(  # pyright: ignore[reportPrivateUsage]
+        {
+            "registration": {"outcome": "already_registered"},
+            "service": {"reachable": True, "state": "ready"},
+            "provider": {
+                "binding": "configured",
+                "credential": "external_runtime_oauth",
+                "login_reused": login_reused,
+            },
+            "integration": {},
+            "next_steps": [],
+        }
+    )
+
+    plain = _plain(capsys.readouterr().out)
+    assert "Credential authority: Codex-managed ChatGPT login" in plain
+    assert ("Sign-in: reused the existing Codex login" in plain) is login_reused
+
+
 def test_blocked_privacy_step_reports_its_own_reason_for_the_credential(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/tui/test_commands.py
+++ b/tests/tui/test_commands.py
@@ -8,7 +8,7 @@ import pytest
 
 from builders.tui_runtime import RECOMMEND_PRIVATE, FakeRuntime
 from yoetz.tui.app import YoetzTui
-from yoetz.tui.models import CheckMode, PrivacyPosture, ProviderPosture
+from yoetz.tui.models import CheckMode, PrivacyPosture, ProviderOption, ProviderPosture
 
 pytestmark = pytest.mark.anyio
 
@@ -512,6 +512,49 @@ async def test_provider_can_switch_the_codex_account(make_app: MakeApp) -> None:
         await pilot.press("enter")
         await pilot.pause()
         assert runtime.subscription_actions == ["switch"]
+
+
+async def test_provider_discloses_and_reports_a_reused_codex_login(make_app: MakeApp) -> None:
+    """Setup on a home Codex already reports signed in reuses it and says so (#534)."""
+
+    runtime = FakeRuntime()
+    runtime.subscription_login_reused = True
+    base_options = runtime.provider_options()
+    codex_option = ProviderOption(
+        choice="codex_subscription",
+        label="Codex with ChatGPT subscription",
+        provider_id="openai-codex",
+        host="openai.com",
+        base_path_prefix=" through Codex-managed login",
+        default_model="gpt-5.6-sol",
+        api_style="Codex app-server v2 (stdio)",
+        endpoint_profile_id="codex-chatgpt-subscription",
+        endpoint_profile_version="1.0.0",
+    )
+    runtime.provider_options = lambda: (*base_options, codex_option)  # type: ignore[method-assign]
+    app = make_app(runtime=runtime)
+    async with app.run_test(size=WIDE) as pilot:
+        await pilot.pause()
+        await run_command(pilot, app, "/provider")
+        view = app.open_view
+        assert view is not None
+        view.filter("Codex with ChatGPT subscription")  # type: ignore[attr-defined]
+        await pilot.press("enter")
+        await pilot.pause()
+        for _ in range(4):
+            await pilot.press("enter")
+            await pilot.pause()
+        view = app.open_view
+        assert view is not None
+        body = " ".join(getattr(view, "body", ()) or getattr(view, "_body", ()))
+        assert "reused without a new sign-in" in body.casefold()
+        assert "log out the dedicated home first" not in body.casefold()
+        await pilot.press("up")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert runtime.subscription_actions == ["setup"]
+        assert "reused the existing Codex login" in transcript(app)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_codex_subscription.py
+++ b/tests/unit/cli/test_codex_subscription.py
@@ -62,6 +62,62 @@ def _binding(executable: Path, home: Path):
     )
 
 
+async def _logged_out_probe(_profile: object) -> CodexRuntimeStatus:
+    """The pre-login readiness probe for a dedicated home Codex reports as logged out."""
+
+    return CodexRuntimeStatus(True, None, None, False, "terminated")
+
+
+def _stub_setup_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    binding: ExternalRuntimeProfileConfig,
+    written: list[object],
+) -> None:
+    """Replace every local persistence step of ``setup`` with recording stubs."""
+
+    def build_binding(**_kwargs: object) -> ExternalRuntimeProfileConfig:
+        return binding
+
+    def build_profile(_binding: ExternalRuntimeProfileConfig) -> object:
+        return object()
+
+    def write_binding(_config: YoetzConfig, **_kwargs: object) -> Path:
+        written.append(binding)
+        return tmp_path / "config.toml"
+
+    def snapshot(_path: Path) -> tuple[YoetzConfig, bytes | None]:
+        return YoetzConfig(), None
+
+    def preflight(*_args: object, **_kwargs: object) -> Path:
+        return tmp_path / "config.toml"
+
+    def prepare(_home: Path) -> None:
+        return None
+
+    monkeypatch.setattr(module, "_binding", build_binding)
+    monkeypatch.setattr(module, "_profile", build_profile)
+    monkeypatch.setattr(module, "_config_snapshot", snapshot)
+    monkeypatch.setattr(module, "preflight_config_write", preflight)
+    monkeypatch.setattr(module, "prepare_codex_home", prepare)
+    monkeypatch.setattr(module, "write_config_toml_if_unchanged", write_binding)
+
+
+async def _run_setup(
+    tmp_path: Path, *, switch_account: bool = False, config_path: Path | None = None
+) -> Mapping[str, object]:
+    return await module.codex_subscription_setup(
+        executable=tmp_path / "codex",
+        codex_home=tmp_path / "dedicated-home",
+        model="gpt-5.6-sol",
+        reasoning_effort="high",
+        login_mode="browser",
+        open_browser=False,
+        switch_account=switch_account,
+        config_path=config_path,
+    )
+
+
 def _write_codex_package_layout(
     root: Path,
     *,
@@ -413,6 +469,7 @@ async def test_setup_persists_binding_only_after_codex_confirms_chatgpt_readines
     async def login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
         return CodexRuntimeStatus(True, "chatgpt", "plus", True, "terminated")
 
+    monkeypatch.setattr(module, "codex_account_status", _logged_out_probe)
     monkeypatch.setattr(module, "codex_login", login)
     monkeypatch.setattr(module, "write_config_toml_if_unchanged", write_binding)
 
@@ -466,6 +523,7 @@ async def test_setup_failure_never_writes_a_binding(
     async def login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
         return CodexRuntimeStatus(True, None, None, False, "terminated")
 
+    monkeypatch.setattr(module, "codex_account_status", _logged_out_probe)
     monkeypatch.setattr(module, "codex_login", login)
     monkeypatch.setattr(module, "write_config_toml_if_unchanged", forbidden_write)
 
@@ -505,6 +563,7 @@ async def test_setup_preserves_a_concurrent_config_edit_during_login(
         target.write_text("# concurrent config edit\n", encoding="utf-8")
         return CodexRuntimeStatus(True, "chatgpt", "plus", True, "terminated")
 
+    monkeypatch.setattr(module, "codex_account_status", _logged_out_probe)
     monkeypatch.setattr(module, "codex_login", login)
 
     with pytest.raises(ValueError, match="config_preimage_mismatch"):
@@ -808,6 +867,253 @@ def test_guided_setup_offers_account_switch(
     assert any(item.startswith("Continue to Codex sign-in") for item in confirms)
     assert any("switch ChatGPT account" in item for item in confirms)
     assert captured == [True]
+
+
+@pytest.mark.anyio
+async def test_setup_reuses_an_already_signed_in_dedicated_home_without_a_login_challenge(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The second setup against the same logged-in home must not open a sign-in (#534)."""
+
+    binding = _binding(tmp_path / "codex", tmp_path / "dedicated-home")
+    written: list[object] = []
+    _stub_setup_persistence(monkeypatch, tmp_path, binding, written)
+    calls: list[str] = []
+
+    async def probe(_profile: object) -> CodexRuntimeStatus:
+        calls.append("account_status")
+        return CodexRuntimeStatus(True, "chatgpt", "plus", True, "terminated")
+
+    async def forbidden_login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
+        pytest.fail("a home Codex reports as signed in must not receive a new login challenge")
+
+    async def forbidden_logout(_profile: object) -> CodexRuntimeStatus:
+        pytest.fail("reuse must not log the dedicated home out")
+
+    monkeypatch.setattr(module, "codex_account_status", probe)
+    monkeypatch.setattr(module, "codex_login", forbidden_login)
+    monkeypatch.setattr(module, "codex_logout", forbidden_logout)
+
+    result = await _run_setup(tmp_path)
+
+    assert calls == ["account_status"]
+    assert written == [binding]
+    assert result["login_reused"] is True
+    assert result["auth_mode"] == "chatgpt"
+    assert result["model_available"] is True
+    assert result["process_cleanup"] == "terminated"
+
+
+@pytest.mark.anyio
+async def test_setup_reports_a_completed_login_as_not_reused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binding = _binding(tmp_path / "codex", tmp_path / "dedicated-home")
+    written: list[object] = []
+    _stub_setup_persistence(monkeypatch, tmp_path, binding, written)
+    calls: list[str] = []
+
+    async def probe(_profile: object) -> CodexRuntimeStatus:
+        calls.append("account_status")
+        return CodexRuntimeStatus(True, None, None, False, "terminated")
+
+    async def login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
+        calls.append("login")
+        return CodexRuntimeStatus(True, "chatgpt", "plus", True, "terminated")
+
+    monkeypatch.setattr(module, "codex_account_status", probe)
+    monkeypatch.setattr(module, "codex_login", login)
+
+    result = await _run_setup(tmp_path)
+
+    assert calls == ["account_status", "login"]
+    assert written == [binding]
+    assert result["login_reused"] is False
+
+
+@pytest.mark.anyio
+async def test_setup_signed_in_home_without_the_exact_model_still_takes_the_login_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reuse needs the whole cell proven: a login without the model is not readiness."""
+
+    binding = _binding(tmp_path / "codex", tmp_path / "dedicated-home")
+    written: list[object] = []
+    _stub_setup_persistence(monkeypatch, tmp_path, binding, written)
+    calls: list[str] = []
+
+    async def probe(_profile: object) -> CodexRuntimeStatus:
+        calls.append("account_status")
+        return CodexRuntimeStatus(True, "chatgpt", "plus", False, "terminated")
+
+    async def login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
+        calls.append("login")
+        return CodexRuntimeStatus(True, "chatgpt", "plus", False, "terminated")
+
+    monkeypatch.setattr(module, "codex_account_status", probe)
+    monkeypatch.setattr(module, "codex_login", login)
+
+    with pytest.raises(ValueError, match="codex_subscription_readiness_unproven"):
+        await _run_setup(tmp_path)
+
+    assert calls == ["account_status", "login"]
+    assert written == []
+
+
+@pytest.mark.anyio
+async def test_setup_switch_account_always_logs_out_and_signs_in_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binding = _binding(tmp_path / "codex", tmp_path / "dedicated-home")
+    written: list[object] = []
+    _stub_setup_persistence(monkeypatch, tmp_path, binding, written)
+    calls: list[str] = []
+
+    async def forbidden_probe(_profile: object) -> CodexRuntimeStatus:
+        pytest.fail("switching accounts must not consult the current login")
+
+    async def logout(_profile: object) -> CodexRuntimeStatus:
+        calls.append("logout")
+        return CodexRuntimeStatus(True, None, None, False, "terminated")
+
+    async def login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
+        calls.append("login")
+        return CodexRuntimeStatus(True, "chatgpt", "plus", True, "terminated")
+
+    monkeypatch.setattr(module, "codex_account_status", forbidden_probe)
+    monkeypatch.setattr(module, "codex_logout", logout)
+    monkeypatch.setattr(module, "codex_login", login)
+
+    result = await _run_setup(tmp_path, switch_account=True)
+
+    assert calls == ["logout", "login"]
+    assert written == [binding]
+    assert result["login_reused"] is False
+
+
+@pytest.mark.anyio
+async def test_setup_unconfirmed_probe_cleanup_fails_closed_before_login_or_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binding = _binding(tmp_path / "codex", tmp_path / "dedicated-home")
+    written: list[object] = []
+    _stub_setup_persistence(monkeypatch, tmp_path, binding, written)
+
+    async def probe(_profile: object) -> CodexRuntimeStatus:
+        return CodexRuntimeStatus(True, "chatgpt", "plus", True, "failed")
+
+    async def forbidden_login(*_args: object, **_kwargs: object) -> CodexRuntimeStatus:
+        pytest.fail("a probe whose process group is unconfirmed must not launch another child")
+
+    monkeypatch.setattr(module, "codex_account_status", probe)
+    monkeypatch.setattr(module, "codex_login", forbidden_login)
+
+    with pytest.raises(ValueError, match="codex_subscription_readiness_unproven"):
+        await _run_setup(tmp_path)
+
+    assert written == []
+
+
+class _SignedInAppServer:
+    """Fake app-server v2 runtime whose dedicated home Codex already reports as signed in."""
+
+    def __init__(self, profile: object) -> None:
+        self.profile = profile
+        self.workdir = Path("/private/empty-setup-attempt")
+        self.pending_notifications: list[dict[str, object]] = []
+        self.methods: list[str] = []
+        self.sent: list[dict[str, object]] = []
+
+    async def send(self, value: dict[str, object]) -> None:
+        self.sent.append(value)
+
+    async def request(
+        self, request_id: int, method: str, params: object, timeout: float
+    ) -> Mapping[str, object]:
+        del request_id, timeout
+        self.methods.append(method)
+        if method == "initialize":
+            return {
+                "codexHome": str(getattr(self.profile, "codex_home")),
+                "userAgent": "yoetz_semantic_evaluator/0.150.1",
+            }
+        if method == "account/read":
+            assert params == {"refreshToken": False}
+            return {"account": {"type": "chatgpt", "planType": "plus", "email": "x@y"}}
+        if method == "model/list":
+            return {
+                "data": [
+                    {
+                        "id": "gpt-5.6-sol",
+                        "supportedReasoningEfforts": [{"reasoningEffort": "high"}],
+                    }
+                ],
+                "nextCursor": None,
+            }
+        pytest.fail(f"unexpected app-server request {method}")
+
+    async def read(self, timeout: float) -> dict[str, object]:
+        del timeout
+        pytest.fail("a reused login must not wait on login notifications")
+
+
+@pytest.mark.anyio
+async def test_setup_against_fake_app_server_reads_account_and_never_starts_login(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End to end through the real adapter: ``account/read`` ready means no ``account/login/start``."""
+
+    from yoetz.adapters.providers import codex_app_server
+
+    executable = tmp_path / "codex"
+    home = tmp_path / "dedicated-home"
+    target = tmp_path / "config.toml"
+    target.write_text(_data_dir_config_text(tmp_path / "state"), encoding="utf-8")
+    binding = _binding(executable, home)
+    runtimes: list[_SignedInAppServer] = []
+
+    def build_binding(**_kwargs: object) -> ExternalRuntimeProfileConfig:
+        return binding
+
+    async def launch(profile: object) -> _SignedInAppServer:
+        runtime = _SignedInAppServer(profile)
+        runtimes.append(runtime)
+        return runtime
+
+    async def cleanup(value: object) -> str:
+        assert value is runtimes[-1]
+        return "terminated"
+
+    monkeypatch.setattr(module, "_binding", build_binding)
+    monkeypatch.setattr(codex_app_server, "_launch", launch)
+    monkeypatch.setattr(codex_app_server, "_cleanup", cleanup)
+
+    result = await _run_setup(tmp_path, config_path=target)
+
+    assert [runtime.methods for runtime in runtimes] == [
+        ["initialize", "account/read", "model/list"]
+    ]
+    assert "account/login/start" not in runtimes[0].methods
+    assert result["login_reused"] is True
+    assert result["auth_mode"] == "chatgpt"
+    assert (home / "config.toml").read_bytes() == codex_app_server.CODEX_EVALUATOR_CONFIG.encode()
+    rewritten = module._base_config(target)  # pyright: ignore[reportPrivateUsage]
+    assert rewritten.external_runtime is not None
+    assert rewritten.external_runtime.codex_home == str(home)
+    assert "x@y" not in json.dumps(result)
+
+
+def test_setup_rejects_a_reused_home_whose_config_differs_before_any_process(
+    tmp_path: Path,
+) -> None:
+    from yoetz.adapters.providers.codex_app_server import prepare_codex_home
+
+    home = tmp_path / "dedicated-home"
+    home.mkdir(mode=0o700)
+    (home / "config.toml").write_text('model = "other"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="codex_runtime_config_conflict"):
+        prepare_codex_home(home)
 
 
 def _data_dir_config_text(data_dir: Path) -> str:

--- a/tests/unit/cli/test_codex_subscription.py
+++ b/tests/unit/cli/test_codex_subscription.py
@@ -1084,7 +1084,12 @@ async def test_setup_against_fake_app_server_reads_account_and_never_starts_logi
         assert value is runtimes[-1]
         return "terminated"
 
+    def allow_private_bundle(_path: Path) -> None:
+        # pytest's temp root is shared temp on Linux; the owner-only gate is locked elsewhere.
+        return None
+
     monkeypatch.setattr(module, "_binding", build_binding)
+    monkeypatch.setattr(codex_app_server, "verify_private_local_bundle", allow_private_bundle)
     monkeypatch.setattr(codex_app_server, "_launch", launch)
     monkeypatch.setattr(codex_app_server, "_cleanup", cleanup)
 
@@ -1104,10 +1109,15 @@ async def test_setup_against_fake_app_server_reads_account_and_never_starts_logi
 
 
 def test_setup_rejects_a_reused_home_whose_config_differs_before_any_process(
-    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    from yoetz.adapters.providers import codex_app_server
     from yoetz.adapters.providers.codex_app_server import prepare_codex_home
 
+    def allow_private_bundle(_path: Path) -> None:
+        return None
+
+    monkeypatch.setattr(codex_app_server, "verify_private_local_bundle", allow_private_bundle)
     home = tmp_path / "dedicated-home"
     home.mkdir(mode=0o700)
     (home / "config.toml").write_text('model = "other"\n', encoding="utf-8")

--- a/tests/unit/cli/test_codex_subscription.py
+++ b/tests/unit/cli/test_codex_subscription.py
@@ -869,6 +869,104 @@ def test_guided_setup_offers_account_switch(
     assert captured == [True]
 
 
+def test_guided_setup_discloses_login_reuse_before_the_confirmation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The prompt-loop screen must say a signed-in home is reused before asking to continue."""
+
+    prompts = iter(
+        [
+            str(tmp_path / "codex"),
+            str(tmp_path / "home"),
+            "gpt-5.6-sol",
+            "high",
+            "browser",
+        ]
+    )
+    disclosed_before_confirm: list[bool] = []
+
+    def prompt(message: str, **_kwargs: object) -> str:
+        del message
+        return next(prompts)
+
+    def confirm(message: str, **_kwargs: object) -> bool:
+        if message.startswith("Continue to Codex sign-in"):
+            disclosed_before_confirm.append(
+                "reused without a new sign-in" in capsys.readouterr().out
+            )
+            return True
+        return False
+
+    async def setup(**_kwargs: object) -> dict[str, object]:
+        return {"auth_mode": "chatgpt", "login_reused": False}
+
+    def preview(**_kwargs: object) -> dict[str, str]:
+        return {
+            "executable_path": "/opt/codex",
+            "executable_sha256": "sha256:" + "a" * 64,
+            "runtime_version": "0.150.1",
+            "capability_cell_sha256": "sha256:" + "b" * 64,
+            "capability_evidence_expires_at": "2026-11-30T00:00:00Z",
+            "codex_home": "/home",
+            "disconnect_command": "yoetz provider codex-subscription disconnect",
+            "rollback_command": "yoetz provider codex-subscription rollback",
+        }
+
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_discovery.discover_codex_binaries", list)
+    monkeypatch.setattr("typer.prompt", prompt)
+    monkeypatch.setattr("typer.confirm", confirm)
+    monkeypatch.setattr(module, "codex_subscription_preview", preview)
+    monkeypatch.setattr(module, "codex_subscription_setup", setup)
+
+    import anyio
+
+    anyio.run(module.prompt_codex_subscription_setup)
+
+    assert disclosed_before_confirm == [True]
+
+
+def test_cli_setup_discloses_reuse_and_names_its_override_before_the_confirmation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The `setup` notice must state reuse and the flag that forces a fresh sign-in (#534)."""
+
+    from yoetz.cli.app import app
+
+    def resolve(selected: Path) -> tuple[Path, str, str]:
+        return selected, "sha256:" + "a" * 64, "openai-codex-npm-darwin-arm64-0.150.1"
+
+    async def setup(**_kwargs: object) -> dict[str, object]:
+        return {"schema": "yoetz.codex-subscription-status/1", "login_reused": True}
+
+    async def restart() -> dict[str, object]:
+        return {"reachable": True, "state": "ready", "vault_mode": None}
+
+    monkeypatch.setattr(module, "resolve_supported_codex_executable", resolve)
+    monkeypatch.setattr(module, "codex_subscription_setup", setup)
+    monkeypatch.setattr("yoetz.cli.setup.restart_service_for_semantic_composition", restart)
+
+    runner = CliRunner()
+    arguments = [
+        "provider",
+        "codex-subscription",
+        "setup",
+        "--executable",
+        str(tmp_path / "codex"),
+        "--accept",
+        "--no-open-browser",
+    ]
+    reuse = runner.invoke(app, arguments)
+    switch = runner.invoke(app, [*arguments, "--switch-account"])
+
+    assert reuse.exit_code == 0
+    assert "existing sign-in: reused when Codex reports the home already signed in" in reuse.stdout
+    assert "--switch-account" in reuse.stdout
+    assert '"login_reused":true' in reuse.stdout
+    assert switch.exit_code == 0
+    assert "existing sign-in: logged out first, then a new Codex sign-in" in switch.stdout
+    assert "reused when Codex reports" not in switch.stdout
+
+
 @pytest.mark.anyio
 async def test_setup_reuses_an_already_signed_in_dedicated_home_without_a_login_challenge(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #534
- I searched existing issues and PRs for duplicates before opening this PR.
- Design-gated (OAuth-bearing state, ADR-026 amendment): the maintainer requested this fix and PR directly.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/usage/providers.md` (product voice), `docs/runbooks/codex-subscription-evaluator.md` (login lives once per dedicated home, `--switch-account` override, cross-run reuse), `docs/runbooks/codex-dogfood.md` (host-home vs evaluator-home lifetime, `--codex-home` reuse, default home stays fresh under the isolation root), `docs/adr/ADR-026-isolated-root-runtime-identity.md` (explicit exemption for a dedicated evaluator home passed by path; default home stays beneath the root).

## Verification

Commands run (paste):

```text
uv run ruff format src/yoetz/cli/codex_subscription.py src/yoetz/cli/app.py src/yoetz/tui/app.py tests/unit/cli/test_codex_subscription.py
uv run ruff check src/yoetz/cli/codex_subscription.py src/yoetz/cli/app.py src/yoetz/tui/app.py tests/unit/cli/test_codex_subscription.py
uv run pytest tests/unit/cli/test_codex_subscription.py tests/unit/adapters/providers/test_codex_app_server.py tests/unit/tui -q   # 244 passed
/Users/shayb/yoetz-core/node_modules/.bin/pyright src/yoetz/cli/codex_subscription.py src/yoetz/cli/app.py src/yoetz/tui/app.py tests/unit/cli/test_codex_subscription.py   # 0 errors
```

Not run: a live Codex sign-in against a real dedicated home. The fake-app-server test drives the real adapter (`initialize` → `account/read` → `model/list`) through the real `codex_subscription_setup`, `prepare_codex_home`, and config write, and asserts `account/login/start` is never requested.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

**Problem.** `setup` went preflight → `prepare_codex_home` → unconditional `account/login/start`, so pointing `--codex-home` at yesterday's already signed-in dedicated evaluator home still opened a browser/device-code challenge. Under `YOETZ_ISOLATED_ROOT` the default evaluator home additionally lands beneath the per-run root, so nobody reused one.

**Fix (option A + B from the issue).**
- `codex_subscription_setup` now runs the existing `codex_account_status` probe (app-server `account/read` with `refreshToken: false`, then `model/list`) after the local preflight and home preparation. If Codex reports `auth_mode == "chatgpt"` and the exact model/reasoning cell is available, the binding is persisted and the result carries `login_reused: true`; no login challenge is issued. Otherwise the existing login ceremony runs unchanged and the result carries `login_reused: false`.
- Fail-closed edges kept: a probe whose process-group cleanup is unconfirmed raises `codex_subscription_readiness_unproven` before any further child launches; a signed-in home without the model still takes the login path and fails with the existing token; `prepare_codex_home`'s exact-config digest check (`codex_runtime_config_conflict`) and owner-only/symlink-free gate run before any process; `--switch-account` skips the probe and always logs out + signs in again.
- Yoetz still never reads, copies, or moves `auth.json`; readiness is only what Codex answers over the app-server protocol.
- Surfaces: CLI `setup` (notice line + flag help), prompt-loop/first-run `prompt_codex_subscription_setup` (disclosure before confirm), TUI `/provider` (disclosure in the approval body, "Sign-in: reused/completed" in the result). `status` output is unchanged.
- Cause 2 is handled by documentation (option B): the evaluator home may be a stable owner-private directory reused across isolated runs via `--codex-home`, identified by its `codex_home_digest`; ADR-026 records the exemption. No silent default-path change (option C rejected).

**Model and harness.** Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Review pass (383040df)

Reviewer follow-up commit `383040df`:

- ADR-026 `**Status:**` now records the amendment (date + issue #534), matching the convention every
  other amended ADR follows; the exemption text no longer claims root deletion removes every
  artifact in the evaluator home (`prepare_codex_home` writes the exact Codex `config.toml` there),
  and names `disconnect` + operator directory removal as its teardown.
- The evaluator runbook now separates the three non-reuse edges (logged-out/missing model → login
  path; unconfirmed probe cleanup → fails closed, never reaches login; incomplete probe → its own
  bounded token) instead of conflating them.
- `--switch-account` is named in the CLI setup notice and the `/provider` approval body, so the way
  out of a reused sign-in is visible at the decision point.
- New coverage for the three previously untested surfaces: the CLI setup notice in both branches
  (asserting `login_reused` in the emitted payload), the prompt-loop disclosure preceding the
  confirmation, and the first-run human report's sign-in line.

```text
uv run ruff check .                                    # All checks passed
uv run ruff format --check .                           # 670 files already formatted
/Users/shayb/yoetz-core/node_modules/.bin/pyright      # 0 errors, 0 warnings
uv run python scripts/sync_resource_ripple.py --check  # fixed point
uv run pytest tests/unit/cli tests/unit/adapters/providers tests/tui \
  tests/subprocess/test_setup_wizard_cli.py::test_human_report_states_whether_the_codex_sign_in_was_reused -q
# 945 passed
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows Codex subscription setup to reuse a dedicated evaluator home when an app-server readiness probe confirms an existing ChatGPT login and the exact model cell. It also documents persistent evaluator-home reuse and exposes the setup outcome through CLI and TUI surfaces.
- Probes `account/read` and `model/list` before beginning login unless account switching is requested.
- Persists the binding without a new login challenge when full readiness is proven.
- Adds `login_reused` to setup results and corresponding CLI/TUI messaging.
- Preserves forced logout and sign-in behavior for explicit account switching.
- Adds focused tests for reuse, fallback login, cleanup failure, account switching, and persistence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete actionable failure identified in the changed behavior.

The new probe handles the repository-defined logged-out response, reuses only fully ready ChatGPT/model state, fails closed on unconfirmed cleanup, and preserves the explicit account-switch path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/cli/codex_subscription.py | Adds the readiness probe, reuse decision, account-switch override, cleanup guard, and additive setup-result field without an accepted defect. |
| src/yoetz/cli/app.py | Updates setup disclosure and account-switch help to explain reuse behavior. |
| src/yoetz/tui/app.py | Discloses possible login reuse and reports whether setup reused or completed sign-in. |
| tests/unit/cli/test_codex_subscription.py | Adds coverage for reusable login state, fallback login, account switching, cleanup failure, and the real adapter request sequence. |
| docs/runbooks/codex-subscription-evaluator.md | Documents the readiness proof, dedicated-home lifetime, reuse contract, and switch-account override. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Setup
    participant Codex as Codex app-server
    participant Config as Yoetz config
    User->>Setup: setup(dedicated home)
    Setup->>Setup: validate binding and prepare home
    alt switch account
        Setup->>Codex: logout
        Setup->>Codex: account/login/start
    else reuse allowed
        Setup->>Codex: "account/read(refreshToken=false)"
        Setup->>Codex: model/list
        alt ChatGPT login and exact model available
            Codex-->>Setup: readiness proven
        else readiness not proven
            Setup->>Codex: account/login/start
        end
    end
    Setup->>Config: write binding if unchanged
    Setup-->>User: status plus login_reused
```

<sub>Reviews (1): Last reviewed commit: ["fix(providers): reuse an already signed-..."](https://github.com/thegaysupreme123/yoetz/commit/893a7ebc3aaab3f01690f70468c54085ef5a996c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59950297)</sub>

<!-- /greptile_comment -->
