### PR TITLE
fix(observation): identify the scope of capture status fields

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3264,7 +3264,14 @@ retains its structural contract, while its eligible hook content uses the fenced
 below.
 
 `yoetz observe content-enable`, `content-disable`, and `content-status` operate on the same canonical
-workspace as observation consent. The local content fence combines a durable per-workspace epoch
+workspace as observation consent. Their JSON responses and `observe status` identify
+`content_capture_scope: ordinary_profiles` and `codex_hook_capture_scope: observation_consent`.
+The profile list, effective profile list, and `enabled`/`content_capture_enabled` describe only the
+Claude Code and Cursor ordinary profiles. An empty list does not disable profileless Codex hooks,
+whose local authority follows observation consent and the runtime gate. Text status names the same
+scope. These are configuration facts, not proof of actual capture, successful execution, or
+semantic selection; those require evidence and the check/receipt (issue #622).
+The local content fence combines a durable per-workspace epoch
 with a persisted runtime-gate nonce; every real consent or runtime transition advances it, including
 pause/resume and off/on ABA cycles, and legacy state receives a fresh epoch before authority is
 accepted. Pause, disable, and revoke must fence retained native content reads and subsequent

--- a/src/yoetz/cli/observe.py
+++ b/src/yoetz/cli/observe.py
@@ -266,7 +266,7 @@ class _DeliveryFacts:
 
 @dataclass(frozen=True, slots=True)
 class _ContentCaptureFacts:
-    """Requested native profiles and the profiles currently able to capture."""
+    """Requested ordinary profiles and their current local configuration fences."""
 
     requested_profiles: tuple[str, ...]
     effective_profiles: tuple[str, ...]
@@ -394,6 +394,8 @@ def observe_status(
             {
                 "workspace_commitment": commitment,
                 "consent": consent_label,
+                "content_capture_scope": "ordinary_profiles",
+                "codex_hook_capture_scope": "observation_consent",
                 "content_capture_profiles": content_profiles,
                 "effective_content_capture_profiles": content_facts.effective_profiles,
                 "content_capture_enabled": content_facts.enabled,
@@ -420,6 +422,7 @@ def observe_status(
     payload: dict[str, JsonValue] = {
         "workspace_commitment": commitment,
         "consent": consent_label,
+        "content_capture_scope": "ordinary profiles; Codex hooks follow observation consent",
         "content_profiles": ",".join(content_profiles) if content_profiles else "none",
         "effective_content_profiles": (
             ",".join(content_facts.effective_profiles)
@@ -783,6 +786,8 @@ def enable_observation_content(
             {
                 "workspace_commitment": commitment,
                 "content_capture_profile": profile,
+                "content_capture_scope": "ordinary_profiles",
+                "codex_hook_capture_scope": "observation_consent",
                 "content_capture_profiles": content_facts.requested_profiles,
                 "effective_content_capture_profiles": content_facts.effective_profiles,
                 "consent_active": content_facts.consent_active,
@@ -820,6 +825,8 @@ def disable_observation_content(
             {
                 "workspace_commitment": commitment,
                 "content_capture_profile": profile,
+                "content_capture_scope": "ordinary_profiles",
+                "codex_hook_capture_scope": "observation_consent",
                 "content_capture_profiles": content_facts.requested_profiles,
                 "effective_content_capture_profiles": content_facts.effective_profiles,
                 "consent_active": content_facts.consent_active,
@@ -846,6 +853,8 @@ def observation_content_status(
     content_facts = _content_capture_facts(store, commitment)
     payload = {
         "workspace_commitment": commitment,
+        "content_capture_scope": "ordinary_profiles",
+        "codex_hook_capture_scope": "observation_consent",
         "content_capture_profiles": content_facts.requested_profiles,
         "effective_content_capture_profiles": content_facts.effective_profiles,
         "consent_active": content_facts.consent_active,
@@ -856,7 +865,7 @@ def observation_content_status(
         _emit(payload, json_output=True)
     else:
         typer.echo(
-            "observation_content_capture_status:"
+            "observation_content_capture_status:scope=ordinary_profiles; "
             + (", ".join(content_facts.effective_profiles) if content_facts.enabled else "disabled")
             + " (configured: "
             + (
@@ -864,7 +873,8 @@ def observation_content_status(
                 if content_facts.requested_profiles
                 else "none"
             )
-            + ")"
+            + "); Codex hook capture follows observation consent. "
+            "This status does not prove captured evidence or semantic selection."
         )
     return 0
 

--- a/tests/unit/cli/test_native_observation_profiles.py
+++ b/tests/unit/cli/test_native_observation_profiles.py
@@ -21,7 +21,11 @@ from yoetz.adapters.integrations.cursor_integration import (
 from yoetz.adapters.integrations.observation_local import LocalObservationStore
 from yoetz.cli import observe as observe_cli
 from yoetz.cli import observe_hooks
-from yoetz.domain.observation import ObservationSource
+from yoetz.domain.observation import (
+    ObservationControlCommand,
+    ObservationRevokeCommand,
+    ObservationSource,
+)
 from yoetz.domain.observation_profiles import (
     CLAUDE_CODE_ORDINARY_HOOK_MAPPING_VERSION,
     CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
@@ -86,7 +90,58 @@ def test_content_profiles_are_independent_and_user_controls_are_reversible(
     )
     status = json.loads(capsys.readouterr().out)
     assert status["enabled"] is True
+    assert status["content_capture_scope"] == "ordinary_profiles"
+    assert status["codex_hook_capture_scope"] == "observation_consent"
     assert status["content_capture_profiles"] == [CURSOR_ORDINARY_OBSERVATION_PROFILE_ID]
+
+
+@pytest.mark.parametrize("mode", ("active", "paused", "revoked", "runtime_disabled", "mixed"))
+def test_profileless_codex_status_names_the_ordinary_profile_scope(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = tmp_path / "state"
+    store = LocalObservationStore(_state=state)
+    commitment = store.workspace_commitment(str(tmp_path.resolve()))
+    store.grant_consent(commitment)
+    if mode == "paused":
+        store.pause(ObservationControlCommand(commitment))
+    elif mode == "revoked":
+        store.revoke(ObservationRevokeCommand(commitment))
+    elif mode == "runtime_disabled":
+        store.set_runtime_enabled(False)
+    elif mode == "mixed":
+        store.enable_content_capture(commitment, CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID)
+        store.enable_content_capture(commitment, CURSOR_ORDINARY_OBSERVATION_PROFILE_ID)
+
+    observe_cli.observation_content_status(workspace=str(tmp_path), json_output=True, _state=state)
+    status = json.loads(capsys.readouterr().out)
+    assert status["content_capture_scope"] == "ordinary_profiles"
+    assert status["codex_hook_capture_scope"] == "observation_consent"
+    assert status["enabled"] is (mode == "mixed")
+    assert status["consent_active"] is (mode not in {"paused", "revoked"})
+    assert status["runtime_enabled"] is (mode != "runtime_disabled")
+    assert all("codex" not in profile for profile in status["content_capture_profiles"])
+
+    observe_cli.observation_content_status(workspace=str(tmp_path), json_output=False, _state=state)
+    text = capsys.readouterr().out
+    assert "scope=ordinary_profiles" in text
+    assert "Codex hook capture follows observation consent" in text
+    assert "does not prove captured evidence or semantic selection" in text
+
+    def no_activation_probe(*args: object, **kwargs: object) -> dict[str, JsonValue]:
+        return {}
+
+    monkeypatch.setattr(observe_cli, "_activation_state", no_activation_probe)
+    observe_cli.observe_status(workspace=str(tmp_path), json_output=True, _state=state)
+    overall = json.loads(capsys.readouterr().out)
+    assert overall["content_capture_scope"] == status["content_capture_scope"]
+    assert overall["codex_hook_capture_scope"] == status["codex_hook_capture_scope"]
+    assert overall["content_capture_enabled"] == status["enabled"]
+    observe_cli.observe_status(workspace=str(tmp_path), json_output=False, _state=state)
+    assert "ordinary profiles; Codex hooks follow observation consent" in capsys.readouterr().out
 
 
 def test_content_actions_report_requested_and_effective_profiles(


### PR DESCRIPTION
Capture status derived its enabled flag solely from ordinary Claude/Cursor profiles, so an empty profile list could be read as disabling Codex capture. Explicitly name the scope of those existing fields and identify profileless Codex's separate observation-consent scope.

Stacked on #617 at `c3e661eb`; retarget to main after that PR lands.

## Issue

- Fixes #622.
- Checked the current PR list and issue timeline. #617 explicitly deferred this follow-up.
- The maintainer requested proposed fixes. This implements the issue's scope-clarification option and adds no capture authority.

## Documentation

- Behavior change: additive CLI JSON scope labels and clearer text.
- Updated `docs/INTERFACES.md`. No new Codex ordinary profile or capture-success fact is invented.

## Verification

```text
uv run --no-sync pytest tests/unit/cli/test_native_observation_profiles.py -q
# 17 passed
uv run --no-sync ruff check src/yoetz/cli/observe.py tests/unit/cli/test_native_observation_profiles.py
uv run --no-sync ruff format src/yoetz/cli/observe.py tests/unit/cli/test_native_observation_profiles.py
pyright src/yoetz/cli/observe.py tests/unit/cli/test_native_observation_profiles.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Five state cases cover active, paused, revoked, runtime-disabled, and mixed-host configuration. They check both content-status and overall observe-status in JSON and text. Existing enable/disable response behavior is retained with the same additive scope labels.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

`content_capture_scope=ordinary_profiles` describes the existing profile and enabled fields. `codex_hook_capture_scope=observation_consent` explains Codex's independent lane. Text explicitly says configuration status does not prove captured evidence or semantic selection.

Implementation: Codex in ChatGPT Work Mode. No merge performed.