### PR TITLE
test(protocol): measure paired CPU ratios for codec regressions

### DIFF
--- a/tests/unit/protocol/test_canonical_performance.py
+++ b/tests/unit/protocol/test_canonical_performance.py
@@ -6,8 +6,8 @@ implement string validation/escaping made those operations ~70x slower than
 the stdlib on the same bytes, which dominated the hook 'store' stage. A
 fixture-sized document passes any implementation trivially, so this fence
 measures a ~1 MiB document and bounds the cost relative to the stdlib codec
-on the same machine — immune to CI hardware variance, generous enough to
-never flap, and far below the regressed ratio.
+on the same machine. Paired CPU-time samples exclude runner descheduling,
+and the median limits the influence of an isolated noisy sample.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Callable
+from statistics import median
 
 from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 
@@ -23,9 +24,6 @@ from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_pa
 # and far below the regressed one, so it catches a return to per-character
 # work without flapping on ordinary hardware variance.
 _MAX_STDLIB_RATIO = 20.0
-# Below this absolute cost the ratio is noise-dominated and irrelevant to the
-# hook budget either way.
-_ABSOLUTE_FLOOR_SECONDS = 0.080
 
 
 def _realistic_document() -> dict[str, JsonValue]:
@@ -54,13 +52,23 @@ def _realistic_document() -> dict[str, JsonValue]:
     }
 
 
-def _best_of(operation: Callable[[], object], runs: int = 3) -> float:
-    best = float("inf")
-    for _ in range(runs):
-        started = time.perf_counter()
-        operation()
-        best = min(best, time.perf_counter() - started)
-    return best
+def _paired_cpu_ratio(reference: Callable[[], object], candidate: Callable[[], object]) -> float:
+    # Warm both paths before measuring. Each adjacent pair sees similar CPU/cache
+    # conditions; alternate order so neither path always pays the first-run cost.
+    reference()
+    candidate()
+    ratios: list[float] = []
+    for sample in range(5):
+        durations: dict[str, int] = {}
+        pair = (("reference", reference), ("candidate", candidate))
+        for name, operation in pair if sample % 2 == 0 else reversed(pair):
+            started = time.process_time_ns()
+            for _ in range(3):
+                operation()
+            durations[name] = time.process_time_ns() - started
+        assert durations["reference"] > 0
+        ratios.append(durations["candidate"] / durations["reference"])
+    return median(ratios)
 
 
 def test_parse_and_encode_stay_within_ratio_of_stdlib_on_large_state() -> None:
@@ -68,15 +76,18 @@ def test_parse_and_encode_stay_within_ratio_of_stdlib_on_large_state() -> None:
     raw = canonical_encode(document)
     assert len(raw) > 700_000
 
-    stdlib_parse = _best_of(lambda: json.loads(raw))
-    strict_parse = _best_of(lambda: strict_json_parse(raw))
-    assert strict_parse <= max(stdlib_parse * _MAX_STDLIB_RATIO, _ABSOLUTE_FLOOR_SECONDS)
-
-    stdlib_encode = _best_of(
-        lambda: json.dumps(document, separators=(",", ":"), sort_keys=True).encode()
+    assert (
+        _paired_cpu_ratio(lambda: json.loads(raw), lambda: strict_json_parse(raw))
+        <= _MAX_STDLIB_RATIO
     )
-    canonical = _best_of(lambda: canonical_encode(document))
-    assert canonical <= max(stdlib_encode * _MAX_STDLIB_RATIO, _ABSOLUTE_FLOOR_SECONDS)
+
+    assert (
+        _paired_cpu_ratio(
+            lambda: json.dumps(document, separators=(",", ":"), sort_keys=True).encode(),
+            lambda: canonical_encode(document),
+        )
+        <= _MAX_STDLIB_RATIO
+    )
 
 
 def test_fast_string_paths_are_output_identical() -> None:


### PR DESCRIPTION
The codec regression test could fail when a shared CI runner descheduled Python, even with unchanged codec code. Measure the median of adjacent, alternating CPU-time pairs and retain the 20x stdlib ratio fence. Remove the absolute wall-clock floor.

## Issue

- Fixes #585.
- Checked open/closed PRs and the issue timeline for duplicates.
- Test-only change requested in the maintainer's proposed-fix PR sweep.

## Documentation

- Product behavior: unchanged.
- Updated the test's measurement rationale; the byte-identity test and differential-fuzz tests are unchanged.

## Verification

```text
uv run --no-sync pytest tests/unit/protocol/test_canonical_performance.py tests/unit/protocol/test_canonical_fast_path_equivalence.py -q
# 32 passed
uv run --no-sync ruff check tests/unit/protocol/test_canonical_performance.py
uv run --no-sync ruff format tests/unit/protocol/test_canonical_performance.py
pyright tests/unit/protocol/test_canonical_performance.py
# 0 errors, pinned npm Pyright 1.1.411
git diff --check
```

A separate calibration loaded the real pre-fix codec from `fe504248^` and measured it with the new helper on the same document and process. Current parse: 14.76x; historical parse: 55.54x. Current encode: 11.19x; historical encode: 45.46x. The unchanged 20x fence passes the current implementation and rejects the historical regression on both legs. These numbers are local calibration, not a cross-platform benchmark.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

Warm both paths, alternate measurement order, repeat each operation three times per sample, and compare the median of five paired CPU-time ratios. CPU time excludes time the process is not scheduled; pairing reduces temporal load drift.

Implementation: Codex in ChatGPT Work Mode. No merge performed.