### PR TITLE
perf(semantic): bound packet sections with exact suffix search

### DIFF
--- a/src/yoetz/application/semantic_case.py
+++ b/src/yoetz/application/semantic_case.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Final, Literal, cast
 
@@ -2336,15 +2336,46 @@ def _drop_catalog_row(envelope: dict[str, JsonValue]) -> bool:
     return True
 
 
-def _drop_packet_row(envelope: dict[str, JsonValue], key: str) -> bool:
+def _fit_packet_section(
+    envelope: dict[str, JsonValue],
+    reductions: dict[str, int],
+    key: str,
+    accounting_key: str,
+) -> bytes | None:
+    """Find the first fitting suffix reduction, or remove this section completely."""
+
     packet_obj = envelope.get("review_packet")
     if not isinstance(packet_obj, dict):
-        return False
+        return None
     rows = packet_obj.get(key)
     if type(rows) is not list or not rows:
-        return False
-    packet_obj[key] = cast(JsonValue, cast(list[object], rows)[:-1])
-    return True
+        return None
+    original_rows = cast(list[JsonValue], rows)
+    total = len(original_rows)
+    prior_count = reductions[accounting_key]
+
+    def encode_after_dropping(count: int) -> bytes:
+        packet_obj[key] = original_rows[: total - count]
+        reductions[accounting_key] = prior_count + count
+        _set_selection_accounting(envelope, reductions)
+        return canonical_encode(cast(JsonValue, envelope))
+
+    best = encode_after_dropping(total)
+    if len(best) > MAX_EGRESS_ENVELOPE_BYTES:
+        return None
+    low, high = 1, total
+    # Removing a row cannot increase encoded size: the row/comma bytes offset
+    # any extra counter digit. Search the same first-fitting point as the old
+    # one-row-at-a-time loop, including its exact selection accounting.
+    while low < high:
+        middle = (low + high) // 2
+        candidate = encode_after_dropping(middle)
+        if len(candidate) <= MAX_EGRESS_ENVELOPE_BYTES:
+            high = middle
+            best = candidate
+        else:
+            low = middle + 1
+    return best
 
 
 def _strip_assessment_links(envelope: dict[str, JsonValue]) -> int:
@@ -2398,10 +2429,10 @@ def bounded_case_envelope(case: SemanticCase) -> bytes:
     catalog to 64 rows — dead code, because a ``SemanticCase`` already admits at most 64 items.
     A real 44 KiB case therefore reduced to 38 KiB and then raised, stranding the whole check.
 
