### PR TITLE
fix(cursor): normalize fractional hook payloads

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -4105,7 +4105,13 @@ loading has no independent installed-artifact, event-delivery, privacy-filtering
 or accepted-observation proof. Native IDE rendering or schema validity cannot populate those
 neighboring cells.
 Cursor ingress maps only bounded session/generation/tool IDs, exact Cursor/model/effort tokens,
-duration, capability profile, and an installation-keyed HMAC changed-path commitment. It discards
+duration, capability profile, and an installation-keyed HMAC changed-path commitment. Cursor's
+`afterMCPExecution` duration is admitted as a finite decimal millisecond value only at this host
+boundary and truncated to the canonical integer `duration_ms`; the canonical parser remains
+float-free. Discarded vendor-field floats are replaced transiently, and malformed or unsafe Cursor
+envelopes remain fail-open while recording the payload-free `cursor_payload_invalid` diagnostic.
+The `model` spelling from execution/file-edit events normalizes to `model_id`; a valid `model_id`
+spelling wins when both are present. It discards
 prompt, reasoning, response text, paths, file contents/edits, MCP/tool inputs/results, transcripts,
 commands/output, and email before storage and never reconciles a Cursor transcript stream. It uses
 `workspace_roots` transiently, then `CURSOR_PROJECT_DIR`, then the explicit hook argument to choose

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -373,7 +373,15 @@ is repaired by restarting a service that already reports ready.
 not enqueued for delivery, while `start`, `publish_work`, `check`, and `respond` enqueue one row
 each. Cursor's hook payload states no outcome fact for MCP executions, so a failed Yoetz call is
 indistinguishable from a successful one at this ingress; the service's own record of the call is
-the authority on its outcome. `afterFileEdit` and lifecycle events are unchanged.
+the authority on its outcome. Cursor reports `duration` as a finite decimal number of milliseconds
+for MCP executions, while the canonical structural field is the bounded integer `duration_ms`.
+Cursor ingress truncates that vendor value to whole milliseconds before structural filtering; the canonical parser
+continues to reject floats on every ledger and non-Cursor host surface. Decimal values in discarded
+vendor fields are replaced transiently and never reach the structural envelope. Execution and file
+edit payloads use `model`, while lifecycle payloads may also provide `model_id`; a valid
+`model_id` takes precedence when both spellings are present, and `model` is its bounded fallback.
+Malformed or unsafe Cursor envelopes remain fail-open but record `cursor_payload_invalid` as a
+payload-free hook diagnostic. `afterFileEdit` and lifecycle events are otherwise unchanged.
 
 Measured on 2026-08-28 with Cursor Agent CLI `2026.08.25-3e8eec8` (payload `cursor_version`;
 `cursor-agent --version` printed `2026.08.11-e8db854`) loading the native plugin through

