### PR TITLE
fix(privacy): align disclosure lookup validation across adapters

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -2458,6 +2458,13 @@ structural sidecar, rejects conflicting/ambiguous request bindings, and distingu
 absence from unavailable or corrupt storage. Admitted recovery preserves the proposal/request
 identity; consumed or completed admission cannot authorize another dispatch. This lookup is not
 an MCP or control-wire method.
+Both audit adapters require an exact string request ID in the `req_` UUID-v4 vocabulary and a
+lowercase `sha256:` digest. Wrong Python types raise `TypeError`; malformed strings raise
+`ValueError`, both with `privacy_disclosure_attempt_lookup_invalid`. The authenticated catalog
+sidecar must contain a valid `prepared_case_digest`: missing or malformed values are
+`privacy_audit_attempt_corrupt`, while a valid different digest is
+`privacy_audit_attempt_case_mismatch`. Only exact absence returns `None`; storage errors propagate
+and never authorize a fresh attempt (issue #626).
 Internal `PrivacyAuditPort.get_receipt`/`list_receipts` queries project bounded structural views
 only through the ordinary CLI/UI control methods `privacy_receipts_get` and
 `privacy_receipts_list`; the port names are not wire aliases and MCP has no access.

--- a/src/yoetz/adapters/memory/privacy.py
+++ b/src/yoetz/adapters/memory/privacy.py
@@ -28,6 +28,7 @@ from yoetz.domain.privacy import (
     PrivacyAuditSubject,
     PrivacyPolicy,
 )
+from yoetz.domain.values import validate_sha256_digest
 from yoetz.ports.clock import ClockPort
 from yoetz.ports.keys import MacKeyHandle
 from yoetz.ports.objects import ObjectKind, ObjectMetadata, ObjectRef, ObjectSource, ObjectStorePort
@@ -59,6 +60,7 @@ from yoetz.ports.privacy import (
     RepositoryPrivacyAuthority,
 )
 from yoetz.protocol.canonical import JsonValue, canonical_digest, canonical_encode
+from yoetz.protocol.ids import IdKind, validate_id
 
 __all__ = [
     "MemoryPrivacyAudit",
@@ -715,6 +717,11 @@ class MemoryPrivacyAudit:
 
         if type(request_id) is not str or type(case_digest) is not str:
             raise TypeError("privacy_disclosure_attempt_lookup_invalid")
+        try:
+            validate_id(IdKind.REQUEST, request_id)
+            validate_sha256_digest(case_digest)
+        except ValueError as exc:
+            raise ValueError("privacy_disclosure_attempt_lookup_invalid") from exc
         async with self._lock:
             disclosure_rows = tuple(
                 row

--- a/src/yoetz/adapters/privacy/catalog.py
+++ b/src/yoetz/adapters/privacy/catalog.py
@@ -1954,6 +1954,10 @@ class CatalogPrivacyAudit:
                     _mac(self._key, _LOOKUP_DOMAIN, structural_bytes), lookup_identity
                 ):
                     raise ValueError("privacy_audit_attempt_corrupt")
+                prepared_case_digest = structural.get("prepared_case_digest")
+                if type(prepared_case_digest) is not str:
+                    raise ValueError("privacy_audit_attempt_corrupt")
+                validate_sha256_digest(prepared_case_digest)
             except (TypeError, ValueError) as exc:
                 raise ValueError("privacy_audit_attempt_corrupt") from exc
             if structural.get("prepared_case_digest") != case_digest:

--- a/tests/unit/privacy/test_catalog_audit.py
+++ b/tests/unit/privacy/test_catalog_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import json
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -20,7 +21,12 @@ from yoetz.adapters.memory.privacy import (
     MemoryPrivacyCatalogState,
     MemoryPrivacyPolicyStore,
 )
-from yoetz.adapters.privacy.catalog import CatalogPrivacyAudit, CatalogPrivacyPolicyStore
+from yoetz.adapters.privacy.catalog import (  # pyright: ignore[reportPrivateUsage]
+    _LOOKUP_DOMAIN,  # pyright: ignore[reportPrivateUsage]
+    CatalogPrivacyAudit,
+    CatalogPrivacyPolicyStore,
+    _mac,  # pyright: ignore[reportPrivateUsage]
+)
 from yoetz.adapters.privacy.local_enforcer import LocalPrivacyEnforcer
 from yoetz.application.egress import (
     PrivacyCoordinator,
@@ -70,6 +76,7 @@ from yoetz.ports.privacy import (
     PolicyOverlay,
     PolicyTransitionMember,
     PolicyTransitionProposal,
+    PrivacyAuditPort,
     PrivacyAuditState,
     PrivacyClassifierPort,
     PrivacyPolicyStorePort,
@@ -951,6 +958,94 @@ def test_catalog_disclosure_attempt_rejects_tampered_lookup_identity() -> None:
             )
 
     asyncio.run(run())
+
+
+@pytest.fixture(params=("memory", "catalog"))
+def disclosure_audit(request: pytest.FixtureRequest) -> PrivacyAuditPort:
+    if request.param == "memory":
+        return MemoryPrivacyAudit(
+            MemoryPrivacyCatalogState(routes={_TASK: _ROUTE_DIGEST}),
+            cast(ObjectStorePort, _StoredObjects()),
+            _Key(),
+            _Clock(),
+        )  # type: ignore[arg-type]
+    db = _database()
+    _insert_task_route(db)
+    return CatalogPrivacyAudit(db, _StoredObjects(), _Key(), _Clock())  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("request_id", "digest", "error"),
+    (
+        (None, _DIGEST, TypeError),
+        (_REQUEST, None, TypeError),
+        (True, _DIGEST, TypeError),
+        (_REQUEST, b"digest", TypeError),
+        ("req_invalid", _DIGEST, ValueError),
+        (_REQUEST.upper(), _DIGEST, ValueError),
+        (_REQUEST, "sha256:bad", ValueError),
+        (_REQUEST, "sha256:" + "A" * 64, ValueError),
+    ),
+)
+async def test_disclosure_lookup_input_contract_matches_across_adapters(
+    disclosure_audit: PrivacyAuditPort,
+    request_id: object,
+    digest: object,
+    error: type[Exception],
+) -> None:
+    with pytest.raises(error, match="privacy_disclosure_attempt_lookup_invalid"):
+        await disclosure_audit.load_disclosure_attempt(cast(str, request_id), cast(str, digest))
+
+
+@pytest.mark.anyio
+async def test_disclosure_lookup_distinguishes_absence_match_and_mismatch(
+    disclosure_audit: PrivacyAuditPort,
+) -> None:
+    assert await disclosure_audit.load_disclosure_attempt(_REQUEST, _DIGEST) is None
+    prepared = await disclosure_audit.prepare_disclosure_proposal(_external_disclosure_request())
+    state = await disclosure_audit.load_disclosure_attempt(_REQUEST, _DIGEST)
+    assert state is not None and state.reservation == prepared.reservation
+    assert await disclosure_audit.load_disclosure_attempt(_REQUEST_2, _DIGEST) is None
+    with pytest.raises(ValueError, match="privacy_audit_attempt_case_mismatch"):
+        await disclosure_audit.load_disclosure_attempt(_REQUEST, "sha256:" + "4" * 64)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("mutation", ("absent", "null", "number", "malformed"))
+async def test_authenticated_disclosure_sidecar_requires_a_valid_case_digest(mutation: str) -> None:
+    db = _database()
+    _insert_task_route(db)
+    audit = CatalogPrivacyAudit(db, _StoredObjects(), _Key(), _Clock())  # type: ignore[arg-type]
+    await audit.prepare_disclosure_proposal(_external_disclosure_request())
+    row = db.execute("SELECT subject_structural_canonical FROM privacy_audit_records").fetchone()
+    assert row is not None and isinstance(row[0], bytes)
+    structural = json.loads(row[0])
+    if mutation == "absent":
+        del structural["prepared_case_digest"]
+    else:
+        structural["prepared_case_digest"] = {"null": None, "number": 3, "malformed": "bad"}[
+            mutation
+        ]
+    raw = canonical_encode(structural)
+    # Authenticate the synthetic malformed sidecar, so the test reaches structural
+    # validation rather than passing merely because its MAC is invalid.
+    identity = _mac(_Key(), _LOOKUP_DOMAIN, raw)
+    db.execute(
+        "UPDATE privacy_audit_records SET subject_structural_canonical = ?, subject_lookup_identity = ?",
+        (raw, identity),
+    )
+    with pytest.raises(ValueError, match="privacy_audit_attempt_corrupt"):
+        await audit.load_disclosure_attempt(_REQUEST, _DIGEST)
+
+
+@pytest.mark.anyio
+async def test_disclosure_lookup_storage_failure_is_not_absence() -> None:
+    db = _database()
+    audit = CatalogPrivacyAudit(db, _StoredObjects(), _Key(), _Clock())  # type: ignore[arg-type]
+    db.close()
+    with pytest.raises(apsw.ConnectionClosedError):
+        await audit.load_disclosure_attempt(_REQUEST, _DIGEST)
 
 
 def test_catalog_disclosure_attempt_rejects_multiple_rows_for_request() -> None:


### PR DESCRIPTION
Memory disclosure lookup accepted malformed request IDs and digests that Catalog rejected. Catalog also treated an authenticated sidecar with a missing or malformed prepared-case digest as a case mismatch. Align input validation and distinguish corrupt structure from a valid different case.

Stacked on #617 at `c3e661eb`; retarget to main after that PR lands.

## Issue

- Fixes #626.
- Checked current PRs and the issue timeline; #617 explicitly deferred this follow-up.
- The maintainer requested proposed fixes. This tightens validation without changing successful lookup or dispatch authority.

## Documentation

- Behavior change: bounded validation failures agree across adapters.
- Updated `docs/INTERFACES.md` with input types/formats, corruption versus mismatch, and exact absence versus storage failure.

## Verification

```text
uv run --no-sync pytest tests/unit/privacy/test_catalog_audit.py tests/unit/application/test_semantic_authorization_resume.py -q
# 47 passed
uv run --no-sync ruff check tests/unit/privacy/test_catalog_audit.py src/yoetz/adapters/memory/privacy.py src/yoetz/adapters/privacy/catalog.py
uv run --no-sync ruff format src/yoetz/adapters/memory/privacy.py src/yoetz/adapters/privacy/catalog.py tests/unit/privacy/test_catalog_audit.py
pyright src/yoetz/adapters/memory/privacy.py src/yoetz/adapters/privacy/catalog.py tests/unit/privacy/test_catalog_audit.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Shared Memory/Catalog cases cover malformed types, request-ID and digest formats, exact absence, exact match, and a valid different digest. Four Catalog cases authenticate deliberately malformed synthetic sidecars, proving the structural validation is reached. A closed database raises a storage failure rather than returning absence. Existing tampered-MAC, ambiguous-request, and consumed one-use admission regressions remain in the suite.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

The private HMAC subject lookup key remains authoritative and is not replaced by the public case digest. No fallback masks invalid or unavailable audit state.

Implementation: Codex in ChatGPT Work Mode. No live provider call or merge performed.