### PR TITLE
fix(observation): retire Codex capture tickets on global disable

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3308,6 +3308,11 @@ infer success.
 Native service-side staging and FIFO handoff (ADR-003 and ADR-022 decision 22) applies to the
 Claude Code and Cursor ordinary native profiles and to the source-qualified profileless `codex_hook`
 arm. A capture-only control request enters a separate bounded lane, reserves an
+`ObservationCaptureTicket`. Global observation disable retires matching unfinished tickets for
+Codex, Claude Code, and Cursor through the authenticated session/workspace cleanup path. Repeated
+cleanup is idempotent; a later consent generation cannot revive a revoked ticket. Session-stream
+requests do not enter this cleanup lane, and ticket retirement does not delete historical content
+(issue #624). The enabled capture lane reserves an
 `ObservationCaptureTicket`, secret-scans and encrypts eligible chunks, publishes the objects and
 manifests, and marks the ticket pending before the host's structural envelope advances the FIFO
 cursor. For Codex, active observation consent selects the profileless arm; no Claude/Cursor content

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -1022,12 +1022,12 @@ class ObservationCoordinator:
             if type(request) is not ObservationIngestRequest:
                 return _reject("observation_disabled")
             if request.envelope.source not in {
+                ObservationSource.CODEX_HOOK,
                 ObservationSource.CLAUDE_HOOK,
                 ObservationSource.CURSOR_HOOK,
             }:
-                # Keep the global admission switch inert for the historical
-                # structural/session-stream path.  Only native envelopes can
-                # carry the capture handoff that needs retirement below.
+                # Session-stream envelopes cannot carry capture tickets. Keep
+                # their disabled path inert before resolving any task route.
                 return _reject("observation_disabled")
         if type(request) is not ObservationIngestRequest:
             return _reject(ObservationGapCode.CONSENT_MISSING.value)
@@ -1064,6 +1064,7 @@ class ObservationCoordinator:
             # structurally valid non-native request cannot revoke unrelated
             # native tickets merely by sharing the session commitment.
             if request.envelope.source in {
+                ObservationSource.CODEX_HOOK,
                 ObservationSource.CLAUDE_HOOK,
                 ObservationSource.CURSOR_HOOK,
             }:

--- a/tests/integration/application/test_capture_control_cleanup.py
+++ b/tests/integration/application/test_capture_control_cleanup.py
@@ -34,6 +34,7 @@ from yoetz.domain.observation import (
     ObservationContentKind,
     ObservationIngestDisposition,
     ObservationIngestRequest,
+    ObservationRevokeCommand,
     ObservationSource,
 )
 from yoetz.domain.observation_profiles import CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID
@@ -124,6 +125,84 @@ async def test_disabled_runtime_sweeper_revokes_native_ticket_before_successor_f
         _ZERO_DIGEST,
     )
     assert isinstance(frozen, FrozenCase)
+
+
+@pytest.mark.anyio
+async def test_global_disable_retires_profileless_codex_ticket_idempotently(
+    tmp_path: Path,
+) -> None:
+    codex_session = "codex-disabled-ticket"
+    (
+        _project,
+        workspace,
+        session_commitment,
+        local,
+        observation,
+        _ledger,
+        _runtime,
+        coordinator,
+        _client,
+        _connect,
+    ) = await _pipeline(tmp_path, codex_session_id=codex_session, profile=None)
+    envelope = map_hook_payload_to_envelope(
+        "PostToolUse",
+        {"tool_name": "shell", "tool_call_id": "disabled-ticket-tool"},
+        session_commitment=session_commitment,
+        event_ordinal=1,
+        key_material=local.key_material(),
+        source=ObservationSource.CODEX_HOOK,
+    )
+    capture = ObservationIngestRequest(
+        codex_session_id=codex_session,
+        envelope=envelope,
+        content_chunks=(
+            ObservationContentChunk(
+                content_kind=ObservationContentKind.TOOL_OUTPUT,
+                correlation_identity=f"{envelope.source_identity}:tool-output",
+                source_commitment=envelope.cursor.last_source_commitment,
+                media_type="text/plain",
+                part_index=0,
+                part_count=1,
+                content=b"disabled-codex-ticket-marker",
+            ),
+        ),
+        capture_only=True,
+    )
+    staged = await coordinator.ingest_request(capture)
+    assert staged.reason == OBSERVATION_CONTENT_CAPTURE_PENDING_REASON
+    logical_identity = observation_content_identity(envelope)
+    pending = observation.load_capture_ticket(
+        workspace=workspace, logical_identity=logical_identity
+    )
+    assert pending is not None and pending.state == "pending"
+    assert pending.object_ids
+
+    structural = ObservationIngestRequest(codex_session_id=codex_session, envelope=envelope)
+    coordinator.observation_enabled = False
+    for _ in range(2):
+        rejected = await coordinator.ingest_request(structural)
+        assert rejected.reason == "observation_disabled"
+        retired = observation.load_capture_ticket(
+            workspace=workspace,
+            logical_identity=logical_identity,
+        )
+        assert retired is not None and retired.state == "revoked"
+        assert retired.object_ids == pending.object_ids
+
+    # A later generation cannot resurrect the retired handoff.
+    local.revoke(ObservationRevokeCommand(workspace))
+    local.grant_consent(workspace)
+    coordinator.observation_enabled = True
+    resumed = await coordinator.ingest_request(structural)
+    # Structural history may still be recorded under the new grant, but the old
+    # content must not follow it into the ledger.
+    assert resumed.disposition is ObservationIngestDisposition.ACCEPTED
+    recorded = observation.list_envelopes(workspace)
+    assert recorded and all(not item.content_object_refs for item in recorded)
+    retired = observation.load_capture_ticket(
+        workspace=workspace, logical_identity=logical_identity
+    )
+    assert retired is not None and retired.state == "revoked"
 
 
 @pytest.mark.anyio

