### PR TITLE
fix(observation): fence Codex capture to reviewed hook mappings

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3310,7 +3310,10 @@ Claude Code and Cursor ordinary native profiles and to the source-qualified prof
 arm. A capture-only control request enters a separate bounded lane, reserves an
 `ObservationCaptureTicket`, secret-scans and encrypts eligible chunks, publishes the objects and
 manifests, and marks the ticket pending before the host's structural envelope advances the FIFO
-cursor. For Codex, active observation consent selects the profileless arm; no Claude/Cursor content
+cursor. For Codex, selection additionally requires the reviewed cursor mapping
+`codex-obs-hook/1.0.0`. Unknown, future, and other-source mappings are rejected before resolving or
+opening a captured object; no legacy mapping is implicitly accepted (issue #621).
+Active observation consent selects the profileless arm; no Claude/Cursor content
 profile is accepted. The structural retry must present the same exact source/session/cursor
 identity, workspace/task binding, tool-call correlation, and original source and authority
 generations, and the service accepts the ticket only when every expected content group and part is

--- a/src/yoetz/application/semantic_content.py
+++ b/src/yoetz/application/semantic_content.py
@@ -71,6 +71,9 @@ _CURSOR_ORDINARY_PROFILE: Final = CURSOR_ORDINARY_OBSERVATION_PROFILE_ID
 # that historical, profileless grant; it is never accepted as a local consent
 # profile or as a capture-only request profile.
 _CODEX_HISTORICAL_CAPTURE_SCOPE: Final = ObservationSource.CODEX_HOOK.value
+# Only the reviewed native hook vocabulary can authorize selection. A shared
+# source token does not make future or session-stream mappings compatible.
+_CODEX_REVIEWED_HOOK_MAPPINGS: Final = frozenset({"codex-obs-hook/1.0.0"})
 # These are the only Claude ordinary hook mappings whose captured-content wire
 # contract has been reviewed. Keep the historical v1 literal so upgrading the
 # ingress mapping does not make already-authenticated v1 envelopes unreadable;
@@ -290,7 +293,11 @@ def _profile_for_envelope(envelope: ObservationEnvelope) -> str | None:
         # unselected rather than letting the source-only historical arm hide that
         # contradiction. The hook mapper itself does not stamp either field for
         # Codex.
-        if profile is None and mapping_hint is None:
+        if (
+            profile is None
+            and mapping_hint is None
+            and envelope.cursor.mapping_version in _CODEX_REVIEWED_HOOK_MAPPINGS
+        ):
             return _CODEX_HISTORICAL_CAPTURE_SCOPE
     elif envelope.source is ObservationSource.CLAUDE_HOOK:
         if (

--- a/tests/unit/application/test_semantic_content.py
+++ b/tests/unit/application/test_semantic_content.py
@@ -315,6 +315,7 @@ def _codex_profileless_fixture() -> tuple[FrozenCase, TaskRuntime, _Objects, _Ob
         envelope,
         source=ObservationSource.CODEX_HOOK,
         source_identity="codex-phase-1",
+        cursor=replace(envelope.cursor, mapping_version="codex-obs-hook/1.0.0"),
         structural_payload=JsonObject(
             {
                 "tool_name": "Bash",
@@ -537,6 +538,40 @@ async def test_profileless_codex_hook_content_reaches_guarded_semantic_packet(
         {item.item_id for item in semantic.items},
     )
     assert b"planted-defect-marker: missing validation" in prepared
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "mapping_version",
+    (
+        "codex-obs-hook/9.9.9",
+        "codex-obs-session/1.0.0",
+        "claude-code-hooks-ordinary-v2",
+        "cursor-hooks-ordinary-v1",
+    ),
+)
+async def test_profileless_codex_rejects_unreviewed_mapping_before_object_access(
+    tmp_path: Path,
+    mapping_version: str,
+) -> None:
+    frozen, runtime, objects, observation = _codex_profileless_fixture()
+    observation.envelope = replace(
+        observation.envelope,
+        cursor=replace(observation.envelope.cursor, mapping_version=mapping_version),
+    )
+    local = LocalObservationStore(_state=tmp_path / "local-state")
+    local.grant_consent(_WORKSPACE, timestamp_from_string("2026-07-01T00:00:00.000Z"))
+
+    resolved = await resolve_captured_semantic_content(
+        runtime=runtime,
+        frozen=frozen,
+        workspace_commitment=_WORKSPACE,
+        local_observation=local,
+    )
+
+    assert resolved.content == ()
+    assert objects.resolve_calls == []
+    assert objects.open_calls == 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Profileless Codex capture accepted unknown cursor mappings during semantic selection. Require the closed reviewed native hook mapping before resolving or opening any captured object.

This PR is stacked on #617 at `c3e661eb`. Its diff contains only this follow-up and should be retargeted to main after #617 lands.

## Issue

- Fixes #621.
- #617 explicitly deferred this issue; checked the current open PR list and timeline for duplicate implementation.
- The maintainer requested proposed fixes in the current conversation. This tightens selection to the existing reviewed mapping and grants no new capture or provider authority.

## Documentation

- Behavior change: unknown and cross-lane mapping metadata cannot select content.
- Updated `docs/INTERFACES.md` with the closed mapping and before-object-access rejection.

## Verification

```text
uv run --no-sync pytest tests/unit/application/test_semantic_content.py -q
# 32 passed
uv run --no-sync ruff check src/yoetz/application/semantic_content.py tests/unit/application/test_semantic_content.py
uv run --no-sync ruff format src/yoetz/application/semantic_content.py tests/unit/application/test_semantic_content.py
pyright src/yoetz/application/semantic_content.py tests/unit/application/test_semantic_content.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

The four new regressions all fail against the unmodified #617 implementation. They verify no object resolution and no object opening for future Codex, session-stream, Claude, and Cursor mappings. The existing positive fixture now carries the actual reviewed Codex cursor mapping instead of inheriting the Claude fixture's cursor. Known Codex content still reaches the guarded packet and coexists with ordinary host profiles.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

No historical mapping is accepted without an explicit fixture. Capture grants, evidence linkage, source/session/generation checks, and independent provider admission are preserved.

Implementation: Codex in ChatGPT Work Mode; Python 3.14.6, uv 0.11.29, npm Pyright 1.1.411. No live provider call or merge performed.