### PR TITLE
perf(observation): select fair outbox lanes with a heap

### DIFF
--- a/src/yoetz/application/observation_drain.py
+++ b/src/yoetz/application/observation_drain.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import heapq
 from asyncio import Future
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -436,22 +437,21 @@ class ObservationOutboxSweeper:
         for workspace in lifecycle_workspaces:
             for row in self.local.list_pending_outbox_rows(workspace):
                 lanes.setdefault((workspace, row.codex_session_id), []).append(row)
-        selected_per_lane = {lane: 0 for lane in lanes}
+        # UTF-8 byte order equals string order for encodable strings. Validate once
+        # so malformed keys still fail, without retaining duplicate encoded keys.
+        for workspace, session in lanes:
+            workspace.encode()
+            session.encode()
+        # Only the selected lane changes priority. Its selection count is also its
+        # FIFO cursor, avoiding list-head shifts and a second per-lane count map.
+        pending = [(rows[0].attempts, 0, lane[0], lane[1], rows) for lane, rows in lanes.items()]
+        del lanes
+        heapq.heapify(pending)
         selected: list[tuple[str, ObservationOutboxRow]] = []
-        while lanes and len(selected) < self.limit:
-            lane = min(
-                lanes,
-                key=lambda item: (
-                    lanes[item][0].attempts,
-                    selected_per_lane[item],
-                    item[0].encode(),
-                    item[1].encode(),
-                ),
-            )
-            workspace, _ = lane
-            queue = lanes[lane]
-            selected.append((workspace, queue.pop(0)))
-            selected_per_lane[lane] += 1
-            if not queue:
-                lanes.pop(lane)
+        while pending and len(selected) < self.limit:
+            _, count, workspace, session, queue = heapq.heappop(pending)
+            selected.append((workspace, queue[count]))
+            count += 1
+            if count < len(queue):
+                heapq.heappush(pending, (queue[count].attempts, count, workspace, session, queue))
         return tuple(selected), lifecycle_workspaces

