### PR TITLE
fix(semantic): preserve unknown outcome after stale wait expiry

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2687,7 +2687,10 @@ endpoint bindings, initial readiness, retry budgets, and cutoffs. `endpoint_role
 the endpoint from this frozen plan and durable prior rows, so changed configuration cannot relabel
 an attempt on replay. Legacy terminal cases recover their stored result; a legacy pending case
 without frozen execution authority terminates without dispatch: `coordinator_failure` before
-dispatch or during a disclosure wait. An uncertain started attempt retains `outcome_unknown`
+dispatch or during a disclosure wait. A task-local `awaiting` row can lag the independent privacy
+audit and does not prove an expired started attempt was never admitted. Deadline recovery keeps
+that attempt `outcome_unknown` without re-entering authorization, retry, or fallback; a new,
+unattempted job still reports `provider_timeout` (issue #625). An uncertain started attempt retains `outcome_unknown`
 in its durable row; without reconstructable provider provenance its public gap is
 `receipt_persistence_unknown`. Each
 fallback attempt is a fresh physical attempt with its own authorization, dispatch id, credential

--- a/src/yoetz/application/semantic_attempts.py
+++ b/src/yoetz/application/semantic_attempts.py
@@ -1173,19 +1173,12 @@ async def run_durable_semantic_attempts(
                 attempt_dispatch = dispatch_fallback
             if remaining <= 0.0:
                 # A resumed started attempt must not be sent after its frozen endpoint cutoff.
-                # Preserve uncertainty for a prior started attempt unless an exact disclosure
-                # wait proves it had not dispatched. A newly claimed attempt is a known timeout.
-                # Neither outcome licenses a fallback dispatch here.
-                wait = await ledger.load_disclosure_wait(
-                    current_lease.writer_id, current_lease.operation_id
-                )
-                known_undispatched = (
-                    wait is not None
-                    and getattr(wait, "job_id", None) == job.job_id
-                    and getattr(wait, "attempt_id", None) == job.active_attempt_id
-                    and getattr(wait, "state", None) == "awaiting"
-                )
-                uncertain = job.state == "leased" and last is None and not known_undispatched
+                # A task-local awaiting row may be stale after the independent privacy audit
+                # consumed admission. It cannot prove that a resumed started attempt never
+                # dispatched. Preserve uncertainty without re-entering provider authorization;
+                # only a newly claimed attempt is a known pre-admission timeout here.
+                # Neither outcome licenses a retry or fallback dispatch.
+                uncertain = job.state == "leased" and last is None
                 terminal_reason = (
                     SemanticReason.OUTCOME_UNKNOWN if uncertain else SemanticReason.PROVIDER_TIMEOUT
                 )

--- a/tests/unit/application/test_semantic_stale_wait.py
+++ b/tests/unit/application/test_semantic_stale_wait.py
@@ -1,0 +1,61 @@
+"""A task-local wait cannot prove an expired physical attempt was never admitted."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from unit.application import test_semantic_attempts as attempts
+from unit.application import test_semantic_attempts_fallback as paired
+from yoetz.application.semantic_attempts import run_durable_semantic_attempts
+from yoetz.ports.semantic import Deadline
+from yoetz.protocol.models import SemanticReason, SemanticStatus
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("resumed", (False, True))
+async def test_expired_attempt_preserves_uncertainty_despite_stale_wait(resumed: bool) -> None:
+    ledger = attempts._FakeLedger(attempts._queued_job(), attempts._lease())  # pyright: ignore[reportPrivateUsage]
+    if resumed:
+        waiting = attempts._AwaitingEval(  # pyright: ignore[reportPrivateUsage]
+            SemanticStatus.AWAITING_HUMAN,
+            SemanticReason.HUMAN_APPROVAL_REQUIRED,
+            attempts._Continuation(  # pyright: ignore[reportPrivateUsage]
+                "ppr_40000000-0000-4000-8000-000000000005",
+                attempts._ExpiresAt(datetime(2030, 1, 1, tzinfo=UTC)),  # pyright: ignore[reportPrivateUsage]
+            ),
+        )
+        await attempts._run(ledger, [waiting], max_retries=1)  # pyright: ignore[reportPrivateUsage]
+        assert ledger.disclosure_waits
+
+    provider_ids = tuple(ledger.provider_ids or ())
+    attempt_ids = tuple(ledger.attempt_ids or ())
+
+    async def forbidden_dispatch(*args: object) -> attempts._Eval:  # pyright: ignore[reportPrivateUsage]
+        raise AssertionError("expired replay must not re-enter admission or call a provider")
+
+    result = await run_durable_semantic_attempts(
+        ledger=ledger,
+        lease=ledger.lease,
+        job=ledger.job,
+        deadline=Deadline(datetime(2030, 1, 1, tzinfo=UTC), 1.0),
+        max_retries=1,
+        now_monotonic=lambda: 2.0,
+        dispatch=forbidden_dispatch,
+        dispatch_fallback=forbidden_dispatch,
+        fallback=paired._plan(primary_retries=1),  # pyright: ignore[reportPrivateUsage]
+        publish_success_response=attempts._publish_response,  # pyright: ignore[reportPrivateUsage]
+        sleep=lambda _: attempts._async_noop(),  # pyright: ignore[reportPrivateUsage]
+        build_final=attempts._build_tuple,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert isinstance(result, tuple)
+    assert result[:2] == (
+        (SemanticStatus.UNAVAILABLE, SemanticReason.OUTCOME_UNKNOWN)
+        if resumed
+        else (SemanticStatus.TIMEOUT, SemanticReason.PROVIDER_TIMEOUT)
+    )
+    assert tuple(ledger.provider_ids or ()) == provider_ids
+    assert tuple(ledger.attempt_ids or ()) == attempt_ids
+    assert ledger.job.state == "failed"


### PR DESCRIPTION
An expired started attempt could be labeled a provider timeout because a task-local disclosure row still said awaiting. That row can lag the independent privacy audit after admission was consumed. Preserve outcome uncertainty for the resumed attempt instead of treating the wait as proof of no dispatch.

Stacked on #617 at `c3e661eb`; retarget to main after that PR lands.

## Issue

- Fixes #625.
- #617 deferred this follow-up; checked existing PRs and the issue timeline.
- The maintainer requested proposed-fix PRs. This selects the issue's conservative classification option and adds no dispatch or authorization path.

## Documentation

- Behavior change: an expired resumed attempt with a stale wait reports unavailable/outcome_unknown.
- Updated `docs/INTERFACES.md`. Newly unattempted work still reports timeout/provider_timeout. Actual approval-expiry results retain their existing classification.

## Verification

```text
uv run --no-sync pytest tests/unit/application/test_semantic_stale_wait.py tests/unit/application/test_semantic_attempts.py tests/unit/application/test_semantic_attempts_fallback.py tests/unit/application/test_semantic_authorization_resume.py -q
# 68 passed
uv run --no-sync ruff check src/yoetz/application/semantic_attempts.py tests/unit/application/test_semantic_stale_wait.py
uv run --no-sync ruff format --check src/yoetz/application/semantic_attempts.py tests/unit/application/test_semantic_stale_wait.py
pyright src/yoetz/application/semantic_attempts.py tests/unit/application/test_semantic_stale_wait.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

The new deterministic test supplies an expired cutoff with and without a prior awaiting attempt. Both primary and fallback dispatch callbacks fail if called, and the test checks no new attempt or provider-request identity is minted. Existing authorization-resume tests separately cover receipt-pending recovery and actual approval expiry.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

The deadline path does not consult the privacy audit or try to resume authorization. Because it cannot establish pre-admission status there, it conservatively keeps a started attempt uncertain. It still terminalizes the durable attempt and resolves its matching task-local wait.

Implementation: Codex in ChatGPT Work Mode. No live provider call or merge performed.