### PR TITLE
fix(mcp): preserve isolated root in Codex registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ reverse-chronological released versions.
 
 ### Fixed
 
+- Yoetz-owned external Codex MCP registration now preserves ADR-026 isolation across the host
+  process boundary. In isolated mode, preview and apply bind only the exact validated
+  `YOETZ_ISOLATED_ROOT` through Codex's native `--env`; status reports whether the stored binding
+  is exact, missing, different, or ambient, and arbitrary environment shapes remain foreign and
+  are never overwritten. Dogfood parity schema 3 adds a pre-model child-start facet, and an
+  installed Codex 0.150.1 regression proves the registered child receives the reviewed root even
+  when the host parent does not (issue #561).
+
 - A Codex MCP route that reverts to `strict` between install and session start no longer reports a
   bare `route_semantic_ceiling`. `yoetz integrate codex mcp install` now records the applied route
   in an owner-only state-directory record (no repository or prompt content); `mcp status`, provider

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3515,12 +3515,14 @@ optional reported version, `supported|untested` compatibility). Shared names are
 `("yoetz", "mcp", "serve", "--semantic", "off")`),
 `McpRegistrationState` (`absent|yoetz_owned|foreign_present`), `McpRegistrationAction`
 (`register|reregister|unregister|noop`), `McpRegistrationReason` (`confirmation_required|preview_stale|
-harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_present`),
-`McpRegistrationPreview`, `McpRegistrationObservation`, `McpRegistrationCommand`,
+harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_present|isolation_invalid`),
+`McpRegistrationPreview` (including the exact proposed `isolated_root` or null),
+`McpRegistrationObservation`, `McpRegistrationCommand`,
 `McpRegistrationResult`, and
-`McpRegistrationError`. `McpRegistrationObservation` carries `harness_id`, `state`, and
-`route_profile` (`policy|strict|null`); `route_profile` is non-null only when the state is
-`yoetz_owned`, because a foreign or absent entry has no Yoetz route to describe.
+`McpRegistrationError`. `McpRegistrationObservation` carries `harness_id`, `state`,
+`route_profile` (`policy|strict|null`), and `isolation_binding`
+(`ambient|isolated_exact|missing|different|null`); route and binding are non-null only when the
+state is `yoetz_owned`, because a foreign or absent entry has no Yoetz route to describe.
 `observe_registration` reads exactly what `status_registration` reads, mutates nothing, and shares
 its `status` diagnostic phase. Each observation starts with `codex mcp get yoetz --json`; because a
 nonzero named lookup is not positive absence, it falls back to bounded `codex mcp list --json`.
@@ -3544,8 +3546,13 @@ serve command, refuse an observed foreign replacement, and treat an already-abse
 `host_remove_not_compare_and_swap`; callers must quiesce concurrent host configuration writers,
 and the port does not claim atomic exclusion inside the final host subprocess window. The same
 positive-absence fallback is required after removal, so a generic failed named lookup never proves
-success. The interactive approval surface prints the exact command, route, warnings, and preview
-digest. The preview binds the exact command and `policy|strict` route profile. The route profile is
+success. The interactive approval surface prints the exact command, route, isolated root, warnings,
+and preview digest. The preview binds the exact command, `policy|strict` route profile, and exact
+ADR-026 isolated root when present. Ambient external registrations carry no environment. Isolated
+external Codex registrations carry exactly one native `--env` pair,
+`YOETZ_ISOLATED_ROOT=<validated-root>`; a missing or different known root is re-registration drift,
+while any arbitrary key, inherited-variable declaration, or malformed root makes the same-name
+entry foreign and preserves it. The route profile is
 explicit input:
 `yoetz setup run` and `yoetz integrate <harness> mcp preview|install` accept
 `--route-profile strict|policy`. Without that input, an existing yoetz-owned registration keeps
@@ -3557,8 +3564,9 @@ is surfaced before mutation: the wizard preview and report carry `route_profile_
 ordinary digest-bound re-registration.
 The setup-wizard
 schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
-`yoetz.setup-status/1`, `yoetz.mcp-registration-preview/1`, and
-`yoetz.mcp-unregistration-preview/1`; the marker lives at `state_dir()/setup-wizard.json` via
+`yoetz.setup-status/1`, `yoetz.mcp-registration-preview/1` (ambient) / `2` (isolated), and
+`yoetz.mcp-unregistration-preview/1` (ambient) / `2` (isolated); the marker lives at
+`state_dir()/setup-wizard.json` via
 `config.paths.setup_marker_path`. The CLI surfaces are
 `yoetz setup run|status` and
 `yoetz integrate <harness> mcp status|preview|preview-remove|install|remove` (ADR-012).

--- a/docs/adr/ADR-012-first-run-setup-wizard.md
+++ b/docs/adr/ADR-012-first-run-setup-wizard.md
@@ -101,8 +101,10 @@ exactly those contracts and connects the steps without weakening any existing tr
    not absence by itself: the adapter runs a bounded `codex mcp list --json` fallback and accepts
    absence only when that successful structural listing contains no `yoetz` name. A failed or
    malformed listing fails closed; a single matching entry is classified normally; duplicate
-   matching names are ambiguous and fail closed. It runs the exact `codex mcp add yoetz -- yoetz
-   mcp serve` command only after that positive absence observation; a foreign same-name entry is
+   matching names are ambiguous and fail closed. In ambient mode it runs the exact `codex mcp add
+   yoetz -- yoetz mcp serve` command; under ADR-026 isolation it runs `codex mcp add yoetz --env
+   YOETZ_ISOLATED_ROOT=<validated-root> -- yoetz mcp serve`. It does so only after that positive
+   absence observation; a foreign same-name entry is
    preserved and refused with `foreign_entry_present` — there is no force path. The structural
    JSON parser rejects duplicate keys, nonstandard constants, and truncated output. Codex exposes
    no compare-and-add token, so operators must quiesce non-cooperating MCP configuration writers
@@ -111,6 +113,14 @@ exactly those contracts and connects the steps without weakening any existing tr
    verified by re-reading state, not by trusting the add exit code. Registration remains a fact
    separate from skill installation and from Codex capability support (E-002/E-013 are untouched);
    "registered" never implies "Codex will successfully connect".
