### PR TITLE
fix(mcp): clarify local workflow effects and host holds

### DIFF
--- a/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
+++ b/docs/adr/ADR-018-host-declared-mcp-route-egress-ceiling.md
@@ -135,7 +135,8 @@ no privacy, disclosure, credential, or human-review gate. Yoetz records a Claude
 `PermissionDenied` on a scoped `check` as a payload-free `host_auto_review_denied` diagnostic;
 Codex and Cursor expose no typed denial and that gap is documented. Rejected: shipping a
 `PermissionRequest` / `beforeMCPExecution` hook that approves Yoetz's own tool (inverts the
-authority this ADR keeps with the host), widening admission to the other tools (they need none),
+authority this ADR keeps with the host), widening the egress admission entry to the other tools
+(their local or read-only effects do not invoke a provider, but a host may still review them),
 customizing a host's reviewer policy on the user's behalf, and relaying "the user authorized this"
 through the agent (the prompt-injection shape #187 forbids).
 

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -175,6 +175,23 @@ server the same way is undocumented and unverified; the acceptance cell in issue
 `status` reports `partial` when only one of the two files carries the entry. A wildcard
 (`yoetz:*`, `*:*`, `Mcp(*:*)`) or a CLI deny rule is `foreign` and never edited.
 
+The other workflow calls have a local effect: `start`, `publish_work`, `respond`, and `receipt`
+append or read records in the local Yoetz ledger, while `status` and `read_guidance` read local or
+packaged state. None of these calls publishes to GitHub or invokes a semantic provider. This
+describes the effect after Yoetz receives the call; it does not predict Cursor's admission decision.
+Cursor Auto-review may still hold a non-allowlisted local call as a shared-state or external-workflow
+action, and Cursor provides no hook event for that classifier decision.
+
+For a held local call, use Cursor's visible approval control for that exact call if the workflow is
+authorized to continue. A hold before invocation is not a Yoetz result and creates no operation,
+semantic status, provider attempt, or receipt. After approval, let Cursor execute the exact held
+call and continue from its returned result. If Cursor requires resubmission or the response is
+missing, retry the same request body and `request_id`. If the call may have started but its result
+is ambiguous, use `status view=operation` with the original request identity or replay that same
+request according to the operation's recovery instructions. Do not mint a replacement request or
+duplicate event identity. This recovery procedure does not change Cursor's Auto-review settings or
+prove that a future call will be admitted.
+
 A mutating preview warns `host_config_not_compare_and_swap`; keep Cursor and other settings writers
 quiescent during apply. Yoetz rechecks each exact preimage immediately before its atomic mutation
 and verifies the combined result, but ordinary files cannot exclude a non-cooperating same-UID
@@ -185,9 +202,9 @@ Reverse: `admission revoke`; `plugin remove` and an install/replace onto the str
 the entry when `--project-root` is given and report `admission_cleanup`; a privacy commit that
 stops external review sweeps it; `provider status` reports `host_admission_drift`. That report
 walks from the launch directory to the repository root, so a subdirectory cwd does not read as
-`absent`. Cursor
-publishes no hook for a classifier denial, so a held check is visible only through the #187
-pause/approval flow; that gap is documented, not diagnosed.
+`absent`. Cursor publishes no hook for a classifier denial. A held `check` is visible only through
+the #187 pause/approval flow, while a held local call has no Yoetz-side denial diagnostic; that
+gap is documented, not diagnosed.
 
 ## Upgrading Yoetz under a running service
 

--- a/docs/usage/auto-approving-agents.md
+++ b/docs/usage/auto-approving-agents.md
@@ -51,6 +51,22 @@ denies or the approval expires, the agent may use a deterministic-only fallback 
 explicitly chooses it after seeing the semantic-review limitation. A later Yoetz
 `awaiting_human` result remains a separate Yoetz decision flow.
 
+## Local workflow calls and host holds
+
+`start`, `publish_work`, `respond`, and `receipt` append records to the local Yoetz
+ledger. They do not publish to GitHub or invoke a semantic provider. `status` and `read_guidance`
+read local or packaged state. These effects describe what Yoetz does after it receives a call; the
+host still decides whether to invoke an MCP tool.
+
+If an auto-review host holds one of these calls, treat the hold as a host authorization event, not
+as a Yoetz result. Use the host's visible approval control for that exact call when you want to
+continue, then let the host execute that held call and continue from its returned result. If the
+host requires resubmission or the response is unavailable, resend the same request body and
+`request_id`. If a call may have started but its result is unclear, recover the operation through
+`status view=operation` or replay the same `request_id` according to the operation's recovery
+instructions; do not mint replacement requests or duplicate event identities. A host refusal
+before invocation creates no Yoetz operation, semantic status, provider attempt, or receipt.
+
 ## Letting an auto-review host admit the authorized check
 
 Claude Code auto mode, Codex `approvals_reviewer = "auto_review"`, and Cursor Auto-review each
@@ -80,8 +96,10 @@ privacy grant permits external review. A grant is written only when all of these
   edited or written beside;
 - the file could be read. An unreadable file is `unknown`, never treated as empty.
 
-Only `check` is ever admitted. Start, publish, respond, status, receipt, and guidance already
-pass every host's rules.
+Host admission currently covers only `check`. The other operations remain local or read-only, but
+an auto-review host may still hold a non-allowlisted MCP call. Yoetz cannot guarantee that a host
+will admit any call, and no host hold should be described as a Yoetz privacy denial or semantic
+result.
 
 What each host receives:
 

--- a/src/yoetz/adapters/integrations/host_admission.py
+++ b/src/yoetz/adapters/integrations/host_admission.py
@@ -10,7 +10,8 @@ decision, never the agent and never a self-approving hook, tells the host to adm
 
 Rules shared by every host surface:
 
-- Only ``check`` is ever admitted; the other tools pass every host's rules already.
+- Only ``check`` is admitted by this adapter. The other operations have local or read-only
+  effects, but host invocation policies remain independent and may hold them.
 - An entry is recognized by exact bytes. A wider rule (a server-wide allow, a wildcard, a Codex
   server-level default) or a deny rule for the same tool is ``foreign``: reported, never edited,
   and never a reason to write beside it.

--- a/src/yoetz/mcp/descriptors.py
+++ b/src/yoetz/mcp/descriptors.py
@@ -1463,7 +1463,9 @@ _POLICY_TOOL_DESCRIPTORS: Final = (
         "publish_work",
         "Publish recorded work",
         "Records a bounded batch of agent-published work events and returns the accepted event "
-        "range and coverage. It has no information about work outside that batch. Every set-valued "
+        "range and coverage. This appends records to the local Yoetz ledger; it "
+        "does not publish to GitHub or run a semantic evaluation. It has no information about "
+        "work outside that batch. Every set-valued "
         "reference list in a draft envelope or payload (obligation_refs, obligation_ids, "
         "supporting_refs, and the other canonical set fields) is admitted only when its members "
         "are unique and already in ascending ASCII order; uniqueItems does not express order, and "
@@ -1559,8 +1561,10 @@ _POLICY_TOOL_DESCRIPTORS: Final = (
         "respond",
         "Respond to a finding",
         "Records an acknowledgement, provenance dispute, or rejection for one finding at the "
-        "result frontier of the check that returned it, not its subject_frontier. It does not "
-        "resolve other findings or establish that underlying work changed. "
+        "result frontier of the check that returned it, not its subject_frontier. This appends one "
+        "finding-response record to the local Yoetz ledger; it does not publish to "
+        "GitHub or run a semantic evaluation. It does not resolve other findings or establish "
+        "that underlying work changed. "
         "A provenance_disputed response contests the finding's authorship or provenance premise "
         "rather than its conclusion, requires a reason, and never resolves the finding. "
         "Bounded waiver is reserved for an authorized local-CLI human and is not an agent option. "
@@ -1678,9 +1682,9 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
         "policy": MappingProxyType(
             {
                 "start": "sha256:ac5c4ac0bd12f67e08437f3aea4b7bc328c060f08809ef6f20e86b879d683a29",
-                "publish_work": "sha256:676036fa37e435770bb9d96d9ecb4a09121337576437023e3af5a4c4f8bbbad5",
+                "publish_work": "sha256:189ff72e5023b7e723d2002a9c5097102c3e5fdf0a6382720a1cfc676b993e98",
                 "check": "sha256:3175800b79a9ea035fabde6c64227ff8a0c9783a4f5d13a29a7a9b80e91c41a2",
-                "respond": "sha256:669697ed16dc7cbb14bab5528a5e06d7782d3ce7b943b2a9036ae1dfd5ca8717",
+                "respond": "sha256:6003245eb4b02e6a81fa4f1083bfa00da675ec247398e302bcfbd2b82219664c",
                 "status": "sha256:e4798c4fedc7cb6bc7dda204b52ec2734b9dc319c27ca3834bdbaadd5c2613e4",
                 "receipt": "sha256:cf4b426af9764747848d3334d0671d0d0961ab5c86173d70c067222e9feb5ee2",
                 "read_guidance": "sha256:737b75bde002ab35255e19169d29f38d40a29d580b8165c759b1bc2373dd28bd",
@@ -1689,9 +1693,9 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
         "strict": MappingProxyType(
             {
                 "start": "sha256:ac5c4ac0bd12f67e08437f3aea4b7bc328c060f08809ef6f20e86b879d683a29",
-                "publish_work": "sha256:676036fa37e435770bb9d96d9ecb4a09121337576437023e3af5a4c4f8bbbad5",
+                "publish_work": "sha256:189ff72e5023b7e723d2002a9c5097102c3e5fdf0a6382720a1cfc676b993e98",
                 "check": "sha256:b1cf1b1554d437b315f10f38080590b919c355b38f678bdcc458cd78620e1d60",
-                "respond": "sha256:669697ed16dc7cbb14bab5528a5e06d7782d3ce7b943b2a9036ae1dfd5ca8717",
+                "respond": "sha256:6003245eb4b02e6a81fa4f1083bfa00da675ec247398e302bcfbd2b82219664c",
                 "status": "sha256:e4798c4fedc7cb6bc7dda204b52ec2734b9dc319c27ca3834bdbaadd5c2613e4",
                 "receipt": "sha256:cf4b426af9764747848d3334d0671d0d0961ab5c86173d70c067222e9feb5ee2",
                 "read_guidance": "sha256:737b75bde002ab35255e19169d29f38d40a29d580b8165c759b1bc2373dd28bd",
@@ -1701,8 +1705,8 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
 )
 TOOL_DESCRIPTOR_SET_DIGEST: Final[Mapping[McpRouteProfile, str]] = MappingProxyType(
     {
-        "policy": "sha256:5795465d4e1890f9c8ded84afbc916c4c7d4d4bdc0b1853a7aae52ad0bc1c2e2",
-        "strict": "sha256:c90fb52fbd0511dcaffc0f8d60e31f6b0a6fd167a01f47b3ee2f2efc0952a40f",
+        "policy": "sha256:d4581664b6746ae6862d05ff032f1edee83c4d298c4421df0183fb360d8b7c93",
+        "strict": "sha256:ae74c5d65e11b97ae2785484c0ceffd17e4417251382904837a0c71c63bd20dd",
     }
 )
 

--- a/src/yoetz/mcp/descriptors.py
+++ b/src/yoetz/mcp/descriptors.py
@@ -1463,7 +1463,8 @@ _POLICY_TOOL_DESCRIPTORS: Final = (
         "publish_work",
         "Publish recorded work",
         "Records a bounded batch of agent-published work events and returns the accepted event "
-        "range and coverage. This appends records to the local Yoetz ledger; it "
+        "range and coverage. When `dry_run` is false, this appends records to the local Yoetz "
+        "ledger; it "
         "does not publish to GitHub or run a semantic evaluation. It has no information about "
         "work outside that batch. Every set-valued "
         "reference list in a draft envelope or payload (obligation_refs, obligation_ids, "
@@ -1682,7 +1683,7 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
         "policy": MappingProxyType(
             {
                 "start": "sha256:ac5c4ac0bd12f67e08437f3aea4b7bc328c060f08809ef6f20e86b879d683a29",
-                "publish_work": "sha256:189ff72e5023b7e723d2002a9c5097102c3e5fdf0a6382720a1cfc676b993e98",
+                "publish_work": "sha256:4e90f9bdb94adb0a0de05bd5ec046f54fcab4c89f93d4c4b7191c12e19e229de",
                 "check": "sha256:3175800b79a9ea035fabde6c64227ff8a0c9783a4f5d13a29a7a9b80e91c41a2",
                 "respond": "sha256:6003245eb4b02e6a81fa4f1083bfa00da675ec247398e302bcfbd2b82219664c",
                 "status": "sha256:e4798c4fedc7cb6bc7dda204b52ec2734b9dc319c27ca3834bdbaadd5c2613e4",
@@ -1693,7 +1694,7 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
         "strict": MappingProxyType(
             {
                 "start": "sha256:ac5c4ac0bd12f67e08437f3aea4b7bc328c060f08809ef6f20e86b879d683a29",
-                "publish_work": "sha256:189ff72e5023b7e723d2002a9c5097102c3e5fdf0a6382720a1cfc676b993e98",
+                "publish_work": "sha256:4e90f9bdb94adb0a0de05bd5ec046f54fcab4c89f93d4c4b7191c12e19e229de",
                 "check": "sha256:b1cf1b1554d437b315f10f38080590b919c355b38f678bdcc458cd78620e1d60",
                 "respond": "sha256:6003245eb4b02e6a81fa4f1083bfa00da675ec247398e302bcfbd2b82219664c",
                 "status": "sha256:e4798c4fedc7cb6bc7dda204b52ec2734b9dc319c27ca3834bdbaadd5c2613e4",
@@ -1705,8 +1706,8 @@ TOOL_DESCRIPTOR_DIGESTS: Final[Mapping[McpRouteProfile, Mapping[str, str]]] = Ma
 )
 TOOL_DESCRIPTOR_SET_DIGEST: Final[Mapping[McpRouteProfile, str]] = MappingProxyType(
     {
-        "policy": "sha256:d4581664b6746ae6862d05ff032f1edee83c4d298c4421df0183fb360d8b7c93",
-        "strict": "sha256:ae74c5d65e11b97ae2785484c0ceffd17e4417251382904837a0c71c63bd20dd",
+        "policy": "sha256:de1d9f9bd2f821bbf0cdf2ff64616213b2def4ad9d6952fbd1a485508700706c",
+        "strict": "sha256:1910d370ae257ff094984bf98ec5390added1cce159d5f045f10a7eafe44dcce",
     }
 )
 

--- a/tests/conformance/surfaces/test_mcp_contract_matrix.py
+++ b/tests/conformance/surfaces/test_mcp_contract_matrix.py
@@ -284,8 +284,8 @@ def test_descriptor_text_is_frozen_and_honest() -> None:
     assert tuple(TOOL_DESCRIPTORS) == ("policy", "strict")
     assert tuple(TOOL_DESCRIPTOR_DIGESTS) == ("policy", "strict")
     assert TOOL_DESCRIPTOR_SET_DIGEST == {
-        "policy": "sha256:5795465d4e1890f9c8ded84afbc916c4c7d4d4bdc0b1853a7aae52ad0bc1c2e2",
-        "strict": "sha256:c90fb52fbd0511dcaffc0f8d60e31f6b0a6fd167a01f47b3ee2f2efc0952a40f",
+        "policy": "sha256:d4581664b6746ae6862d05ff032f1edee83c4d298c4421df0183fb360d8b7c93",
+        "strict": "sha256:ae74c5d65e11b97ae2785484c0ceffd17e4417251382904837a0c71c63bd20dd",
     }
     for profile, descriptors in TOOL_DESCRIPTORS.items():
         assert tuple(item.name for item in descriptors) == _EXPECTED_TOOL_NAMES
@@ -302,6 +302,10 @@ def test_descriptor_text_is_frozen_and_honest() -> None:
     respond_description = descriptor_for("respond").description
     assert "result frontier of the check that returned it" in respond_description
     assert "not its subject_frontier" in respond_description
+    for local_description in (descriptor_for("publish_work").description, respond_description):
+        assert "local Yoetz ledger" in local_description
+        assert "does not publish to GitHub" in local_description
+        assert "run a semantic evaluation" in local_description
     assert descriptor_for("start").description.startswith(
         "Call for material multi-step, delegated, resumable, or verification-heavy work"
     )

--- a/tests/conformance/surfaces/test_mcp_contract_matrix.py
+++ b/tests/conformance/surfaces/test_mcp_contract_matrix.py
@@ -284,8 +284,8 @@ def test_descriptor_text_is_frozen_and_honest() -> None:
     assert tuple(TOOL_DESCRIPTORS) == ("policy", "strict")
     assert tuple(TOOL_DESCRIPTOR_DIGESTS) == ("policy", "strict")
     assert TOOL_DESCRIPTOR_SET_DIGEST == {
-        "policy": "sha256:d4581664b6746ae6862d05ff032f1edee83c4d298c4421df0183fb360d8b7c93",
-        "strict": "sha256:ae74c5d65e11b97ae2785484c0ceffd17e4417251382904837a0c71c63bd20dd",
+        "policy": "sha256:de1d9f9bd2f821bbf0cdf2ff64616213b2def4ad9d6952fbd1a485508700706c",
+        "strict": "sha256:1910d370ae257ff094984bf98ec5390added1cce159d5f045f10a7eafe44dcce",
     }
     for profile, descriptors in TOOL_DESCRIPTORS.items():
         assert tuple(item.name for item in descriptors) == _EXPECTED_TOOL_NAMES


### PR DESCRIPTION
Cursor Auto-review held explicitly requested local Yoetz publication and finding-response calls, contradicting our guarantee that those calls pass every host's rules. Descriptors now state their local ledger effects precisely, and docs explain the host's independent decision and exact-call recovery.

Based on main after #598 merged. This PR is limited to issue #595; the ancestry-only rebase preserved the exact reviewed file tree.

## Issue

- Fixes #595.
- Searched existing issues and PRs. This corrects a guarantee outside #467's check-only admission scope; it does not implement #479 or #569.
- The maintainer explicitly requested and acknowledged this dogfood follow-up before the PR.

## Documentation

- Behavior change: no runtime authority change; corrects user/agent-facing effect and recovery guidance.
- Updated ADR-018, the Cursor runbook, auto-approving usage docs and the host-admission docstring.

## Verification

```text
uv run pytest tests/conformance/surfaces/test_mcp_contract_matrix.py tests/conformance/surfaces/test_user_controlled_agent_setup.py -q
uv run pytest tests/capability/test_codex_six_tools.py -q
uv run ruff check src/yoetz/mcp/descriptors.py src/yoetz/adapters/integrations/host_admission.py tests/conformance/surfaces/test_mcp_contract_matrix.py
uv run ruff format --check src/yoetz/mcp/descriptors.py src/yoetz/adapters/integrations/host_admission.py tests/conformance/surfaces/test_mcp_contract_matrix.py
git diff --check
```

Post-rebase results: 26 + 4 tests passed, Ruff/format and diff checks passed. Independent review also checked admission/authorization guidance. Descriptor and set digests were recomputed after stacking on #598.

## Boundaries

- [x] No ignored private drafting inputs included.
- [x] Review findings have been dispositioned; later comments will be addressed before merge.
- No allowlists, auto-approval settings, self-approving hooks, privacy grants or annotations changed.
- Clear wording is not authorization and does not prove that future Cursor holds disappear.

## Summary

`publish_work` explicitly distinguishes dry runs from local appends, and `respond` names its local finding-response effect. Neither operation publishes to GitHub or runs semantic evaluation. Recovery lets the host execute the held call once and preserves its identity when the outcome is unknown.

Model/harness: GPT-6 in Codex desktop with delegated implementation and independent review agents.

Final adversarial review covered Cursor correctness, Claude/Codex applicability, and overall code/regression risk on combined head `24a876c5c3febcb3f55a4931219eaa597213d1a7`. All findings were fixed or explicitly dispositioned. Final exact PR heads have green CI and no unresolved review threads. The combined wheel also passed the real MCP stdio/service/CLI smoke with a simulated host roots callback; this is not fresh live-host dogfood.