-    This reduces one row at a time in a declared priority order and re-encodes, so it terminates:
-    every step strictly shrinks the document, and the loop ends when the irreducible core is all
-    that remains. Anything the catalog loses is counted in ``selection_accounting`` so the reader
-    of the packet — and the receipt derived from it — sees that the case was minimized.
+    Packet sections keep their declared priority and exact first-fitting suffix, found with a
+    bounded search instead of re-encoding the whole document after every removed row. Catalog
+    fallback still removes one row at a time with its reference cleanup. Anything removed is
+    counted in ``selection_accounting`` so the packet and its receipt disclose minimization.
     """
 
     envelope = _case_envelope_json(case)
@@ -2419,33 +2450,26 @@ def bounded_case_envelope(case: SemanticCase) -> bytes:
         return encoded
 
     reductions["assessment_links_stripped_count"] += _strip_assessment_links(envelope)
-    reducers: tuple[tuple[str, Callable[[dict[str, JsonValue]], bool]], ...] = (
-        (
-            "change_observations_dropped_count",
-            lambda env: _drop_packet_row(env, "change_observations"),
-        ),
-        (
-            "targeted_excerpts_dropped_count",
-            lambda env: _drop_packet_row(env, "targeted_excerpts"),
-        ),
-        ("omissions_dropped_count", lambda env: _drop_packet_row(env, "omissions")),
-        (
-            "deterministic_assessments_dropped_count",
-            lambda env: _drop_packet_row(env, "deterministic_assessments"),
-        ),
-        ("catalog_dropped_count", _drop_catalog_row),
-    )
-    while True:
+    _set_selection_accounting(envelope, reductions)
+    encoded = canonical_encode(cast(JsonValue, envelope))
+    if len(encoded) <= MAX_EGRESS_ENVELOPE_BYTES:
+        return encoded
+    for key, accounting_key in (
+        ("change_observations", "change_observations_dropped_count"),
+        ("targeted_excerpts", "targeted_excerpts_dropped_count"),
+        ("omissions", "omissions_dropped_count"),
+        ("deterministic_assessments", "deterministic_assessments_dropped_count"),
+    ):
+        fitted = _fit_packet_section(envelope, reductions, key, accounting_key)
+        if fitted is not None:
+            return fitted
+    while _drop_catalog_row(envelope):
+        reductions["catalog_dropped_count"] += 1
         _set_selection_accounting(envelope, reductions)
         encoded = canonical_encode(cast(JsonValue, envelope))
         if len(encoded) <= MAX_EGRESS_ENVELOPE_BYTES:
             return encoded
-        for accounting_key, reduce in reducers:
-            if reduce(envelope):
-                reductions[accounting_key] += 1
-                break
-        else:
-            raise SemanticCaseTooLarge("semantic_case_envelope_too_large")
+    raise SemanticCaseTooLarge("semantic_case_envelope_too_large")
 
 
 def semantic_case_to_candidate_context(

--- a/tests/unit/application/test_semantic_case_envelope.py
+++ b/tests/unit/application/test_semantic_case_envelope.py
@@ -8,12 +8,13 @@ run that code, so four PRs shipped over it.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import cast
 
 import pytest
 
 from builders.large_semantic_cases import large_case
+from yoetz.application import semantic_case as semantic_case_module
 from yoetz.application.check import (
     CheckScope,
     allocate_findings,
@@ -39,7 +40,7 @@ from yoetz.domain.privacy import (
 )
 from yoetz.kernel.deterministic_checks import DeterministicCase
 from yoetz.ports.semantic import SemanticCase
-from yoetz.protocol.canonical import JsonValue, strict_json_parse
+from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 from yoetz.protocol.ids import IdKind, new_id
 
 _SCOPE = AuthorizationScope(
@@ -87,6 +88,117 @@ def _parsed(envelope: bytes) -> Mapping[str, JsonValue]:
     document = strict_json_parse(envelope)
     assert isinstance(document, Mapping)
     return cast(Mapping[str, JsonValue], document)
+
+
+def _original_reduction_states(case: SemanticCase) -> Iterator[bytes]:
+    """The original greedy row-removal sequence, independent of the search algorithm."""
+    module = semantic_case_module
+    envelope = module._case_envelope_json(case)  # pyright: ignore[reportPrivateUsage]
+    counts = {
+        "assessment_links_stripped_count": 0,
+        "catalog_dropped_count": 0,
+        "change_observations_dropped_count": 0,
+        "deterministic_assessments_dropped_count": 0,
+        "omissions_dropped_count": 0,
+        "targeted_excerpts_dropped_count": 0,
+    }
+
+    def encoded() -> bytes:
+        module._set_selection_accounting(envelope, counts)  # pyright: ignore[reportPrivateUsage]
+        return canonical_encode(envelope)
+
+    yield encoded()
+    counts["assessment_links_stripped_count"] += module._strip_assessment_links(envelope)  # pyright: ignore[reportPrivateUsage]
+    yield encoded()
+    packet = cast(dict[str, JsonValue], envelope["review_packet"])
+    for key in (
+        "change_observations",
+        "targeted_excerpts",
+        "omissions",
+        "deterministic_assessments",
+    ):
+        values = packet.get(key)
+        if type(values) is not list:
+            continue
+        rows = cast(list[JsonValue], values)
+        while rows:
+            rows = rows[:-1]
+            packet[key] = rows
+            counts[f"{key}_dropped_count"] += 1
+            yield encoded()
+    while module._drop_catalog_row(envelope):  # pyright: ignore[reportPrivateUsage]
+        counts["catalog_dropped_count"] += 1
+        yield encoded()
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        ReviewContextProfile.STRUCTURAL,
+        ReviewContextProfile.GOAL_AWARE,
+        ReviewContextProfile.ASSISTED,
+        ReviewContextProfile.EXPANDED,
+    ],
+)
+def test_bounding_matches_original_bytes_at_reduction_boundaries(
+    monkeypatch: pytest.MonkeyPatch, profile: ReviewContextProfile
+) -> None:
+    case = _semantic(profile)
+    states = tuple(_original_reduction_states(case))
+    indices = {
+        0,
+        1,
+        2,
+        9,
+        10,
+        11,
+        len(states) // 3,
+        2 * len(states) // 3,
+        len(states) - 2,
+        len(states) - 1,
+    }
+    bounds = {
+        len(states[index]) + delta
+        for index in indices
+        if index < len(states)
+        for delta in (-1, 0, 1)
+    }
+    for bound in sorted(bounds):
+        monkeypatch.setattr(semantic_case_module, "MAX_EGRESS_ENVELOPE_BYTES", bound)
+        expected = next((state for state in states if len(state) <= bound), None)
+        if expected is None:
+            with pytest.raises(SemanticCaseTooLarge, match="semantic_case_envelope_too_large"):
+                bounded_case_envelope(case)
+        else:
+            assert bounded_case_envelope(case) == expected
+
+
+def test_packet_search_avoids_full_encode_per_removed_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    case = _semantic(ReviewContextProfile.EXPANDED)
+    source = semantic_case_module._case_envelope_json(case)  # pyright: ignore[reportPrivateUsage]
+    packet = cast(dict[str, JsonValue], source["review_packet"])
+    packet["change_observations"] = [{"note": "synthetic" * 100} for _ in range(64)]
+
+    def envelope_for(_case: SemanticCase) -> dict[str, JsonValue]:
+        return source
+
+    monkeypatch.setattr(semantic_case_module, "_case_envelope_json", envelope_for)
+    states = tuple(_original_reduction_states(case))
+    # The independent oracle mutated its private envelope; supply a fresh copy for production.
+    source = cast(dict[str, JsonValue], strict_json_parse(states[0]))
+    bound = len(states[34])
+    expected = next(state for state in states if len(state) <= bound)
+    monkeypatch.setattr(semantic_case_module, "MAX_EGRESS_ENVELOPE_BYTES", bound)
+    calls = 0
+
+    def counting_encode(value: JsonValue) -> bytes:
+        nonlocal calls
+        calls += 1
+        return canonical_encode(value)
+
+    monkeypatch.setattr(semantic_case_module, "canonical_encode", counting_encode)
+    assert bounded_case_envelope(case) == expected
+    assert calls <= 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Issue

Fixes #633. Duplicate search covered open issues and PRs, including #571, #623 and #617. The maintainer's authorization for this exact output-preserving implementation scope is recorded on the issue.

## Summary

Oversized semantic packets were canonically serialized in full after every discarded row. Packet sections now use a bounded binary search to find the same first-fitting suffix removal. Sections that cannot fit after complete removal advance to the next existing priority. Catalog fallback keeps its original row-by-row reference cleanup.

The result, selected content, ordering, accounting, byte limit and irreducible error are unchanged. Size is monotonic because removing a row offsets any extra decimal counter digit. No cache, concurrency, provider, disclosure or policy change is introduced.

## Documentation

Behavior change: no. The implementation docstring describes the search. No schema, policy, public documentation or generated-resource changes. The shared semantic packet path applies to every host, CLI/MCP delivery and external evaluator.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/unit/application/test_semantic_case_envelope.py tests/unit/application/test_semantic_case.py tests/unit/application/test_semantic_case_recheck.py tests/unit/application/test_semantic_local_egress.py tests/conformance/privacy -q
uvx --from uv==0.11.29 uv run ruff check src/yoetz/application/semantic_case.py tests/unit/application/test_semantic_case_envelope.py
uvx --from uv==0.11.29 uv run ruff format --check src/yoetz/application/semantic_case.py tests/unit/application/test_semantic_case_envelope.py
node node_modules/pyright/index.js src/yoetz/application/semantic_case.py tests/unit/application/test_semantic_case_envelope.py
uvx --from uv==0.11.29 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

70 tests passed; Ruff and pinned Pyright passed. New tests compare the entire canonical output with the original greedy reduction sequence at exact boundaries and +/- one byte for all four review profiles, including irreducible failures. A 64-row synthetic section verifies exact output using at most ten full-envelope encodes. Existing tests cover catalog-reference cleanup and correspondence between authorized and delivered content.

Local CPython 3.14.6, expanded large-case fixture, median of three batches of five calls:

| Byte limit | Output bytes, identical | Full encodes before/after | Before | After |
| --- | ---: | ---: | ---: | ---: |
| 8,192 | 8,151 | 89 / 72 | 63.753 ms | 45.192 ms |
| 16,384 | 16,230 | 70 / 53 | 57.663 ms | 37.562 ms |
| 24,576 | 24,329 | 51 / 34 | 47.406 ms | 28.960 ms |

Peak traced allocation remained approximately 193 KiB before and after. The catalog fallback dominates the remaining encodes at these bounds. These are local packet-building measurements, not model latency or quality claims. The full suite was not run locally. All six performance changes (#636, #637, #639, #641, #643, #647) together passed 579 focused tests (2 platform skips), Ruff and pinned Pyright in a separate combined checkout. A merge-tree check also found no merge conflicts with PR #617 at c3e661eb; that is merge compatibility, not a test run of #617. Node 24.19.0/npm 11.9.0 hosted pinned Pyright 1.1.411.

Model and harness: GPT-based Codex in ChatGPT Work Mode; exact model identifier is not exposed by the runtime.

## Boundaries

- [x] Public-boundary scan passed; synthetic fixtures only.
- [x] Exact output, omission accounting, privacy and coverage behavior preserved.
- [x] Review comments will be dispositioned before merge.
