### PR TITLE
fix(workflow): explain repository context conflicts

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -100,7 +100,11 @@ keys. `SESSION_NOT_FOUND` with
 repository_identity_required` (the control handshake carried no workspace locator) or
 `repository_identity_mismatch` (the locator resolved to a different repository than the route, or
 the route holds no repository binding); neither discloses a commitment, and a hook uses the reason
-to keep a live mapping out of the `mapping_stale` class (issue #578). The separate
+to keep a live mapping out of the `mapping_stale` class (issue #578). The
+repository-fence message names missing context or the current closed identity kind
+(`git_common_root` or `directory`) and directs the operator to the original workspace. It exposes
+no path or commitment. Read-only operation status retains the same fence: when that workspace is
+unavailable, the task workflow cannot inspect the operation (issue #444). The separate
 `workspace_task_exists` conflict deliberately carries no task selector or count: possession of a
 workspace reference alone is not authority to discover or attach another task. A host hook may
 recover from that exact conflict only with a validated selector it already holds in the private

--- a/src/yoetz/application/service.py
+++ b/src/yoetz/application/service.py
@@ -779,9 +779,22 @@ class Application:
             # repository than the route" without disclosing either commitment
             # (issue #578): a hook status probe sent without a workspace was
             # otherwise indistinguishable from a replaced session.
+            if repository_privacy_context is None:
+                message = (
+                    "The request has no repository context. Run from the original workspace "
+                    "directory or reconnect the host to that workspace before retrying."
+                )
+            else:
+                message = (
+                    "The request's repository context does not match the task attachment "
+                    f"(current identity kind: {repository_privacy_context.identity_kind}). "
+                    "Run from the original workspace directory or reconnect the host to that "
+                    "workspace before retrying. If the original directory is unavailable, "
+                    "this operation cannot be inspected through the task workflow."
+                )
             raise PublicOperationError(
                 PublicErrorCode.SESSION_CONFLICT,
-                "The requested task attachment conflicts.",
+                message,
                 False,
                 safe_details={
                     "reason_code": (

--- a/tests/unit/application/test_service_facade.py
+++ b/tests/unit/application/test_service_facade.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import replace
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 
@@ -140,14 +140,16 @@ def _application(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("method", ("publish_work", "check", "respond", "status", "receipt"))
+@pytest.mark.parametrize("identity_kind", ("git_common_root", "directory"))
 async def test_task_workflows_reject_cross_repository_context_before_execution(
     method: str,
+    identity_kind: Literal["git_common_root", "directory"],
 ) -> None:
     commitment_a = "hmac-sha256:" + "a" * 64
     commitment_b = "hmac-sha256:" + "b" * 64
     catalog = _Catalog(_route(repository_privacy_commitment=commitment_a))
     app = _application(catalog, enforce_repository_identity=True)
-    context_b = RepositoryPrivacyContext(commitment_b, "git_common_root")
+    context_b = RepositoryPrivacyContext(commitment_b, identity_kind)
     request_type = {
         "publish_work": PublishWorkRequest,
         "check": CheckRequest,
@@ -166,6 +168,9 @@ async def test_task_workflows_reject_cross_repository_context_before_execution(
     assert failure.value.code is PublicErrorCode.SESSION_CONFLICT
     assert failure.value.safe_details == {"reason_code": "repository_identity_mismatch"}
     assert commitment_a not in failure.value.message
+    assert commitment_b not in failure.value.message
+    assert f"current identity kind: {identity_kind}" in failure.value.message
+    assert "original workspace directory" in failure.value.message
     assert catalog.calls == 1
 
 
@@ -191,6 +196,8 @@ async def test_task_workflows_name_a_missing_repository_context_distinctly(metho
     assert failure.value.code is PublicErrorCode.SESSION_CONFLICT
     assert failure.value.retryable is False
     assert failure.value.safe_details == {"reason_code": "repository_identity_required"}
+    assert "no repository context" in failure.value.message
+    assert "original workspace directory" in failure.value.message
     assert catalog.calls == 1
 
 


### PR DESCRIPTION
A read-only operation lookup from the wrong folder reported only that the task attachment conflicted. Use the diagnostic-only option proposed in the issue: explain missing or mismatched repository context, name the current closed identity kind, and tell the operator to return to the original workspace.

## Issue

- Fixes #444.
- Duplicate search included open and closed PRs and the issue timeline.
- The maintainer requested proposed-fix PRs in the current conversation.
- This change preserves the repository fence and all authorization decisions. It implements the issue's existing diagnostic alternative, without adding unfenced inspection.

## Documentation

- Behavior change: clearer public error messages.
- Updated `docs/INTERFACES.md` with the diagnostic contract and the remaining limitation when the original directory is unavailable.

## Verification

```text
uv run --no-sync pytest tests/unit/application/test_service_facade.py -q
uv run --no-sync ruff check src/yoetz/application/service.py tests/unit/application/test_service_facade.py
uv run --no-sync ruff format src/yoetz/application/service.py tests/unit/application/test_service_facade.py
pyright src/yoetz/application/service.py tests/unit/application/test_service_facade.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Regression coverage exercises all five task workflows with both directory and Git-common-root contexts, verifies missing-context wording, and checks that neither commitment appears in the error. The existing closed reason codes and rejection behavior are unchanged.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

CLI and host consumers of the common application error now receive actionable repository-context wording. The change does not make operations inspectable when the original workspace cannot be supplied.

Implementation: Codex in ChatGPT Work Mode; Python 3.14.6, uv 0.11.29, npm Pyright 1.1.411. No merge performed.