### PR TITLE
perf(codex): drain buffered notifications without list shifts

### DIFF
--- a/src/yoetz/adapters/providers/codex_app_server.py
+++ b/src/yoetz/adapters/providers/codex_app_server.py
@@ -16,6 +16,7 @@ import shutil
 import signal
 import stat
 import tempfile
+from collections import deque
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -465,7 +466,7 @@ class _CodexProcess:
     process: asyncio.subprocess.Process
     workdir: Path
     stderr_task: asyncio.Task[bool]
-    pending_notifications: list[Mapping[str, object]]
+    pending_notifications: deque[Mapping[str, object]]
 
     async def send(self, value: Mapping[str, object]) -> None:
         stdin = self.process.stdin
@@ -581,7 +582,7 @@ async def _launch(profile: CodexAppServerProfile) -> _CodexProcess:
                 process=process,
                 workdir=workdir,
                 stderr_task=asyncio.create_task(_drain_stderr(process.stderr)),
-                pending_notifications=[],
+                pending_notifications=deque(),
             )
             try:
                 await _cleanup_guaranteed(owned)
@@ -594,7 +595,7 @@ async def _launch(profile: CodexAppServerProfile) -> _CodexProcess:
             process=process,
             workdir=workdir,
             stderr_task=asyncio.create_task(_drain_stderr(process.stderr)),
-            pending_notifications=[],
+            pending_notifications=deque(),
         )
     except BaseException:
         # Spawn cancellation above owns and cleans a returned process before it reaches here.
@@ -950,7 +951,7 @@ def _take_account_updated(runtime: _CodexProcess) -> bool:
 
     updated = False
     pending = runtime.pending_notifications
-    runtime.pending_notifications = []
+    runtime.pending_notifications = deque()
     for message in pending:
         notification = _login_notification(message, "")
         if notification == "account_updated":
