### PR TITLE
fix(vault): prepare the bundle root before the initialization guard opens

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2006,7 +2006,14 @@ uninitialized vault). CLI-side staging, promotion, and proof-based discard seria
 bundle-scoped advisory lock held by the initializing process for its whole
 stage→ceremony→promote span and re-checked by discard-only callers while held, so a stale status
 read can never delete a credential whose vault commit is in flight, and generated-passphrase
-installations cannot be stranded.
+installations cannot be stranded. Because trusted initialization may run before any service start
+has created the bundle root (issue #565), the guard first creates exactly that root, owner-only and
+only when its parent already exists, then verifies the path symlink-free, owned, and owner-only with
+the same helper the service uses; it never creates anything outside the selected bundle. Guard
+filesystem failures keep distinct bounded reasons — `bundle_parent_missing`,
+`bundle_permission_denied`, `bundle_unsafe`, `guard_unavailable` — and `unsupported` is reserved
+for a platform that genuinely lacks the mechanism, so only that reason may take setup's
+human-chosen-passphrase fallback.
 
 `SecretMemoryPort` exposes `capability`, `capture`, `allocate`, and `close` over opaque one-shot
 `SecretHandle` values. `SecretPurpose` is exactly `vault_initialize`, `vault_unlock`,

--- a/docs/adr/ADR-015-elevated-bootstrap-consent.md
+++ b/docs/adr/ADR-015-elevated-bootstrap-consent.md
@@ -91,7 +91,12 @@ generate and store one locally without any secret-bearing agent channel.
    uninitialized; any unprovable outcome retains the entry as a typed orphan that
    `yoetz service auto-unlock status` names and that restart reconciliation resolves by
    cryptographic proof against the vault envelope, so a failed attempt never strands the
-   credential or blocks retry with `entry_exists`. `vault_passphrase_rotate` likewise carries no secret:
+   credential or blocks retry with `entry_exists`. **Pristine-root amendment (2026-09-03, issue
+   #565).** The bundle-scoped guard creates and verifies exactly the selected bundle root when
+   initialization runs before any service start has created it, and a missing parent,
+   permission failure, or symlink rejection is reported as its own bounded reason rather than
+   as an unsupported keyring, so the start-first continuation suffices on a pristine root.
+   `vault_passphrase_rotate` likewise carries no secret:
    the helper locally loads the active scoped secret, stages a generated replacement, completes
    reauthentication and rewrap, and then promotes the replacement. Trusted CLI/TUI remains the
    stronger recommended path.

--- a/src/yoetz/adapters/keys/os_keyring.py
+++ b/src/yoetz/adapters/keys/os_keyring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import errno
 import hashlib
 import hmac
 import os
@@ -18,6 +19,7 @@ from typing import Final, Protocol, cast
 import keyring
 
 from yoetz.adapters.keys.vault_passphrase import VaultPassphraseError, validate_passphrase_view
+from yoetz.config.paths import PathSafetyError, ensure_owner_only_dir
 from yoetz.domain.values import validate_sha256_digest
 from yoetz.ports.secret_memory import (
     SecretConsumer,
@@ -75,8 +77,30 @@ _ERRORS: Final = frozenset(
         "entry_invalid",
         "correlation_mismatch",
         "migration_not_proven",
+        "bundle_parent_missing",
+        "bundle_permission_denied",
+        "bundle_unsafe",
+        "guard_unavailable",
     }
 )
+_GUARD_UNSAFE_ERRNOS: Final = frozenset({errno.ELOOP, errno.EMLINK, errno.ENOTDIR})
+_GUARD_PERMISSION_ERRNOS: Final = frozenset({errno.EACCES, errno.EPERM, errno.EROFS})
+
+
+def _guard_os_reason(exc: OSError) -> str:
+    """Map one guard filesystem failure to its distinct bounded reason (issue #565).
+
+    ``unsupported`` is reserved for a platform that genuinely lacks the mechanism; a missing
+    parent, a permission failure, and a symlink rejection are separate, actionable outcomes.
+    """
+
+    if exc.errno == errno.ENOENT:
+        return "bundle_parent_missing"
+    if exc.errno in _GUARD_UNSAFE_ERRNOS:
+        return "bundle_unsafe"
+    if exc.errno in _GUARD_PERMISSION_ERRNOS:
+        return "bundle_permission_denied"
+    return "guard_unavailable"
 
 
 class OSKeyringState(str, Enum):  # noqa: UP042
@@ -236,10 +260,15 @@ class AutoUnlockPassphraseStore:
             import fcntl
         except ImportError:
             raise OSKeyringError("unsupported") from None
+        self._ensure_bundle_root()
         try:
-            fd = os.open(self._guard_path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
-        except OSError:
-            raise OSKeyringError("unsupported") from None
+            fd = os.open(
+                self._guard_path,
+                os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW | os.O_CLOEXEC,
+                0o600,
+            )
+        except OSError as exc:
+            raise OSKeyringError(_guard_os_reason(exc)) from None
         try:
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -248,6 +277,35 @@ class AutoUnlockPassphraseStore:
             yield
         finally:
             os.close(fd)
+
+    def _ensure_bundle_root(self) -> None:
+        """Create and verify exactly the scoped bundle root before the guard opens (#565).
+
+        Trusted initialization may legitimately run before any service start has created the
+        bundle root, and the credential store is keyed by that path rather than its existence.
+        Only the bundle root itself is created, owner-only, and only when its parent already
+        exists; the whole path is then verified symlink-free, owned, and owner-only with the
+        same helper the service uses. Nothing outside the exact selected bundle is ever
+        created, and each failure keeps a distinct reason instead of collapsing to a keyring
+        ``unsupported`` verdict.
+        """
+
+        bundle = self._guard_path.parent
+        try:
+            bundle.lstat()
+        except FileNotFoundError:
+            try:
+                os.mkdir(bundle, 0o700)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise OSKeyringError(_guard_os_reason(exc)) from None
+        except OSError as exc:
+            raise OSKeyringError(_guard_os_reason(exc)) from None
+        try:
+            ensure_owner_only_dir(bundle)
+        except PathSafetyError:
+            raise OSKeyringError("bundle_unsafe") from None
 
     @property
     def entry_identity(self) -> tuple[str, str]:

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -193,9 +193,13 @@ _PROVIDER_SETUP_AUTO_UNLOCK_REASONS: Final = frozenset(
     {
         "ambiguous_write",
         "authority_mismatch",
+        "bundle_parent_missing",
+        "bundle_permission_denied",
+        "bundle_unsafe",
         "correlation_mismatch",
         "entry_exists",
         "entry_invalid",
+        "guard_unavailable",
         "human_authority_unavailable",
         "initialization_in_progress",
         "locked",
@@ -206,6 +210,11 @@ _PROVIDER_SETUP_AUTO_UNLOCK_REASONS: Final = frozenset(
         "unsupported",
         "unverified",
     }
+)
+# Filesystem failures of the bundle-scoped initialization guard (issue #565); each is distinct
+# from a genuinely unsupported keyring and never triggers the manual-passphrase fallback.
+_BUNDLE_GUARD_REASONS: Final = frozenset(
+    {"bundle_parent_missing", "bundle_permission_denied", "bundle_unsafe", "guard_unavailable"}
 )
 _PROVIDER_SETUP_CONFIDENTIAL_REASONS: Final = frozenset(
     {
@@ -1863,6 +1872,14 @@ async def _interactive_provider_setup(
                             typer.echo(
                                 "Another Yoetz vault initialization is already in progress. "
                                 "Wait for it to finish, then rerun 'yoetz setup'.",
+                                err=True,
+                            )
+                        elif error.reason in _BUNDLE_GUARD_REASONS:
+                            typer.echo(
+                                "The Yoetz data directory could not be prepared for vault "
+                                f"initialization ({error.reason}). Its parent directory must "
+                                "exist, be owned by you, contain no symlinks, and be "
+                                "writable. Fix that, then rerun 'yoetz setup'.",
                                 err=True,
                             )
                         elif error.reason == "staged_entry_exists":

--- a/tests/integration/objects/test_key_backends.py
+++ b/tests/integration/objects/test_key_backends.py
@@ -6,6 +6,8 @@ import asyncio
 import base64
 import hashlib
 import inspect
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -486,3 +488,122 @@ def test_keyring_signatures_and_unapproved_backend_are_fail_closed() -> None:
     assert probe.state is OSKeyringState.UNSUPPORTED
     assert probe.create_if_absent
     memory.close()
+
+
+def test_staged_initialization_guard_creates_a_missing_bundle_root_owner_private(
+    tmp_path: Path,
+) -> None:
+    """#565: trusted initialization before any service start must not read as unsupported."""
+
+    import stat
+
+    parent = tmp_path.resolve() / "isolated"
+    parent.mkdir(mode=0o700)
+    bundle = parent / "data"
+    store = AutoUnlockPassphraseStore(bundle, backend=_AtomicBackend())
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    with store.staged_initialization_guard():
+        pass
+
+    facts = bundle.lstat()
+    assert stat.S_ISDIR(facts.st_mode) and not stat.S_ISLNK(facts.st_mode)
+    assert stat.S_IMODE(facts.st_mode) == 0o700
+    assert stat.S_IMODE((bundle / "auto-unlock-init.lock").lstat().st_mode) == 0o600
+    assert sorted(child.name for child in parent.iterdir()) == ["data"]
+
+
+def test_staged_initialization_guard_reports_a_missing_bundle_parent_distinctly(
+    tmp_path: Path,
+) -> None:
+    """#565: only the exact bundle root is created; a missing parent is its own outcome."""
+
+    absent_parent = tmp_path.resolve() / "absent"
+    store = AutoUnlockPassphraseStore(absent_parent / "data", backend=_AtomicBackend())
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(OSKeyringError) as exc:
+        with store.staged_initialization_guard():
+            pass
+
+    assert exc.value.reason == "bundle_parent_missing"
+    assert not absent_parent.exists()
+
+
+def test_staged_initialization_guard_rejects_a_symlinked_bundle_root(tmp_path: Path) -> None:
+    """#565: a symlink where the bundle root belongs is unsafe, never merely unsupported."""
+
+    root = tmp_path.resolve()
+    real = root / "real-data"
+    real.mkdir(mode=0o700)
+    link = root / "data"
+    link.symlink_to(real, target_is_directory=True)
+    store = AutoUnlockPassphraseStore(link, backend=_AtomicBackend())
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(OSKeyringError) as exc:
+        with store.staged_initialization_guard():
+            pass
+
+    assert exc.value.reason == "bundle_unsafe"
+    assert not (real / "auto-unlock-init.lock").exists()
+
+
+def test_staged_initialization_guard_rejects_a_symlinked_lock_file(tmp_path: Path) -> None:
+    """#565: O_NOFOLLOW rejection of a planted lock symlink stays distinct from unsupported."""
+
+    bundle = tmp_path.resolve() / "data"
+    bundle.mkdir(mode=0o700)
+    (bundle / "elsewhere").write_bytes(b"")
+    (bundle / "auto-unlock-init.lock").symlink_to(bundle / "elsewhere")
+    store = AutoUnlockPassphraseStore(bundle, backend=_AtomicBackend())
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    with pytest.raises(OSKeyringError) as exc:
+        with store.staged_initialization_guard():
+            pass
+
+    assert exc.value.reason == "bundle_unsafe"
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid") or os.geteuid() == 0, reason="permission checks need a non-root uid"
+)
+def test_staged_initialization_guard_reports_a_permission_failure_distinctly(
+    tmp_path: Path,
+) -> None:
+    """#565: an unwritable parent is a permission outcome, not a keyring verdict."""
+
+    parent = tmp_path.resolve() / "readonly"
+    parent.mkdir(mode=0o500)
+    store = AutoUnlockPassphraseStore(parent / "data", backend=_AtomicBackend())
+    store._backend_id = "keyring.backends.macOS.Keyring"  # pyright: ignore[reportPrivateUsage]
+
+    try:
+        with pytest.raises(OSKeyringError) as exc:
+            with store.staged_initialization_guard():
+                pass
+    finally:
+        parent.chmod(0o700)
+
+    assert exc.value.reason == "bundle_permission_denied"
+    assert not (parent / "data").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="installed macOS keyring backend")
+def test_installed_macos_keyring_guard_succeeds_on_a_pristine_bundle_root(
+    tmp_path: Path,
+) -> None:
+    """#565: the real installed macOS backend is supported and its guard opens before any
+    service has created the bundle root. The guard never touches the keychain itself."""
+
+    import keyring
+
+    store = AutoUnlockPassphraseStore(tmp_path.resolve() / "data", backend=keyring.get_keyring())
+    if store._backend_id != "keyring.backends.macOS.Keyring":  # pyright: ignore[reportPrivateUsage]
+        pytest.skip("macOS keychain backend is not the installed default here")
+
+    assert store.available is True
+    with store.staged_initialization_guard():
+        pass
+    assert (tmp_path.resolve() / "data" / "auto-unlock-init.lock").exists()

--- a/tests/unit/cli/test_elevated.py
+++ b/tests/unit/cli/test_elevated.py
@@ -1205,7 +1205,13 @@ def test_forged_approval_arguments_fail_before_mutation(
 class _StagedInitStore:
     """Fake staged-initialization keyring lifecycle (#511) for elevated-flow tests."""
 
-    def __init__(self, generated: bytearray, *, staged_leftover: bool = False) -> None:
+    def __init__(
+        self,
+        generated: bytearray,
+        *,
+        staged_leftover: bool = False,
+        guard_reason: str | None = None,
+    ) -> None:
         self._generated = generated
         self.active = False
         self.staged = staged_leftover
@@ -1214,10 +1220,15 @@ class _StagedInitStore:
         self.staged_calls = 0
         self.guard_acquisitions = 0
         self.guard_held = False
+        self.guard_reason = guard_reason
 
     @contextmanager
     def staged_initialization_guard(self) -> Generator[None]:
+        from yoetz.adapters.keys.os_keyring import OSKeyringError
+
         assert not self.guard_held, "the guard is exclusive"
+        if self.guard_reason is not None:
+            raise OSKeyringError(self.guard_reason)
         self.guard_held = True
         self.guard_acquisitions += 1
         try:
@@ -1406,6 +1417,60 @@ def test_unprovable_staged_leftover_fails_closed_without_entry_exists() -> None:
     anyio.run(run)
     assert store.discarded == 0
     assert store.staged is True
+
+
+def test_missing_bundle_parent_is_a_distinct_bounded_failure_before_staging() -> None:
+    """#565: a guard filesystem failure surfaces as its own reason, never as unsupported."""
+
+    generated = bytearray(b"m" * 64)
+    store = _StagedInitStore(generated, guard_reason="bundle_parent_missing")
+
+    async def run() -> None:
+        with patch("yoetz.cli.elevated._auto_unlock_store", return_value=store):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_initialize_generated()  # pyright: ignore[reportPrivateUsage]
+        assert exc.value.reason == "auto_unlock_bundle_parent_missing"
+
+    anyio.run(run)
+    assert store.staged_calls == 0
+    assert store.staged is False
+    assert store.discarded == 0
+
+
+def test_trusted_review_never_falls_back_to_manual_passphrase_for_guard_failures() -> None:
+    """#565: only a genuinely unsupported keyring may take the local-human ceremony path."""
+
+    generated = bytearray(b"t" * 64)
+    ceremonies: list[object] = []
+
+    async def ceremony(
+        _console: object,
+        _kind: object,
+        _target: object,
+        **kwargs: object,
+    ) -> VaultStateResult:
+        ceremonies.append(kwargs.get("passphrase"))
+        return VaultStateResult("ready", "succeeded")
+
+    async def run(reason: str) -> str:
+        store = _StagedInitStore(generated, guard_reason=reason)
+        with (
+            patch("yoetz.cli.elevated._auto_unlock_store", return_value=store),
+            patch(
+                "yoetz.cli.elevated.run_human_ceremony_on_terminal",
+                side_effect=ceremony,
+            ),
+        ):
+            with pytest.raises(ElevatedBootstrapError) as exc:
+                await elevated._complete_vault_initialize(  # pyright: ignore[reportPrivateUsage]
+                    cast(TrustedForegroundConsole, _Console())
+                )
+        return exc.value.reason
+
+    assert anyio.run(run, "bundle_parent_missing") == "auto_unlock_bundle_parent_missing"
+    assert anyio.run(run, "bundle_permission_denied") == "auto_unlock_bundle_permission_denied"
+    assert anyio.run(run, "bundle_unsafe") == "auto_unlock_bundle_unsafe"
+    assert ceremonies == []
 
 
 def test_pre_existing_active_entry_is_still_refused() -> None:


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #565
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: no protocol, egress, storage-format, or packaging change. ADR-015 gets a short amendment recording the behavior.

## Documentation

- Behavior change? `yes`
- Docs updated: `docs/INTERFACES.md` (`AutoUnlockPassphraseStore` paragraph) and `docs/adr/ADR-015-elevated-bootstrap-consent.md` (pristine-root amendment).

## Verification

Commands run (paste):

```text
uv run ruff check src/yoetz/adapters/keys/os_keyring.py src/yoetz/cli/setup.py tests/integration/objects/test_key_backends.py tests/unit/cli/test_elevated.py
uv run ruff format --check <same files>
node_modules/.bin/pyright <same files>            # 0 errors
uv run pytest tests/integration/objects/test_key_backends.py tests/unit/cli/test_elevated.py tests/unit/cli/test_auto_unlock.py -q   # 121 passed
uv run pytest tests/integration/service/test_consent_vault_initialize_composition.py tests/integration/service/test_start_initialization_continuation_composition.py tests/unit/cli/test_setup_activation.py tests/unit/cli/test_setup_review_mode.py tests/unit/cli/test_service_diagnostics.py -q   # 14 passed
grep -rl "os_keyring\|auto_unlock" tests/unit tests/integration | <minus the above> | xargs uv run pytest -q   # 280 passed
```

Live repro on macOS arm64 with a fresh owner-private `YOETZ_ISOLATED_ROOT` and no service ever started, calling `_auto_unlock_store().staged_initialization_guard()`:

```text
main 8ab0fd20:  guard: OSKeyringError unsupported   (bundle root never created)
this branch:    guard: acquired                      (<root>/data created 0700, lock file 0600)
```

The new installed-macOS regression (`test_installed_macos_keyring_guard_succeeds_on_a_pristine_bundle_root`) ran against the real `keyring.backends.macOS.Keyring` backend on this machine, not skipped.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

**Problem.** On a pristine root, agent-authorized `vault_initialize` enters `AutoUnlockPassphraseStore.staged_initialization_guard()` before any service start has created the bundle root. The guard's `os.open(.../auto-unlock-init.lock, O_CREAT|...)` fails with ENOENT and every `OSError` was collapsed to `OSKeyringError("unsupported")`, so a supported macOS keychain was reported as `auto_unlock_unsupported` and success silently depended on starting the service first.

**Fix.** The guard now:
- creates exactly the selected bundle root, mode 0700, and only when its parent already exists (nothing outside the bundle is ever created);
- verifies the path symlink-free, owned, and owner-only with `ensure_owner_only_dir`, the same helper the daemon uses at startup, so an existing bundle keeps the daemon's invariant;
- opens the lock with `O_CLOEXEC` and maps filesystem failures to distinct bounded reasons: `bundle_parent_missing` (ENOENT), `bundle_unsafe` (ELOOP/EMLINK/ENOTDIR or any path-safety rejection), `bundle_permission_denied` (EACCES/EPERM/EROFS), and `guard_unavailable` (anything else). `unsupported` is reserved for a platform without `fcntl`.

Because the trusted-console path only falls back to the human-chosen passphrase ceremony on `unsupported`, these reasons now surface as `auto_unlock_<reason>` bounded failures instead of a misleading keyring verdict. `yoetz setup` allowlists the new reasons and prints an actionable message for them. Staged-secret cleanup and the no-secret-output guarantees are untouched: the new checks run before any keyring write.

**Surfaces walked.** CLI consent authorize (trusted and agent-chat paths), `yoetz setup`, and `yoetz service auto-unlock enable` all share the store guard, so one change covers them; no wire schema changes (`ElevatedBootstrapError` reasons are stderr tokens, the review-result reason is `const: succeeded`, and setup's `credential_reason` allowlist is code-only); MCP start-first continuation unchanged; hosts not applicable.

Model and harness: Claude Fable 5.1 via Claude Code (desktop app), in a git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares and validates a pristine bundle root before acquiring the auto-unlock initialization lock.
- Creates only the selected bundle root with owner-only permissions when its parent exists.
- Maps guard filesystem failures to distinct bounded reasons and surfaces actionable setup diagnostics.
- Adds integration and elevated-flow regression coverage for root creation, unsafe paths, permissions, and reason propagation.
- Updates the interface documentation and elevated-bootstrap ADR.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The bundle root is created narrowly, validated using the existing owner-only path helper, and guard failures propagate through the documented bounded-reason handling with focused regression coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/keys/os_keyring.py | Creates and validates the bundle root before opening the guard lock and maps filesystem errors to bounded reasons without an accepted defect. |
| src/yoetz/cli/setup.py | Allowlists the new guard reasons and reports an actionable diagnostic without triggering the unsupported-keyring fallback. |
| tests/integration/objects/test_key_backends.py | Covers pristine-root creation, missing parents, symlink rejection, permission failures, and the installed macOS backend. |
| tests/unit/cli/test_elevated.py | Verifies bounded reason propagation and confirms guard failures do not enter the manual-passphrase fallback. |
| docs/INTERFACES.md | Documents pristine-root preparation and the bounded guard failure reasons consistently with the implementation. |
| docs/adr/ADR-015-elevated-bootstrap-consent.md | Records the pristine-root behavior amendment and its failure reporting semantics. |

<sub>Reviews (1): Last reviewed commit: ["fix(vault): prepare the bundle root befo..."](https://github.com/thegaysupreme123/yoetz/commit/774ee5a29f8349a973b262a1872158cce66ea13f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60150644)</sub>

<!-- /greptile_comment -->