### PR TITLE
fix(ci): keep network guard outside the config namespace

### DIFF
--- a/.github/workflows/capability.yml
+++ b/.github/workflows/capability.yml
@@ -190,7 +190,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
@@ -293,7 +293,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
@@ -369,7 +369,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --all-extras --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \

--- a/.github/workflows/nightly-fault.yml
+++ b/.github/workflows/nightly-fault.yml
@@ -117,7 +117,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           echo "YOETZ_TEST_MARKER=nightly-fault-linux-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
           uv sync --locked --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
@@ -220,7 +220,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           echo "YOETZ_TEST_MARKER=nightly-fault-macos-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
           uv sync --locked --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
@@ -308,7 +308,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
 
       - name: Extended Hypothesis/reference-machine profile (fixed + randomized seed)
         env:
@@ -387,7 +387,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Validate schema $id/$ref resolution from the local manifest (network denied)
         env:
-          YOETZ_DENY_NETWORK: "1"
+          YZCI_DENY_NETWORK: "1"
         run: |
           uv run --locked pytest \
             tests/conformance/surfaces \
@@ -301,7 +301,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
 
       - name: Unit, property, and conformance (bounded, excludes fault/soak/live)
         run: |
@@ -345,7 +345,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
 
       - name: Assert exact locked APSW/SQLite identity before tests
         run: |
@@ -428,7 +428,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/subprocess-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Bounded console/module/MCP subprocess cases (excludes full kill matrix)
@@ -498,7 +498,7 @@ jobs:
           echo "XDG_DATA_HOME=$iso/.local/share" >> "$GITHUB_ENV"
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
 
       - name: Run import, help, version --json, and strict-local vertical slice
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,12 +507,12 @@ jobs:
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900
-          YOETZ_DENY_NETWORK=1 \
+          YZCI_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/subprocess \
             -m "not fault and not soak and not live" -q --timeout=900
           # Linux approved-command execution remains a documented fail-closed alpha limitation.
-          YOETZ_DENY_NETWORK=1 \
+          YZCI_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/integration \
             --deselect tests/integration/observation/test_acceptance_scenarios.py::test_approved_check_stale_when_digest_changes \
@@ -627,11 +627,11 @@ jobs:
             tests/packaging/test_offline_reinstall.py::test_corrupted_wheel_fails_exact_hash_verification_before_any_install \
             tests/packaging/test_offline_reinstall.py::test_correct_hash_matching_the_real_wheel_installs_cleanly \
             -q --timeout=900
-          YOETZ_DENY_NETWORK=1 \
+          YZCI_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/subprocess \
             -m "not fault and not soak and not live" -q --timeout=900
-          YOETZ_DENY_NETWORK=1 \
+          YZCI_DENY_NETWORK=1 \
           YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \
             uv run --locked pytest tests/integration \
             -m "not fault and not soak and not live" -q --timeout=900

--- a/.github/workflows/security-privacy.yml
+++ b/.github/workflows/security-privacy.yml
@@ -391,7 +391,7 @@ jobs:
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "XDG_RUNTIME_DIR=$iso/.runtime" >> "$GITHUB_ENV"
-          echo "YOETZ_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv venv "${{ runner.temp }}/runtime-venv"
           uv pip install --python "${{ runner.temp }}/runtime-venv/bin/python" \
             --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"

--- a/tests/packaging/test_release_workflow_contract.py
+++ b/tests/packaging/test_release_workflow_contract.py
@@ -241,9 +241,9 @@ def test_platform_verifiers_split_suites_and_bound_linux_alpha_claims() -> None:
         assert verifier.count("test_correct_hash_matching_the_real_wheel_installs_cleanly") == 2
         assert "pytest tests/subprocess \\" in verifier
         assert "pytest tests/integration \\" in verifier
-        assert "export YOETZ_DENY_NETWORK" not in verifier
+        assert "export YZCI_DENY_NETWORK" not in verifier
         assert "export YOETZ_CANDIDATE_PYTHON" not in verifier
