### PR TITLE
perf(observation): omit unused Codex input capture

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3230,9 +3230,9 @@ Independent verification support (local control, not MCP):
   bytes, and workspace-diff bytes become `observation_captured` immutable evidence. For the
   source-qualified profileless Codex hook arm, those bytes must be explicitly linked to the hook
   event. Session-stream records are a separate source and are excluded from semantic selection;
-  tool input and path/locator content are also excluded from semantic selection. The current
-  Codex hook path may still stage consented input/locator chunks in the bounded encrypted local
-  capture lane pending a follow-up staging filter. Visible messages, unsupported visible payloads,
+  tool input and path/locator content are also excluded from semantic selection. The Codex hook
+  extractor omits raw tool-input bytes but keeps the encrypted workspace locator needed by local
+  inspection and verification; existing structural evidence remains intact (issue #623). Visible messages, unsupported visible payloads,
   and approved-check output do not enter this capture path. The repository privacy authority and
   each provider attempt authorize semantic selection independently of local encrypted capture.
   Inspection fact/excerpt objects materialize through their own idempotent evidence operation.
@@ -3322,9 +3322,12 @@ admitted host correlation or native source/label identity before they can become
 For `codex_hook`, only explicitly linked tool output, selected changed-file/code bytes, and
 workspace-diff bytes are eligible for semantic selection. Session-stream records remain outside
 this native handoff and are excluded from semantic selection. Tool input and path/locator content
-are excluded from semantic selection too, although the current Codex hook path may still stage
-consented input/locator chunks in the bounded encrypted local capture lane pending a follow-up
-staging filter. Missing or conflicting native binding metadata retains
+are excluded from semantic selection too. The Codex hook extractor omits raw `TOOL_INPUT` bytes
+while retaining structural tool identity and correlation. It keeps the encrypted
+`WORKSPACE_LOCATOR` from SessionStart because the local inspection and verification scheduler
+opens that locator to resolve the workspace and its approved-check policy. Removing it would
+break a supported local consumer. Neither kind becomes semantic content; ordinary Claude/Cursor
+profile contracts remain unchanged (issue #623). Missing or conflicting native binding metadata retains
 `content_capture_unavailable`, including when materialization is called independently of semantic
 review. A terminal structural rejection retires only its exact admitted capture ticket so it
 cannot permanently block later checks; retryable coordination retains that ticket for the next

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -866,7 +866,12 @@ def _visible_content_chunks(
             payload.get("message") or payload.get("output") or payload.get("content"),
         )
     elif event_name == "PreToolUse":
-        add(ObservationContentKind.TOOL_INPUT, "tool-input", payload.get("tool_input"))
+        # Codex input bytes have no capture consumer and are excluded from
+        # semantic selection. Keep the structural envelope/correlation, but
+        # avoid encrypting a second copy of command arguments. Ordinary native
+        # profiles retain their explicitly selected capture contract.
+        if envelope.source is not ObservationSource.CODEX_HOOK:
+            add(ObservationContentKind.TOOL_INPUT, "tool-input", payload.get("tool_input"))
     elif event_name == "PostToolUse":
         add(
             ObservationContentKind.TOOL_OUTPUT,

--- a/tests/unit/cli/test_observe_hooks_codex_capture.py
+++ b/tests/unit/cli/test_observe_hooks_codex_capture.py
@@ -21,6 +21,7 @@ from yoetz.domain.observation import (
     ObservationSource,
     observation_ingest_result_to_json,
 )
+from yoetz.domain.values import JsonObject
 
 
 @pytest.mark.anyio
@@ -118,5 +119,65 @@ async def test_codex_content_is_staged_before_a_blocked_fifo_row(tmp_path: Path)
     finally:
         release_head.set()
         await asyncio.wait_for(drain, timeout=1.0)
-
     assert store.list_pending_outbox_rows(workspace) == ()
+
+
+@pytest.mark.parametrize(
+    "source",
+    (ObservationSource.CODEX_HOOK, ObservationSource.CLAUDE_HOOK, ObservationSource.CURSOR_HOOK),
+)
+def test_codex_omits_raw_input_but_preserves_structural_identity_and_other_hosts(
+    tmp_path: Path,
+    source: ObservationSource,
+) -> None:
+    local = LocalObservationStore(_state=tmp_path)
+    payload = JsonObject(
+        {
+            "tool_name": "shell",
+            "tool_call_id": "read-call",
+            "tool_input": {"command": "cat example.py"},
+        }
+    )
+    envelope = map_hook_payload_to_envelope(
+        "PreToolUse",
+        payload,
+        session_commitment=local.session_commitment("input-retention"),
+        event_ordinal=1,
+        key_material=local.key_material(),
+        source=source,
+    )
+    chunks, truncated = observe_hooks_module._visible_content_chunks(  # pyright: ignore[reportPrivateUsage]
+        "PreToolUse",
+        payload,
+        envelope=envelope,
+        workspace_locator=None,
+    )
+    assert not truncated
+    assert envelope.structural_payload["tool_call_id"] == "read-call"
+    assert envelope.structural_payload["tool_name"] == "shell"
+    if source is ObservationSource.CODEX_HOOK:
+        assert chunks == ()
+    else:
+        assert len(chunks) == 1 and chunks[0].content_kind is ObservationContentKind.TOOL_INPUT
+
+
+def test_codex_keeps_the_locator_needed_by_local_inspection(tmp_path: Path) -> None:
+    local = LocalObservationStore(_state=tmp_path)
+    envelope = map_hook_payload_to_envelope(
+        "SessionStart",
+        {},
+        session_commitment=local.session_commitment("locator-retention"),
+        event_ordinal=1,
+        key_material=local.key_material(),
+        source=ObservationSource.CODEX_HOOK,
+    )
+    chunks, truncated = observe_hooks_module._visible_content_chunks(  # pyright: ignore[reportPrivateUsage]
+        "SessionStart",
+        {},
+        envelope=envelope,
+        workspace_locator=str(tmp_path),
+    )
+    assert not truncated
+    assert len(chunks) == 1
+    assert chunks[0].content_kind is ObservationContentKind.WORKSPACE_LOCATOR
+    assert chunks[0].content == str(tmp_path).encode()


### PR DESCRIPTION
Codex retained raw tool-input bytes with no supported content consumer, even though semantic selection excludes them. Stop extracting that raw input while preserving the structural event and correlation.

The workspace locator must remain: `_capture_content` binds it, and local inspection/verification decrypt it to open the workspace and load its approved-check policy. This PR therefore retains locators and documents that consumer.

Stacked on #617 at `c3e661eb`; retarget to main after that PR lands.

## Issue

- Fixes #623.
- Checked the issue timeline, open PRs, and every production reference to TOOL_INPUT and WORKSPACE_LOCATOR.
- The maintainer requested proposed fixes. This reduces local retention; provider eligibility and authority are unchanged.

## Documentation

- Behavior change: Codex PreToolUse keeps structural identity without encrypting raw arguments.
- Updated both capture descriptions in `docs/INTERFACES.md`, including the locator's local purpose. Existing objects and ordinary Claude/Cursor profile contracts are preserved.

## Verification

```text
uv run --no-sync pytest tests/unit/cli/test_observe_hooks_codex_capture.py tests/unit/application/test_semantic_content.py -q
# 33 passed
uv run --no-sync ruff check src/yoetz/cli/observe_hooks.py tests/unit/cli/test_observe_hooks_codex_capture.py
uv run --no-sync ruff format src/yoetz/cli/observe_hooks.py tests/unit/cli/test_observe_hooks_codex_capture.py
pyright src/yoetz/cli/observe_hooks.py tests/unit/cli/test_observe_hooks_codex_capture.py
uv run --no-sync python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

A separate synthetic SessionStart/read/test sequence used the real SQLite coordinator and encrypted object store in fresh temporary roots, comparing the parent extractor with this change:

| Measurement | Parent | Fix |
| --- | ---: | ---: |
| Encrypted objects staged | 5 | 3 |
| Retained content bytes inside those objects | 127 | 66 |
| Extraction plus staging, one local sample | 27.42 ms | 16.55 ms |

The timing is a single local measurement, not a general latency claim. Both variants retained the workspace locator and both tool outputs; only the two raw inputs disappeared. Tests retain semantic input/locator exclusion, prove structural tool identity survives, and preserve input extraction for the ordinary host contracts.

## Boundaries

- [x] No ignored private drafting material is included.
- [x] Review comments will be checked and dispositioned before merge.

## Summary

Omit only content without a supported consumer. Keep the locator required for local inspection and verification, and keep output/code/diff capture unchanged.

Implementation: Codex in ChatGPT Work Mode. No live provider call or merge performed.