+
+   **Amended 2026-09-04 — isolated external registration (issue #561).** The environment shape is
+   closed: ambient has none; isolated has only the exact `YOETZ_ISOLATED_ROOT` pair. Preview binds
+   and displays that root, apply passes it through Codex's native `--env`, and observation verifies
+   the stored value. Missing/different known roots request re-registration; arbitrary keys,
+   inherited-variable names, and malformed environment shapes remain foreign with no force path.
+   Ambient preview digests keep schema token `/1`; isolated registration and unregistration use
+   additive `/2` tokens so the new root field cannot alter the older digest contract silently.
 
    **Founder-authorized Codex activation repair (2026-08-03).** An accepted setup now also installs
    the packaged project skill at `.agents/skills/yoetz` before it installs the structural plugin

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -88,7 +88,9 @@ identity along with it, and nothing validates or proves it.
    `provision_isolated_yoetz_root` continuation. It adds `mcp_child_isolation`, which can pass only
    when registration status is `yoetz_owned`, its binding is `isolated_exact`, and a pre-model
    Codex app-server inventory starts the registered child successfully. A non-pass row carries
-   `reregister_isolated_mcp`. Version 1 and 2 reports are no longer accepted.
+   `reregister_isolated_mcp` when the registration or its binding is not exact, and
+   `recapture_isolated_mcp_child` when the binding is already exact and only the child start is
+   unproven. Version 1 and 2 reports are no longer accepted.
 
 ## Reverse states and rollback
 

--- a/docs/adr/ADR-026-isolated-root-runtime-identity.md
+++ b/docs/adr/ADR-026-isolated-root-runtime-identity.md
@@ -4,12 +4,15 @@
 [issue #518](https://github.com/TheGaySupreme123/yoetz/issues/518); amended 2026-09-03,
 maintainer-authorized in [issue #534](https://github.com/TheGaySupreme123/yoetz/issues/534), to
 exempt one explicitly passed dedicated Codex evaluator home from the "every artifact lives beneath
-the root" reverse state.
+the root" reverse state; amended 2026-09-04, maintainer-authorized in
+[issue #561](https://github.com/TheGaySupreme123/yoetz/issues/561), to bind the root into
+Yoetz-owned external Codex MCP registrations.
 **Implemented by:** `src/yoetz/config/paths.py` (`isolated_root()`, `runtime_dir()`,
 `ISOLATED_ROOT_ENV`), `src/yoetz/adapters/control/unix_socket.py`, `src/yoetz/config/load.py`,
 `src/yoetz/service/client.py`, `src/yoetz/cli/isolation_status.py`, the
 `yoetz service isolation` CLI command, `scripts/check_codex_dogfood_parity.py`
-(`yoetz.codex-dogfood-parity/2`), and `tests/packaging/test_isolated_root_boundary.py`.
+(`yoetz.codex-dogfood-parity/3`), `tests/packaging/test_isolated_root_boundary.py`, and
+`tests/packaging/test_codex_mcp_isolated_registration.py`.
 **Relates to:** ADR-001 (single service/writer authority), ADR-003 (durable storage), and the
 [Codex dogfood parity runbook](../runbooks/codex-dogfood.md).
 
@@ -64,15 +67,28 @@ identity along with it, and nothing validates or proves it.
    compares those reports; it never substitutes platform defaults for the normal target, because
    its config or storage may be relocated. Each report contains canonical path-identity digests,
    never raw paths. The command is CLI-only; MCP and hooks inherit isolation through environment.
-6. **The dogfood parity gate fails closed on shared identity.** Report schema
-   `yoetz.codex-dogfood-parity/2` adds the `service_isolation` preflight facet, the
+6. **The host-launched external Codex MCP child keeps the same identity.** In ambient mode the
+   Yoetz-owned registration has no environment block. In isolated mode preview and apply bind
+   exactly one allowed entry, `YOETZ_ISOLATED_ROOT=<validated-root>`, into `codex mcp add`; the
+   preview digest covers the exact root, and post-apply observation re-reads both argv and the
+   environment block. Missing or different roots are Yoetz-owned but require re-registration;
+   unknown keys, inherited-variable declarations, malformed roots, or any other environment
+   shape are foreign and never overwritten. Status reports only the closed binding state
+   (`ambient|isolated_exact|missing|different`), while preview shows the exact proposed root for
+   local review. This exception is limited to external Codex registration; plugin-managed routes
+   retain their own host-specific environment contracts.
+7. **The dogfood parity gate fails closed on shared or unlaunched identity.** Report schema
+   `yoetz.codex-dogfood-parity/3` retains the `service_isolation` preflight facet, the
    `identity.yoetz_isolation` digest block, and the `observed.yoetz_isolation_state` closed state
    (`isolated|shared|ambient|unknown`). The facet can pass only when the observed state is
    `isolated`, the candidate mode is `isolated`, the normal mode is `ambient`, and every resolved
    state/endpoint/storage/config/executable digest differs from its exact normal-target counterpart;
    any equality, wrong mode, or unknown
    state is rejected or fails preflight, and a non-pass row must carry the
-   `provision_isolated_yoetz_root` continuation. Version 1 reports are no longer accepted.
+   `provision_isolated_yoetz_root` continuation. It adds `mcp_child_isolation`, which can pass only
+   when registration status is `yoetz_owned`, its binding is `isolated_exact`, and a pre-model
+   Codex app-server inventory starts the registered child successfully. A non-pass row carries
+   `reregister_isolated_mcp`. Version 1 and 2 reports are no longer accepted.
 
 ## Reverse states and rollback
 
@@ -86,10 +102,12 @@ endpoint, or storage, so deleting the root still removes every Yoetz identity ar
 parity gate still fails on any shared Yoetz identity. That home is reverse-stated by
 `yoetz provider codex-subscription disconnect` — Codex logout plus binding removal — and then by
 the operator deleting the directory they provisioned; root deletion is not its rollback. The
-default evaluator home (no explicit path) stays beneath the root. The packaged regression
-(`tests/packaging/test_isolated_root_boundary.py`) locks this: an isolated service run leaves the
-ambient home tree byte-identical before/after, an ambient client cannot reach the isolated
-singleton, and removing the root removes every trace.
+default evaluator home (no explicit path) stays beneath the root. The packaged regressions lock
+both boundaries: `test_isolated_root_boundary.py` proves an isolated service run leaves the ambient
+home tree byte-identical before/after, an ambient client cannot reach the isolated singleton, and
+removing the root removes every trace; `test_codex_mcp_isolated_registration.py` uses installed
+Codex 0.150.1 to launch a registered child from an ambient parent and proves that only the reviewed
+registration supplied the exact root.
 
 ## Consequences
 

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -95,6 +95,11 @@ plugin's MCP bridge, hook commands, and any service they spawn derive config, st
 endpoints from the isolated root; prove it beforehand with `yoetz service isolation --json` run
 under the same environment.
 
+Issue #561 does not add an external-registration mutation path for Claude Code. The supported
+Claude development/plugin route continues to inherit the explicitly exported root from the exact
+session environment, and its MCP bridge and hooks must be tested under that same environment. No
+Codex registration status or `--env` behavior is inferred for Claude Code.
+
 ## Upgrading Yoetz under a running service
 
 The local-control handshake pins the exact schema-manifest digest, so after installing a new Yoetz

--- a/docs/runbooks/codex-dogfood.md
+++ b/docs/runbooks/codex-dogfood.md
@@ -114,11 +114,17 @@ its normal-target counterpart — record the non-pass `service_isolation` row wi
 `YOETZ_ISOLATED_ROOT`, and rebuild the report from fresh status. Never launch over shared,
 ambient, or unknown Yoetz identity.
 
-If the MCP binding or child launch is not proven, record the non-pass `mcp_child_isolation` row with
-the `reregister_isolated_mcp` continuation. Re-run the isolated registration preview, review the
-exact `isolated_root`, apply that same preview digest, confirm status reports
-`isolation_binding=isolated_exact`, and recapture the app-server inventory before rebuilding the
-report. The capture starts the registered child without a model task; inventory is child-start
+If the MCP registration is not `yoetz_owned` or its binding is not `isolated_exact`, record the
+non-pass `mcp_child_isolation` row with the `reregister_isolated_mcp` continuation. Re-run the
+isolated registration preview, review the exact `isolated_root`, apply that same preview digest,
+confirm status reports `isolation_binding=isolated_exact`, and recapture the app-server inventory
+before rebuilding the report.
+
+If the registration is already owned and exact but the child state is `failed` or `unknown`,
+re-registering changes nothing; record the row with the `recapture_isolated_mcp_child`
+continuation instead. Inspect the capture output for the child launch error, repair the candidate
+executable or its environment outside the registration, and re-run the capture until the child
+starts. The capture starts the registered child without a model task; inventory is child-start
 evidence, not proof that a model received or used a tool.
 
 If consent is missing, record `blocked / observation_consent_missing /

--- a/docs/runbooks/codex-dogfood.md
+++ b/docs/runbooks/codex-dogfood.md
@@ -82,6 +82,7 @@ YOETZ_ISOLATED_ROOT=<exact-root> <candidate-yoetz> service isolation --json
 yoetz recommend list --codex-path <exact-executable> --codex-home <exact-home> --json
 yoetz integrate codex plugin status --project-root <exact-worktree> --codex-path <exact-executable> --codex-home <exact-home> --json
 CODEX_HOME=<exact-home> CODEX_TESTING_HOME=<exact-home> yoetz integrate codex mcp status --codex-path <exact-executable> --json
+python scripts/capture_codex_mcp_surface.py --codex-binary <exact-executable> --codex-testing-home <exact-home> --output <capture-outside-worktree.json>
 yoetz observe status --workspace <exact-worktree> --codex-path <exact-executable> --codex-home <exact-home> --json
 ```
 
@@ -94,6 +95,7 @@ bounded reason token, an optional evidence digest, and a closed next action.
 | `source_identity` | Worktree HEAD equals `source_ref`. |
 | `package_identity` | Installed candidate is the recorded package digest. |
 | `service_isolation` | The exact normal report has mode `ambient`, the exact launch report has mode `isolated`, and every state/endpoint/storage/config/executable digest differs. Shared, relocated, ambient, or unknown identity cannot pass. |
+| `mcp_child_isolation` | MCP status is `yoetz_owned` with `isolation_binding=isolated_exact`, and the pre-model app-server capture starts the registered server successfully. This combines the exact reviewed binding, ADR-026 root derivation, and the installed Codex propagation regression; a bare, missing, different, foreign, failed, or unverifiable child cannot pass. |
 | `workspace_binding` | Codex and every Yoetz control use the same exact worktree. |
 | `observation_consent` | Consent is `active` for that worktree commitment. |
 | `plugin_source` | Exact managed source is present in that worktree. |
@@ -111,6 +113,13 @@ its normal-target counterpart — record the non-pass `service_isolation` row wi
 `provision_isolated_yoetz_root` continuation, provision a fresh isolation root, re-export
 `YOETZ_ISOLATED_ROOT`, and rebuild the report from fresh status. Never launch over shared,
 ambient, or unknown Yoetz identity.
+
+If the MCP binding or child launch is not proven, record the non-pass `mcp_child_isolation` row with
+the `reregister_isolated_mcp` continuation. Re-run the isolated registration preview, review the
+exact `isolated_root`, apply that same preview digest, confirm status reports
+`isolation_binding=isolated_exact`, and recapture the app-server inventory before rebuilding the
+report. The capture starts the registered child without a model task; inventory is child-start
+evidence, not proof that a model received or used a tool.
 
 If consent is missing, record `blocked / observation_consent_missing /
 yoetz_observe_grant_exact_worktree`, show the trusted local command, and stop. If activation is
@@ -195,13 +204,16 @@ an out-of-scope pass, failure, or block is inconsistent evidence and invalidates
 ## 7. Report shape and statuses
 
 The top-level keys are exactly `schema`, `identity`, `scope`, `observed`, and `facets`; the current
-schema is `yoetz.codex-dogfood-parity/2` (version 1 reports, which carried no Yoetz isolation
-identity, are no longer accepted). `observed` retains only closed states/counts:
-activation state, Yoetz isolation state (`isolated|shared|ambient|unknown`), exact/primary consent
-states, workspace-match boolean, mapping presence, accepted envelope count, undelivered count,
-drain success, hook coverage, and stream coverage. The validator rejects a passing
+schema is `yoetz.codex-dogfood-parity/3` (version 1 lacked Yoetz isolation identity; version 2
+lacked host-child binding proof; neither is accepted). `observed` retains only closed states/counts:
+activation state, Yoetz isolation state (`isolated|shared|ambient|unknown`), MCP registration state,
+MCP isolation binding, MCP child state (`ready|failed|unknown`), exact/primary consent states,
+workspace-match boolean, mapping presence, accepted envelope count, undelivered count, drain
+success, hook coverage, and stream coverage. The validator rejects a passing
 `service_isolation` row whose observed state is not `isolated`, whose identity mode is not
-`isolated`, or whose digests show any shared identity root.
+`isolated`, or whose digests show any shared identity root; it rejects a passing
+`mcp_child_isolation` row unless the registration is owned, the binding is exact, and the child is
+ready.
 
 Every facet is reported even when unsupported or not run. The validator rejects extra top-level,
 identity, scope, observed, or facet-row fields; this is the privacy boundary that keeps paths and

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -585,6 +585,16 @@ and any service they spawn resolve the normal singleton, state directory, and st
 mode with `yoetz service isolation --json` before launch; the parity gate's `service_isolation`
 facet fails closed on shared, ambient, or unknown identity.
 
+For the Yoetz-owned external registration, issue #561 makes this propagation a supported product
+contract: an isolated preview displays and digest-binds the exact root, apply uses Codex's native
+`--env YOETZ_ISOLATED_ROOT=<exact-root>`, and status must report
+`isolation_binding=isolated_exact`. Ambient registration stores no environment. A missing or
+different known root requires re-registration; arbitrary environment keys, inherited-variable
+declarations, and malformed roots classify the same-name entry as foreign and are never replaced.
+Before a dogfood model task, use the app-server capture in the parity runbook to launch the real
+registered child and satisfy `mcp_child_isolation`; registration status alone is not child-start
+evidence.
+
 ## Subscription evaluator is a separate Codex role
 
 Codex may be both the host carrying Yoetz and the selected external semantic evaluator, but those

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -35,6 +35,11 @@ replacement); the generic `update`, `enable`, `disable`, and `export` commands l
 group are Claude Code lifecycles and refuse for Cursor with
 `cursor_plugin_command_unsupported:<command> supported=preview,install,status,remove` (exit 2).
 
+Issue #561 changes only Yoetz-owned external Codex registration. Cursor remains supported through
+its native plugin projection: the exact isolated root is rendered into the test cell's `mcp.json`
+and hook commands and is bound by that artifact's preview digest. Cursor does not consume the Codex
+`mcp add --env` path or its `isolation_binding` status field.
+
 ```text
 yoetz integrate cursor plugin preview \
   --cursor-config-root /exact/testing/home/.cursor \

--- a/scripts/check_codex_dogfood_parity.py
+++ b/scripts/check_codex_dogfood_parity.py
@@ -1,4 +1,4 @@
-"""Validate the retained exact-worktree Codex dogfood parity gate (issues #463/#464/#518).
+"""Validate the retained exact-worktree Codex dogfood parity gate (issues #463/#464/#518/#561).
 
 The input is a bounded structural report assembled from the runbook's named commands. It carries
 digests and closed states only: no paths, prompts, transcripts, credentials, or provider payloads.
@@ -18,7 +18,7 @@ from typing import Final, Literal, TypedDict, cast
 
 GateStatus = Literal["pass", "fail", "unsupported", "blocked", "not_run"]
 
-_SCHEMA: Final = "yoetz.codex-dogfood-parity/2"
+_SCHEMA: Final = "yoetz.codex-dogfood-parity/3"
 _MAX_REPORT_BYTES: Final = 131_072
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$", re.ASCII)
 _SOURCE_REF = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$", re.ASCII)
@@ -29,6 +29,7 @@ PREFLIGHT_FACETS: Final = (
     "source_identity",
     "package_identity",
     "service_isolation",
+    "mcp_child_isolation",
     "workspace_binding",
     "observation_consent",
     "plugin_source",
@@ -69,6 +70,7 @@ _NEXT_ACTIONS: Final = frozenset(
         "none",
         "do_not_launch",
         "provision_isolated_yoetz_root",
+        "reregister_isolated_mcp",
         "yoetz_observe_grant_exact_worktree",
         "yoetz_recommend_list_exact_target",
         "manual_activation_review",
@@ -125,6 +127,9 @@ class DogfoodIdentity(TypedDict):
 class DogfoodObserved(TypedDict):
     activation_state: str
     yoetz_isolation_state: str
+    mcp_registration_state: str
+    mcp_isolation_binding: str
+    mcp_child_state: str
     exact_worktree_consent: str
     primary_checkout_consent: str
     controls_workspace_match: bool
@@ -277,6 +282,9 @@ def _parse_observed(value: object) -> DogfoodObserved:
     expected = {
         "activation_state",
         "yoetz_isolation_state",
+        "mcp_registration_state",
+        "mcp_isolation_binding",
+        "mcp_child_state",
         "exact_worktree_consent",
         "primary_checkout_consent",
         "controls_workspace_match",
@@ -291,6 +299,9 @@ def _parse_observed(value: object) -> DogfoodObserved:
         raise _error("observed_fields_invalid")
     activation = row["activation_state"]
     isolation_state = row["yoetz_isolation_state"]
+    mcp_registration_state = row["mcp_registration_state"]
+    mcp_isolation_binding = row["mcp_isolation_binding"]
+    mcp_child_state = row["mcp_child_state"]
     exact_consent = row["exact_worktree_consent"]
     primary_consent = row["primary_checkout_consent"]
     if activation not in {
@@ -303,6 +314,18 @@ def _parse_observed(value: object) -> DogfoodObserved:
         raise _error("activation_state_invalid")
     if isolation_state not in {"isolated", "shared", "ambient", "unknown"}:
         raise _error("yoetz_isolation_state_invalid")
+    if mcp_registration_state not in {"yoetz_owned", "absent", "foreign_present", "unknown"}:
+        raise _error("mcp_registration_state_invalid")
+    if mcp_isolation_binding not in {
+        "ambient",
+        "isolated_exact",
+        "missing",
+        "different",
+        "unknown",
+    }:
+        raise _error("mcp_isolation_binding_invalid")
+    if mcp_child_state not in {"ready", "failed", "unknown"}:
+        raise _error("mcp_child_state_invalid")
     consent_states = {"active", "missing", "paused", "revoked", "unknown"}
     if exact_consent not in consent_states or primary_consent not in consent_states:
         raise _error("consent_state_invalid")
@@ -315,6 +338,9 @@ def _parse_observed(value: object) -> DogfoodObserved:
     return DogfoodObserved(
         activation_state=cast(str, activation),
         yoetz_isolation_state=cast(str, isolation_state),
+        mcp_registration_state=cast(str, mcp_registration_state),
+        mcp_isolation_binding=cast(str, mcp_isolation_binding),
+        mcp_child_state=cast(str, mcp_child_state),
         exact_worktree_consent=cast(str, exact_consent),
         primary_checkout_consent=cast(str, primary_consent),
         controls_workspace_match=_require_bool(
@@ -462,6 +488,13 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
         )
         if any(resolved == normal for resolved, normal in shared_identity_pairs):
             raise _error("service_isolation_identity_shared")
+    mcp_child_exact = (
+        observed["mcp_registration_state"] == "yoetz_owned"
+        and observed["mcp_isolation_binding"] == "isolated_exact"
+        and observed["mcp_child_state"] == "ready"
+    )
+    if (facets["mcp_child_isolation"]["status"] == "pass") != mcp_child_exact:
+        raise _error("mcp_child_isolation_state_mismatch")
     if facets["mapping"]["status"] == "pass" and not observed["mapping_present"]:
         raise _error("mapping_observation_missing")
     if (
@@ -488,6 +521,9 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
         "provision_isolated_yoetz_root"
     ):
         raise _error("service_isolation_continuation_missing")
+    mcp_child = facets["mcp_child_isolation"]
+    if mcp_child["status"] != "pass" and mcp_child["next_action"] != ("reregister_isolated_mcp"):
+        raise _error("mcp_child_isolation_continuation_missing")
     activation = facets["plugin_activation"]
     if activation["reason"] == "installed_not_activated" and activation["next_action"] != (
         "yoetz_recommend_list_exact_target"

--- a/scripts/check_codex_dogfood_parity.py
+++ b/scripts/check_codex_dogfood_parity.py
@@ -71,6 +71,7 @@ _NEXT_ACTIONS: Final = frozenset(
         "do_not_launch",
         "provision_isolated_yoetz_root",
         "reregister_isolated_mcp",
+        "recapture_isolated_mcp_child",
         "yoetz_observe_grant_exact_worktree",
         "yoetz_recommend_list_exact_target",
         "manual_activation_review",
@@ -522,8 +523,19 @@ def classify_codex_dogfood_report(document: object) -> DogfoodGateResult:
     ):
         raise _error("service_isolation_continuation_missing")
     mcp_child = facets["mcp_child_isolation"]
-    if mcp_child["status"] != "pass" and mcp_child["next_action"] != ("reregister_isolated_mcp"):
-        raise _error("mcp_child_isolation_continuation_missing")
+    if mcp_child["status"] != "pass":
+        # An exact owned binding cannot be repaired by re-registering it; only the child
+        # start or its capture is unproven there. Every other non-pass shape needs the
+        # reviewed registration redone before the child is worth capturing again.
+        mcp_binding_exact = (
+            observed["mcp_registration_state"] == "yoetz_owned"
+            and observed["mcp_isolation_binding"] == "isolated_exact"
+        )
+        expected_action = (
+            "recapture_isolated_mcp_child" if mcp_binding_exact else "reregister_isolated_mcp"
+        )
+        if mcp_child["next_action"] != expected_action:
+            raise _error("mcp_child_isolation_continuation_missing")
     activation = facets["plugin_activation"]
     if activation["reason"] == "installed_not_activated" and activation["next_action"] != (
         "yoetz_recommend_list_exact_target"

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -13,9 +13,12 @@ import subprocess
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from types import MappingProxyType
 from typing import Final, Literal, cast
 
+from yoetz.config.paths import ISOLATED_ROOT_ENV, PathSafetyError, isolated_root
+from yoetz.domain.values import JsonValue
 from yoetz.ports.harness_mcp import (
     MCP_SERVE_COMMAND,
     MCP_SERVER_NAME,
@@ -136,6 +139,45 @@ def _entry_command_tokens(entry: Mapping[str, object]) -> tuple[str, ...] | None
     return None
 
 
+def _entry_isolated_root(entry: Mapping[str, object]) -> tuple[bool, str | None]:
+    """Read the only environment binding this owned registration may carry.
+
+    The command tokens establish Yoetz ownership; this separate parser refuses to bless a
+    same-command entry with any other environment key, inherited variable, or malformed root.
+    A known but different absolute root remains readable so the digest-bound lifecycle can
+    re-register or remove the Yoetz-owned entry without gaining an arbitrary-env force path.
+    """
+
+    transport = entry.get("transport")
+    source: Mapping[str, object] = entry
+    if isinstance(transport, Mapping):
+        nested = cast(Mapping[str, object], transport)
+        if "command" in nested or "args" in nested:
+            source = nested
+    env_vars = source.get("env_vars")
+    if env_vars not in (None, []):
+        return False, None
+    environment = source.get("env")
+    if environment is None:
+        return True, None
+    if not isinstance(environment, Mapping):
+        return False, None
+    values = cast(Mapping[object, object], environment)
+    if not values:
+        return True, None
+    if set(values) != {ISOLATED_ROOT_ENV}:
+        return False, None
+    raw = values.get(ISOLATED_ROOT_ENV)
+    if (
+        type(raw) is not str
+        or not 1 <= len(raw) <= 4_096
+        or not Path(raw).is_absolute()
+        or any(ord(char) < 32 or ord(char) == 127 for char in raw)
+    ):
+        return False, None
+    return True, raw
+
+
 class CodexMcpAdapter:
     """Implements ``HarnessMcpPort`` for the Codex CLI via bounded subprocesses."""
 
@@ -161,19 +203,22 @@ class CodexMcpAdapter:
     @staticmethod
     def _classify_entry(
         entry: Mapping[str, object],
-    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None, str | None]:
         tokens = _entry_command_tokens(entry)
         for command in (MCP_STRICT_SERVE_COMMAND, MCP_SERVE_COMMAND):
             if tokens == command:
+                environment_readable, registered_root = _entry_isolated_root(entry)
+                if not environment_readable:
+                    return McpRegistrationState.FOREIGN_PRESENT, None, None
                 # Return the matched constant, not the parsed tokens, so the route mapping below
                 # reads off one source of truth instead of re-comparing the argv.
-                return McpRegistrationState.YOETZ_OWNED, command
+                return McpRegistrationState.YOETZ_OWNED, command, registered_root
         # An unreadable or different command is preserved, never replaced.
-        return McpRegistrationState.FOREIGN_PRESENT, None
+        return McpRegistrationState.FOREIGN_PRESENT, None, None
 
     def _classify_get(
         self, output: CommandOutput
-    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None, str | None]:
         if output.exit_code != 0:
             raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
         try:
@@ -186,7 +231,7 @@ class CodexMcpAdapter:
 
     def _classify_list(
         self, output: CommandOutput
-    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None, str | None]:
         if output.exit_code != 0:
             raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
         try:
@@ -206,7 +251,7 @@ class CodexMcpAdapter:
             if name == MCP_SERVER_NAME:
                 matches.append(entry)
         if not matches:
-            return McpRegistrationState.ABSENT, None
+            return McpRegistrationState.ABSENT, None, None
         if len(matches) != 1:
             # A same-name duplicate is not a trustworthy absence or ownership observation.
             raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
@@ -214,7 +259,7 @@ class CodexMcpAdapter:
 
     def _observe_registration_state(
         self, binary: HarnessBinary
-    ) -> tuple[McpRegistrationState, tuple[str, ...] | None]:
+    ) -> tuple[McpRegistrationState, tuple[str, ...] | None, str | None]:
         output = self._run((binary.executable_path, "mcp", "get", MCP_SERVER_NAME, "--json"))
         if output.exit_code == 0:
             return self._classify_get(output)
@@ -224,13 +269,41 @@ class CodexMcpAdapter:
 
     async def status_registration(self, binary: HarnessBinary) -> McpRegistrationState:
         self._require_codex(binary)
+        self._expected_isolated_root()
         return self._observe_registration_state(binary)[0]
 
     async def observe_registration(self, binary: HarnessBinary) -> McpRegistrationObservation:
         self._require_codex(binary)
-        state, command = self._observe_registration_state(binary)
+        expected_root = self._expected_isolated_root()
+        state, command, registered_root = self._observe_registration_state(binary)
         route_profile = None if command is None else _ROUTE_PROFILE_BY_COMMAND.get(command)
-        return McpRegistrationObservation(binary.harness_id, state, route_profile)
+        isolation_binding = None
+        if state is McpRegistrationState.YOETZ_OWNED:
+            if expected_root is None and registered_root is None:
+                isolation_binding = "ambient"
+            elif expected_root is not None and registered_root == expected_root:
+                isolation_binding = "isolated_exact"
+            elif expected_root is not None and registered_root is None:
+                isolation_binding = "missing"
+            else:
+                isolation_binding = "different"
+        return McpRegistrationObservation(
+            binary.harness_id,
+            state,
+            route_profile,
+            isolation_binding,
+        )
+
+    @staticmethod
+    def _expected_isolated_root() -> str | None:
+        try:
+            root = isolated_root()
+        except PathSafetyError as exc:
+            raise McpRegistrationError(
+                McpRegistrationReason.ISOLATION_INVALID,
+                {"reason": exc.reason_code},
+            ) from exc
+        return None if root is None else str(root)
 
     @staticmethod
     def _require_codex(binary: HarnessBinary) -> None:
@@ -242,31 +315,35 @@ class CodexMcpAdapter:
         binary: HarnessBinary,
         state: McpRegistrationState,
         current_command: tuple[str, ...] | None,
+        current_root: str | None,
     ) -> McpRegistrationPreview:
+        expected_root = self._expected_isolated_root()
         action = (
             McpRegistrationAction.REGISTER
             if state is McpRegistrationState.ABSENT
             else (
                 McpRegistrationAction.REREGISTER
                 if state is McpRegistrationState.YOETZ_OWNED
-                and current_command != self._serve_command
+                and (current_command != self._serve_command or current_root != expected_root)
                 else McpRegistrationAction.NOOP
             )
         )
         warnings: tuple[str, ...] = ()
         if state is McpRegistrationState.FOREIGN_PRESENT:
             warnings = ("foreign_entry_present",)
-        digest = canonical_digest(
-            {
-                "action": action.value,
-                "executable_path": binary.executable_path,
-                "harness": binary.harness_id.value,
-                "schema": "yoetz.mcp-registration-preview/1",
-                "serve_command": list(self._serve_command),
-                "server_name": MCP_SERVER_NAME,
-                "state_before": state.value,
-            }
-        )
+        digest_input: dict[str, object] = {
+            "action": action.value,
+            "executable_path": binary.executable_path,
+            "harness": binary.harness_id.value,
+            "schema": "yoetz.mcp-registration-preview/1",
+            "serve_command": list(self._serve_command),
+            "server_name": MCP_SERVER_NAME,
+            "state_before": state.value,
+        }
+        if expected_root is not None:
+            digest_input["schema"] = "yoetz.mcp-registration-preview/2"
+            digest_input["isolated_root"] = expected_root
+        digest = canonical_digest(cast(JsonValue, digest_input))
         return McpRegistrationPreview(
             binary.harness_id,
             action,
@@ -275,12 +352,13 @@ class CodexMcpAdapter:
             digest,
             self._serve_command,
             self._route_profile,
+            expected_root,
         )
 
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         self._require_codex(binary)
-        state, current_command = self._observe_registration_state(binary)
-        return self._preview_for(binary, state, current_command)
+        state, current_command, current_root = self._observe_registration_state(binary)
+        return self._preview_for(binary, state, current_command, current_root)
 
     async def apply_registration(
         self,
@@ -305,8 +383,21 @@ class CodexMcpAdapter:
                 preview.state_before,
                 preview.preview_digest,
             )
+        environment_args = (
+            ()
+            if preview.isolated_root is None
+            else ("--env", f"{ISOLATED_ROOT_ENV}={preview.isolated_root}")
+        )
         add_output = self._run(
-            (binary.executable_path, "mcp", "add", MCP_SERVER_NAME, "--", *self._serve_command)
+            (
+                binary.executable_path,
+                "mcp",
+                "add",
+                MCP_SERVER_NAME,
+                *environment_args,
+                "--",
+                *self._serve_command,
+            )
         )
         if add_output.exit_code != 0:
             raise McpRegistrationError(
@@ -314,10 +405,11 @@ class CodexMcpAdapter:
                 {"exit_code_class": "nonzero"},
             )
         # Verify by re-reading state rather than trusting the add exit code alone.
-        state_after, command_after = self._observe_registration_state(binary)
+        state_after, command_after, root_after = self._observe_registration_state(binary)
         if (
             state_after is not McpRegistrationState.YOETZ_OWNED
             or command_after != self._serve_command
+            or root_after != preview.isolated_root
         ):
             raise McpRegistrationError(
                 McpRegistrationReason.REGISTRATION_FAILED,
@@ -336,6 +428,7 @@ class CodexMcpAdapter:
         binary: HarnessBinary,
         state: McpRegistrationState,
         current_command: tuple[str, ...] | None,
+        current_root: str | None,
     ) -> McpRegistrationPreview:
         action = (
             McpRegistrationAction.NOOP
@@ -362,17 +455,19 @@ class CodexMcpAdapter:
             # binds ``state_before``, so apply refuses the same-name entry.
             serve_command = self._serve_command
             route_profile = self._route_profile
-        digest = canonical_digest(
-            {
-                "action": action.value,
-                "executable_path": binary.executable_path,
-                "harness": binary.harness_id.value,
-                "schema": "yoetz.mcp-unregistration-preview/1",
-                "serve_command": list(serve_command),
-                "server_name": MCP_SERVER_NAME,
-                "state_before": state.value,
-            }
-        )
+        digest_input: dict[str, object] = {
+            "action": action.value,
+            "executable_path": binary.executable_path,
+            "harness": binary.harness_id.value,
+            "schema": "yoetz.mcp-unregistration-preview/1",
+            "serve_command": list(serve_command),
+            "server_name": MCP_SERVER_NAME,
+            "state_before": state.value,
+        }
+        if current_root is not None:
+            digest_input["schema"] = "yoetz.mcp-unregistration-preview/2"
+            digest_input["isolated_root"] = current_root
+        digest = canonical_digest(cast(JsonValue, digest_input))
         return McpRegistrationPreview(
             binary.harness_id,
             action,
@@ -381,12 +476,14 @@ class CodexMcpAdapter:
             digest,
             serve_command,
             route_profile,
+            current_root,
         )
 
     async def preview_unregistration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         self._require_codex(binary)
-        state, current_command = self._observe_registration_state(binary)
-        return self._unregistration_preview_for(binary, state, current_command)
+        self._expected_isolated_root()
+        state, current_command, current_root = self._observe_registration_state(binary)
+        return self._unregistration_preview_for(binary, state, current_command, current_root)
 
     async def apply_unregistration(
         self,
@@ -411,12 +508,15 @@ class CodexMcpAdapter:
                 preview.state_before,
                 preview.preview_digest,
             )
-        state_before_remove, command_before_remove = self._observe_registration_state(binary)
+        state_before_remove, command_before_remove, root_before_remove = (
+            self._observe_registration_state(binary)
+        )
         if state_before_remove is McpRegistrationState.FOREIGN_PRESENT:
             raise McpRegistrationError(McpRegistrationReason.FOREIGN_ENTRY_PRESENT, {})
         if (
             state_before_remove is not McpRegistrationState.YOETZ_OWNED
             or command_before_remove != preview.serve_command
+            or root_before_remove != preview.isolated_root
         ):
             raise McpRegistrationError(McpRegistrationReason.PREVIEW_STALE, {})
         try:
@@ -432,7 +532,7 @@ class CodexMcpAdapter:
                 {"exit_code_class": "nonzero"},
             )
         try:
-            state_after, _command_after = self._observe_registration_state(binary)
+            state_after, _command_after, _root_after = self._observe_registration_state(binary)
         except McpRegistrationError as exc:
             # The name-based remove command already succeeded. Any unreadable or
             # malformed verification is therefore an outcome-unknown mutation,

--- a/src/yoetz/cli/menu.py
+++ b/src/yoetz/cli/menu.py
@@ -185,7 +185,10 @@ async def _harness_summary() -> tuple[str, ...]:
     for binary in binaries:
         version = binary.reported_version or "unknown version"
         try:
-            state = (await service.status(binary)).value
+            observation = await service.observe(binary)
+            state = observation.state.value
+            if observation.isolation_binding is not None:
+                state += f", isolation: {observation.isolation_binding}"
         except McpRegistrationError as error:
             state = f"unknown ({error.reason.value})"
         lines.append(f"codex ({version}) — MCP registration: {state}")

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -749,6 +749,10 @@ def _emit_registration_preview(
     typer.echo("  MCP server name: yoetz")
     serve_command = getattr(mcp_preview, "serve_command", ())
     typer.echo(f"  Command: {' '.join(serve_command)}")
+    isolated_root = getattr(mcp_preview, "isolated_root", None)
+    typer.echo(
+        "  MCP isolation root: " + (str(isolated_root) if isolated_root is not None else "ambient")
+    )
     route_profile = getattr(mcp_preview, "route_profile", None)
     if type(route_profile) is str:
         if route_profile_before is not None and route_profile_before != route_profile:
@@ -835,6 +839,10 @@ def _emit_unregistration_preview(mcp_preview: object) -> None:
     typer.echo(f"  State before: {getattr(mcp_preview, 'state_before').value}")
     serve_command = getattr(mcp_preview, "serve_command", ())
     typer.echo(f"  Command: {' '.join(serve_command)}")
+    isolated_root = getattr(mcp_preview, "isolated_root", None)
+    typer.echo(
+        "  MCP isolation root: " + (str(isolated_root) if isolated_root is not None else "ambient")
+    )
     route_profile = getattr(mcp_preview, "route_profile", None)
     if type(route_profile) is str:
         typer.echo(f"  MCP route profile: {route_profile}")
@@ -1604,6 +1612,7 @@ async def _codex_integration_step(
         "route_profile": mcp_preview.route_profile,
         "route_profile_before": route_profile_before,
         "serve_command": list(mcp_preview.serve_command),
+        "isolated_root": mcp_preview.isolated_root,
         "state": mcp_state.value,
         "plugin": plugin_report,
         "plugin_activation": activation_report,
@@ -2955,6 +2964,7 @@ async def integrate_mcp(
             _emit(
                 {
                     "harness": harness,
+                    "isolation_binding": observation.isolation_binding,
                     "route_profile": observation.route_profile,
                     "state": observation.state.value,
                     "registered_profile": _registered_profile,
@@ -2972,6 +2982,7 @@ async def integrate_mcp(
                         "action": preview.action.value,
                         "admission_cleanup": _admission_cleanup_preview(project_root),
                         "harness": harness,
+                        "isolated_root": preview.isolated_root,
                         "preview_digest": preview.preview_digest,
                         "route_profile": preview.route_profile,
                         "serve_command": list(preview.serve_command),
@@ -3063,6 +3074,7 @@ async def integrate_mcp(
                         else None
                     ),
                     "harness": harness,
+                    "isolated_root": preview.isolated_root,
                     "preview_digest": preview.preview_digest,
                     "route_profile": preview.route_profile,
                     "route_profile_before": route_profile_before,

--- a/src/yoetz/ports/harness_mcp.py
+++ b/src/yoetz/ports/harness_mcp.py
@@ -22,6 +22,7 @@ __all__ = [
     "McpRegistrationAction",
     "McpRegistrationCommand",
     "McpRegistrationError",
+    "McpIsolationBinding",
     "McpRegistrationObservation",
     "McpRegistrationPreview",
     "McpRegistrationReason",
@@ -39,6 +40,7 @@ _MAX_WARNINGS: Final = 16
 _TOKEN_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,127}$", re.ASCII)
 
 type Compatibility = Literal["supported", "untested"]
+type McpIsolationBinding = Literal["ambient", "isolated_exact", "missing", "different"]
 
 
 def _port_error(reason: str) -> ProtocolValueError:
@@ -68,6 +70,7 @@ class McpRegistrationReason(str, Enum):  # noqa: UP042 - exact wire-valued Enum 
     TIMEOUT = "timeout"
     REGISTRATION_FAILED = "registration_failed"
     FOREIGN_ENTRY_PRESENT = "foreign_entry_present"
+    ISOLATION_INVALID = "isolation_invalid"
 
 
 @dataclass(frozen=True, slots=True, repr=False)
@@ -118,6 +121,7 @@ class McpRegistrationPreview:
     preview_digest: str
     serve_command: tuple[str, ...] = MCP_SERVE_COMMAND
     route_profile: Literal["policy", "strict"] = "policy"
+    isolated_root: str | None = None
 
     def __post_init__(self) -> None:
         if type(self.harness_id) is not HarnessId:
@@ -141,6 +145,13 @@ class McpRegistrationPreview:
         )
         if self.route_profile not in {"policy", "strict"} or self.serve_command != expected_command:
             raise _port_error("integration_value_invalid")
+        if self.isolated_root is not None and (
+            type(self.isolated_root) is not str
+            or not 1 <= len(self.isolated_root) <= _MAX_PATH_CHARS
+            or not self.isolated_root.startswith("/")
+            or any(ord(char) < 32 or ord(char) == 127 for char in self.isolated_root)
+        ):
+            raise _port_error("integration_target_invalid")
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,6 +167,7 @@ class McpRegistrationObservation:
     harness_id: HarnessId
     state: McpRegistrationState
     route_profile: Literal["policy", "strict"] | None
+    isolation_binding: McpIsolationBinding | None = None
 
     def __post_init__(self) -> None:
         if type(self.harness_id) is not HarnessId:
@@ -163,10 +175,13 @@ class McpRegistrationObservation:
         if type(self.state) is not McpRegistrationState:
             raise _port_error("integration_state_invalid")
         if self.route_profile is None:
+            if self.isolation_binding is not None:
+                raise _port_error("integration_value_invalid")
             return
         if (
             self.route_profile not in {"policy", "strict"}
             or self.state is not McpRegistrationState.YOETZ_OWNED
+            or self.isolation_binding not in {"ambient", "isolated_exact", "missing", "different"}
         ):
             raise _port_error("integration_value_invalid")
 

--- a/src/yoetz/tui/models.py
+++ b/src/yoetz/tui/models.py
@@ -155,6 +155,7 @@ class IntegrationPlan:
     activation_marketplace_preimage_digest: str
     activation_config_preimage_digest: str
     activation_cache_mutation_planned: bool
+    mcp_isolated_root: str | None = None
 
     @property
     def changes(self) -> tuple[str, ...]:

--- a/src/yoetz/tui/render.py
+++ b/src/yoetz/tui/render.py
@@ -267,6 +267,7 @@ def render_integration_technical_details(plan: IntegrationPlan, width: int) -> t
         ("Project root", plan.project_root),
         ("MCP server name", plan.mcp_server_name),
         ("MCP command", plan.mcp_command),
+        ("MCP isolation root", plan.mcp_isolated_root or "ambient"),
         ("MCP preview digest", plan.preview_digest),
         ("Skill preview digest", plan.skill_preview_digest),
         ("Activation preview digest", plan.activation_preview_digest),

--- a/src/yoetz/tui/runtime.py
+++ b/src/yoetz/tui/runtime.py
@@ -490,6 +490,7 @@ class YoetzRuntime:
             activation_marketplace_preimage_digest=(activation_preview.marketplace_preimage_digest),
             activation_config_preimage_digest=activation_preview.config_preimage_digest,
             activation_cache_mutation_planned=activation_preview.cache_mutation_planned,
+            mcp_isolated_root=mcp_preview.isolated_root,
         )
 
     async def apply_integration(

--- a/tests/packaging/test_codex_mcp_isolated_registration.py
+++ b/tests/packaging/test_codex_mcp_isolated_registration.py
@@ -1,0 +1,217 @@
+"""Installed Codex 0.150.1 propagation regression for issue #561.
+
+The test uses a fresh Codex home and a test-owned executable named ``yoetz``.  Product code
+registers the exact allowlisted isolation binding, then the real Codex app-server launches that
+registered child while its own parent environment deliberately lacks ``YOETZ_ISOLATED_ROOT``.
+The child records the value it actually received and completes the MCP handshake.  This proves
+the reviewed registration, not ambient parent inheritance, supplied the exact isolated root.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import secrets
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final, cast
+
+import anyio
+import pytest
+
+from yoetz.adapters.integrations.codex_mcp import CodexMcpAdapter
+from yoetz.application.harness_mcp import HarnessMcpService, McpRegistrationConfirmation
+from yoetz.config.paths import ISOLATED_ROOT_ENV
+from yoetz.ports.harness_mcp import HarnessBinary, McpRegistrationState
+from yoetz.ports.integrations import HarnessId
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+_EXPECTED_CODEX_VERSION: Final = "codex-cli 0.150.1"
+_PROBE_MARKER: Final = "codex-child-isolated-root.txt"
+_PROBE_SCRIPT: Final = r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+root = os.environ.get("YOETZ_ISOLATED_ROOT")
+if not root:
+    raise SystemExit(73)
+pathlib.Path(root, "codex-child-isolated-root.txt").write_text(root, encoding="utf-8")
+
+for raw in sys.stdin.buffer:
+    try:
+        request = json.loads(raw)
+    except Exception:
+        continue
+    request_id = request.get("id")
+    if request_id is None:
+        continue
+    method = request.get("method")
+    if method == "initialize":
+        params = request.get("params") or {}
+        result = {
+            "protocolVersion": params.get("protocolVersion", "2024-11-05"),
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "yoetz-isolation-probe", "version": "0.1.0"},
+        }
+    elif method == "tools/list":
+        result = {"tools": []}
+    elif method == "resources/list":
+        result = {"resources": []}
+    elif method == "resources/templates/list":
+        result = {"resourceTemplates": []}
+    elif method == "prompts/list":
+        result = {"prompts": []}
+    elif method == "ping":
+        result = {}
+    else:
+        response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method not found"},
+        }
+        sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+        continue
+    response = {"jsonrpc": "2.0", "id": request_id, "result": result}
+    sys.stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+"""
+
+
+def _is_advertised_host() -> bool:
+    return sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_advertised_host(),
+    reason="the issue #561 host regression is the installed macOS arm64 Codex 0.150.1 cell",
+)
+
+
+def _installed_codex_01501() -> Path:
+    candidate = shutil.which("codex")
+    if candidate is None:
+        pytest.skip("installed Codex 0.150.1 is unavailable")
+    executable = Path(candidate).resolve(strict=True)
+    result = subprocess.run(
+        [str(executable), "--version"],
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    if result.returncode != 0 or result.stdout.decode("utf-8").strip() != _EXPECTED_CODEX_VERSION:
+        pytest.skip("installed Codex is not the frozen 0.150.1 regression cell")
+    return executable
+
+
+def _short_private_root() -> Path:
+    base = Path.home() / ".yz-mcp561"
+    base.mkdir(mode=0o700, exist_ok=True)
+    base.chmod(0o700)
+    root = base / secrets.token_hex(4)
+    root.mkdir(mode=0o700)
+    return root
+
+
+def test_installed_codex_child_receives_only_the_reviewed_isolated_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex = _installed_codex_01501()
+    root = _short_private_root()
+    try:
+        isolated_root = root / "isolated"
+        codex_home = root / "codex-home"
+        probe_bin = root / "bin"
+        isolated_root.mkdir(mode=0o700)
+        codex_home.mkdir(mode=0o700)
+        probe_bin.mkdir(mode=0o700)
+        probe = probe_bin / "yoetz"
+        probe.write_text(_PROBE_SCRIPT, encoding="utf-8")
+        probe.chmod(0o700)
+
+        original_path = os.environ.get("PATH", "")
+        monkeypatch.setenv("PATH", f"{probe_bin}{os.pathsep}{original_path}")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("CODEX_TESTING_HOME", str(codex_home))
+        monkeypatch.setenv(ISOLATED_ROOT_ENV, str(isolated_root))
+
+        binary = HarnessBinary(HarnessId.CODEX, str(codex), "0.150.1", "supported")
+        service = HarnessMcpService(CodexMcpAdapter(route_profile="strict"))
+        preview = anyio.run(lambda: service.preview(binary))
+        assert preview.isolated_root == str(isolated_root)
+        result = anyio.run(
+            lambda: service.register(
+                binary,
+                McpRegistrationConfirmation(
+                    preview.preview_digest,
+                    True,
+                    "noninteractive_flag",
+                ),
+                _state=root / "applied-route",
+            )
+        )
+        assert result.state_after is McpRegistrationState.YOETZ_OWNED
+
+        observed = anyio.run(lambda: service.observe(binary))
+        assert observed.isolation_binding == "isolated_exact"
+
+        # The host parent has no isolation variable. Only the reviewed Codex registration can
+        # supply the value to the child that the real app-server now launches.
+        monkeypatch.delenv(ISOLATED_ROOT_ENV)
+        capture = root / "mcp-server-status.json"
+        launched = subprocess.run(
+            [
+                sys.executable,
+                str(_REPO_ROOT / "scripts" / "capture_codex_mcp_surface.py"),
+                "--codex-binary",
+                str(codex),
+                "--codex-testing-home",
+                str(codex_home),
+                "--output",
+                str(capture),
+            ],
+            capture_output=True,
+            timeout=45,
+            env=os.environ.copy(),
+            check=False,
+        )
+        assert launched.returncode == 0, launched.stderr.decode("utf-8", errors="replace")
+        document = cast(dict[str, object], json.loads(capture.read_bytes()))
+        inventory = cast(dict[str, object], document["inventory"])
+        result_body = cast(dict[str, object], inventory["result"])
+        entries = cast(list[dict[str, object]], result_body["data"])
+        assert entries[0]["serverInfo"] == {
+            "description": None,
+            "icons": None,
+            "name": "yoetz-isolation-probe",
+            "title": None,
+            "version": "0.1.0",
+            "websiteUrl": None,
+        }
+        assert (isolated_root / _PROBE_MARKER).read_text(encoding="utf-8") == str(isolated_root)
+
+        monkeypatch.setenv(ISOLATED_ROOT_ENV, str(isolated_root))
+        removal = anyio.run(lambda: service.preview_unregistration(binary))
+        removed = anyio.run(
+            lambda: service.unregister(
+                binary,
+                McpRegistrationConfirmation(
+                    removal.preview_digest,
+                    True,
+                    "noninteractive_flag",
+                ),
+                _state=root / "applied-route",
+            )
+        )
+        assert removed.state_after is McpRegistrationState.ABSENT
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        try:
+            root.parent.rmdir()
+        except OSError:
+            pass

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import anyio
 import pytest
 
 from yoetz.adapters.integrations.codex_mcp import CodexMcpAdapter, CommandOutput
+from yoetz.config.paths import PathSafetyError
 from yoetz.ports.harness_mcp import (
     HarnessBinary,
     McpRegistrationAction,
@@ -17,6 +19,7 @@ from yoetz.ports.harness_mcp import (
     McpRegistrationState,
 )
 from yoetz.ports.integrations import HarnessId
+from yoetz.protocol.canonical import canonical_digest
 
 _BINARY = HarnessBinary(
     harness_id=HarnessId.CODEX,
@@ -26,11 +29,14 @@ _BINARY = HarnessBinary(
 )
 
 
-def _yoetz_entry(*, strict: bool = False) -> bytes:
+def _yoetz_entry(*, strict: bool = False, isolated_root: str | None = None) -> bytes:
     args = ["mcp", "serve"]
     if strict:
         args.extend(["--semantic", "off"])
-    return json.dumps({"command": "yoetz", "args": args}).encode("utf-8")
+    transport: dict[str, object] = {"command": "yoetz", "args": args}
+    if isolated_root is not None:
+        transport["env"] = {"YOETZ_ISOLATED_ROOT": isolated_root}
+    return json.dumps(transport).encode("utf-8")
 
 
 def _absent_outputs() -> list[CommandOutput]:
@@ -136,6 +142,30 @@ def test_status_foreign_on_different_or_unreadable_command() -> None:
             "name": "yoetz",
             "transport": {"type": "stdio", "command": "other", "args": ["mcp", "serve"]},
         },
+        {
+            "name": "yoetz",
+            "transport": {
+                "type": "stdio",
+                "command": "yoetz",
+                "args": ["mcp", "serve"],
+                "env": {"ARBITRARY_KEY": "value"},
+            },
+        },
+        {
+            "name": "yoetz",
+            "transport": {
+                "type": "stdio",
+                "command": "yoetz",
+                "args": ["mcp", "serve"],
+                "env_vars": ["YOETZ_ISOLATED_ROOT"],
+            },
+        },
+        {
+            "command": "yoetz",
+            "args": ["mcp", "serve"],
+            "env": {"ARBITRARY_KEY": "value"},
+            "transport": {"type": "stdio"},
+        },
     ):
         runner = _Runner([CommandOutput(0, json.dumps(payload).encode("utf-8"))])
         state = anyio.run(lambda: CodexMcpAdapter(runner).status_registration(_BINARY))
@@ -154,7 +184,36 @@ def test_observe_reports_which_route_is_registered() -> None:
         observation = anyio.run(lambda: CodexMcpAdapter(runner).observe_registration(_BINARY))
         assert observation.state is McpRegistrationState.YOETZ_OWNED
         assert observation.route_profile == expected
+        assert observation.isolation_binding == "ambient"
         assert observation.harness_id is HarnessId.CODEX
+
+
+def test_observe_reports_exact_missing_and_different_isolation_bindings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = str(tmp_path)
+    monkeypatch.setenv("YOETZ_ISOLATED_ROOT", root)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: tmp_path)
+
+    exact = anyio.run(
+        lambda: CodexMcpAdapter(
+            _Runner([CommandOutput(0, _yoetz_entry(isolated_root=root))])
+        ).observe_registration(_BINARY)
+    )
+    missing = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())])).observe_registration(
+            _BINARY
+        )
+    )
+    different = anyio.run(
+        lambda: CodexMcpAdapter(
+            _Runner([CommandOutput(0, _yoetz_entry(isolated_root="/different/root"))])
+        ).observe_registration(_BINARY)
+    )
+
+    assert exact.isolation_binding == "isolated_exact"
+    assert missing.isolation_binding == "missing"
+    assert different.isolation_binding == "different"
 
 
 def test_observe_reports_no_route_when_the_entry_is_not_ours() -> None:
@@ -187,6 +246,23 @@ def test_observe_parse_failure_is_a_typed_error() -> None:
     with pytest.raises(McpRegistrationError) as caught:
         anyio.run(lambda: CodexMcpAdapter(runner).observe_registration(_BINARY))
     assert caught.value.reason is McpRegistrationReason.PARSE_FAILED
+
+
+def test_invalid_isolated_root_fails_before_the_host_is_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def invalid_root() -> Path:
+        raise PathSafetyError("isolation_root_invalid")
+
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", invalid_root)
+    runner = _Runner([])
+
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(lambda: CodexMcpAdapter(runner).observe_registration(_BINARY))
+
+    assert caught.value.reason is McpRegistrationReason.ISOLATION_INVALID
+    assert caught.value.safe_details == {"reason": "isolation_root_invalid"}
+    assert runner.calls == []
 
 
 def test_observe_rejects_a_non_codex_binary() -> None:
@@ -251,9 +327,42 @@ def test_strict_preview_binds_exact_command_and_changes_digest() -> None:
 
     assert policy.serve_command == ("yoetz", "mcp", "serve")
     assert policy.route_profile == "policy"
+    assert policy.preview_digest == canonical_digest(
+        {
+            "action": "register",
+            "executable_path": _BINARY.executable_path,
+            "harness": "codex",
+            "schema": "yoetz.mcp-registration-preview/1",
+            "serve_command": ["yoetz", "mcp", "serve"],
+            "server_name": "yoetz",
+            "state_before": "absent",
+        }
+    )
     assert strict.serve_command == ("yoetz", "mcp", "serve", "--semantic", "off")
     assert strict.route_profile == "strict"
     assert strict.preview_digest != policy.preview_digest
+
+
+def test_isolated_preview_binds_exact_root_and_requires_reregistration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = str(tmp_path)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: tmp_path)
+    ambient = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())])).preview_registration(
+            _BINARY
+        )
+    )
+    exact = anyio.run(
+        lambda: CodexMcpAdapter(
+            _Runner([CommandOutput(0, _yoetz_entry(isolated_root=root))])
+        ).preview_registration(_BINARY)
+    )
+
+    assert ambient.action is McpRegistrationAction.REREGISTER
+    assert ambient.isolated_root == root
+    assert exact.action is McpRegistrationAction.NOOP
+    assert exact.isolated_root == root
 
 
 def test_explicit_preview_allows_reregistering_an_owned_route_profile() -> None:
@@ -337,6 +446,76 @@ def test_apply_registers_then_verifies_by_rereading_state() -> None:
         "yoetz",
         "mcp",
         "serve",
+    )
+
+
+def test_apply_isolated_registration_passes_only_the_reviewed_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = str(tmp_path)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: tmp_path)
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(_Runner(_absent_outputs())).preview_registration(_BINARY)
+    )
+    runner = _Runner(
+        [
+            *_absent_outputs(),
+            CommandOutput(0, b""),
+            CommandOutput(0, _yoetz_entry(isolated_root=root)),
+        ]
+    )
+
+    result = anyio.run(
+        lambda: CodexMcpAdapter(runner).apply_registration(
+            _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+        )
+    )
+
+    assert result.state_after is McpRegistrationState.YOETZ_OWNED
+    assert runner.calls[2] == (
+        "/opt/harness/bin/codex",
+        "mcp",
+        "add",
+        "yoetz",
+        "--env",
+        f"YOETZ_ISOLATED_ROOT={root}",
+        "--",
+        "yoetz",
+        "mcp",
+        "serve",
+    )
+
+
+def test_apply_reregisters_a_legacy_bare_entry_with_the_isolated_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = str(tmp_path)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: tmp_path)
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(_Runner([CommandOutput(0, _yoetz_entry())])).preview_registration(
+            _BINARY
+        )
+    )
+    assert preview.action is McpRegistrationAction.REREGISTER
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry()),
+            CommandOutput(0, b""),
+            CommandOutput(0, _yoetz_entry(isolated_root=root)),
+        ]
+    )
+
+    result = anyio.run(
+        lambda: CodexMcpAdapter(runner).apply_registration(
+            _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+        )
+    )
+
+    assert result.action is McpRegistrationAction.REREGISTER
+    assert runner.calls[1][4:7] == (
+        "--env",
+        f"YOETZ_ISOLATED_ROOT={root}",
+        "--",
     )
 
 
@@ -478,6 +657,34 @@ def test_apply_unregistration_refuses_replacement_before_name_based_remove() -> 
 
     assert caught.value.reason is McpRegistrationReason.FOREIGN_ENTRY_PRESENT
     assert all(call[1:3] == ("mcp", "get") for call in runner.calls)
+
+
+def test_apply_unregistration_refuses_an_isolated_root_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = str(tmp_path)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: tmp_path)
+    preview = anyio.run(
+        lambda: CodexMcpAdapter(
+            _Runner([CommandOutput(0, _yoetz_entry(isolated_root=root))])
+        ).preview_unregistration(_BINARY)
+    )
+    runner = _Runner(
+        [
+            CommandOutput(0, _yoetz_entry(isolated_root=root)),
+            CommandOutput(0, _yoetz_entry(isolated_root="/replacement/root")),
+        ]
+    )
+
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: CodexMcpAdapter(runner).apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+
+    assert caught.value.reason is McpRegistrationReason.PREVIEW_STALE
+    assert all(call[1:3] != ("mcp", "remove") for call in runner.calls)
 
 
 def test_apply_unregistration_does_not_remove_after_unreadable_ownership_recheck() -> None:

--- a/tests/unit/application/test_applied_mcp_route.py
+++ b/tests/unit/application/test_applied_mcp_route.py
@@ -254,7 +254,10 @@ class _RoutePort:
         if self._observe_fails:
             raise McpRegistrationError(McpRegistrationReason.PARSE_FAILED, {})
         return McpRegistrationObservation(
-            binary.harness_id, McpRegistrationState.YOETZ_OWNED, self._profile
+            binary.harness_id,
+            McpRegistrationState.YOETZ_OWNED,
+            self._profile,
+            "ambient",
         )
 
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview:

--- a/tests/unit/application/test_harness_mcp_service.py
+++ b/tests/unit/application/test_harness_mcp_service.py
@@ -66,7 +66,12 @@ class _Port:
         route_profile: Literal["policy", "strict"] | None = (
             "strict" if self.state is McpRegistrationState.YOETZ_OWNED else None
         )
-        return McpRegistrationObservation(binary.harness_id, self.state, route_profile)
+        return McpRegistrationObservation(
+            binary.harness_id,
+            self.state,
+            route_profile,
+            "ambient" if route_profile is not None else None,
+        )
 
     async def preview_registration(self, binary: HarnessBinary) -> McpRegistrationPreview:
         if self.fail_with is not None:
@@ -165,9 +170,13 @@ def test_a_route_profile_is_only_meaningful_for_a_yoetz_owned_entry() -> None:
     """A foreign or absent entry has no Yoetz route, so claiming one is a construction error."""
 
     with pytest.raises(ValueError):
-        McpRegistrationObservation(HarnessId.CODEX, McpRegistrationState.ABSENT, "policy")
+        McpRegistrationObservation(
+            HarnessId.CODEX, McpRegistrationState.ABSENT, "policy", "ambient"
+        )
     with pytest.raises(ValueError):
-        McpRegistrationObservation(HarnessId.CODEX, McpRegistrationState.FOREIGN_PRESENT, "strict")
+        McpRegistrationObservation(
+            HarnessId.CODEX, McpRegistrationState.FOREIGN_PRESENT, "strict", "ambient"
+        )
 
 
 def test_register_requires_explicit_acceptance() -> None:

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -880,6 +880,7 @@ def _stub_live_route(
         HarnessId.CODEX,
         McpRegistrationState.YOETZ_OWNED if observed else McpRegistrationState.ABSENT,
         registered if observed else None,
+        "ambient" if observed else None,
     )
 
     monkeypatch.setattr(

--- a/tests/unit/cli/test_registration_drift.py
+++ b/tests/unit/cli/test_registration_drift.py
@@ -84,6 +84,7 @@ def _observation_with_state(
         HarnessId.CODEX,
         state,
         profile,  # type: ignore[arg-type]
+        "ambient" if profile is not None else None,
     )
 
 

--- a/tests/unit/dogfood/test_codex_dogfood_parity.py
+++ b/tests/unit/dogfood/test_codex_dogfood_parity.py
@@ -284,23 +284,25 @@ def test_failed_isolation_without_the_provisioning_continuation_is_invalid() -> 
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    ("field", "value", "next_action"),
     [
-        ("mcp_registration_state", "absent"),
-        ("mcp_isolation_binding", "missing"),
-        ("mcp_isolation_binding", "different"),
-        ("mcp_child_state", "failed"),
-        ("mcp_child_state", "unknown"),
+        ("mcp_registration_state", "absent", "reregister_isolated_mcp"),
+        ("mcp_isolation_binding", "missing", "reregister_isolated_mcp"),
+        ("mcp_isolation_binding", "different", "reregister_isolated_mcp"),
+        ("mcp_child_state", "failed", "recapture_isolated_mcp_child"),
+        ("mcp_child_state", "unknown", "recapture_isolated_mcp_child"),
     ],
 )
-def test_mcp_child_isolation_fails_closed_before_launch(field: str, value: str) -> None:
+def test_mcp_child_isolation_fails_closed_before_launch(
+    field: str, value: str, next_action: str
+) -> None:
     report = _report()
     _observed(report)[field] = value
     _facets(report)["mcp_child_isolation"] = {
         "status": "fail" if value != "unknown" else "blocked",
         "reason": "mcp_child_isolation_unproven",
         "evidence_digest": _DIGEST if value != "unknown" else None,
-        "next_action": "reregister_isolated_mcp",
+        "next_action": next_action,
     }
 
     result = classify_codex_dogfood_report(report)
@@ -310,14 +312,26 @@ def test_mcp_child_isolation_fails_closed_before_launch(field: str, value: str) 
     assert result["failed_facets"] == (["mcp_child_isolation"] if value != "unknown" else [])
 
 
-def test_mcp_child_isolation_requires_the_reregistration_continuation() -> None:
+@pytest.mark.parametrize(
+    ("field", "value", "rejected_action"),
+    [
+        ("mcp_isolation_binding", "missing", "do_not_launch"),
+        # An exact owned binding is not repaired by re-registering it.
+        ("mcp_child_state", "failed", "reregister_isolated_mcp"),
+        # A wrong binding is not repaired by recapturing the child.
+        ("mcp_isolation_binding", "different", "recapture_isolated_mcp_child"),
+    ],
+)
+def test_mcp_child_isolation_requires_the_matching_continuation(
+    field: str, value: str, rejected_action: str
+) -> None:
     report = _report()
-    _observed(report)["mcp_isolation_binding"] = "missing"
+    _observed(report)[field] = value
     _facets(report)["mcp_child_isolation"] = {
         "status": "fail",
         "reason": "mcp_child_isolation_unproven",
         "evidence_digest": _DIGEST,
-        "next_action": "do_not_launch",
+        "next_action": rejected_action,
     }
 
     with pytest.raises(DogfoodGateError, match="mcp_child_isolation_continuation_missing"):

--- a/tests/unit/dogfood/test_codex_dogfood_parity.py
+++ b/tests/unit/dogfood/test_codex_dogfood_parity.py
@@ -43,7 +43,7 @@ def _gate(status: str = "pass") -> dict[str, object]:
 
 def _report() -> dict[str, object]:
     return {
-        "schema": "yoetz.codex-dogfood-parity/2",
+        "schema": "yoetz.codex-dogfood-parity/3",
         "identity": {
             "source_ref": "a" * 40,
             "package_digest": _DIGEST,
@@ -77,6 +77,9 @@ def _report() -> dict[str, object]:
         "observed": {
             "activation_state": "active",
             "yoetz_isolation_state": "isolated",
+            "mcp_registration_state": "yoetz_owned",
+            "mcp_isolation_binding": "isolated_exact",
+            "mcp_child_state": "ready",
             "exact_worktree_consent": "active",
             "primary_checkout_consent": "active",
             "controls_workspace_match": True,
@@ -277,6 +280,47 @@ def test_failed_isolation_without_the_provisioning_continuation_is_invalid() -> 
     }
 
     with pytest.raises(DogfoodGateError, match="service_isolation_continuation_missing"):
+        classify_codex_dogfood_report(report)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("mcp_registration_state", "absent"),
+        ("mcp_isolation_binding", "missing"),
+        ("mcp_isolation_binding", "different"),
+        ("mcp_child_state", "failed"),
+        ("mcp_child_state", "unknown"),
+    ],
+)
+def test_mcp_child_isolation_fails_closed_before_launch(field: str, value: str) -> None:
+    report = _report()
+    _observed(report)[field] = value
+    _facets(report)["mcp_child_isolation"] = {
+        "status": "fail" if value != "unknown" else "blocked",
+        "reason": "mcp_child_isolation_unproven",
+        "evidence_digest": _DIGEST if value != "unknown" else None,
+        "next_action": "reregister_isolated_mcp",
+    }
+
+    result = classify_codex_dogfood_report(report)
+
+    assert result["preflight_outcome"] in {"fail", "blocked"}
+    assert result["launch_allowed"] is False
+    assert result["failed_facets"] == (["mcp_child_isolation"] if value != "unknown" else [])
+
+
+def test_mcp_child_isolation_requires_the_reregistration_continuation() -> None:
+    report = _report()
+    _observed(report)["mcp_isolation_binding"] = "missing"
+    _facets(report)["mcp_child_isolation"] = {
+        "status": "fail",
+        "reason": "mcp_child_isolation_unproven",
+        "evidence_digest": _DIGEST,
+        "next_action": "do_not_launch",
+    }
+
+    with pytest.raises(DogfoodGateError, match="mcp_child_isolation_continuation_missing"):
         classify_codex_dogfood_report(report)
 
 


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #561
- I searched open and closed issues and pull requests for `YOETZ_ISOLATED_ROOT`, isolated MCP registration, ambient service reuse, and Codex MCP environment propagation. #518 / #522 established the root-level isolation contract; no existing issue or PR covered this external-registration boundary.
- Design-gated (MCP route identity and isolated-runtime contract): the maintainer acknowledged the exact issue contract before this PR was opened: https://github.com/TheGaySupreme123/yoetz/issues/561#issuecomment-5538108838

## Documentation

- Behavior change? `yes`
- Updated ADR-012 and ADR-026, `docs/INTERFACES.md`, the Codex integration/dogfood runbooks, explicit Claude Code and Cursor support decisions, and the changelog.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/adapters/test_codex_mcp_registration.py tests/unit/application/test_harness_mcp_service.py tests/unit/application/test_applied_mcp_route.py tests/unit/cli/test_registration_drift.py tests/unit/cli/test_provider_status.py tests/unit/cli/test_setup_activation.py tests/unit/cli/test_setup_review_mode.py tests/unit/dogfood tests/unit/tui -q
# 293 passed

HOME=<fresh-owner-private-home> UV_CACHE_DIR=<existing-uv-cache> uv run pytest tests/subprocess/test_setup_wizard_cli.py -q
# 89 passed

# Run from the primary checkout, using the worktree project:
uv run --project <worktree> python -m pytest <worktree>/tests/packaging/test_codex_mcp_isolated_registration.py -q
# 1 passed against installed Codex 0.150.1

uv run ruff format --check .
uv run ruff check .
<primary-checkout>/node_modules/.bin/pyright --project <worktree>/pyproject.toml
uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check origin/main...HEAD
# clean; Pyright 0 errors; public-boundary PASS (1209 files)

# Additional disposable CLI lifecycle smoke:
# isolated preview -> install -> status -> remove
# register/owned -> isolation_binding=isolated_exact -> absent
```

Implemented and independently self-reviewed in Codex desktop by the GPT-5 Codex agent/harness.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Yoetz-owned external Codex MCP registrations now preserve ADR-026 isolation across the host process boundary. An isolated preview binds the exact validated root, apply passes only `YOETZ_ISOLATED_ROOT` through Codex's native `--env`, and status distinguishes `ambient`, `isolated_exact`, `missing`, and `different`. Arbitrary environment keys and inherited-variable declarations remain foreign and are never overwritten.

The reverse lifecycle is equally bound: legacy bare or wrong-root Yoetz entries can be explicitly re-registered, exact entries no-op, and removal rechecks both argv and root before the name-based host mutation. Dogfood parity schema 3 adds a pre-model `mcp_child_isolation` facet. The installed Codex 0.150.1 regression launches the registered MCP child from a parent without `YOETZ_ISOLATED_ROOT` and proves the child receives the reviewed root.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the validated isolated root across Codex MCP registration and exposes the resulting binding through status, setup, and TUI surfaces. It also extends the dogfood parity gate with MCP child-start evidence.

- Adds closed parsing and classification of Codex MCP environment bindings.
- Digest-binds isolated registration and unregistration previews and verifies the root after host mutation.
- Adds MCP isolation details to CLI and TUI output.
- Advances the dogfood parity report to schema 3 with an MCP child-isolation facet.
- Adds unit and installed-Codex regression coverage.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking dogfood diagnostic issue that directs already-correct registrations through re-registration when child startup fails.

The registration path binds, applies, and verifies the isolated root correctly; the remaining concern is limited to inaccurate remediation in the dogfood parity workflow.

**Files Needing Attention:** scripts/check_codex_dogfood_parity.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/yoetz/adapters/integrations/codex_mcp.py | Adds closed environment parsing, root-bound preview/apply behavior, drift classification, and compare-before-remove checks without an accepted functional defect. |
| src/yoetz/ports/harness_mcp.py | Extends MCP preview and observation contracts with validated isolated-root and binding fields. |
| scripts/check_codex_dogfood_parity.py | Adds schema-3 child-isolation validation, but maps independent child launch failures to an ineffective registration-only continuation. |
| src/yoetz/cli/setup.py | Propagates isolation binding and root details through setup and integration JSON and human-readable output. |
| tests/packaging/test_codex_mcp_isolated_registration.py | Adds an installed Codex regression proving that the registered environment reaches a child launched from an ambient parent. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resolve validated isolated root] --> B[Preview Codex MCP registration]
  B --> C[Digest binds command and root]
  C --> D[Apply through codex mcp add --env]
  D --> E[Read registration back]
  E --> F{Command and root exact?}
  F -->|Yes| G[Report isolated_exact]
  F -->|No| H[Fail registration verification]
  G --> I[Capture MCP child startup]
  I --> J{Child ready?}
  J -->|Yes| K[Dogfood preflight passes]
  J -->|No or unknown| L[Dogfood preflight blocks]
```

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): preserve isolated root in Code..."](https://github.com/thegaysupreme123/yoetz/commit/d25caa5b2eeecd424a91b0e2bd48193481f3ff38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60348468)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->