### PR TITLE
perf(kernel): resolve policy sources with direct map lookups

### DIFF
--- a/src/yoetz/kernel/deterministic_checks.py
+++ b/src/yoetz/kernel/deterministic_checks.py
@@ -1834,8 +1834,24 @@ def _source_event_for_ref(case: DeterministicCase, ref: FindingBasisRef) -> Even
         return None
     if ref.startswith("evt_"):
         return event_id(ref)
-    logical_sources = _logical_sources(case.projection)
-    return logical_sources.get(ref)
+    # Each logical family already owns an indexed map. Rebuilding all six maps for
+    # each policy reference makes repeated lookups quadratic in the task size.
+    match ref[:4]:
+        case "obl_":
+            record = case.projection.obligations.get(cast(ObligationId, ref))
+        case "act_":
+            record = case.projection.actions.get(cast(ActionId, ref))
+        case "res_":
+            record = case.projection.results.get(cast(ResultId, ref))
+        case "evd_":
+            record = case.projection.evidence.get(cast(EvidenceId, ref))
+        case "clm_":
+            record = case.projection.claims.get(cast(ClaimId, ref))
+        case "fnd_":
+            record = case.projection.findings.get(cast(FindingId, ref))
+        case _:
+            return None
+    return None if record is None else record.source_event_id
 
 
 def policy_public_root(

--- a/tests/unit/kernel/test_policy_reference_lookup.py
+++ b/tests/unit/kernel/test_policy_reference_lookup.py
@@ -1,0 +1,67 @@
+"""Policy roots preserve source identity without task-wide lookup allocations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+
+import pytest
+
+from builders.policy_cases import act, clm, evd, evt, fnd, obl, res
+from builders.replay import replay_records
+from yoetz.kernel import deterministic_checks as checks
+from yoetz.kernel.deterministic_checks import (
+    CaseAvailabilityFacts,
+    FindingBasisRef,
+    build_deterministic_case,
+)
+from yoetz.kernel.reducers import replay
+
+
+def test_source_lookup_matches_all_logical_families_without_rebuilding_map(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = replay_records("all-event-families")
+    case = build_deterministic_case(replay(records), records, CaseAvailabilityFacts())
+    expected = checks._logical_sources(case.projection)  # pyright: ignore[reportPrivateUsage]
+    assert {ref[:4] for ref in expected} == {"obl_", "act_", "res_", "evd_", "clm_", "fnd_"}
+
+    def no_scan(*_args: object) -> None:
+        pytest.fail("A single reference lookup must not rebuild the task-wide source map")
+
+    monkeypatch.setattr(checks, "_logical_sources", no_scan)
+    for ref, source in expected.items():
+        assert checks._source_event_for_ref(case, ref) == source  # pyright: ignore[reportPrivateUsage]
+        root = ref if ref.startswith(("obl_", "clm_")) else source
+        assert checks.policy_public_root(case, ref) == root
+    for source in expected.values():
+        assert checks.policy_public_root(case, source) == source
+
+
+@pytest.mark.parametrize("make_ref", [act, res, evd, obl, clm, fnd, evt])
+def test_missing_and_unadmitted_source_lookup(make_ref: Callable[[int], FindingBasisRef]) -> None:
+    ref = make_ref(999)
+    records = replay_records("all-event-families")
+    case = build_deterministic_case(replay(records), records, CaseAvailabilityFacts())
+    assert checks._source_event_for_ref(case, ref) is None  # pyright: ignore[reportPrivateUsage]
+    with pytest.raises(ValueError, match="policy_wiring_invalid"):
+        checks.policy_public_root(case, ref)
+
+    coverage = next(iter(case.coverage_by_ref.values()))
+    admitted = replace(
+        case,
+        allowed_ids=case.allowed_ids | {ref},
+        coverage_by_ref={**case.coverage_by_ref, ref: coverage},
+    )
+    expected = ref if ref.startswith("evt_") else None
+    assert checks._source_event_for_ref(admitted, ref) == expected  # pyright: ignore[reportPrivateUsage]
+
+
+def test_redacted_record_keeps_its_source_identity() -> None:
+    records = replay_records("all-event-families")
+    case = build_deterministic_case(replay(records), records, CaseAvailabilityFacts())
+    ref, record = next(iter(case.projection.actions.items()))
+    tombstone = replace(record, payload=None, redacted=True)
+    projection = replace(case.projection, actions={**case.projection.actions, ref: tombstone})
+    redacted = replace(case, projection=projection)
+    assert checks.policy_public_root(redacted, ref) == record.source_event_id


### PR DESCRIPTION
## Issue

Fixes #628. Reviewed all open issues and PRs and inspected #617's replay changes before opening this independent fix. No public contract or design decision changes.

## Summary

Every policy source lookup rebuilt a dictionary containing all logical entities in the task. The reference prefix now selects the existing owning projection map directly. This removes repeated full-task scans and allocations while preserving allowed-id checks, event roots, missing-reference behavior, and redacted source identity.

## Documentation

Behavior change: no. No docs or schema changes are needed. Applies to every host and delivery path that runs the shared deterministic policies; no lifecycle or reverse-state behavior changes.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/unit/kernel tests/conformance/operations/test_check_contract.py tests/conformance/honesty/test_adversarial_cases.py -q
uvx --from uv==0.11.29 uv run ruff check src/yoetz/kernel/deterministic_checks.py tests/unit/kernel/test_policy_reference_lookup.py
uvx --from uv==0.11.29 uv run ruff format --check src/yoetz/kernel/deterministic_checks.py tests/unit/kernel/test_policy_reference_lookup.py
node node_modules/pyright/index.js src/yoetz/kernel/deterministic_checks.py tests/unit/kernel/test_policy_reference_lookup.py
uvx --from uv==0.11.29 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

244 tests passed; Ruff and pinned Pyright passed. The new regression tests cover all six logical families, event passthrough, allowed-but-missing and unadmitted ids, tombstones, and prohibit rebuilding the full map during lookup.

Local CPython 3.14.6 synthetic benchmark, median of five runs of 500 lookups against fixed immutable projections:

| Entities | Original lookup | Direct lookup | Original peak allocation | Direct peak allocation |
| --- | ---: | ---: | ---: | ---: |
| 100 | 2.012 ms | 0.088 ms | 4,856 B | 45 B |
| 1,000 | 15.748 ms | 0.090 ms | 39,032 B | 45 B |
| 10,000 | 242.481 ms | 0.090 ms | 311,416 B | 45 B |

These are isolated lookup measurements, not end-to-end or live-host speed claims. No external provider was called. The full suite was not run locally. All six performance changes (#636, #637, #639, #641, #643, #647) together passed 579 focused tests (2 platform skips), Ruff and pinned Pyright in a separate combined checkout. A merge-tree check also found no merge conflicts with PR #617 at c3e661eb; that is merge compatibility, not a test run of #617. Python/dependency versions are pinned; npm's host runtime was Node 24.19.0/npm 11.9.0, while the installed Pyright version is the repository-pinned 1.1.411.

Model and harness: GPT-based Codex in ChatGPT Work Mode; exact model identifier is not exposed by the runtime.

## Boundaries

- [x] Public-boundary scan passed; no private drafting or runtime data included.
- [x] No change to coverage, replay validation, persistence, privacy or network authority.
- [x] Review comments will be dispositioned before merge.
