### PR TITLE
fix(cursor): bind native plugin launches to isolated state

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3992,35 +3992,50 @@ unpopulated evidence cell.
 It is redacted in representations and never inferred from regular Cursor, `$HOME`, caches, or a
 single installed candidate. The managed destination is `plugins/local/yoetz` below that selected
 root. `CursorPluginArtifact` contains one `PortablePluginPlan`, one sorted member mapping, and one
-artifact digest. Its format is exactly `agent_plugins_1` or `cursor_plugin_native`; one artifact
-never contains both root `plugin.json` and `.cursor-plugin/plugin.json`.
+artifact digest. Native artifacts also carry the validated `YOETZ_ISOLATED_ROOT` binding when the
+invoking runtime is isolated; portable artifacts never carry a host isolation binding. Its format
+is exactly `agent_plugins_1` or `cursor_plugin_native`; one artifact never contains both root
+`plugin.json` and `.cursor-plugin/plugin.json`. The host may still consult the regular shared
+`~/.cursor/plugins/local/yoetz` during discovery when launched with another user-data directory;
+an isolated Cursor home does not prove isolated plugin discovery. The explicit target, child root
+binding, and host discovery observation remain separate proof facets.
 
 `CursorPluginPreview` carries request ID, effective action, before state, exact format, target
 identity digest, current-state digest, artifact digest, preview digest, intended MCP ownership,
-observed `McpOwnershipState`, optional exact route, and sorted warnings. `CursorPluginStatus`
-carries artifact/operation state, detected format, artifact/installed digests, marker validity,
-rollback availability, one `CursorMcpObservation`, one `CursorMcpRuntimeObservation`, one
-`CursorLauncherStatus`, and every independent `PluginProofFacet`.
+observed `McpOwnershipState`, optional exact route, proposed isolated root or null, and sorted
+warnings. `CursorPluginStatus` carries artifact/operation state, detected format,
+artifact/installed digests, marker validity, rollback availability, one `CursorMcpObservation`,
+one `CursorMcpRuntimeObservation`, one `CursorLauncherStatus`, the Cursor-specific isolation
+binding (`ambient|isolated_exact|missing|different|unobserved`), and every independent
+`PluginProofFacet`. `ambient` and `isolated_exact` require both a marker root match and intact
+root-bearing MCP/hook members; a marker alone never proves that the child launch binding remains
+intact. `different` covers a changed root or a root-bearing member whose binding no longer matches.
 `CursorPluginResult` carries request/action/operation, before/after states, format,
 preview/artifact/installed digests, and sorted changed members. Portable artifacts retain marker
 schema `yoetz.cursor-plugin-install/1`. Newly rendered native artifacts use
-`yoetz.cursor-plugin-install/2`, which adds the resolved absolute invoking `yoetz` executable path
+`yoetz.cursor-plugin-install/3`, which adds the resolved absolute invoking `yoetz` executable path
 (never a different ambient-PATH installation when the CLI was invoked by an explicit absolute or
 relative path) to the