-        assert verifier.count("YOETZ_DENY_NETWORK=1 \\") == 2
+        assert verifier.count("YZCI_DENY_NETWORK=1 \\") == 2
         assert (
             verifier.count('YOETZ_CANDIDATE_PYTHON="${{ runner.temp }}/verify-venv/bin/python" \\')
             == 2

--- a/tests/subprocess/conftest.py
+++ b/tests/subprocess/conftest.py
@@ -37,7 +37,7 @@ def _hermetic_yoetz_environment(  # pyright: ignore[reportUnusedFunction]
     extended with ``XDG_RUNTIME_DIR`` so endpoint resolution cannot fall back to a platform
     default outside the tree (on Linux that would be the real ``/run/user/<uid>``), and with a
     scrub of inherited ``YOETZ_*`` variables so neither a developer's exports nor the CI job's
-    own ``YOETZ_DENY_NETWORK``/``YOETZ_CANDIDATE_PYTHON`` reach the strict config loader, which
+    own ``YOETZ_CANDIDATE_PYTHON`` reaches the strict config loader, which
     refuses every unknown ``YOETZ_``-prefixed name. Underscore-prefixed harness variables such
     as ``_YOETZ_TEST_INSTALLATION`` are not product configuration and survive.
 

--- a/tests/unit/cli/test_codex_subscription.py
+++ b/tests/unit/cli/test_codex_subscription.py
@@ -33,10 +33,9 @@ def _ambient_config_environment(  # pyright: ignore[reportUnusedFunction]
     """Resolve the default evaluator home from an empty configuration, not the ambient one.
 
     ``default_codex_home`` reads the process environment through the strict loader, which
-    refuses every unknown ``YOETZ_``-prefixed variable. The CI unit job exports
-    ``YOETZ_DENY_NETWORK=1`` for the whole job and a developer machine carries its own
-    ``config.toml``; neither is configuration resolution under test here, so every case in this
-    module starts from no ``YOETZ_`` variables and a config path that does not exist.
+    refuses every unknown ``YOETZ_``-prefixed variable. A developer machine can carry
+    configuration overrides and its own ``config.toml``; neither is under test here, so every
+    case starts from no ``YOETZ_`` variables and a config path that does not exist.
     """
 
     for name in tuple(os.environ):

--- a/tests/unit/cli/test_installation_recovery_cli.py
+++ b/tests/unit/cli/test_installation_recovery_cli.py
@@ -157,7 +157,7 @@ async def test_recovery_status_is_pathless_and_agent_safe(
     monkeypatch.setattr(cli, "_installation_recovery_store", lambda: _Store())
     monkeypatch.setattr(cli, "build_service_client", _unavailable)
     monkeypatch.setattr("yoetz.config.paths.bundle_root", _bundle_root)
-    # The strict loader rejects unknown YOETZ_* variables, and CI sets YOETZ_DENY_NETWORK=1.
+    # Keep inherited configuration out of this status-only test.
     # Status reporting is what is under test here, not configuration resolution.
     monkeypatch.setattr("yoetz.config.load.load_config", _stub_config)
 


### PR DESCRIPTION
CI exported a harness flag in the strict product configuration namespace, causing unrelated configuration reads to fail. Rename that flag to `YZCI_DENY_NETWORK` across all five workflows and update the release contract assertions and isolation comments. The strict `YOETZ_` validation remains intact.

## Issue

- Fixes #493.
- Searched open PRs, recent closed PRs, and the issue timeline for duplicates.
- The maintainer requested proposed-fix PRs in the current conversation. This is a mechanical CI harness rename, with no release authority or distribution change.

## Documentation

- Behavior change: no product behavior change.
- Updated test comments to describe the remaining configuration isolation.

## Verification

```text
YZCI_DENY_NETWORK=1 uv run --no-sync pytest tests/packaging/test_release_workflow_contract.py -q
# 12 passed
YZCI_DENY_NETWORK=1 uv run --no-sync pytest tests/unit/config/test_load_precedence.py -q
# 11 passed
uv run --no-sync ruff check tests/subprocess/conftest.py tests/unit/cli/test_codex_subscription.py tests/unit/cli/test_installation_recovery_cli.py tests/packaging/test_release_workflow_contract.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Used the repository-pinned uv 0.11.29 and Python 3.14.6.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

All job-level and command-scoped exports now use the harness namespace. Release verification still limits the flag to the same commands.

Implementation: Codex in ChatGPT Work Mode. No merge performed.