--- a/tests/unit/application/test_observation_coordinator.py
+++ b/tests/unit/application/test_observation_coordinator.py
@@ -2309,7 +2309,9 @@ async def test_storage_corrupt_blocks_session_for_coordinator_generation(tmp_pat
 
 
 @pytest.mark.anyio
-async def test_coordinator_rejects_disabled_before_mapping_or_runtime(tmp_path: Path) -> None:
+async def test_coordinator_rejects_disabled_stream_before_mapping_or_runtime(
+    tmp_path: Path,
+) -> None:
     class _NoRuntime:
         async def route(self, command: object) -> object:
             raise AssertionError("disabled observation must not route")
@@ -2340,7 +2342,9 @@ async def test_coordinator_rejects_disabled_before_mapping_or_runtime(tmp_path: 
     result = await coordinator.ingest_request(
         ObservationIngestRequest(
             codex_session_id="disabled-sess",
-            envelope=_envelope(session=session),
+            envelope=replace(
+                _envelope(session=session), source=ObservationSource.CODEX_SESSION_STREAM
+            ),
         )
     )
     assert result.disposition is ObservationIngestDisposition.REJECTED


### PR DESCRIPTION
Global observation disable skipped profileless Codex capture tickets, leaving cleanup to a later reconciliation. Include Codex hooks in the existing authenticated ticket-retirement path.

Stacked on #617 at `c3e661eb`; retarget to main after that PR lands.

## Issue

- Fixes #624.
- Checked the issue timeline and current open PRs. #617 explicitly deferred this follow-up.
- The maintainer requested proposed fixes in the current conversation. Existing disable authority and source/session/workspace checks are unchanged.

## Documentation

- Behavior change: matching unfinished Codex tickets retire during disabled ingestion.
- Updated `docs/INTERFACES.md` with cleanup, idempotency, generation, and retained-history behavior.

## Verification

```text
uv run --no-sync pytest tests/integration/application/test_capture_control_cleanup.py -q
# 7 passed
uv run --no-sync pytest tests/unit/application/test_observation_coordinator.py -q
# 127 passed; 6 pre-existing failures on both this branch and unchanged c3e661eb
uv run --no-sync ruff check src/yoetz/application/observation_coordinator.py tests/unit/application/test_observation_coordinator.py tests/integration/application/test_capture_control_cleanup.py
pyright src/yoetz/application/observation_coordinator.py tests/unit/application/test_observation_coordinator.py tests/integration/application/test_capture_control_cleanup.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

The six baseline failures are `ledger_event_invalid`, `duplicate_ingest_reconciles`, the three `check_barrier_deferral` cases, and `identity_claim_conflict`. All six were rerun against the unchanged parent source and fail identically. No test was disabled or marked xfail.

The new SQLite/encrypted-store integration regression stages a real profileless Codex ticket, disables observation, runs cleanup twice, preserves the ticket's object IDs, and re-enables under a fresh consent generation. Structural history can then be recorded, while the old content stays unlinked and the ticket stays revoked. The session-stream test still proves disabled requests do not resolve mappings or runtimes.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

Only the three capture-capable hook sources enter authenticated disable cleanup. Session streams remain excluded. Retirement does not delete historical objects or grant provider authority.

Implementation: Codex in ChatGPT Work Mode. No merge performed.