### PR TITLE
perf(kernel): reuse action subjects in unresolved-work checks

### DIFF
--- a/src/yoetz/kernel/policies/work_integrity.py
+++ b/src/yoetz/kernel/policies/work_integrity.py
@@ -183,24 +183,19 @@ def _active_requested_obligations(case: DeterministicCase) -> frozenset[Obligati
 def _action_subject_key(
     obligation_refs: tuple[str, ...],
     attempted_items: tuple[str, ...],
-) -> tuple[str, frozenset[str]] | None:
+) -> tuple[str, tuple[str, ...]] | None:
     if obligation_refs:
-        return ("obligations", frozenset(obligation_refs))
+        return ("obligations", obligation_refs)
     if attempted_items:
-        return ("requested_items", frozenset(attempted_items))
+        return ("requested_items", attempted_items)
     return None
 
 
 def _keys_are_disjoint(
-    left: tuple[str, frozenset[str]] | None,
-    right: tuple[str, frozenset[str]] | None,
+    left: tuple[str, frozenset[str]],
+    right: tuple[str, tuple[str, ...]] | None,
 ) -> bool:
-    return (
-        left is not None
-        and right is not None
-        and left[0] == right[0]
-        and left[1].isdisjoint(right[1])
-    )
+    return right is not None and left[0] == right[0] and left[1].isdisjoint(right[1])
 
 
 def _response_support_admissible(
@@ -381,7 +376,11 @@ def _unresolved_action_findings(case: DeterministicCase) -> list[DeterministicAs
         action = record.payload
         if action is None or action_id in linked_actions:
             continue
-        key = _action_subject_key(action.obligation_refs, action.attempted_items)
+        subjects = _action_subject_key(action.obligation_refs, action.attempted_items)
+        if subjects is None:
+            continue
+        # Reuse the later action's tuple instead of rebuilding its set for every pair.
+        key = (subjects[0], frozenset(subjects[1]))
         later = tuple(
             later_id
             for later_id, later_record in actions

--- a/tests/unit/kernel/test_policy_work_integrity.py
+++ b/tests/unit/kernel/test_policy_work_integrity.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from builders.policy_cases import (
     BASE_COVERAGE,
     FRONTIER,
@@ -342,6 +344,75 @@ def test_action_without_result_requires_later_disjoint_work() -> None:
     assert FindingKind.ACTION_WITHOUT_RESULT in _kinds(trigger)
     latest_only = make_case(actions={act(1): record(unresolved, 1)})
     assert FindingKind.ACTION_WITHOUT_RESULT not in _kinds(latest_only)
+
+
+@pytest.mark.parametrize(
+    ("left_obligations", "left_items", "right_obligations", "right_items", "expected"),
+    [
+        ((1,), ("shared",), (2,), ("shared",), True),
+        ((1,), ("left",), (1,), ("right",), False),
+        ((1, 2), (), (2, 3), (), False),
+        ((1, 2), (), (3, 4), (), True),
+        ((), ("a", "b"), (), ("b", "c"), False),
+        ((), ("a",), (), ("c",), True),
+        ((1,), ("same",), (), ("same",), False),
+        ((), ("same",), (1,), ("other",), False),
+        ((), (), (), ("known",), False),
+        ((), ("known",), (), (), False),
+        ((), (), (), (), False),
+    ],
+)
+def test_action_subject_precedence_and_unknown_subjects(
+    left_obligations: tuple[int, ...],
+    left_items: tuple[str, ...],
+    right_obligations: tuple[int, ...],
+    right_items: tuple[str, ...],
+    expected: bool,
+) -> None:
+    left = replace(
+        _action(1, 1),
+        obligation_refs=tuple(obl(number) for number in left_obligations),
+        attempted_items=left_items,
+    )
+    right = replace(
+        _action(2, 2),
+        obligation_refs=tuple(obl(number) for number in right_obligations),
+        attempted_items=right_items,
+    )
+    case = make_case(actions={act(1): record(left, 1), act(2): record(right, 2)})
+
+    assert (FindingKind.ACTION_WITHOUT_RESULT in _kinds(case)) is expected
+
+
+def test_unresolved_action_basis_preserves_frontier_and_reference_order() -> None:
+    case = make_case(
+        actions={
+            act(5): replace(record(_action(5, 3), 5), source_frontier=3),
+            act(3): replace(record(_action(3, 2), 3), source_frontier=2),
+            act(4): replace(record(_action(4, 4), 4), source_frontier=2),
+            act(2): replace(record(_action(2, 2), 2), source_frontier=1),
+            act(1): record(_action(1, 1), 1),
+            act(6): replace(record(_action(6, 2), 6), source_frontier=4),
+            act(7): replace(record(_action(7, 7), 7), payload=None, redacted=True),
+        },
+        results={res(1): record(_result(1, 6, ResultOutcome.SUCCESS), 8)},
+    )
+    result = run_deterministic_policies(case, WORK_INTEGRITY_POLICY_PACK)
+    facts = tuple(
+        fact.subject_refs
+        for assessment in result.assessments
+        if assessment.candidate.kind is FindingKind.ACTION_WITHOUT_RESULT
+        for fact in assessment.basis.observed_facts
+        if fact.fact_code == "subsequent_unrelated_work_present"
+    )
+
+    assert facts == (
+        (act(1), act(3), act(4), act(5), act(6)),
+        (act(2), act(4), act(5)),
+        (act(3), act(5)),
+        (act(4), act(5), act(6)),
+        (act(5), act(6)),
+    )
 
 
 def test_stale_evidence_requires_comparable_different_tree_state() -> None:


### PR DESCRIPTION
## Issue

- Fixes #646.
- Reviewed current open issues/PRs and searched for work-integrity, unresolved-action, frozenset, and action-performance coverage. #628/#636 optimize source-map lookup; #617 owns observation/replay/leases. This allocation path is separate.
- The maintainer explicitly requested performance issues and PRs in the current session. This is an internal algorithm change outside the design-gated areas; no policy, protocol, privacy, storage, or packaging behavior changes.

## Documentation

- Behavior change? `no`.
- Docs: n/a, no public behavior change. Finding kinds, exact basis references, ordering, and coverage remain the same.
- Surfaces: the shared deterministic policy serves every host and delivery path. No host integration, schema, receipt format, lifecycle, reverse-state, or generated-resource change is required.

## Verification

```text
uvx --from uv==0.11.29 uv run pytest tests/unit/kernel tests/conformance/operations/test_check_contract.py tests/conformance/honesty/test_adversarial_cases.py -q
# 247 passed
.venv/bin/ruff check src/yoetz/kernel/policies/work_integrity.py tests/unit/kernel/test_policy_work_integrity.py
.venv/bin/ruff format --check src/yoetz/kernel/policies/work_integrity.py tests/unit/kernel/test_policy_work_integrity.py
node node_modules/pyright/index.js src/yoetz/kernel/policies/work_integrity.py tests/unit/kernel/test_policy_work_integrity.py
# lint/format pass; 0 type errors
.venv/bin/python scripts/scan_public_boundary.py --source-tree .
# PASS, 1255 tracked files
git diff --check
```

The new tests cover obligation precedence, same/mixed subject categories, overlapping/disjoint sets, unknown subjects, result suppression, redacted records, strict later-frontier comparison, and exact finding/reference order.

An additional scratch differential compared complete assessments against the functions from base `59b71702` for 40 seeded, shuffled 32-action cases containing mixed subject categories, overlap, unknown subjects, tombstones, linked results, and tied frontiers. All results matched.

Synthetic no-finding histories with 16 overlapping obligation refs per action, median of 5 repeats of 3 calls on Python 3.14.6:

| Actions | Before | After | Peak traced allocation, before/after |
| --- | ---: | ---: | ---: |
| 64 | 0.7352 ms | 0.4175 ms | 5,864 / 5,864 B |
| 256 | 12.1679 ms | 5.9601 ms | 23,560 / 23,560 B |
| 1,024 | 193.7072 ms | 101.7476 ms | 95,496 / 95,496 B |

These timings measure this policy scan only. Sorting still determines peak allocation, and enumerating all required later references can still require quadratic work. There is no end-to-end latency claim.

Environment: frozen repository dependencies, pinned uv 0.11.29, Python 3.14.6, Ruff 0.15.22 and npm Pyright 1.1.411. Local Node/npm are 24.19.0/11.9.0 rather than the repository's 26.5.0/12.0.1; GitHub CI owns the complete pinned toolchain and full suite.

Model and harness: GPT-based Codex in ChatGPT Work Mode; the exact model identifier is not exposed by this runtime.

The combined six-PR audit branch (#636, #637, #639, #641, #643, #647) passed 579 focused tests with 2 platform skips, lint/format checks over all 11 changed files, pinned Pyright with 0 errors, and the public-boundary scan of 1257 tracked files. A merge-tree check found no conflicts with PR #617 at `c3e661eb`; this checks merge compatibility, not runtime behavior of #617.

## Boundaries

- [x] No material from `docs/architecture/` or ignored private drafting inputs is included.
- [x] Tests use synthetic cases and isolated fixtures; no live service, vault, provider request, or paid call.
- [x] No dependency or retained cache added.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

Unresolved-action checks rebuilt a later action's subject frozenset for every candidate pair. Keep the later subjects as their existing immutable tuple and build a set only once for the unresolved action being examined. `isdisjoint` accepts that tuple directly. Actions with no subject now skip the scan because they cannot produce this finding.

This reduces repeated hashing and transient allocations while retaining every comparison and ordering rule.