--- a/src/yoetz/cli/hook_diagnostics.py
+++ b/src/yoetz/cli/hook_diagnostics.py
@@ -78,6 +78,10 @@ _REASONS: Final = frozenset(
         "runtime_gate_contended",
         "runtime_gate_unsafe",
         "stdout_write_failed",
+        # Cursor's vendor envelope uses fractional millisecond durations. A
+        # malformed or otherwise unsafe host payload is fail-open, but must be
+        # distinguishable from a hook that never ran (#593).
+        "cursor_payload_invalid",
         # Workspace binding outcomes for every host ingress (#420/#435): an
         # explicit locator that cannot be canonicalized, and a canonical
         # locator that carries no active consent. Without them a dropped hook

--- a/src/yoetz/cli/hook_io.py
+++ b/src/yoetz/cli/hook_io.py
@@ -1,6 +1,6 @@
 """Leaf hook IO helpers: stdin payload, stdout JSON, stderr line, context output.
 
-Deliberately imports nothing beyond ``yoetz.protocol``. ``yoetz.cli.hooks``
+Deliberately imports no Yoetz modules beyond ``yoetz.protocol``. ``yoetz.cli.hooks``
 re-exports these names unchanged; the split exists so a hook process does not
 pay for ``service.client`` → ``control_protocol`` → ``protocol.schemas`` →
 jsonschema just to write one JSON object to stdout (#242).
@@ -8,11 +8,19 @@ jsonschema just to write one JSON object to stdout (#242).
 
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Mapping
+from decimal import Decimal, InvalidOperation
 from typing import BinaryIO, Final, cast
 
-from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
+from yoetz.protocol.canonical import (
+    MAX_JSON_DEPTH,
+    JsonValue,
+    canonical_encode,
+    ensure_canonical_value,
+    strict_json_parse,
+)
 from yoetz.protocol.errors import ProtocolValueError
 
 __all__ = [
@@ -22,6 +30,7 @@ __all__ = [
     "claude_context_output",
     "context_output",
     "cursor_context_output",
+    "read_cursor_hook_payload",
     "read_hook_payload",
     "stderr_line",
     "stdout_json",
@@ -30,6 +39,7 @@ __all__ = [
 _MAX_STDIN_BYTES: Final = 262_144
 _MAX_CONTEXT_CHARS: Final = 2_000
 _MAX_STDERR_CHARS: Final = 200
+_MAX_SAFE_INTEGER: Final = 2**53 - 1
 # Codex events whose output schema admits hookSpecificOutput.additionalContext.
 ADDITIONAL_CONTEXT_EVENTS: Final = frozenset(
     {
@@ -175,3 +185,124 @@ def read_hook_payload(raw: bytes | None = None) -> Mapping[str, JsonValue]:
     if not isinstance(parsed, Mapping):
         raise ProtocolValueError("unsupported_json_type")
     return cast(Mapping[str, JsonValue], parsed)
+
+
+def _parse_cursor_integer(literal: str) -> int:
+    """Parse a Cursor host integer with the same safe bound as canonical JSON."""
+
+    if literal == "-0":
+        raise ProtocolValueError("float_forbidden")
+    try:
+        value = int(literal)
+    except ValueError as exc:
+        raise ProtocolValueError("integer_out_of_safe_range") from exc
+    if not -_MAX_SAFE_INTEGER <= value <= _MAX_SAFE_INTEGER:
+        raise ProtocolValueError("integer_out_of_safe_range")
+    return value
+
+
+def _reject_cursor_constant(_: str) -> object:
+    raise ProtocolValueError("float_forbidden")
+
+
+def _normalize_cursor_duration(value: Decimal) -> int:
+    """Truncate one finite, nonnegative Cursor duration to canonical milliseconds."""
+
+    if not value.is_finite() or value < 0 or (value.is_zero() and value.is_signed()):
+        raise ProtocolValueError("invalid_duration")
+    if value > _MAX_SAFE_INTEGER:
+        raise ProtocolValueError("integer_out_of_safe_range")
+    return int(value)
+
+
+def _normalize_cursor_value(value: object, *, key: str | None, depth: int) -> JsonValue:
+    """Convert Cursor floats without admitting them to the canonical payload.
+
+    The host may place ordinary decimal numbers in discarded vendor fields such
+    as tool metadata. Those values remain transient and are replaced with
+    ``null``; only the top-level duration is retained after normalization.
+    """
+
+    if isinstance(value, Decimal):
+        if key == "duration" and depth == 1:
+            return _normalize_cursor_duration(value)
+        if depth == 0:
+            raise ProtocolValueError("float_forbidden")
+        return None
+    if value is None or type(value) in {bool, int, str}:
+        return cast(JsonValue, value)
+    if type(value) is list:
+        if depth >= MAX_JSON_DEPTH:
+            raise ProtocolValueError("nesting_too_deep")
+        return [
+            _normalize_cursor_value(item, key=None, depth=depth + 1)
+            for item in cast(list[object], value)
+        ]
+    if type(value) is dict:
+        if depth >= MAX_JSON_DEPTH:
+            raise ProtocolValueError("nesting_too_deep")
+        normalized: dict[str, JsonValue] = {}
+        for child_key, item in cast(dict[object, object], value).items():
+            if type(child_key) is not str:
+                raise ProtocolValueError("object_key_not_string")
+            normalized[child_key] = _normalize_cursor_value(
+                item,
+                key=child_key,
+                depth=depth + 1,
+            )
+        return normalized
+    raise ProtocolValueError("unsupported_json_type")
+
+
+def read_cursor_hook_payload(raw: bytes | None = None) -> Mapping[str, JsonValue]:
+    """Read Cursor's bounded host JSON, normalizing its decimal duration field.
+
+    Cursor reports MCP hook durations as fractional milliseconds. That vendor shape
+    is admitted only here; canonical ledger and all other host parsers remain
+    float-free. Unknown or nested numeric floats are replaced with ``null`` before
+    structural filtering, while all host-controlled values are still discarded
+    by the caller.
+    """
+
+    data = sys.stdin.buffer.read(_MAX_STDIN_BYTES + 1) if raw is None else raw
+    if type(data) is bytearray:
+        data = bytes(data)
+    elif type(data) is not bytes:
+        raise ProtocolValueError("input_not_bytes")
+    if not data or len(data) > _MAX_STDIN_BYTES:
+        raise ProtocolValueError("invalid_event_value_type")
+    if b"\x00" in data:
+        raise ProtocolValueError("nul_byte_forbidden")
+    try:
+        text = data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ProtocolValueError("invalid_utf8") from exc
+    if text.startswith("\ufeff"):
+        raise ProtocolValueError("byte_order_mark_forbidden")
+
+    def _decode_object_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = dict(pairs)
+        if len(result) != len(pairs):
+            raise ProtocolValueError("duplicate_object_key")
+        return result
+
+    try:
+        parsed = json.loads(
+            text,
+            object_pairs_hook=_decode_object_pairs,
+            parse_float=Decimal,
+            parse_int=_parse_cursor_integer,
+            parse_constant=_reject_cursor_constant,
+        )
+    except json.JSONDecodeError as exc:
+        raise ProtocolValueError("malformed_json") from exc
+    except RecursionError as exc:
+        raise ProtocolValueError("nesting_too_deep") from exc
+    except InvalidOperation as exc:
+        raise ProtocolValueError("float_forbidden") from exc
+
+    normalized = _normalize_cursor_value(parsed, key=None, depth=0)
+    ensure_canonical_value(normalized)
+    if not isinstance(normalized, Mapping):
+        raise ProtocolValueError("unsupported_json_type")
+    return cast(Mapping[str, JsonValue], normalized)

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -48,6 +48,7 @@ from yoetz.cli.hook_io import (
     cursor_context_output as _cursor_context_output,
 )
 from yoetz.cli.hook_io import (
+    read_cursor_hook_payload,
     read_hook_payload,
 )
 from yoetz.cli.hook_io import (
@@ -2611,7 +2612,23 @@ def handle_cursor_observe(
         "stop": "Stop",
     }
     try:
-        payload = read_hook_payload(stdin_bytes)
+        try:
+            payload = read_cursor_hook_payload(stdin_bytes)
+        except ProtocolValueError:
+            # Cursor emits vendor-shaped decimal durations. Keep malformed host
+            # ingress fail-open, but make the dropped event visible through the
+            # bounded owner-only diagnostic stream.
+            with contextlib.suppress(BaseException):
+                record_hook_diagnostic(
+                    "cursor_payload_invalid",
+                    event_map.get(event_name or "", "unknown_event"),
+                    _state=_state,
+                )
+            with contextlib.suppress(BaseException):
+                _stderr_line("hook_cursor_observe_degraded: invalid_payload")
+            with contextlib.suppress(BaseException):
+                hook_io.stdout_json({}, stdout)
+            return 0
         raw_event = event_name or payload.get("hook_event_name")
         if type(raw_event) is not str or raw_event not in event_map:
             return 0 if hook_io.stdout_json({}, stdout) else 0
@@ -2668,12 +2685,18 @@ def handle_cursor_observe(
         for source_key, target_key in (
             ("cursor_version", "cursor_version"),
             ("generation_id", "correlation_id"),
-            ("model_id", "model_id"),
             ("tool_name", "tool_name"),
         ):
             value = _token_or_none(payload.get(source_key))
             if value is not None:
                 structural[target_key] = value
+        # Cursor's lifecycle payloads use ``model_id`` while execution and file
+        # edit payloads use ``model``. Prefer the canonical lifecycle spelling
+        # when both are present (they can intentionally differ: e.g. a provider
+        # alias in ``model`` and the selected model in ``model_id``).
+        model_id = _token_or_none(payload.get("model_id")) or _token_or_none(payload.get("model"))
+        if model_id is not None:
+            structural["model_id"] = model_id
         duration = _int_or_none(payload.get("duration"))
         if duration is not None:
             structural["duration_ms"] = duration

--- a/tests/unit/cli/test_cursor_observe_hooks.py
+++ b/tests/unit/cli/test_cursor_observe_hooks.py
@@ -119,6 +119,177 @@ def test_cursor_hook_ingress_drops_every_content_and_identity_denylist_field(
     assert forbidden.isdisjoint(sanitized)
 
 
+@pytest.mark.parametrize(
+    ("event_name", "extra", "expected_duration"),
+    [
+        (
+            "afterMCPExecution",
+            {"duration": 428.607, "model": "grok-4.6"},
+            428,
+        ),
+        (
+            "afterFileEdit",
+            {"model": "grok-4.6"},
+            None,
+        ),
+    ],
+)
+def test_cursor_raw_vendor_fields_reach_structural_observation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    event_name: str,
+    extra: dict[str, object],
+    expected_duration: int | None,
+) -> None:
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
+    captured: dict[str, object] = {}
+
+    def fake_handle_observe(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", fake_handle_observe)
+    payload: dict[str, object] = {
+        "conversation_id": "cursor-raw-vendor-fields",
+        "cursor_version": "3.17.8",
+        "generation_id": "generation-1",
+        "hook_event_name": event_name,
+        "tool_name": "status",
+        "tool_input": {"private": 1.5},
+        "result_json": "private result",
+        **extra,
+    }
+
+    assert (
+        observe_hooks.handle_cursor_observe(
+            event_name=event_name,
+            stdin_bytes=json.dumps(payload, separators=(",", ":")).encode(),
+            stdout=io.BytesIO(),
+            workspace=str(tmp_path),
+        )
+        == 0
+    )
+
+    sanitized = strict_json_parse(cast(bytes, captured["stdin_bytes"]))
+    assert isinstance(sanitized, Mapping)
+    assert sanitized["model_id"] == "grok-4.6"
+    if expected_duration is None:
+        assert "duration_ms" not in sanitized
+    else:
+        assert sanitized["duration_ms"] == expected_duration
+    assert sanitized["tool_name"] == "status"
+    assert "tool_input" not in sanitized
+    assert "result_json" not in sanitized
+
+
+def test_cursor_model_id_takes_precedence_over_vendor_model_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_handle_observe(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", fake_handle_observe)
+    payload = json.dumps(
+        {
+            "conversation_id": "cursor-model-precedence",
+            "hook_event_name": "stop",
+            "model": "cursor-grok-4.6-medium-fast",
+            "model_id": "grok-4.6",
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    assert (
+        observe_hooks.handle_cursor_observe(
+            event_name="stop",
+            stdin_bytes=payload,
+            stdout=io.BytesIO(),
+            workspace=str(tmp_path),
+        )
+        == 0
+    )
+
+    sanitized = strict_json_parse(cast(bytes, captured["stdin_bytes"]))
+    assert isinstance(sanitized, Mapping)
+    assert sanitized["model_id"] == "grok-4.6"
+
+
+def test_cursor_raw_fractional_duration_is_stored_structurally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
+    store, commitment = _consented_store(tmp_path)
+    canaries = {
+        "tool_input": {"prompt": "PROMPT_CANARY", "ratio": 1.5},
+        "result_json": "RESULT_CANARY",
+        "transcript_path": "/private/TRANSCRIPT_CANARY",
+    }
+    payload = {
+        "conversation_id": "cursor-stored-fraction",
+        "hook_event_name": "afterMCPExecution",
+        "model": "grok-4.6",
+        "duration": 428.607,
+        "tool_name": "status",
+        **canaries,
+    }
+
+    assert (
+        observe_hooks.handle_cursor_observe(
+            event_name="afterMCPExecution",
+            stdin_bytes=json.dumps(payload, separators=(",", ":")).encode(),
+            stdout=io.BytesIO(),
+            workspace=str(tmp_path),
+            _state=tmp_path,
+            skip_service=True,
+        )
+        == 0
+    )
+
+    envelopes = store.list_envelopes(commitment)
+    assert len(envelopes) == 1
+    structural = envelopes[0].structural_payload
+    assert structural["duration_ms"] == 428
+    assert structural["model_id"] == "grok-4.6"
+    assert structural["tool_name"] == "status"
+    stored = b"".join(
+        path.read_bytes()
+        for path in tmp_path.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )
+    for canary in ("PROMPT_CANARY", "RESULT_CANARY", "TRANSCRIPT_CANARY"):
+        assert canary.encode() not in stored
+
+
+def test_cursor_invalid_vendor_payload_records_bounded_diagnostic(
+    tmp_path: Path,
+) -> None:
+    stdout = io.BytesIO()
+
+    assert (
+        observe_hooks.handle_cursor_observe(
+            event_name="afterMCPExecution",
+            stdin_bytes=b'{"conversation_id":"cursor-invalid","duration":-1.0}',
+            stdout=stdout,
+            workspace=str(tmp_path),
+            _state=tmp_path,
+        )
+        == 0
+    )
+
+    assert stdout.getvalue() == b"{}\n"
+    diagnostic = tmp_path / "observation/hook-diagnostics.jsonl"
+    row = json.loads(diagnostic.read_text(encoding="utf-8"))
+    assert row == {
+        "event": "PostToolUse",
+        "reason": "cursor_payload_invalid",
+        "ts": row["ts"],
+    }
+    assert "cursor-invalid" not in diagnostic.read_text(encoding="utf-8")
+
+
 def test_cursor_file_edit_uses_keyed_path_commitment_and_drops_outcomes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_hook_io.py
+++ b/tests/unit/cli/test_hook_io.py
@@ -126,7 +126,7 @@ def test_claude_context_is_bounded_by_the_shared_context_limit() -> None:
     ("literal", "expected"),
     [("428.607", 428), ("428.5", 428), ("428.499", 428), ("0.0", 0), ("1e3", 1_000)],
 )
-def test_cursor_hook_payload_rounds_fractional_duration_to_canonical_integer(
+def test_cursor_hook_payload_truncates_fractional_duration_to_canonical_integer(
     literal: str, expected: int
 ) -> None:
     payload = ('{"duration":' + literal + ',"hook_event_name":"afterMCPExecution"}').encode()

--- a/tests/unit/cli/test_hook_io.py
+++ b/tests/unit/cli/test_hook_io.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import io
 
+import pytest
+
 from yoetz.cli.hook_io import (
     claude_context_output,
     context_output,
     cursor_context_output,
+    read_cursor_hook_payload,
     stdout_json,
 )
+from yoetz.protocol.canonical import strict_json_parse
+from yoetz.protocol.errors import ProtocolValueError
 
 
 def test_session_start_and_post_tool_use_emit_additional_context() -> None:
@@ -115,3 +120,46 @@ def test_claude_context_is_bounded_by_the_shared_context_limit() -> None:
     assert claude_context_output("Stop", "x" * 2_001) == {
         "hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": "x" * 2_000}
     }
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [("428.607", 428), ("428.5", 428), ("428.499", 428), ("0.0", 0), ("1e3", 1_000)],
+)
+def test_cursor_hook_payload_rounds_fractional_duration_to_canonical_integer(
+    literal: str, expected: int
+) -> None:
+    payload = ('{"duration":' + literal + ',"hook_event_name":"afterMCPExecution"}').encode()
+
+    parsed = read_cursor_hook_payload(payload)
+
+    assert parsed["duration"] == expected
+    # The canonical parser remains float-free for every non-Cursor wire surface.
+    with pytest.raises(ProtocolValueError, match="float_forbidden"):
+        strict_json_parse(payload)
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        (b'{"duration":-1.0}', "invalid_duration"),
+        (b'{"duration":NaN}', "float_forbidden"),
+        (b'{"duration":1.2,"duration":2.3}', "duplicate_object_key"),
+        (b'{"duration":9007199254740992}', "integer_out_of_safe_range"),
+        (b'{"duration":9007199254740991.4}', "integer_out_of_safe_range"),
+        (b'{"value":"\\u0000"}', "nul_byte_forbidden"),
+    ],
+)
+def test_cursor_hook_payload_preserves_bounded_wire_rejections(payload: bytes, reason: str) -> None:
+    with pytest.raises(ProtocolValueError, match=reason):
+        read_cursor_hook_payload(payload)
+
+
+def test_cursor_hook_payload_discards_nested_vendor_floats() -> None:
+    parsed = read_cursor_hook_payload(
+        b'{"model_params":[{"id":"temperature","value":0.2}],'
+        b'"tool_input":{"ratio":1.5},"hook_event_name":"afterMCPExecution"}'
+    )
+
+    assert parsed["model_params"] == [{"id": "temperature", "value": None}]
+    assert parsed["tool_input"] == {"ratio": None}


### PR DESCRIPTION
Cursor's fractional hook durations were rejected before structural filtering, silently losing whole MCP observations. Cursor ingress now truncates finite nonnegative milliseconds, retains valid model aliases, and emits a bounded diagnostic for rejected envelopes.

## Issue

- Fixes #593.
- Searched existing issues/PRs; no focused duplicate.
- Maintainer-requested dogfood follow-up, acknowledged on the issue before this PR.

## Documentation

- Behavior change: yes, valid Cursor vendor payloads now reach structural observation.
- Updated `docs/INTERFACES.md` and the Cursor integration runbook.

## Verification

```text
uv run pytest tests/unit/cli/test_hook_io.py tests/unit/cli/test_cursor_observe_hooks.py tests/unit/cli/test_observe_hooks.py tests/unit/cli/test_hook_diagnostics.py
uv run ruff check src/yoetz/cli/hook_io.py src/yoetz/cli/observe_hooks.py src/yoetz/cli/hook_diagnostics.py tests/unit/cli/test_hook_io.py tests/unit/cli/test_cursor_observe_hooks.py
uv run ruff format --check src/yoetz/cli/hook_io.py src/yoetz/cli/observe_hooks.py src/yoetz/cli/hook_diagnostics.py tests/unit/cli/test_hook_io.py tests/unit/cli/test_cursor_observe_hooks.py
/Users/shayb/yoetz-core/node_modules/.bin/pyright src/yoetz/cli/hook_io.py src/yoetz/cli/observe_hooks.py src/yoetz/cli/hook_diagnostics.py tests/unit/cli/test_hook_io.py tests/unit/cli/test_cursor_observe_hooks.py
```

193 tests passed; Ruff/format and pinned Pyright passed. Independent review reran the focused 45-test parser/Cursor slice and probed malformed input, numeric bounds, nesting and privacy canaries without finding an actionable regression.

## Boundaries

- [x] No ignored private drafting inputs or raw dogfood transcripts included.
- [x] Review findings have been dispositioned; later comments will be addressed before merge.
- Canonical ledger/MCP/other-host JSON remains float-free. Decimal values in ignored vendor fields are transient and never become structural content.
- This verifies bounded ingress and local retention, not a fresh installed-host run or resolution of all mapping/drain gaps.

## Summary

Adds a Cursor-specific bounded parser, explicit model/model_id normalization, and payload-free rejection diagnostics while keeping hooks fail-open. Regression tests exercise raw ingress, retention, field precedence and malformed-input protections.

Model/harness: GPT-6 in Codex desktop with delegated implementation and independent review agents.

Final adversarial review covered Cursor correctness, Claude/Codex applicability, and overall code/regression risk on combined head `24a876c5c3febcb3f55a4931219eaa597213d1a7`. All findings were fixed or explicitly dispositioned. Final exact PR heads have green CI and no unresolved review threads. The combined wheel also passed the real MCP stdio/service/CLI smoke with a simulated host roots callback; this is not fresh live-host dogfood.