@@ -1058,7 +1059,7 @@ async def codex_login(
                     break
                 try:
                     message = (
-                        runtime.pending_notifications.pop(0)
+                        runtime.pending_notifications.popleft()
                         if runtime.pending_notifications
                         else await runtime.read(remaining)
                     )
@@ -1089,7 +1090,7 @@ async def codex_login(
                         raise TimeoutError
                     try:
                         message = (
-                            runtime.pending_notifications.pop(0)
+                            runtime.pending_notifications.popleft()
                             if runtime.pending_notifications
                             else await runtime.read(remaining)
                         )
@@ -1567,11 +1568,11 @@ class CodexAppServerEvaluator:
             # the fallback candidate set. Exactly one candidate must remain.
             final_texts: list[str] = []
             untagged_texts: list[str] = []
-            messages = list(runtime.pending_notifications)
-            runtime.pending_notifications.clear()
+            messages = runtime.pending_notifications
+            runtime.pending_notifications = deque()
             for _ in range(_MAX_EVENT_COUNT):
                 message = (
-                    messages.pop(0)
+                    messages.popleft()
                     if messages
                     else await runtime.read(_remaining(deadline, self.clock))
                 )

--- a/tests/unit/adapters/providers/test_codex_app_server.py
+++ b/tests/unit/adapters/providers/test_codex_app_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+from collections import deque
 from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -204,7 +205,7 @@ class _Runtime:
     ) -> None:
         self.profile = profile
         self.workdir = Path("/private/empty-attempt")
-        self.pending_notifications: list[dict[str, object]] = []
+        self.pending_notifications: deque[dict[str, object]] = deque()
         self.model_available = model_available
         self.account = (
             {"type": "chatgpt", "email": "discard@example", "planType": "plus"}
@@ -320,7 +321,7 @@ class _LoginRuntime:
         self.login_notifications = list(login_notifications or [])
         self.cancel_error = cancel_error
         self.block_read = block_read
-        self.pending_notifications: list[dict[str, object]] = []
+        self.pending_notifications: deque[dict[str, object]] = deque()
         self.methods: list[str] = []
         self.timeouts: list[float] = []
         self.read_timeouts: list[float] = []
@@ -502,7 +503,7 @@ async def test_login_demultiplexes_exact_remote_control_notice_before_completion
     assert result.auth_mode == "chatgpt"
     assert result.model_available is True
     assert runtime.methods.count("account/login/cancel") == 0
-    assert runtime.pending_notifications == []
+    assert not runtime.pending_notifications
     assert "discard-installation-canary" not in repr(result)
     assert "discard-server-canary" not in repr(result)
 
@@ -907,7 +908,7 @@ async def test_cleanup_reaps_child_after_process_group_signal_race(
         process=cast(asyncio.subprocess.Process, process),
         workdir=workdir,
         stderr_task=asyncio.create_task(stderr_drain()),
-        pending_notifications=[],
+        pending_notifications=deque(),
     )
     probes = 0
 
@@ -952,7 +953,7 @@ async def test_cleanup_reports_failed_when_process_disappears_without_reap(
         process=cast(asyncio.subprocess.Process, FakeProcess()),
         workdir=workdir,
         stderr_task=asyncio.create_task(stderr_drain()),
-        pending_notifications=[],
+        pending_notifications=deque(),
     )
 
     def absent_group(_pid: int, _sig: int) -> None:
@@ -1556,6 +1557,41 @@ async def test_large_streamed_judgment_fits_the_event_budget(
     result = await _evaluate(monkeypatch, runtime)
 
     assert type(result) is SemanticResultSuccess
+
+
+@pytest.mark.parametrize("buffered_count", [1, 4094, 4096])
+async def test_buffered_notifications_drain_before_live_events_with_the_same_limit(
+    monkeypatch: pytest.MonkeyPatch, buffered_count: int
+) -> None:
+    class BufferedRuntime(_Runtime):
+        reads = 0
+
+        async def request(
+            self, request_id: int, method: str, params: object, timeout: float
+        ) -> dict[str, object]:
+            result = await super().request(request_id, method, params, timeout)
+            if method == "turn/start":
+                self.pending_notifications.extend(
+                    {"method": "item/agentMessage/delta", "params": {"delta": "x"}}
+                    for _ in range(buffered_count)
+                )
+            return result
+
+        async def read(self, timeout: float) -> dict[str, object]:
+            self.reads += 1
+            return await super().read(timeout)
+
+    runtime = BufferedRuntime(_profile())
+    result = await _evaluate(monkeypatch, runtime)
+    if buffered_count == 4096:
+        assert type(result) is SemanticResultInvalid
+        assert result.provenance.runtime_evidence is not None
+        assert result.provenance.runtime_evidence.failure_stage == "event_limit"
+        assert runtime.reads == 0
+    else:
+        assert type(result) is SemanticResultSuccess
+        assert runtime.reads == 2
+    assert not runtime.pending_notifications
 
 
 async def test_tool_event_and_unconfirmed_cleanup_name_their_stages(


### PR DESCRIPTION
## Issue

Fixes #634. Reviewed open issues and PRs and the historical #530 notification fix. The event acceptance work in #584 and sampling/progress work in #571 remain separate.

## Summary

Buffered app-server events used list-head removal in both subscription login and semantic evaluation. They now use FIFO deques without a maxlen, preserving the explicit fail-closed event limit. Evaluation transfers its pending buffer instead of duplicating it before draining.

All accepted/rejected event shapes, ordering, deadlines, login correlation, dispatch authority and process cleanup remain unchanged.

## Documentation

Behavior change: no. No schema or documentation changes. This is the Codex subscription evaluator's internal queue, used regardless of which host or CLI/MCP path requested semantic review. It adds no threads, workers, connections or caches.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/unit/adapters/providers/test_codex_app_server.py -q
uvx --from uv==0.11.29 uv run ruff check src/yoetz/adapters/providers/codex_app_server.py tests/unit/adapters/providers/test_codex_app_server.py
uvx --from uv==0.11.29 uv run ruff format --check src/yoetz/adapters/providers/codex_app_server.py tests/unit/adapters/providers/test_codex_app_server.py
node node_modules/pyright/index.js src/yoetz/adapters/providers/codex_app_server.py tests/unit/adapters/providers/test_codex_app_server.py
uvx --from uv==0.11.29 uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

80 tests passed; Ruff and pinned Pyright passed. Existing login tests exercise queued account/initialization notices. New tests buffer 1, 4,094 and 4,096 notifications before live judgment/completion events, proving buffered-first processing and the same event-limit failure at saturation. Cleanup/cancellation and forbidden-event tests continue to pass.

Local CPython 3.14.6, 4,096 preconstructed synthetic notifications, median of five batches of 100 buffer-and-drain operations:

| Implementation | Time | Peak traced allocation |
| --- | ---: | ---: |
| Lists with buffer copy and pop(0) | 0.9259 ms | 65,648 B |
| Deque with buffer transfer and popleft() | 0.1056 ms | 35,312 B |

This is a sub-millisecond queue optimization at the maximum burst, not a model latency claim. No live Codex login or provider was used. The full suite was not run locally. All six performance changes (#636, #637, #639, #641, #643, #647) together passed 579 focused tests (2 platform skips), Ruff and pinned Pyright in a separate combined checkout. A merge-tree check also found no merge conflicts with PR #617 at c3e661eb; that is merge compatibility, not a test run of #617. Node 24.19.0/npm 11.9.0 hosted repository-pinned Pyright 1.1.411.

Model and harness: GPT-based Codex in ChatGPT Work Mode; exact model identifier is not exposed by the runtime.

CI note: the first SQLite-integration job failed in the existing Claude native-capture fixture because it observed 3 ingest attempts rather than 2. The failed-job rerun on this unchanged head passed. All other PR CI jobs and Security and Privacy passed. That native-capture test file also passed locally (3 tests) on the base plus the independent #647 kernel change; this PR does not enter the Claude hook path. Native-capture work remains owned by #617.

## Boundaries

- [x] Public-boundary scan passed; synthetic fixtures only.
- [x] Notification bounds, privacy, coverage, authority and cleanup preserved.
- [x] Review comments will be dispositioned before merge.
