### PR TITLE
perf(objects): assemble encrypted frames in one allocation

### DIFF
--- a/src/yoetz/adapters/objects/envelope.py
+++ b/src/yoetz/adapters/objects/envelope.py
@@ -210,14 +210,16 @@ def encode_object_envelope(
 ) -> bytes:
     header_bytes = canonical_encode(cast(JsonValue, header.to_json()))
     envelope = ObjectEnvelope(header, header_bytes, payload_nonce, ciphertext, tag)
-    return (
-        _MAGIC
-        + bytes((_VERSION,))
-        + len(envelope.header_bytes).to_bytes(4, "big")
-        + envelope.header_bytes
-        + envelope.payload_nonce
-        + envelope.ciphertext
-        + envelope.tag
+    return b"".join(
+        (
+            _MAGIC,
+            bytes((_VERSION,)),
+            len(envelope.header_bytes).to_bytes(4, "big"),
+            envelope.header_bytes,
+            envelope.payload_nonce,
+            envelope.ciphertext,
+            envelope.tag,
+        )
     )
 
 


### PR DESCRIPTION
## Issue

Fixes #631. Open issues and PRs were checked for overlap. The maintainer's current-task authorization for this exact byte-preserving storage implementation change is recorded on the issue.

## Summary

Chained bytes additions copied the ciphertext-sized frame again when appending the authentication tag. Joining the same seven validated components creates the final frame in one allocation. The ObjectEnvelope constructor and all existing validation still run.

## Documentation

Behavior change: no. Encryption, framing, authentication, maximum size, writes, fsync, recovery and retention are unchanged. This shared encoder serves every host and operation that stores encrypted objects. No documentation or generated-resource changes.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/integration/objects -q
uvx --from uv==0.11.29 uv run pytest tests/conformance/adapters/test_object_store_port.py -q
uvx --from uv==0.11.29 uv run ruff check src/yoetz/adapters/objects/envelope.py
uvx --from uv==0.11.29 uv run ruff format --check src/yoetz/adapters/objects/envelope.py
node node_modules/pyright/index.js src/yoetz/adapters/objects/envelope.py
uvx --from uv==0.11.29 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

56 tests passed, two existing platform cases skipped. Reviewed golden frame vectors, malformed-frame rejection, encrypted-file lifecycle and object-store conformance passed. Ruff and pinned Pyright passed.

A separate differential check compared the original function from main with the new function and decoded the result for payload sizes 0, 1, 4,096, 1,048,576 and 4,194,304 bytes. All outputs matched exactly.

Local CPython 3.14.6 benchmark, median of five batches of 50 complete encoder calls with identical synthetic ciphertext and validated headers:

| Ciphertext size | Before | After | Peak before | Peak after |
| --- | ---: | ---: | ---: | ---: |
| 4 KiB | 0.027 ms | 0.027 ms | 9,759 B | 5,234 B |
| 1 MiB | 0.624 ms | 0.053 ms | 2,098,728 B | 1,049,720 B |
| 4 MiB | 2.580 ms | 0.132 ms | 8,390,184 B | 4,195,448 B |

This measures frame encoding, not encryption, disk or end-to-end service performance. Small frames have effectively unchanged timing. The full suite was not run locally. All six performance changes (#636, #637, #639, #641, #643, #647) together passed 579 focused tests (2 platform skips), Ruff and pinned Pyright in a separate combined checkout. A merge-tree check also found no merge conflicts with PR #617 at c3e661eb; that is merge compatibility, not a test run of #617. Node 24.19.0/npm 11.9.0 hosted pinned Pyright 1.1.411.

Model and harness: GPT-based Codex in ChatGPT Work Mode; exact model identifier is not exposed by the runtime.

## Boundaries

- [x] Public-boundary scan passed; synthetic data only.
- [x] No encryption, durability, policy, privacy, or output-byte changes.
- [x] Review comments will be dispositioned before merge.