-format, renderer/Yoetz versions, hook mapping version, MCP owner/route, artifact digest, exact
-managed inventory, and marker digest. A valid legacy native `/1` marker remains managed but reports
-`modified` against the `/2` desired artifact, so an exact previewed replace or remove remains
-reachable. Neither schema carries a project path, content, credential, transcript, timestamp,
-activation, coverage, or receipt claim.
+format, renderer/Yoetz versions, hook mapping version, MCP owner/route, exact isolated-root
+binding (or null for ambient mode), artifact digest, exact managed inventory, and marker digest.
+A valid legacy native `/1` or `/2` marker remains managed but reports `modified` against the
+current desired artifact when its binding is absent, so an exact previewed replace or remove
+remains reachable. Neither schema carries a project path, content, credential, transcript,
+timestamp, activation, coverage, or receipt claim.
 
 Native hooks **and the plugin-owned `mcp.json`** launch that one recorded launcher (issue #468):
 the MCP entry is `command = launcher[0]`, `args = [*launcher[1:], "mcp", "serve", "--host",
 "cursor"(, "--semantic", "off")]`, never a bare `yoetz` that Cursor's sanitized desktop PATH may
-resolve to another installation. Because the entry is a managed member, its bytes are part of the
-artifact digest and the marker inventory. Route recognition (`observe_cursor_mcp`) accepts an
-exact Yoetz route as a hand-written bare `yoetz` or one of the known launchers — this artifact's
-and the installed marker's — followed by the exact serve arguments; any other command, prefix, or
-key set is `foreign`. `CursorLauncherStatus` reports `artifact_launcher`, `installed_launcher`,
+resolve to another installation. In isolated mode the entry carries exactly
+`env = {"YOETZ_ISOLATED_ROOT": "<validated-root>"}` and every native hook command carries the
+same shell-safe assignment; ambient artifacts omit both. Because these entries are managed
+members, their bytes are part of the artifact digest and marker inventory. Route-shape recognition
+accepts a hand-written bare `yoetz` or one of the known launchers — this artifact's and the
+installed marker's — followed by the exact serve arguments, optionally with that one structurally
+valid environment binding. Lifecycle ownership passes the artifact's exact expected root into the
+same classifier; a different valid root is therefore `foreign` and cannot count as owned or
+admitted. Any other command, prefix, or key set is `foreign`. `CursorLauncherStatus` reports
+`artifact_launcher`, `installed_launcher`,
 `executable` (`matched|drifted|missing|unbound|unobserved`: the installed launcher versus the one
 this runtime would render, and whether it still exists), `mcp_binding`
 (`exact_launcher|ambient_path|absent|foreign|unobserved`: what the installed plugin entry spawns),
@@ -4080,8 +4095,8 @@ a surviving Cursor-helper child on the strict argv is `full_restart_required`, a
 stays `not_observed`. Reload Window is not a sufficient activation proof. SDK precedence is exactly that enum order. A higher-precedence or duplicate
 same-name source cannot create a plugin-managed pass: plugin plus external is `dual`, multiple
 same-class sources are `ambiguous`, and any non-exact same-name entry is `foreign`. Route
-recognition is key-set exact — exactly `command`, `type`, `args` — so an entry carrying any
-additional key such as `env` or `cwd` is foreign however compatible its values look.
+recognition is key-set exact — exactly `command`, `type`, `args`, or those three plus the one
+`env` binding above; arbitrary additional keys such as `cwd` remain foreign.
 
 `CursorSdkBinding` is exactly `typescript|python`. `CursorArtifactIdentity` carries binding,
 package version/digest, bridge protocol exactly `sdk.v1`, and optional bridge digest.

--- a/docs/adr/ADR-010-harness-integration-port.md
+++ b/docs/adr/ADR-010-harness-integration-port.md
@@ -197,7 +197,7 @@ separately.** A bare `command: "yoetz"` let Cursor's sanitized desktop PATH reso
 ambient runtime (control schema 2.1.0) behind a marker-valid then-current plugin (2.3.0); the model's
 `start` then reached an incompatible bridge and no task, evidence, or receipt could exist. Cursor's
 MCP reference admits a full path in `command`, so the native entry is now `launcher[0]` plus
-`[*launcher[1:], "mcp", "serve", "--host", "cursor", …]` from the same `/2` marker launcher the
+`[*launcher[1:], "mcp", "serve", "--host", "cursor", …]` from the same `/3` marker launcher the
 hooks use; the entry is a managed member, so carrier bytes bind it. Route recognition accepts a
 bare `yoetz` or a known launcher (this artifact's or the installed marker's) with the exact serve
 arguments. `CursorPluginStatus.launcher` reports executable state (`matched|drifted|missing|

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -161,7 +161,7 @@ fully quit Cursor.
 
 Decision for Cursor: not supported here — no additional state-root applied-route record
 at this time. The plugin-managed `mcp.json` entry already binds the route profile (the exact
-serve arguments, including `--semantic off` for strict) and the `/2` marker records the same
+serve arguments, including `--semantic off` for strict) and the `/3` marker records the same
 launcher the native hooks use; the live binding and launcher read-backs above remain the
 authority for which route this host serves. A stale serving process shows as
 `executable_mismatch` / `full_restart_required`, not as applied-vs-serving drift. If a

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -36,9 +36,10 @@ group are Claude Code lifecycles and refuse for Cursor with
 `cursor_plugin_command_unsupported:<command> supported=preview,install,status,remove` (exit 2).
 
 Issue #561 changes only Yoetz-owned external Codex registration. Cursor remains supported through
-its native plugin projection: the exact isolated root is rendered into the test cell's `mcp.json`
-and hook commands and is bound by that artifact's preview digest. Cursor does not consume the Codex
-`mcp add --env` path or its `isolation_binding` status field.
+its native plugin projection: when `YOETZ_ISOLATED_ROOT` is set, the exact validated root is
+rendered into the plugin-managed `mcp.json` environment and every native hook command, and is
+bound by that artifact's preview and marker digests. Cursor uses its own
+`isolation_binding` status field; it does not consume the Codex `mcp add --env` path.
 
 ```text
 yoetz integrate cursor plugin preview \
@@ -87,6 +88,12 @@ status` reports `mcp.runtime.activation` as `matched` or `full_restart_required`
 is available. That is activation work, not installation proof. For CLI use the exact installed tree with `--plugin-dir`. Do not copy
 the skill to `.cursor/skills`, add a rule, or rely on `.agents/skills` as fallback evidence.
 
+The current Cursor desktop host can still discover a user-local plugin under the regular shared
+`~/.cursor/plugins/local/yoetz` when launched with another user-data directory. Treat that as a
+host discovery limitation: an isolated user-data directory does not by itself prove isolated
+plugin discovery. Keep the explicit plugin root, Yoetz root binding, and discovery observation as
+separate proof facets; a clean cell must verify which plugin directory Cursor actually loaded.
+
 ## MCP ownership and source precedence
 
 Ownership mode is exactly `external_registration` or `plugin_managed`. Observed state is exactly
@@ -109,23 +116,35 @@ route. The exact plugin-managed routes are `yoetz mcp serve` (policy) and
 Cursor target adds `--host cursor` and binds the exact launcher: its `mcp.json` entry is
 `command: <absolute yoetz executable>` (or the interpreter, with `-m yoetz` leading `args`) followed
 by `mcp serve --host cursor` (policy) or `mcp serve --host cursor --semantic off` (strict) — the
-same launcher the native hooks use and the `/2` marker records. Cursor's MCP reference resolves a
+same launcher the native hooks use and the `/3` marker records. In an isolated artifact the MCP
+entry also carries exactly `env: {YOETZ_ISOLATED_ROOT: <validated-root>}`; arbitrary environment
+keys remain foreign. Cursor's MCP reference resolves a
 bare `command` through the desktop app's sanitized PATH, which in the 2026-08-29 dogfood launched
 an older ambient runtime (control schema 2.1.0) behind a marker-valid then-current plugin (2.3.0); the
 bound entry removes PATH from the runtime choice (issue #468). That profile retains
 `structuredContent` and also repeats the exact canonical JSON body in text `content`, because
 pinned Cursor `3.17.x` can otherwise hide structured results from the model. It adds no
-environment or secret field and does not widen the service route. Decision for Cursor (issue
+environment or secret beyond the exact isolated-root binding and does not widen the service
+route. Decision for Cursor (issue
 #579): supported here — the `--host cursor` text channel is the exact canonical JSON wire body,
 so `safe_details.reason_code` and `safe_details.field` are already model-visible for
 `EVENT_INVALID`. The generic bounded `Reason:` summary is the Claude Code path; Cursor tests lock
 that the JSON copy still carries those tokens and is not reduced to the weaker summary. Route recognition accepts a
 hand-written bare `yoetz` (external registrations) or a known launcher (this runtime's or the
-installed marker's) with the exact serve arguments; anything else is `foreign`. Raw initialize and
+installed marker's) with the exact serve arguments, optionally with exactly the validated
+`YOETZ_ISOLATED_ROOT` environment binding. Route-shape recognition can describe a structurally
+valid binding, but lifecycle ownership requires the artifact's exact root; a different valid root
+is `foreign` and cannot count as owned or admitted. Any other command, prefix, or key set is
+`foreign`. Raw initialize and
 tools/list prove only runtime registration. Require a correlated model-controlled `start` or
 `status` call for use.
 
-`yoetz integrate cursor plugin status` reports the binding under `launcher`: `installed` and
+`yoetz integrate cursor plugin status` reports the state-root binding as `isolation_binding`
+(`ambient|isolated_exact|missing|different|unobserved`). `ambient` and `isolated_exact` require
+the marker and every root-bearing MCP/hook member to agree; a marker alone does not prove the
+child launch binding. `different` covers a changed root or a root-bearing member whose binding
+drifted. It reports the executable binding under
+`launcher`: `installed` and
 `artifact` launchers; `executable` (`matched` — same launcher and it exists; `drifted` — the
 installed tree binds another installation than the one reading status; `missing` — the bound
 executable is gone; `unbound` — portable or legacy `/1` marker; `unobserved`); `mcp_binding`
@@ -271,10 +290,10 @@ console-script invocation resolves to that absolute executable; the documented `
 entrypoint (ADR-007) is preserved as an equivalent module invocation of the same interpreter.
 Explicit absolute and relative invocations retain their path intent and never fall back to
 an ambient `PATH` entry; only a bare `yoetz` name uses `PATH`. The resolved launcher command is
-recorded in native marker schema `/2`; an explicit invocation does not silently bind a
-different ambient-PATH installation, and a malformed `/2` launcher invalidates the marker. Portable
-markers
-remain `/1`. A valid legacy native `/1` marker is recognized as managed-but-modified so users can
+recorded in native marker schema `/3`; an explicit invocation does not silently bind a
+different ambient-PATH installation, and a malformed `/2` or `/3` launcher invalidates the marker.
+The `/3` marker also records the exact isolated root or null for ambient mode. Portable markers
+remain `/1`. A valid legacy native `/1` or `/2` marker is recognized as managed-but-modified so users can
 perform one exact previewed replacement (or safe removal) instead of being stranded. The rendered
 timeouts are 10 seconds for `sessionStart`/`stop`, 5 seconds for
 `afterFileEdit`/`afterMCPExecution`, and 3 seconds for `sessionEnd`; `failClosed` remains false.
@@ -432,7 +451,8 @@ service through the user-selected supervisor before retrying Cursor. Runtime rep
 restart, and Cursor/plugin activation are separate proof facets.
 
 Removal moves only an exact marker-verified managed tree and deletes it after the directory swap is
-durable. Modified plugin bytes or recovery residue are preserved for review. Foreign, dual, or
+durable. Modified plugin bytes or recovery residue, including an isolated-root drift, are preserved
+for review until an explicit replacement or removal preview is accepted. Foreign, dual, or
 ambiguous MCP sources do not block exact plugin removal because the operation leaves every external
 source untouched. Removal does not delete ledgers, vault/keyring state, provider credentials,
 privacy grants, project/user MCP entries, or unrelated Cursor settings. After removal, independently check installed bytes,
@@ -475,7 +495,7 @@ the 2026-08-29 measurement above recorded for a locked cell.
 | Install refuses `authority_required` after `--accept` | no `plugin_artifact_apply` review is prepared for that exact digest |
 | Install refuses `human_authority_unavailable` | LocalAuthentication was cancelled, unavailable, timed out, or the host is outside the pinned macOS authority cell; no mutation occurred |
 | Install replay reports `preview_stale` | the inferred action became `replace`; replay with `--action install` |
-| MCP entry looks right but reads `foreign` | route recognition is key-set exact; an extra `env`/`cwd` key is a foreign entry, and an absolute `command` that is neither this runtime's launcher nor the installed marker's is another installation |
+| MCP entry looks right but reads `foreign` | route recognition is key-set exact; an extra key such as `cwd`, or an `env` object other than exactly `YOETZ_ISOLATED_ROOT=<absolute printable root>`, is foreign, and an absolute `command` that is neither this runtime's launcher nor the installed marker's is another installation |
 | Hooks observe but a model-controlled `start` returns `SERVICE_UNAVAILABLE` / `service_incompatible` right after install | the plugin's MCP process is another Yoetz installation; read `launcher.executable`, `launcher.mcp_binding`, `launcher.identity`, and `mcp.runtime.executable_activation`, replace a legacy `ambient_path` tree, then fully quit Cursor |
 | `launcher.executable` is `drifted` or `missing` | the installed tree binds a launcher that is not this runtime's or no longer exists; one exact previewed replace re-binds hooks and MCP together |
 | Delegated workers each report the same `correlation_id` with `availability_inherited: true` | expected: the bridge latched the parent's outage; repair once, replay the original `request_id`, and do not read those as fresh failures |

--- a/src/yoetz/adapters/integrations/cursor_integration.py
+++ b/src/yoetz/adapters/integrations/cursor_integration.py
@@ -43,6 +43,7 @@ from yoetz.adapters.integrations.portable_plugin import (
     RenderedPortablePlugin,
     build_portable_plugin_plan,
 )
+from yoetz.config.paths import ISOLATED_ROOT_ENV, isolated_root
 from yoetz.domain.values import JsonObject, RequestId
 from yoetz.domain.values import request_id as validate_request_id
 from yoetz.ports.integrations import HarnessHookProfile, HarnessId, HarnessProfile
@@ -79,6 +80,7 @@ __all__ = [
     "CursorArtifactIdentity",
     "CursorCapabilityIdentity",
     "CursorIntegrationError",
+    "CursorIsolationBindingState",
     "CursorMcpObservation",
     "CursorMcpProcessPort",
     "CursorMcpRuntimeObservation",
@@ -140,6 +142,7 @@ CURSOR_HARNESS_PROFILE: Final = HarnessProfile(
 _MARKER_NAME: Final = ".yoetz-cursor-plugin-install.json"
 _MARKER_SCHEMA_V1: Final = "yoetz.cursor-plugin-install/1"
 _MARKER_SCHEMA_V2: Final = "yoetz.cursor-plugin-install/2"
+_MARKER_SCHEMA_V3: Final = "yoetz.cursor-plugin-install/3"
 _RENDERER_VERSION: Final = "cursor-plugin/0.2.0"
 _ROLLBACK_NAME: Final = ".yoetz-cursor-plugin-rollback"
 _STAGE_PREFIX: Final = ".yoetz-cursor-plugin-stage-"
@@ -158,6 +161,10 @@ _DESCRIPTION: Final = (
     "Records material work in a local Yoetz ledger and checks completion claims "
     "against that record."
 )
+
+type CursorIsolationBindingState = Literal[
+    "ambient", "isolated_exact", "missing", "different", "unobserved"
+]
 
 
 class CursorSdkBinding(str, Enum):  # noqa: UP042 - exact public token
@@ -318,12 +325,39 @@ class CursorPluginTarget:
         return "CursorPluginTarget(cursor_config_root=<redacted>, scope='user')"
 
 
+def _valid_isolation_root_text(value: object) -> bool:
+    if type(value) is not str:
+        return False
+    return (
+        1 <= len(value) <= _MAX_PATH
+        and Path(value).is_absolute()
+        and not any(ord(char) < 32 or ord(char) == 127 for char in value)
+    )
+
+
+def _render_isolation_root() -> str | None:
+    """Resolve the one exact isolation binding for a native artifact.
+
+    ``isolated_root`` owns the path-safety contract.  The adapter only adds the bounded text
+    validation needed before a path is copied into a host-owned command/configuration artifact.
+    """
+
+    root = isolated_root()
+    if root is None:
+        return None
+    value = str(root)
+    if not _valid_isolation_root_text(value):
+        raise ValueError("cursor_isolation_root_invalid")
+    return value
+
+
 @dataclass(frozen=True, slots=True)
 class CursorPluginArtifact:
     plan: PortablePluginPlan
     members: Mapping[str, bytes]
     artifact_digest: str
     yoetz_launcher: tuple[str, ...] | None = field(default=None, repr=False)
+    isolation_root: str | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         if type(self.plan) is not PortablePluginPlan:
@@ -336,7 +370,13 @@ class CursorPluginArtifact:
         if self.plan.format_profile is PluginFormatProfile.CURSOR_PLUGIN_NATIVE:
             if not _valid_launcher(self.yoetz_launcher):
                 raise ValueError("cursor_artifact_invalid")
+            if self.isolation_root is not None and not _valid_isolation_root_text(
+                self.isolation_root
+            ):
+                raise ValueError("cursor_artifact_invalid")
         elif self.yoetz_launcher is not None:
+            raise ValueError("cursor_artifact_invalid")
+        elif self.isolation_root is not None:
             raise ValueError("cursor_artifact_invalid")
         _validate_digest(self.artifact_digest)
         expected = tuple(item.relative_path for item in self.plan.inventory)
@@ -380,6 +420,7 @@ class CursorPluginPreview:
     mcp_ownership: McpOwnership
     mcp_ownership_state: McpOwnershipState
     mcp_route_profile: Literal["strict", "policy"] | None
+    isolation_root: str | None = field(repr=False)
     warnings: tuple[str, ...]
 
     def __post_init__(self) -> None:
@@ -397,6 +438,8 @@ class CursorPluginPreview:
             self.preview_digest,
         ):
             _validate_digest(value)
+        if self.isolation_root is not None and not _valid_isolation_root_text(self.isolation_root):
+            raise ValueError("cursor_preview_invalid")
 
 
 type CursorLauncherExecutableState = Literal[
@@ -467,6 +510,7 @@ class CursorPluginStatus:
             None, None, "unobserved", "unobserved", UNOBSERVED_LAUNCHER_IDENTITY
         )
     )
+    isolation_binding: CursorIsolationBindingState = "unobserved"
 
     def __post_init__(self) -> None:
         if type(self.launcher) is not CursorLauncherStatus:
@@ -490,6 +534,14 @@ class CursorPluginStatus:
         ):
             raise ValueError("cursor_status_invalid")
         if any(type(item) is not PluginProofStatus for item in self.proof):
+            raise ValueError("cursor_status_invalid")
+        if self.isolation_binding not in {
+            "ambient",
+            "isolated_exact",
+            "missing",
+            "different",
+            "unobserved",
+        }:
             raise ValueError("cursor_status_invalid")
 
 
@@ -561,6 +613,7 @@ class _Inspection:
     marker_valid: bool
     rollback_available: bool
     installed_launcher: tuple[str, ...] | None = None
+    installed_isolation_root: str | None = None
 
 
 def _error(
@@ -595,7 +648,11 @@ _MCP_SERVE_ARGS: Final = ("mcp", "serve", "--host", "cursor")
 _MCP_SERVE_STRICT_ARGS: Final = (*_MCP_SERVE_ARGS, "--semantic", "off")
 
 
-def _mcp_json(route_profile: Literal["strict", "policy"], yoetz_launcher: tuple[str, ...]) -> bytes:
+def _mcp_json(
+    route_profile: Literal["strict", "policy"],
+    yoetz_launcher: tuple[str, ...],
+    isolation_root: str | None,
+) -> bytes:
     """Render the plugin-owned MCP entry bound to the exact launcher the hooks use.
 
     Cursor resolves a bare ``command`` through the desktop app's PATH, which is sanitized and
@@ -605,15 +662,18 @@ def _mcp_json(route_profile: Literal["strict", "policy"], yoetz_launcher: tuple[
     """
 
     serve = _MCP_SERVE_STRICT_ARGS if route_profile == "strict" else _MCP_SERVE_ARGS
-    args = [*yoetz_launcher[1:], *serve]
+    args = cast(list[JsonValue], [*yoetz_launcher[1:], *serve])
+    entry: dict[str, JsonValue] = {
+        "args": args,
+        "command": yoetz_launcher[0],
+        "type": "stdio",
+    }
+    if isolation_root is not None:
+        entry["env"] = {ISOLATED_ROOT_ENV: isolation_root}
     return canonical_encode(
         cast(
             JsonValue,
-            {
-                "mcpServers": {
-                    "yoetz": {"args": args, "command": yoetz_launcher[0], "type": "stdio"}
-                }
-            },
+            {"mcpServers": {"yoetz": entry}},
         )
     )
 
@@ -636,6 +696,7 @@ def _native_members(
     mcp_ownership: McpOwnership,
     route_profile: Literal["strict", "policy"] | None,
     yoetz_launcher: tuple[str, ...],
+    isolation_root: str | None,
 ) -> dict[str, bytes]:
     manifest: dict[str, JsonValue] = {
         "author": {"name": "Yoetz contributors"},
@@ -652,7 +713,10 @@ def _native_members(
     elif route_profile is not None:
         raise ValueError("cursor_mcp_route_forbidden")
     launcher = " ".join(shlex.quote(part) for part in yoetz_launcher)
-    hook_command = f"{launcher} hooks cursor-observe --workspace ."
+    isolation_prefix = (
+        "" if isolation_root is None else f"{ISOLATED_ROOT_ENV}={shlex.quote(isolation_root)} "
+    )
+    hook_command = f"{isolation_prefix}{launcher} hooks cursor-observe --workspace ."
     hook_timeouts = {
         "afterFileEdit": 5,
         "afterMCPExecution": 5,
@@ -673,7 +737,7 @@ def _native_members(
         members[f"skills/yoetz/references/{name}"] = source.read_bytes(f"guidance/{name}")
     if mcp_ownership is McpOwnership.PLUGIN_MANAGED:
         assert route_profile is not None
-        members["mcp.json"] = _mcp_json(route_profile, yoetz_launcher)
+        members["mcp.json"] = _mcp_json(route_profile, yoetz_launcher, isolation_root)
     return members
 
 
@@ -703,11 +767,13 @@ def render_cursor_plugin(
         )
         return CursorPluginArtifact(rendered.plan, dict(rendered.members), rendered.artifact_digest)
     resolved_yoetz_launcher = _resolve_yoetz_launcher(yoetz_launcher)
+    resolved_isolation_root = _render_isolation_root()
     members = _native_members(
         source=resources,
         mcp_ownership=mcp_ownership,
         route_profile=route_profile,
         yoetz_launcher=resolved_yoetz_launcher,
+        isolation_root=resolved_isolation_root,
     )
     plan = PortablePluginPlan(
         name="yoetz",
@@ -744,7 +810,9 @@ def render_cursor_plugin(
             "renderer_version": _RENDERER_VERSION,
         }
     )
-    return CursorPluginArtifact(plan, members, digest, resolved_yoetz_launcher)
+    return CursorPluginArtifact(
+        plan, members, digest, resolved_yoetz_launcher, resolved_isolation_root
+    )
 
 
 def _safe_existing_ancestor(path: Path) -> Path:
@@ -852,7 +920,7 @@ def _marker(artifact: CursorPluginArtifact) -> bytes:
         "mcp_route_profile": artifact.plan.mcp_route_profile,
         "renderer_version": artifact.plan.renderer_version,
         "schema": (
-            _MARKER_SCHEMA_V2
+            _MARKER_SCHEMA_V3
             if artifact.plan.format_profile is PluginFormatProfile.CURSOR_PLUGIN_NATIVE
             else _MARKER_SCHEMA_V1
         ),
@@ -861,6 +929,7 @@ def _marker(artifact: CursorPluginArtifact) -> bytes:
     if artifact.plan.format_profile is PluginFormatProfile.CURSOR_PLUGIN_NATIVE:
         assert artifact.yoetz_launcher is not None
         body["yoetz_launcher"] = list(artifact.yoetz_launcher)
+        body["isolation_root"] = artifact.isolation_root
     return canonical_encode({**body, "marker_digest": canonical_digest(body)})
 
 
@@ -872,6 +941,7 @@ def _valid_marker(
     if marker is None or marker.get("schema") not in {
         _MARKER_SCHEMA_V1,
         _MARKER_SCHEMA_V2,
+        _MARKER_SCHEMA_V3,
     }:
         return False, None, None
     schema = cast(str, marker["schema"])
@@ -889,14 +959,22 @@ def _valid_marker(
     }:
         return False, None, None
     launcher = marker.get("yoetz_launcher")
-    if schema == _MARKER_SCHEMA_V2:
+    isolation_root = marker.get("isolation_root")
+    if schema in {_MARKER_SCHEMA_V2, _MARKER_SCHEMA_V3}:
         if (
             format_profile is not PluginFormatProfile.CURSOR_PLUGIN_NATIVE
             or type(launcher) is not list
             or not _valid_launcher(tuple(cast(list[object], launcher)))
         ):
             return False, format_profile, cast(str | None, marker.get("artifact_digest"))
-    elif launcher is not None:
+        if schema == _MARKER_SCHEMA_V3 and (
+            "isolation_root" not in marker
+            or (isolation_root is not None and not _valid_isolation_root_text(isolation_root))
+        ):
+            return False, format_profile, cast(str | None, marker.get("artifact_digest"))
+        if schema == _MARKER_SCHEMA_V2 and isolation_root is not None:
+            return False, format_profile, cast(str | None, marker.get("artifact_digest"))
+    elif launcher is not None or isolation_root is not None:
         return False, format_profile, cast(str | None, marker.get("artifact_digest"))
     rows = marker.get("managed_files")
     if type(rows) is not list:
@@ -973,6 +1051,7 @@ def _inspect(target: CursorPluginTarget, artifact: CursorPluginArtifact) -> _Ins
     current_digest = _tree_digest(files)
     valid, format_profile, installed_digest = _valid_marker(files)
     installed_launcher = _marker_launcher(files) if valid else None
+    installed_isolation_root = _marker_isolation_root(files) if valid else None
     if not valid:
         state = (
             PluginArtifactState.MODIFIED
@@ -1014,15 +1093,16 @@ def _inspect(target: CursorPluginTarget, artifact: CursorPluginArtifact) -> _Ins
         True,
         False,
         installed_launcher,
+        installed_isolation_root,
     )
 
 
 def _marker_launcher(files: Mapping[str, bytes]) -> tuple[str, ...] | None:
-    """Return the exact launcher a marker-valid native ``/2`` tree binds, else ``None``."""
+    """Return the exact launcher a marker-valid native tree binds, else ``None``."""
 
     raw = files.get(_MARKER_NAME)
     marker = None if raw is None else _load_object(raw)
-    if marker is None or marker.get("schema") != _MARKER_SCHEMA_V2:
+    if marker is None or marker.get("schema") not in {_MARKER_SCHEMA_V2, _MARKER_SCHEMA_V3}:
         return None
     launcher = marker.get("yoetz_launcher")
     if type(launcher) is not list:
@@ -1031,6 +1111,19 @@ def _marker_launcher(files: Mapping[str, bytes]) -> tuple[str, ...] | None:
     if not _valid_launcher(candidate):
         return None
     return cast(tuple[str, ...], candidate)
+
+
+def _marker_isolation_root(files: Mapping[str, bytes]) -> str | None:
+    """Return the root recorded by a marker-valid native tree, or ``None`` for legacy/ambient."""
+
+    raw = files.get(_MARKER_NAME)
+    marker = None if raw is None else _load_object(raw)
+    if marker is None or marker.get("schema") != _MARKER_SCHEMA_V3:
+        return None
+    value = marker.get("isolation_root")
+    if type(value) is not str or not _valid_isolation_root_text(value):
+        return None
+    return value
 
 
 _ABSENT_STATE_DIGEST: Final = canonical_digest({"state": "absent"})
@@ -1055,6 +1148,28 @@ def _admissible_owner_states(artifact: CursorPluginArtifact) -> set[McpOwnership
     return {McpOwnershipState.ABSENT, McpOwnershipState.PLUGIN}
 
 
+def _isolation_drift_is_replaceable(
+    action: PluginArtifactAction,
+    inspection: _Inspection,
+    artifact: CursorPluginArtifact,
+    mcp_observation: CursorMcpObservation,
+) -> bool:
+    """Allow replacement of only the plugin-owned root binding drift."""
+
+    return (
+        action is PluginArtifactAction.REPLACE
+        and inspection.marker_valid
+        and inspection.format_profile is PluginFormatProfile.CURSOR_PLUGIN_NATIVE
+        and artifact.plan.format_profile is PluginFormatProfile.CURSOR_PLUGIN_NATIVE
+        and artifact.plan.mcp_ownership is McpOwnership.PLUGIN_MANAGED
+        and inspection.installed_isolation_root != artifact.isolation_root
+        and mcp_observation.observed
+        and mcp_observation.ownership_state is McpOwnershipState.FOREIGN
+        and mcp_observation.winning_source is CursorMcpSource.PLUGIN
+        and mcp_observation.present_sources == (CursorMcpSource.PLUGIN,)
+    )
+
+
 def _preview_digest(
     request: RequestId,
     effective: PluginArtifactAction,
@@ -1073,6 +1188,7 @@ def _preview_digest(
             "mcp_ownership": artifact.plan.mcp_ownership.value,
             "mcp_ownership_state": mcp_ownership_state.value,
             "mcp_route_profile": artifact.plan.mcp_route_profile,
+            "isolation_root": artifact.isolation_root,
             "request_id": request,
             "target_identity": target_identity,
         }
@@ -1113,7 +1229,9 @@ def _preview_from_inspection(
         raise _error(PluginArtifactReason.REMOVE_REFUSED)
     if action is not PluginArtifactAction.REMOVE:
         allowed = _admissible_owner_states(artifact)
-        if mcp_observation.ownership_state not in allowed:
+        if mcp_observation.ownership_state not in allowed and not _isolation_drift_is_replaceable(
+            action, inspection, artifact, mcp_observation
+        ):
             raise _error(
                 PluginArtifactReason.MCP_OWNERSHIP_CONFLICT,
                 {"mcp_ownership_state": mcp_observation.ownership_state.value},
@@ -1150,6 +1268,7 @@ def _preview_from_inspection(
         artifact.plan.mcp_ownership,
         mcp_observation.ownership_state,
         artifact.plan.mcp_route_profile,
+        artifact.isolation_root,
         warnings,
     )
 
@@ -1175,6 +1294,7 @@ def preview_cursor_plugin(
         inline_create=inline_create,
         inline_send=inline_send,
         yoetz_launchers=_known_launchers(artifact, inspection),
+        expected_isolation_root=artifact.isolation_root,
     )
     return _preview_from_inspection(request, action, inspection, artifact, observation)
 
@@ -1577,6 +1697,7 @@ def status_cursor_plugin(
         project_root=project_root,
         user_config_root=inspection.root,
         yoetz_launchers=_known_launchers(artifact, inspection),
+        expected_isolation_root=artifact.isolation_root,
     )
     runtime = observe_cursor_mcp_runtime(
         installed_route=observation.route_profile,
@@ -1589,6 +1710,7 @@ def status_cursor_plugin(
         inspection,
         OsLauncherProbe() if launcher_probe is None else launcher_probe,
     )
+    isolation_binding = _isolation_binding(artifact, inspection)
     return CursorPluginStatus(
         inspection.state,
         (
@@ -1607,11 +1729,125 @@ def status_cursor_plugin(
         runtime,
         _proof(inspection.state),
         launcher,
+        isolation_binding,
     )
 
 
+def _isolation_binding(
+    artifact: CursorPluginArtifact, inspection: _Inspection
+) -> CursorIsolationBindingState:
+    """Classify the native artifact's exact state-root binding without exposing the path.
+
+    The marker is necessary but not sufficient: the root-bearing MCP and hook members must also
+    still carry the expected binding before status reports ``ambient`` or ``isolated_exact``.
+    """
+
+    if artifact.plan.format_profile is not PluginFormatProfile.CURSOR_PLUGIN_NATIVE:
+        return "unobserved"
+    if not inspection.marker_valid:
+        return "unobserved"
+    installed = inspection.installed_isolation_root
+    expected = artifact.isolation_root
+    if expected is None:
+        if installed is not None:
+            return "different"
+        return "ambient" if _root_binding_surfaces_match(artifact, inspection) else "different"
+    if installed == expected:
+        return (
+            "isolated_exact" if _root_binding_surfaces_match(artifact, inspection) else "different"
+        )
+    return "missing" if installed is None else "different"
+
+
+def _safe_json_object(path: Path) -> Mapping[str, JsonValue] | None:
+    """Read one regular JSON file without following a host-owned symlink."""
+
+    try:
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > _MAX_FILE_BYTES:
+            return None
+        return _load_object(path.read_bytes())
+    except OSError:
+        return None
+
+
+def _route_isolation_binding(
+    entry: Mapping[str, JsonValue] | None,
+) -> tuple[Literal["ambient", "isolated", "invalid", "missing"], str | None]:
+    """Return only the isolation binding represented by a parsed MCP entry."""
+
+    if entry is None:
+        return "missing", None
+    keys = set(entry)
+    if keys == {"args", "command", "type"}:
+        return "ambient", None
+    if keys == {"args", "command", "type", "env"}:
+        valid, root = _entry_isolation_root(entry)
+        return ("isolated", root) if valid else ("invalid", None)
+    return "invalid", None
+
+
+def _mcp_entry_from_object(
+    document: Mapping[str, JsonValue] | None,
+) -> Mapping[str, JsonValue] | None:
+    if document is None:
+        return None
+    servers = document.get("mcpServers")
+    if not isinstance(servers, Mapping):
+        return None
+    entry = servers.get("yoetz")
+    return cast(Mapping[str, JsonValue], entry) if isinstance(entry, Mapping) else None
+
+
+def _root_binding_surfaces_match(artifact: CursorPluginArtifact, inspection: _Inspection) -> bool:
+    """Check root-bearing MCP and hook members before reporting an exact binding."""
+
+    expected_hooks = _load_object(artifact.members.get("hooks/hooks.json", b""))
+    current_hooks = _safe_json_object(inspection.destination / "hooks" / "hooks.json")
+    if expected_hooks is None or current_hooks is None:
+        return False
+    expected_hook_map = expected_hooks.get("hooks")
+    current_hook_map = current_hooks.get("hooks")
+    if not isinstance(expected_hook_map, Mapping) or not isinstance(current_hook_map, Mapping):
+        return False
+    expected_prefix = (
+        ""
+        if artifact.isolation_root is None
+        else f"{ISOLATED_ROOT_ENV}={shlex.quote(artifact.isolation_root)} "
+    )
+    for event in CURSOR_HOOK_EVENTS:
+        expected_definition = expected_hook_map.get(event)
+        current_definition = current_hook_map.get(event)
+        if not isinstance(expected_definition, list) or not expected_definition:
+            return False
+        if not isinstance(current_definition, list) or not current_definition:
+            return False
+        expected_first = expected_definition[0]
+        current_first = current_definition[0]
+        if not isinstance(expected_first, Mapping) or not isinstance(current_first, Mapping):
+            return False
+        expected_command = expected_first.get("command")
+        current_command = current_first.get("command")
+        if not isinstance(expected_command, str) or not isinstance(current_command, str):
+            return False
+        if artifact.isolation_root is None:
+            if f"{ISOLATED_ROOT_ENV}=" in current_command:
+                return False
+        elif not current_command.startswith(expected_prefix):
+            return False
+
+    if "mcp.json" not in artifact.members:
+        return True
+    expected_mcp = _mcp_entry_from_object(_load_object(artifact.members["mcp.json"]))
+    current_mcp = _mcp_entry_from_object(_safe_json_object(inspection.destination / "mcp.json"))
+    expected_kind, expected_root = _route_isolation_binding(expected_mcp)
+    current_kind, current_root = _route_isolation_binding(current_mcp)
+    return (current_kind, current_root) == (expected_kind, expected_root)
+
+
 def _installed_mcp_binding(
-    inspection: _Inspection, installed_launcher: tuple[str, ...] | None
+    inspection: _Inspection,
+    installed_launcher: tuple[str, ...] | None,
+    expected_isolation_root: str | None,
 ) -> CursorMcpBindingState:
     """Say what the installed plugin-owned ``mcp.json`` would make Cursor spawn."""
 
@@ -1623,12 +1859,20 @@ def _installed_mcp_binding(
     if entry is None:
         return "absent"
     command = entry.get("command")
-    if command == "yoetz" and _route_profile(entry) is not None:
+    if (
+        command == "yoetz"
+        and _route_profile(entry, expected_isolation_root=expected_isolation_root) is not None
+    ):
         return "ambient_path"
     if (
         installed_launcher is not None
         and command == installed_launcher[0]
-        and _route_profile(entry, (installed_launcher,)) is not None
+        and _route_profile(
+            entry,
+            (installed_launcher,),
+            expected_isolation_root=expected_isolation_root,
+        )
+        is not None
     ):
         return "exact_launcher"
     return "foreign"
@@ -1640,7 +1884,7 @@ def _launcher_status(
     launcher_probe: LauncherProbePort,
 ) -> CursorLauncherStatus:
     installed = inspection.installed_launcher
-    binding = _installed_mcp_binding(inspection, installed)
+    binding = _installed_mcp_binding(inspection, installed, artifact.isolation_root)
     if not inspection.marker_valid:
         return CursorLauncherStatus(
             artifact.yoetz_launcher, None, "unobserved", binding, UNOBSERVED_LAUNCHER_IDENTITY
@@ -1719,27 +1963,47 @@ _POLICY_ROUTE_ARGS: Final = frozenset({("mcp", "serve"), _MCP_SERVE_ARGS})
 _STRICT_ROUTE_ARGS: Final = frozenset(
     {("mcp", "serve", "--semantic", "off"), _MCP_SERVE_STRICT_ARGS}
 )
+_UNSET_ISOLATION_ROOT: Final = object()
 
 
 def _route_profile(
     entry: Mapping[str, JsonValue] | None,
     yoetz_launchers: tuple[tuple[str, ...], ...] = (),
+    *,
+    expected_isolation_root: str | None | object = _UNSET_ISOLATION_ROOT,
 ) -> Literal["strict", "policy"] | None:
     """Classify one MCP entry as an exact Yoetz route, else ``None``.
 
     An exact route launches either a bare ``yoetz`` console script (an external registration
     the owner wrote by hand) or one of ``yoetz_launchers`` — this artifact's exact bound
     launcher, or the launcher the installed marker recorded — followed by the exact ``mcp
-    serve`` arguments.
+    serve`` arguments. When ``expected_isolation_root`` is supplied, the route must carry that
+    exact root (or no environment in ambient mode); omission keeps this helper's route-shape
+    classification independent from lifecycle ownership.
     """
 
     if entry is None:
         return None
     # Any non-exact same-name entry is foreign, so recognition is key-set exact and not merely
-    # value-compatible. An extra ``env``, ``cwd``, or any other key changes what the host will
-    # actually launch, and treating such an entry as a known route would silently attribute a
-    # foreign registration to Yoetz.
-    if set(entry) != {"args", "command", "type"}:
+    # value-compatible. The one exception is the exact isolated-root environment binding owned
+    # by this adapter. Route-shape callers may omit ``expected_isolation_root`` to classify a
+    # structurally valid isolated route; lifecycle ownership callers pass the artifact's exact
+    # expected root so a different root cannot count as owned or admitted. Arbitrary environment
+    # keys remain foreign and are never overwritten.
+    registered_isolation_root: str | None = None
+    keys = set(entry)
+    if keys == {"args", "command", "type"}:
+        pass
+    elif keys == {"args", "command", "type", "env"}:
+        readable, registered_isolation_root = _entry_isolation_root(entry)
+        if not readable:
+            return None
+    else:
+        return None
+    if (
+        expected_isolation_root is not _UNSET_ISOLATION_ROOT
+        and registered_isolation_root != expected_isolation_root
+    ):
         return None
     if entry.get("type") != "stdio":
         return None
@@ -1766,6 +2030,21 @@ def _route_profile(
     return None
 
 
+def _entry_isolation_root(entry: Mapping[str, JsonValue]) -> tuple[bool, str | None]:
+    """Read the only environment binding a Cursor route may carry."""
+
+    environment = entry.get("env")
+    if not isinstance(environment, Mapping):
+        return False, None
+    values = cast(Mapping[object, object], environment)
+    if set(values) != {ISOLATED_ROOT_ENV}:
+        return False, None
+    raw = values.get(ISOLATED_ROOT_ENV)
+    if not _valid_isolation_root_text(raw):
+        return False, None
+    return True, cast(str, raw)
+
+
 def observe_cursor_mcp(
     *,
     plugin_root: Path,
@@ -1774,6 +2053,7 @@ def observe_cursor_mcp(
     inline_create: Mapping[str, JsonValue] | None = None,
     inline_send: Mapping[str, JsonValue] | None = None,
     yoetz_launchers: tuple[tuple[str, ...], ...] = (),
+    expected_isolation_root: str | None = None,
 ) -> CursorMcpObservation:
     """Classify exact same-name sources using Cursor SDK precedence.
 
@@ -1781,7 +2061,9 @@ def observe_cursor_mcp(
     Duplicate exact sources remain ambiguous (or dual for plugin+external), and
     any same-name foreign entry remains foreign. ``yoetz_launchers`` are the exact
     bound launchers (this artifact's and the installed marker's) that an exact route
-    may name beside a bare ``yoetz``.
+    may name beside a bare ``yoetz``. The expected isolation root defaults to ambient mode;
+    callers rendering an isolated artifact pass its exact root explicitly. Route-shape-only
+    classification remains available through the private ``_route_profile`` helper.
     """
 
     candidates: list[tuple[CursorMcpSource, Mapping[str, JsonValue] | None]] = []
@@ -1820,7 +2102,17 @@ def observe_cursor_mcp(
         )
     if not candidates:
         return CursorMcpObservation(McpOwnershipState.ABSENT, None, None, (), True)
-    profiles = [(source, _route_profile(entry, yoetz_launchers)) for source, entry in candidates]
+    profiles = [
+        (
+            source,
+            _route_profile(
+                entry,
+                yoetz_launchers,
+                expected_isolation_root=expected_isolation_root,
+            ),
+        )
+        for source, entry in candidates
+    ]
     present = tuple(source for source, _profile in profiles)
     if any(profile is None for _source, profile in profiles):
         foreign_source = next(source for source, profile in profiles if profile is None)

--- a/src/yoetz/cli/cursor_integration.py
+++ b/src/yoetz/cli/cursor_integration.py
@@ -24,6 +24,7 @@ from yoetz.adapters.integrations.portable_plugin import (
     ElevatedPortableArtifactReview,
 )
 from yoetz.cli.host_admission import admission_cleanup_preview, reverse_sweep
+from yoetz.config.paths import PathSafetyError
 from yoetz.domain.values import RequestId, request_id
 from yoetz.ports.plugin_artifacts import (
     ArtifactAuthority,
@@ -133,6 +134,7 @@ def _status_body(status: CursorPluginStatus) -> dict[str, object]:
         "artifact_digest": status.artifact_digest,
         "format_profile": None if status.format_profile is None else status.format_profile.value,
         "installed_digest": status.installed_digest,
+        "isolation_binding": status.isolation_binding,
         "launcher": {
             "artifact": (
                 None
@@ -273,6 +275,7 @@ def run_cursor_plugin_command(
                     "mcp_ownership": preview.mcp_ownership.value,
                     "mcp_ownership_state": preview.mcp_ownership_state.value,
                     "mcp_route_profile": preview.mcp_route_profile,
+                    "isolation_root": preview.isolation_root,
                     "preview_digest": preview.preview_digest,
                     "request_id": preview.request_id,
                     "scope": "user",
@@ -339,6 +342,9 @@ def run_cursor_plugin_command(
             json_output=json_output,
         )
         return 0
+    except PathSafetyError as error:
+        sys.stderr.write(f"cursor_isolation_root_invalid:{error.reason_code}\n")
+        return 1
     except (CursorIntegrationError, ValueError) as error:
         reason = error.reason.value if isinstance(error, CursorIntegrationError) else str(error)
         sys.stderr.write(f"{reason}\n")

--- a/tests/unit/adapters/test_cursor_integration.py
+++ b/tests/unit/adapters/test_cursor_integration.py
@@ -200,6 +200,96 @@ def test_plugin_managed_native_route_is_exact_and_external_omits_it() -> None:
     }
 
 
+def test_isolated_native_artifact_binds_root_in_mcp_and_hook_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    isolated_root = tmp_path / "isolated root with 'quotes'"
+    executable = _fake_yoetz(tmp_path / "runtime" / "yoetz")
+    executable.write_text("#!/bin/sh\nprintf '%s' \"$YOETZ_ISOLATED_ROOT\"\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root",
+        lambda: isolated_root,
+    )
+
+    artifact = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        mcp_ownership=McpOwnership.PLUGIN_MANAGED,
+        route_profile="policy",
+        yoetz_launcher=executable,
+    )
+
+    assert artifact.isolation_root == str(isolated_root)
+    route = json.loads(artifact.members["mcp.json"])["mcpServers"]["yoetz"]
+    assert route["env"] == {"YOETZ_ISOLATED_ROOT": str(isolated_root)}
+    assert set(route) == {"args", "command", "env", "type"}
+
+    hooks = json.loads(artifact.members["hooks/hooks.json"])["hooks"]
+    for definition in hooks.values():
+        command = definition[0]["command"]
+        assert command.startswith(f"YOETZ_ISOLATED_ROOT={shlex.quote(str(isolated_root))} ")
+        # Cursor executes command hooks as shell strings.  This also proves a path containing
+        # spaces and a quote cannot escape the assignment.
+        completed = subprocess.run(
+            ["/bin/sh", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        assert completed.returncode == 0
+        assert completed.stderr == ""
+        assert completed.stdout == str(isolated_root)
+
+
+def test_isolated_root_route_recognition_is_closed_and_drift_readable(tmp_path: Path) -> None:
+    from yoetz.adapters.integrations.cursor_integration import (
+        _route_profile,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    launcher = (str(tmp_path / "bin" / "yoetz"),)
+    serve = ["mcp", "serve", "--host", "cursor"]
+    isolated = str(tmp_path / "isolated")
+    exact = _entry(
+        launcher[0],
+        serve,
+        env={"YOETZ_ISOLATED_ROOT": isolated},  # type: ignore[arg-type]
+    )
+    assert _route_profile(exact, (launcher,)) == "policy"
+    assert _route_profile(exact, (launcher,), expected_isolation_root=isolated) == "policy"
+
+    # Route shape remains classifiable without an expected binding, but the lifecycle ownership
+    # check rejects a different root. Arbitrary, malformed, and empty environments remain foreign.
+    different = _entry(
+        launcher[0],
+        serve,
+        env={"YOETZ_ISOLATED_ROOT": str(tmp_path / "other")},  # type: ignore[arg-type]
+    )
+    assert _route_profile(different, (launcher,)) == "policy"
+    assert _route_profile(different, (launcher,), expected_isolation_root=isolated) is None
+    assert (
+        _route_profile(
+            _entry(launcher[0], serve, env={"YOETZ_TOKEN": "secret"}),  # type: ignore[arg-type]
+            (launcher,),
+        )
+        is None
+    )
+    assert (
+        _route_profile(
+            _entry(launcher[0], serve, env={"YOETZ_ISOLATED_ROOT": "relative"}),  # type: ignore[arg-type]
+            (launcher,),
+        )
+        is None
+    )
+    assert (
+        _route_profile(
+            _entry(launcher[0], serve, env={}),  # type: ignore[arg-type]
+            (launcher,),
+        )
+        is None
+    )
+
+
 def _no_path_lookup(_name: str) -> str | None:
     return None
 
@@ -638,7 +728,8 @@ def test_safe_cursor_lifecycle_is_preview_bound_atomic_and_reversible(tmp_path: 
     )
     assert artifact.yoetz_launcher is not None
     assert marker["yoetz_launcher"] == list(artifact.yoetz_launcher)
-    assert marker["schema"] == "yoetz.cursor-plugin-install/2"
+    assert marker["schema"] == "yoetz.cursor-plugin-install/3"
+    assert marker["isolation_root"] is None
     assert marker["renderer_version"] == "cursor-plugin/0.2.0"
 
     status = status_cursor_plugin(target, artifact)
@@ -668,10 +759,208 @@ def test_safe_cursor_lifecycle_is_preview_bound_atomic_and_reversible(tmp_path: 
     assert status_cursor_plugin(target, artifact).operation_state.value == "not_started"
 
 
+def test_isolation_binding_reports_drift_and_unset_reverts_to_ambient(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_root = tmp_path / "isolated-one"
+    second_root = tmp_path / "isolated-two"
+    executable = _fake_yoetz(tmp_path / "runtime" / "yoetz")
+
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root",
+        lambda: first_root,
+    )
+    first = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        mcp_ownership=McpOwnership.PLUGIN_MANAGED,
+        route_profile="policy",
+        yoetz_launcher=executable,
+    )
+    target = _install_native(tmp_path, first)
+    installed = status_cursor_plugin(target, first)
+    assert installed.state is PluginArtifactState.NATIVE_MANAGED
+    assert installed.isolation_binding == "isolated_exact"
+
+    # A managed tree whose route is changed to another valid root is modified, and the foreign
+    # route cannot be admitted as the current artifact's owned MCP route.
+    route_path = tmp_path / ".cursor" / "plugins" / "local" / "yoetz" / "mcp.json"
+    route = json.loads(route_path.read_bytes())
+    route["mcpServers"]["yoetz"]["env"]["YOETZ_ISOLATED_ROOT"] = str(second_root)
+    route_path.write_text(json.dumps(route), encoding="utf-8")
+    route_drift = status_cursor_plugin(target, first)
+    assert route_drift.state is PluginArtifactState.MODIFIED
+    assert route_drift.marker_valid is False
+    assert route_drift.isolation_binding == "unobserved"
+    assert route_drift.mcp_observation.ownership_state is McpOwnershipState.FOREIGN
+    assert route_drift.launcher.mcp_binding == "unobserved"
+    with pytest.raises(CursorIntegrationError) as route_conflict:
+        preview_cursor_plugin(
+            request_id("req_10000000-0000-4000-8000-000000000026"),
+            target,
+            PluginArtifactAction.REPLACE,
+            first,
+        )
+    assert route_conflict.value.reason is PluginArtifactReason.DESTINATION_CONFLICT
+    route_path.write_bytes(first.members["mcp.json"])
+
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root",
+        lambda: second_root,
+    )
+    second = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        mcp_ownership=McpOwnership.PLUGIN_MANAGED,
+        route_profile="policy",
+        yoetz_launcher=executable,
+    )
+    project = tmp_path / "project"
+    (project / ".cursor").mkdir(parents=True)
+    (project / ".cursor" / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "yoetz": {
+                        "args": ["foreign"],
+                        "command": "other-runtime",
+                        "type": "stdio",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    before_foreign_conflict = route_path.read_bytes()
+    with pytest.raises(CursorIntegrationError) as foreign_conflict:
+        preview_cursor_plugin(
+            request_id("req_10000000-0000-4000-8000-000000000030"),
+            target,
+            PluginArtifactAction.REPLACE,
+            second,
+            project_root=project,
+        )
+    assert foreign_conflict.value.reason is PluginArtifactReason.MCP_OWNERSHIP_CONFLICT
+    assert route_path.read_bytes() == before_foreign_conflict
+
+    drifted = status_cursor_plugin(target, second)
+    assert drifted.state is PluginArtifactState.MODIFIED
+    assert drifted.marker_valid is True
+    assert drifted.isolation_binding == "different"
+    assert drifted.mcp_observation.ownership_state is McpOwnershipState.FOREIGN
+    assert drifted.launcher.mcp_binding == "foreign"
+
+    replace_request = request_id("req_10000000-0000-4000-8000-000000000027")
+    replace_preview = preview_cursor_plugin(
+        replace_request, target, PluginArtifactAction.REPLACE, second
+    )
+    assert replace_preview.mcp_ownership_state is McpOwnershipState.FOREIGN
+    apply_cursor_plugin(
+        replace_request,
+        target,
+        PluginArtifactAction.REPLACE,
+        second,
+        accepted_preview_digest=replace_preview.preview_digest,
+        authority=_authority(replace_preview.preview_digest),
+        review=_AcceptingReview(),
+    )
+    assert status_cursor_plugin(target, second).isolation_binding == "isolated_exact"
+
+    # Unsetting the environment renders the ambient form and exposes the installed isolated form
+    # as drift until the operator explicitly replaces it.
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root", lambda: None
+    )
+    ambient = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        mcp_ownership=McpOwnership.PLUGIN_MANAGED,
+        route_profile="policy",
+        yoetz_launcher=executable,
+    )
+    assert ambient.isolation_root is None
+    ambient_view = status_cursor_plugin(target, ambient)
+    assert ambient_view.state is PluginArtifactState.MODIFIED
+    assert ambient_view.isolation_binding == "different"
+
+    ambient_request = request_id("req_10000000-0000-4000-8000-000000000028")
+    ambient_preview = preview_cursor_plugin(
+        ambient_request, target, PluginArtifactAction.REPLACE, ambient
+    )
+    apply_cursor_plugin(
+        ambient_request,
+        target,
+        PluginArtifactAction.REPLACE,
+        ambient,
+        accepted_preview_digest=ambient_preview.preview_digest,
+        authority=_authority(ambient_preview.preview_digest),
+        review=_AcceptingReview(),
+    )
+    final = status_cursor_plugin(target, ambient)
+    assert final.state is PluginArtifactState.NATIVE_MANAGED
+    assert final.isolation_binding == "ambient"
+    route = json.loads(
+        (tmp_path / ".cursor" / "plugins" / "local" / "yoetz" / "mcp.json").read_bytes()
+    )["mcpServers"]["yoetz"]
+    assert "env" not in route
+    hooks = json.loads(
+        (tmp_path / ".cursor" / "plugins" / "local" / "yoetz" / "hooks" / "hooks.json").read_bytes()
+    )["hooks"]
+    assert all(
+        "YOETZ_ISOLATED_ROOT=" not in definition[0]["command"] for definition in hooks.values()
+    )
+
+
+def test_isolated_legacy_marker_without_root_reports_missing_and_replaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "isolated"
+    executable = _fake_yoetz(tmp_path / "runtime" / "yoetz")
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root", lambda: root
+    )
+    artifact = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        mcp_ownership=McpOwnership.PLUGIN_MANAGED,
+        route_profile="policy",
+        yoetz_launcher=executable,
+    )
+    target = _install_native(tmp_path, artifact)
+    destination = tmp_path / ".cursor" / "plugins" / "local" / "yoetz"
+    marker_path = destination / ".yoetz-cursor-plugin-install.json"
+    marker = json.loads(marker_path.read_bytes())
+    marker.pop("isolation_root")
+    marker["schema"] = "yoetz.cursor-plugin-install/2"
+    body = {key: value for key, value in marker.items() if key != "marker_digest"}
+    marker["marker_digest"] = canonical_digest(body)
+    marker_path.write_bytes(canonical_encode(marker))
+
+    status = status_cursor_plugin(target, artifact)
+    assert status.state is PluginArtifactState.MODIFIED
+    assert status.marker_valid is True
+    assert status.isolation_binding == "missing"
+
+    replacement = preview_cursor_plugin(
+        request_id("req_10000000-0000-4000-8000-000000000029"),
+        target,
+        PluginArtifactAction.REPLACE,
+        artifact,
+    )
+    replaced = apply_cursor_plugin(
+        replacement.request_id,
+        target,
+        PluginArtifactAction.REPLACE,
+        artifact,
+        accepted_preview_digest=replacement.preview_digest,
+        authority=_authority(replacement.preview_digest),
+        review=_AcceptingReview(),
+    )
+    assert replaced.state_after is PluginArtifactState.NATIVE_MANAGED
+    assert status_cursor_plugin(target, artifact).isolation_binding == "isolated_exact"
+
+
 def _rewrite_native_marker_as_legacy_v1(destination: Path) -> None:
     marker_path = destination / ".yoetz-cursor-plugin-install.json"
     marker = json.loads(marker_path.read_bytes())
     marker.pop("yoetz_launcher")
+    marker.pop("isolation_root", None)
     marker["schema"] = "yoetz.cursor-plugin-install/1"
     body = {key: value for key, value in marker.items() if key != "marker_digest"}
     marker["marker_digest"] = canonical_digest(body)
@@ -714,7 +1003,7 @@ def test_legacy_native_v1_marker_has_a_safe_replace_path(tmp_path: Path) -> None
     )
     assert replaced.state_after is PluginArtifactState.NATIVE_MANAGED
     marker = json.loads((destination / ".yoetz-cursor-plugin-install.json").read_bytes())
-    assert marker["schema"] == "yoetz.cursor-plugin-install/2"
+    assert marker["schema"] == "yoetz.cursor-plugin-install/3"
 
 
 def test_portable_v1_marker_remains_exact_and_removable(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_cursor_integration_cli.py
+++ b/tests/unit/cli/test_cursor_integration_cli.py
@@ -126,6 +126,7 @@ def test_cursor_plugin_cli_binds_preview_install_status_and_remove(tmp_path: Pat
     assert status.exit_code == 0, status.output
     status_body = json.loads(status.stdout)
     assert status_body["state"] == "native_managed"
+    assert status_body["isolation_binding"] == "ambient"
     assert status_body["mcp"]["ownership_state"] == "plugin"
     # Issue #468: the CLI status exposes the bound launcher, its MCP binding, and the identity
     # probed from that exact executable (this venv's own console script here).
@@ -215,6 +216,27 @@ def test_cursor_plugin_cli_binds_preview_install_status_and_remove(tmp_path: Pat
         == 1
     )
     assert len(presence.seen) == 3
+
+
+def test_cursor_plugin_cli_preview_surfaces_isolated_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "isolated-root"
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.cursor_integration.isolated_root", lambda: root
+    )
+    runner = CliRunner()
+    preview_result = runner.invoke(
+        app,
+        _args(
+            tmp_path / "cursor-config",
+            tmp_path / "project",
+            "preview",
+        ),
+    )
+    assert preview_result.exit_code == 0, preview_result.output
+    preview = json.loads(preview_result.stdout)
+    assert preview["isolation_root"] == str(root)
 
 
 def test_cursor_plugin_cli_rejects_unknown_action_with_bounded_reason(tmp_path: Path) -> None:


### PR DESCRIPTION
An isolated native Cursor install omitted its state root from the generated MCP and hook launches. Those artifacts now carry the validated root explicitly, with digest-bound lifecycle handling and visible drift instead of relying on the parent Cursor environment.

## Issue

- Fixes #594.
- Searched existing issues/PRs; #561/#575 fixed external Codex registration, not this native Cursor carrier.
- The maintainer explicitly requested and acknowledged this packaging-boundary dogfood repair before the PR.

## Documentation

- Behavior change: yes.
- Updated INTERFACES and Cursor runbook: marker /3, exact environment shape, isolation status/drift, legacy marker replacement, and shared local-plugin discovery limits.

## Verification

```text
uv run pytest tests/unit/adapters/test_cursor_integration.py tests/unit/cli/test_cursor_integration_cli.py -q
uv run ruff check src/yoetz/adapters/integrations/cursor_integration.py src/yoetz/cli/cursor_integration.py tests/unit/adapters/test_cursor_integration.py tests/unit/cli/test_cursor_integration_cli.py
uv run ruff format --check src/yoetz/adapters/integrations/cursor_integration.py src/yoetz/cli/cursor_integration.py tests/unit/adapters/test_cursor_integration.py tests/unit/cli/test_cursor_integration_cli.py
/Users/shayb/yoetz-core/node_modules/.bin/pyright src/yoetz/adapters/integrations/cursor_integration.py src/yoetz/cli/cursor_integration.py tests/unit/adapters/test_cursor_integration.py tests/unit/cli/test_cursor_integration_cli.py
git diff --check
```

47 tests passed; root independently reran that slice and Ruff. Pinned Pyright passed. Regressions cover emitted root/quoting, ambient and changed roots, stale/tampered artifacts, legacy markers, preview/status/removal and foreign-source conflicts.

## Boundaries

- [x] No ignored private drafting inputs included.
- [x] Initial review findings are fixed; the three maintainer-requested final adversarial reviews are complete with no remaining blockers.
- No ordinary Cursor profile or live vault was mutated for these tests.
- Artifact binding is not proof of fresh host activation. A separate user-data directory still does not establish isolated local-plugin discovery.

## Summary

Native marker /3 records the root while preserving legacy marker readability. Status requires the marker and root-bearing MCP/hook surfaces to agree before reporting exact isolation. Explicit replacement can repair sole plugin-owned root drift but still refuses competing foreign MCP entries.

Model/harness: GPT-6 in Codex desktop with delegated implementation and independent review agents.

Final adversarial review covered Cursor correctness, Claude/Codex applicability, and overall code/regression risk on combined head `24a876c5c3febcb3f55a4931219eaa597213d1a7`. All findings were fixed or explicitly dispositioned. Final exact PR heads have green CI and no unresolved review threads. The combined wheel also passed the real MCP stdio/service/CLI smoke with a simulated host roots callback; this is not fresh live-host dogfood.