--- a/tests/unit/application/test_outbox_selection.py
+++ b/tests/unit/application/test_outbox_selection.py
@@ -1,0 +1,108 @@
+"""Exact ordering parity with the original outbox lane-selection policy."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Mapping
+from typing import cast
+
+import pytest
+
+from yoetz.adapters.integrations.observation_local import (
+    LocalObservationStore,
+    ObservationOutboxRow,
+)
+from yoetz.application.observation_drain import (
+    ObservationIngestCoordinator,
+    ObservationOutboxSweeper,
+)
+from yoetz.domain.observation import ObservationCursor, ObservationEnvelope, ObservationSource
+from yoetz.domain.values import JsonObject, Timestamp
+
+
+def row(session: str, ordinal: int, attempts: int) -> ObservationOutboxRow:
+    return ObservationOutboxRow(
+        session,
+        ObservationEnvelope(
+            session_commitment="hmac-sha256:" + "a" * 64,
+            event_kind="PostToolUse",
+            source_identity=f"hook:{ordinal}",
+            source=ObservationSource.CODEX_HOOK,
+            cursor=ObservationCursor(
+                1, 0, ordinal, "hmac-sha256:" + "b" * 64, "codex-obs-hook/1.0.0"
+            ),
+            receipt_time=Timestamp("2026-01-01T00:00:00.000Z"),
+            structural_payload=JsonObject({"tool_name": "shell"}),
+            content_object_refs=(),
+            gap_codes=(),
+        ),
+        attempts=attempts,
+    )
+
+
+class PendingSnapshot:
+    def __init__(self, rows: Mapping[str, tuple[ObservationOutboxRow, ...]]) -> None:
+        self.rows = rows
+
+    def pending_workspaces(self) -> tuple[str, ...]:
+        return tuple(self.rows)
+
+    def list_pending_outbox_rows(self, workspace: str) -> tuple[ObservationOutboxRow, ...]:
+        return self.rows[workspace]
+
+
+def original_selection(
+    snapshot: PendingSnapshot, limit: int
+) -> tuple[tuple[str, ObservationOutboxRow], ...]:
+    """The pre-optimization selection rule, retained as an independent oracle."""
+    lanes: dict[tuple[str, str], list[ObservationOutboxRow]] = {}
+    for workspace in snapshot.pending_workspaces():
+        for item in snapshot.list_pending_outbox_rows(workspace):
+            lanes.setdefault((workspace, item.codex_session_id), []).append(item)
+    counts = dict.fromkeys(lanes, 0)
+    selected: list[tuple[str, ObservationOutboxRow]] = []
+    while lanes and len(selected) < limit:
+        lane = min(
+            lanes,
+            key=lambda key: (lanes[key][0].attempts, counts[key], key[0].encode(), key[1].encode()),
+        )
+        selected.append((lane[0], lanes[lane].pop(0)))
+        counts[lane] += 1
+        if not lanes[lane]:
+            del lanes[lane]
+    return tuple(selected)
+
+
+@pytest.mark.parametrize("seed", range(20))
+@pytest.mark.parametrize("limit", [1, 3, 64, 1000])
+def test_selection_matches_original_across_fifo_skew_and_ties(seed: int, limit: int) -> None:
+    rng = random.Random(seed)
+    workspaces = ["z", "a", "é", "אב", "😀", "lifecycle-only"]
+    rng.shuffle(workspaces)
+    rows: dict[str, tuple[ObservationOutboxRow, ...]] = {}
+    for workspace in workspaces:
+        pending: list[ObservationOutboxRow] = []
+        if workspace != "lifecycle-only":
+            for lane in range(rng.randrange(1, 10)):
+                session = f"{rng.choice(['a', 'é', 'אב', '😀'])}-{lane}"
+                pending.extend(
+                    row(session, ordinal, rng.randrange(5))
+                    for ordinal in range(1, rng.randrange(2, 15))
+                )
+        rng.shuffle(pending)
+        rows[workspace] = tuple(pending)
+    snapshot = PendingSnapshot(rows)
+    sweeper = ObservationOutboxSweeper(
+        cast(LocalObservationStore, snapshot), cast(ObservationIngestCoordinator, None), limit=limit
+    )
+    selected, lifecycle = sweeper._fair_pending_rows_and_lifecycle_workspaces()  # pyright: ignore[reportPrivateUsage]
+    assert selected == original_selection(snapshot, limit)
+    assert lifecycle == tuple(workspaces)
+    assert snapshot.rows == rows
+
+
+def test_empty_pending_snapshot() -> None:
+    sweeper = ObservationOutboxSweeper(
+        cast(LocalObservationStore, PendingSnapshot({})), cast(ObservationIngestCoordinator, None)
+    )
+    assert sweeper._fair_pending_rows_and_lifecycle_workspaces() == ((), ())  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Issue

Fixes #629. Duplicate search covered all open issues and PRs, including #617's sweep changes and #498's future multi-task work. This is a separate implementation optimization with the same selection policy.

## Summary

The scheduler scanned every lane for each selected row and shifted list tails on every removal. It now keeps one heap entry per lane and uses the lane selection count as its FIFO cursor. Encodable string order is identical to UTF-8 byte order, so keys are validated once and reused without duplicate byte strings.

The issue initially proposed deques; list cursors use less per-lane memory and preserve the same FIFO behavior. Pass limits, retry head blocking, leases, acknowledgements, and lifecycle-only workspaces are unchanged. No additional concurrency or workers are introduced.

## Documentation

Behavior change: no. No public schema, policy, storage or documentation changes. The shared scheduler serves all three hosts. Delivery and lifecycle rules remain enforced by the existing sweep.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/unit/application/test_outbox_selection.py tests/unit/application/test_observation_drain.py -q
uvx --from uv==0.11.29 uv run ruff check src/yoetz/application/observation_drain.py tests/unit/application/test_outbox_selection.py
uvx --from uv==0.11.29 uv run ruff format --check src/yoetz/application/observation_drain.py tests/unit/application/test_outbox_selection.py
node node_modules/pyright/index.js src/yoetz/application/observation_drain.py tests/unit/application/test_outbox_selection.py
uvx --from uv==0.11.29 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

117 tests passed; Ruff and pinned Pyright passed. Eighty seeded differential cases compare the entire selected sequence with the original algorithm across skewed retries, uneven lanes, input order, Unicode tie-breakers and limits. Existing tests cover real-store retries, FIFO safety, cancellation, concurrent lease movement and lifecycle work.

Local CPython 3.14.6 scheduling-only benchmark, median of five batches of 50 passes with immutable synthetic rows:

| Lanes x rows | Pass limit | Before | After | Peak before | Peak after |
| --- | ---: | ---: | ---: | ---: | ---: |
| 8 x 32 | 64 | 0.125 ms | 0.040 ms | 3,840 B | 3,184 B |
| 128 x 8 | 64 | 1.631 ms | 0.142 ms | 21,400 B | 16,656 B |
| 1,024 x 2 | 64 | 11.288 ms | 0.402 ms | 160,680 B | 131,448 B |
| 128 x 32 | 1,024 | 23.419 ms | 0.887 ms | 61,944 B | 53,632 B |

These exclude filesystem, service and provider time; they are not live-host throughput claims. The full suite was not run locally. All six performance changes (#636, #637, #639, #641, #643, #647) together passed 579 focused tests (2 platform skips), Ruff and pinned Pyright in a separate combined checkout. A merge-tree check also found no merge conflicts with PR #617 at c3e661eb; that is merge compatibility, not a test run of #617. Node 24.19.0/npm 11.9.0 hosted the repository-pinned Pyright 1.1.411.

Model and harness: GPT-based Codex in ChatGPT Work Mode; exact model identifier is not exposed by the runtime.

CI note: the first dependency scan failed when the PyPI connection was reset. The failed-job rerun on the same head passed; the original PR CI run passed without a retry.

## Boundaries

- [x] Public-boundary scan passed; no private runtime/drafting data included.
- [x] Exact delivery, privacy, durability and coverage behavior preserved.
- [x] Review comments will be dispositioned before merge.
