### PR TITLE
fix(codex): recognize proven absolute MCP launchers

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3720,7 +3720,8 @@ harness_unavailable|parse_failed|timeout|registration_failed|foreign_entry_prese
 `McpRegistrationResult`, and
 `McpRegistrationError`. `McpRegistrationObservation` carries `harness_id`, `state`,
 `route_profile` (`policy|strict|null`), and `isolation_binding`
-(`ambient|isolated_exact|missing|different|null`); route and binding are non-null only when the
+(`ambient|isolated_exact|missing|different|null`), plus optional internal `serve_command` carrying
+the exact observed owned argv for the applied-route record; route and binding are non-null only when the
 state is `yoetz_owned`, because a foreign or absent entry has no Yoetz route to describe.
 `observe_registration` reads exactly what `status_registration` reads, mutates nothing, and shares
 its `status` diagnostic phase. Each observation starts with `codex mcp get yoetz --json`; because a
@@ -3749,7 +3750,8 @@ success. The interactive approval surface prints the exact command, route, isola
 and preview digest. The preview binds the exact command, `policy|strict` route profile, and exact
 ADR-026 isolated root when present. Ambient external registrations carry no environment. Isolated
 external Codex registrations carry exactly one native `--env` pair,
-`YOETZ_ISOLATED_ROOT=<validated-root>`; a missing or different known root is re-registration drift,
+`YOETZ_ISOLATED_ROOT=<validated-root>`; a missing root is re-registration drift, as is a different
+known root on a legacy bare registration,
 while any arbitrary key, inherited-variable declaration, or malformed root makes the same-name
 entry foreign and preserves it. The route profile is
 explicit input:
@@ -3763,12 +3765,39 @@ is surfaced before mutation: the wizard preview and report carry `route_profile_
 ordinary digest-bound re-registration.
 The setup-wizard
 schema tokens are `yoetz.setup-wizard-marker/1`, `yoetz.setup-wizard-report/1`,
-`yoetz.setup-status/1`, `yoetz.mcp-registration-preview/1` (ambient) / `2` (isolated), and
-`yoetz.mcp-unregistration-preview/1` (ambient) / `2` (isolated); the marker lives at
+`yoetz.setup-status/1`, `yoetz.mcp-registration-preview/1` (ambient) / `2` (isolated) / `3`
+(installed absolute launcher), and `yoetz.mcp-unregistration-preview/1` (ambient) / `2`
+(isolated) / `3` (installed absolute launcher); the marker lives at
 `state_dir()/setup-wizard.json` via
 `config.paths.setup_marker_path`. The CLI surfaces are
 `yoetz setup run|status` and
 `yoetz integrate <harness> mcp status|preview|preview-remove|install|remove` (ADR-012).
+
+For issue #654, `mcp_command_profile` validates the shape of a bare or absolute console-script
+command with the exact current or legacy Codex serving suffix; it establishes no ownership.
+`adapters/integrations/codex_launcher.installed_launcher` supplies the adapter's ownership proof:
+the console script in the current interpreter's scripts directory must match exactly one SHA-256
+and size entry in that runtime's installed Yoetz RECORD. The executable and its ancestors must be
+non-symlink, owned by the current user or root, and not writable by group/others. For a pinned
+runtime, the validated root, instance identity, pin, lifetime, package version, and runtime prefix
+must agree. An absolute registration is owned only when its exact launcher matches that proof,
+its serving suffix is recognized, its transport is unambiguous and enabled, and its environment
+contains no unreviewed binding. A different root on an absolute registration is foreign, not a
+repair target. No candidate from host configuration is executed to establish this proof.
+
+New previews prefer that proven absolute console script. An installed CLI without valid proof
+refuses registration instead of falling back to PATH; embedded callers without an invoking
+launcher retain bare-command compatibility. Existing bare and legacy registrations remain
+recognizable for removal or an explicit migration to the absolute current command. Absolute
+preview digests bind the launcher bytes and proposed command/root; registration also binds the
+observed command/root so drift invalidates approval. Applied-route records preserve the exact
+observed argv, including its absolute launcher; their command validator checks shape, never
+confers ownership. Older records remain readable, and an older reader that cannot parse an
+absolute record retains its existing fail-soft missing-record behavior. CLI and terminal previews
+display that exact argv; provider status and preflight consume the shared ownership observation.
+This changes no workflow request/result schema, hook contract, or receipt format. The proof is
+installation-local integrity, not authentication against a machine owner who can rewrite both
+the installed script and RECORD.
 Standalone `yoetz provider endpoint` retains its explicit credential next command. When endpoint
 binding is embedded in the composed setup wizard, that standalone handoff is suppressed because
 the wizard still owns privacy consent and confidential ingress. Every visible yes/no prompt near

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -7,6 +7,10 @@ remote/web/cloud, synced/managed/user/local scopes, Agent SDK, or headless sessi
 
 ## What Yoetz generates
 
+Claude Code keeps the native carrier's marker-bound launcher identity described below. The
+installed-RECORD proof added for Codex external registration in #654 does not classify Claude
+sources or establish Claude activation; use this host's source-precedence and native-plugin checks.
+
 The managed marketplace source contains:
 
 ```text

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -616,7 +616,7 @@ For the Yoetz-owned external registration, issue #561 makes this propagation a s
 contract: an isolated preview displays and digest-binds the exact root, apply uses Codex's native
 `--env YOETZ_ISOLATED_ROOT=<exact-root>`, and status must report
 `isolation_binding=isolated_exact`. Ambient registration stores no environment. A missing or
-different known root requires re-registration; arbitrary environment keys, inherited-variable
+different known root on a bare registration requires re-registration; arbitrary environment keys, inherited-variable
 declarations, and malformed roots classify the same-name entry as foreign and are never replaced.
 Before a dogfood model task, use the app-server capture in the parity runbook to launch the real
 registered child and satisfy `mcp_child_isolation`; registration status alone is not child-start
@@ -632,6 +632,26 @@ name the everyday launcher by absolute path: a bare `command = "yoetz"` resolves
 and a test runtime earlier on `PATH` then reaches the everyday endpoint, answers
 `service_incompatible`, and its `yoetz service restart` advice supersedes the everyday service —
 the failure recorded on issue #604. See [`test-instances.md`](test-instances.md).
+
+Absolute external launchers are managed by the same preview/install/status/remove flow (#654).
+Run that flow from the installation you intend Codex to use. Preview selects its console script
+from that interpreter's scripts directory and verifies its bytes against the installed Yoetz
+RECORD; status recognizes only that exact absolute script, with recognized serving arguments
+and the reviewed root. A pinned instance must also have a matching pin and instance identity,
+current runtime provenance, and an unexpired lifetime. A basename, an executable bit, a different
+installation's matching version, or a path supplied by the host is insufficient.
+
+Review the command and root printed by `integrate codex mcp preview` before applying. An unchanged
+absolute registration is a no-op; explicit route changes preserve the launcher; removal previews
+name the current absolute command. Drift in the command, launcher evidence, or root invalidates
+the preview. Missing or modified launcher evidence, symlink/unsafe paths, conflicting transports,
+unexpected environment/arguments, and an absolute command bound to another root remain protected.
+If the installed CLI cannot prove its console script, repair that installation before registering.
+Symlink aliases and wrapper/module commands are not owned absolute console-script registrations;
+use the direct script printed by the installation's preview. Bare/legacy registrations remain
+recognizable for removal and explicit migration, without granting ownership to unrelated absolute
+binaries. Plugin/external dual ownership remains a blocker. Claude Code and Cursor keep their
+existing native-carrier identity rules; this repair changes only Codex external registration.
 
 ## Subscription evaluator is a separate Codex role
 

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -105,6 +105,10 @@ separate proof facets; a clean cell must verify which plugin directory Cursor ac
 
 ## MCP ownership and source precedence
 
+Cursor keeps its native carrier and installed-marker launcher identity. The installed-RECORD
+proof added for Codex external registration in #654 does not classify Cursor sources or establish
+Cursor activation; use the source-precedence and runtime facets below.
+
 Ownership mode is exactly `external_registration` or `plugin_managed`. Observed state is exactly
 `absent|external|plugin|dual|foreign|ambiguous`. Configuration source is plugin, project, user,
 inline-create, or inline-send. Preserve duplicate and foreign same-name entries.

--- a/docs/runbooks/test-instances.md
+++ b/docs/runbooks/test-instances.md
@@ -89,6 +89,14 @@ launcher (never a bare `yoetz`) and, for Codex external registration and Cursor 
 the root binding those hosts already carry. The everyday install keeps its own registrations
 untouched.
 
+For Codex external registration, run `integrate codex mcp preview|install|status|preview-remove|remove`
+through that snapshot's own absolute launcher and the explicitly selected testing Codex home.
+The preview now emits the snapshot's direct console script, verified against its installed RECORD
+and runtime pin (#654). Status should report `yoetz_owned` and `isolated_exact`; repeat install is
+a no-op, and an explicit route change keeps the same executable. A different instance's launcher
+or root, a symlink alias, or modified script is protected as foreign. Use the direct command in
+the preview, and still obtain real registered-child evidence before passing the parity gate.
+
 Ordinary source tests do not need an instance: `uv run pytest <path>` from the checkout uses the
 checkout's `.venv`, which is unpinned. Provision an instance when a test or dogfood must exercise
 an installed launcher, a real service, a host registration, or the upgrade path.

--- a/src/yoetz/adapters/integrations/codex_launcher.py
+++ b/src/yoetz/adapters/integrations/codex_launcher.py
@@ -1,0 +1,84 @@
+"""Read-only proof of this runtime's installed console script, never a PATH probe."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import stat
+import sys
+import sysconfig
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
+
+from yoetz import __version__
+from yoetz.config.installation import (
+    InstanceIdentityError,
+    read_instance_identity,
+    runtime_prefix_digest,
+    verify_instance_binding,
+)
+from yoetz.config.paths import PathSafetyError, isolated_root, read_runtime_pin
+
+
+def installed_launcher() -> tuple[str, str] | None:
+    """Return the exact script and digest only while its installed RECORD still matches.
+
+    The candidate comes from this interpreter's scripts directory and its Yoetz distribution,
+    not the host entry or a caller-supplied pathname. Symlinks, writable-by-others paths,
+    missing/ambiguous RECORD entries and modified scripts never establish ownership. This
+    proves local installation identity, not publisher authenticity against the machine owner.
+    """
+
+    try:
+        pin = read_runtime_pin()
+        if pin is not None:
+            root = isolated_root()
+            if root is None:
+                return None
+            identity = read_instance_identity(root / "state")
+            verify_instance_binding(identity, isolated=True, pin=pin, now=datetime.now(UTC))
+            if identity is None or (
+                identity.runtime_prefix_digest != runtime_prefix_digest(Path(sys.prefix))
+                or identity.package_version != __version__
+            ):
+                return None
+        candidate = Path(sysconfig.get_path("scripts")) / "yoetz"
+        if not candidate.is_absolute() or len(str(candidate)) > 4096:
+            return None
+        if any(ord(c) < 32 or ord(c) == 127 for c in str(candidate)):
+            return None
+        for path in (candidate, *candidate.parents):
+            facts = path.lstat()
+            if stat.S_ISLNK(facts.st_mode) or facts.st_mode & 0o022:
+                return None
+            if facts.st_uid not in {0, os.geteuid()}:
+                return None
+        facts = candidate.lstat()
+        if not stat.S_ISREG(facts.st_mode) or not os.access(candidate, os.X_OK):
+            return None
+        if facts.st_size > 65_536:
+            return None
+        package = distribution("yoetz")
+        matches = [
+            entry
+            for entry in package.files or ()
+            if Path(os.path.abspath(str(package.locate_file(entry)))) == candidate
+        ]
+        if len(matches) != 1:
+            return None
+        entry = matches[0]
+        expected = entry.hash
+        if expected is None or expected.mode != "sha256" or entry.size != facts.st_size:
+            return None
+        with candidate.open("rb") as stream:
+            raw = stream.read(65_537)
+        if len(raw) != entry.size:
+            return None
+        digest = hashlib.sha256(raw)
+        if base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode() != expected.value:
+            return None
+        return str(candidate), "sha256:" + digest.hexdigest()
+    except OSError, ValueError, PackageNotFoundError, InstanceIdentityError, PathSafetyError:
+        return None

--- a/src/yoetz/adapters/integrations/codex_mcp.py
+++ b/src/yoetz/adapters/integrations/codex_mcp.py
@@ -2,8 +2,9 @@
 
 Automates exactly the runbook's manual check-then-add sequence:
 ``codex mcp get yoetz --json`` first, a bounded ``codex mcp list --json``
-fallback when ``get`` fails, and ``codex mcp add yoetz -- yoetz mcp serve --host codex``
-only after absence is positively observed. A foreign same-name entry is never replaced.
+fallback when ``get`` fails, and registration of this runtime's proven absolute console script
+after absence is positively observed or an owned re-registration is accepted. Bare and legacy
+entries remain recognizable. A foreign same-name entry is never replaced.
 """
 
 from __future__ import annotations
@@ -14,9 +15,10 @@ import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from types import MappingProxyType
 from typing import Final, Literal, cast
 
+from yoetz.adapters.integrations.codex_launcher import installed_launcher
+from yoetz.adapters.integrations.launcher import invoking_launcher
 from yoetz.config.paths import ISOLATED_ROOT_ENV, PathSafetyError, isolated_root
 from yoetz.domain.values import JsonValue
 from yoetz.ports.harness_mcp import (
@@ -34,6 +36,7 @@ from yoetz.ports.harness_mcp import (
     McpRegistrationReason,
     McpRegistrationResult,
     McpRegistrationState,
+    mcp_command_profile,
 )
 from yoetz.ports.integrations import HarnessId
 from yoetz.protocol.canonical import canonical_digest
@@ -45,17 +48,6 @@ __all__ = [
 
 _COMMAND_TIMEOUT_SECONDS: Final = 10.0
 _OUTPUT_LIMIT_BYTES: Final = 65_536
-# The registered argv is the only durable evidence of which route the agent actually gets.
-_ROUTE_PROFILE_BY_COMMAND: Final[Mapping[tuple[str, ...], Literal["policy", "strict"]]] = (
-    MappingProxyType(
-        {
-            MCP_SERVE_COMMAND: "policy",
-            MCP_STRICT_SERVE_COMMAND: "strict",
-            MCP_LEGACY_SERVE_COMMAND: "policy",
-            MCP_LEGACY_STRICT_SERVE_COMMAND: "strict",
-        }
-    )
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,8 +145,8 @@ def _entry_isolated_root(entry: Mapping[str, object]) -> tuple[bool, str | None]
 
     The command tokens establish Yoetz ownership; this separate parser refuses to bless a
     same-command entry with any other environment key, inherited variable, or malformed root.
-    A known but different absolute root remains readable so the digest-bound lifecycle can
-    re-register or remove the Yoetz-owned entry without gaining an arbitrary-env force path.
+    A known but different absolute root remains readable for legacy bare-command repair;
+    absolute-launcher classification additionally requires this runtime's exact root.
     """
 
     transport = entry.get("transport")
@@ -209,11 +201,23 @@ class CodexMcpAdapter:
     def _run(self, argv: tuple[str, ...]) -> CommandOutput:
         return self._runner(argv)
 
-    @staticmethod
     def _classify_entry(
+        self,
         entry: Mapping[str, object],
     ) -> tuple[McpRegistrationState, tuple[str, ...] | None, str | None]:
         tokens = _entry_command_tokens(entry)
+        if tokens and tokens[0] != "yoetz" and mcp_command_profile(tokens) is not None:
+            proof = installed_launcher()
+            readable, root = _entry_isolated_root(entry)
+            if (
+                proof is not None
+                and tokens[0] == proof[0]
+                and readable
+                and (root is None or root == self._expected_isolated_root())
+                and self._unambiguous_absolute_entry(entry)
+            ):
+                return McpRegistrationState.YOETZ_OWNED, tokens, root
+            return McpRegistrationState.FOREIGN_PRESENT, None, None
         for command in (
             MCP_STRICT_SERVE_COMMAND,
             MCP_SERVE_COMMAND,
@@ -229,6 +233,36 @@ class CodexMcpAdapter:
                 return McpRegistrationState.YOETZ_OWNED, command, registered_root
         # An unreadable or different command is preserved, never replaced.
         return McpRegistrationState.FOREIGN_PRESENT, None, None
+
+    @staticmethod
+    def _unambiguous_absolute_entry(entry: Mapping[str, object]) -> bool:
+        """Do not choose between conflicting transport definitions or execution modifiers."""
+
+        transport = entry.get("transport")
+        source = entry
+        if transport is not None:
+            if not isinstance(transport, Mapping):
+                return False
+            if any(key in entry for key in ("command", "args", "env", "env_vars", "cwd", "url")):
+                return False
+            source = cast(Mapping[str, object], transport)
+        return (
+            source.get("type") in (None, "stdio")
+            and source.get("cwd") is None
+            and source.get("url") is None
+            and isinstance(source.get("command"), str)
+            and entry.get("enabled", True) is True
+        )
+
+    def _desired_command(self) -> tuple[tuple[str, ...], str | None]:
+        proof = installed_launcher()
+        if proof is not None:
+            return (proof[0], *self._serve_command[1:]), proof[1]
+        # Embedded clients retain the historical bare command. An installed CLI with missing
+        # or modified launcher evidence must never quietly fall back to PATH.
+        if invoking_launcher() is not None:
+            raise McpRegistrationError(McpRegistrationReason.HARNESS_UNAVAILABLE, {})
+        return self._serve_command, None
 
     def _classify_get(
         self, output: CommandOutput
@@ -290,7 +324,7 @@ class CodexMcpAdapter:
         self._require_codex(binary)
         expected_root = self._expected_isolated_root()
         state, command, registered_root = self._observe_registration_state(binary)
-        route_profile = None if command is None else _ROUTE_PROFILE_BY_COMMAND.get(command)
+        route_profile = None if command is None else mcp_command_profile(command)
         isolation_binding = None
         if state is McpRegistrationState.YOETZ_OWNED:
             if expected_root is None and registered_root is None:
@@ -306,6 +340,7 @@ class CodexMcpAdapter:
             state,
             route_profile,
             isolation_binding,
+            command,
         )
 
     @staticmethod
@@ -332,13 +367,14 @@ class CodexMcpAdapter:
         current_root: str | None,
     ) -> McpRegistrationPreview:
         expected_root = self._expected_isolated_root()
+        serve_command, launcher_digest = self._desired_command()
         action = (
             McpRegistrationAction.REGISTER
             if state is McpRegistrationState.ABSENT
             else (
                 McpRegistrationAction.REREGISTER
                 if state is McpRegistrationState.YOETZ_OWNED
-                and (current_command != self._serve_command or current_root != expected_root)
+                and (current_command != serve_command or current_root != expected_root)
                 else McpRegistrationAction.NOOP
             )
         )
@@ -350,13 +386,20 @@ class CodexMcpAdapter:
             "executable_path": binary.executable_path,
             "harness": binary.harness_id.value,
             "schema": "yoetz.mcp-registration-preview/1",
-            "serve_command": list(self._serve_command),
+            "serve_command": list(serve_command),
             "server_name": MCP_SERVER_NAME,
             "state_before": state.value,
         }
         if expected_root is not None:
             digest_input["schema"] = "yoetz.mcp-registration-preview/2"
             digest_input["isolated_root"] = expected_root
+        if launcher_digest is not None:
+            digest_input.update(
+                schema="yoetz.mcp-registration-preview/3",
+                launcher_digest=launcher_digest,
+                current_command=current_command,
+                current_root=current_root,
+            )
         digest = canonical_digest(cast(JsonValue, digest_input))
         return McpRegistrationPreview(
             binary.harness_id,
@@ -364,7 +407,7 @@ class CodexMcpAdapter:
             state,
             warnings,
             digest,
-            self._serve_command,
+            serve_command,
             self._route_profile,
             expected_root,
         )
@@ -410,7 +453,7 @@ class CodexMcpAdapter:
                 MCP_SERVER_NAME,
                 *environment_args,
                 "--",
-                *self._serve_command,
+                *preview.serve_command,
             )
         )
         if add_output.exit_code != 0:
@@ -422,7 +465,7 @@ class CodexMcpAdapter:
         state_after, command_after, root_after = self._observe_registration_state(binary)
         if (
             state_after is not McpRegistrationState.YOETZ_OWNED
-            or command_after != self._serve_command
+            or command_after != preview.serve_command
             or root_after != preview.isolated_root
         ):
             raise McpRegistrationError(
@@ -460,10 +503,10 @@ class CodexMcpAdapter:
         if (
             state is McpRegistrationState.YOETZ_OWNED
             and current_command is not None
-            and current_command in _ROUTE_PROFILE_BY_COMMAND
+            and mcp_command_profile(current_command) is not None
         ):
             serve_command = current_command
-            route_profile = _ROUTE_PROFILE_BY_COMMAND[current_command]
+            route_profile = cast(Literal["policy", "strict"], mcp_command_profile(current_command))
         else:
             # Never copy a foreign argv into the preview shape. The digest still
             # binds ``state_before``, so apply refuses the same-name entry.
@@ -481,6 +524,10 @@ class CodexMcpAdapter:
         if current_root is not None:
             digest_input["schema"] = "yoetz.mcp-unregistration-preview/2"
             digest_input["isolated_root"] = current_root
+        if serve_command[0] != "yoetz":
+            proof = installed_launcher()
+            digest_input["schema"] = "yoetz.mcp-unregistration-preview/3"
+            digest_input["launcher_digest"] = None if proof is None else proof[1]
         digest = canonical_digest(cast(JsonValue, digest_input))
         return McpRegistrationPreview(
             binary.harness_id,

--- a/src/yoetz/application/applied_mcp_route.py
+++ b/src/yoetz/application/applied_mcp_route.py
@@ -29,6 +29,7 @@ from yoetz.ports.harness_mcp import (
     MCP_LEGACY_STRICT_SERVE_COMMAND,
     MCP_SERVE_COMMAND,
     MCP_STRICT_SERVE_COMMAND,
+    mcp_command_profile,
 )
 from yoetz.protocol.canonical import JsonValue, canonical_digest, canonical_encode
 
@@ -104,7 +105,10 @@ def _validate_command(value: object, *, allowed: tuple[tuple[str, ...], ...]) ->
         if type(entry) is not str:
             raise ValueError("applied_mcp_route_command_invalid")
         items.append(entry)
-    if tuple(items) not in allowed:
+    command = tuple(items)
+    if mcp_command_profile(command) is None or not any(
+        command[1:] == template[1:] for template in allowed
+    ):
         raise ValueError("applied_mcp_route_command_invalid")
     return items
 

--- a/src/yoetz/application/harness_mcp.py
+++ b/src/yoetz/application/harness_mcp.py
@@ -323,7 +323,7 @@ class HarnessMcpService:
             profile = preview.route_profile
             if profile != "policy" and profile != "strict":
                 return
-            serve_command = MCP_STRICT_SERVE_COMMAND if profile == "strict" else MCP_SERVE_COMMAND
+            serve_command = preview.serve_command
             record_applied_route(
                 profile,
                 list(serve_command),
@@ -376,7 +376,9 @@ class HarnessMcpService:
             if profile != "policy" and profile != "strict":
                 _clear_stale()
                 return
-            serve_command = MCP_STRICT_SERVE_COMMAND if profile == "strict" else MCP_SERVE_COMMAND
+            serve_command = observation.serve_command or (
+                MCP_STRICT_SERVE_COMMAND if profile == "strict" else MCP_SERVE_COMMAND
+            )
             try:
                 record_applied_route(
                     profile,

--- a/src/yoetz/cli/setup.py
+++ b/src/yoetz/cli/setup.py
@@ -14,6 +14,7 @@ import contextlib
 import importlib.util
 import io
 import os
+import shlex
 import sys
 import tempfile
 from collections.abc import Awaitable, Callable, Mapping
@@ -748,7 +749,7 @@ def _emit_registration_preview(
     typer.echo("  3. Register the Yoetz MCP server with Codex")
     typer.echo("  MCP server name: yoetz")
     serve_command = getattr(mcp_preview, "serve_command", ())
-    typer.echo(f"  Command: {' '.join(serve_command)}")
+    typer.echo(f"  Command: {shlex.join(serve_command)}")
     isolated_root = getattr(mcp_preview, "isolated_root", None)
     typer.echo(
         "  MCP isolation root: " + (str(isolated_root) if isolated_root is not None else "ambient")
@@ -838,7 +839,7 @@ def _emit_unregistration_preview(mcp_preview: object) -> None:
     typer.echo(f"  Action: {getattr(mcp_preview, 'action').value}")
     typer.echo(f"  State before: {getattr(mcp_preview, 'state_before').value}")
     serve_command = getattr(mcp_preview, "serve_command", ())
-    typer.echo(f"  Command: {' '.join(serve_command)}")
+    typer.echo(f"  Command: {shlex.join(serve_command)}")
     isolated_root = getattr(mcp_preview, "isolated_root", None)
     typer.echo(
         "  MCP isolation root: " + (str(isolated_root) if isolated_root is not None else "ambient")

--- a/src/yoetz/ports/harness_mcp.py
+++ b/src/yoetz/ports/harness_mcp.py
@@ -6,7 +6,8 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Final, Literal, Protocol
+from pathlib import PurePosixPath
+from typing import Final, Literal, Protocol, cast
 
 from yoetz.domain.values import JsonObject, JsonValue, validate_sha256_digest
 from yoetz.ports.integrations import HarnessId
@@ -45,6 +46,31 @@ _TOKEN_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,127}$", re.ASCII
 
 type Compatibility = Literal["supported", "untested"]
 type McpIsolationBinding = Literal["ambient", "isolated_exact", "missing", "different"]
+
+
+def mcp_command_profile(command: tuple[str, ...]) -> Literal["policy", "strict"] | None:
+    """Validate command shape only; executable ownership belongs to the adapter."""
+
+    if type(command) is not tuple or not command or any(type(x) is not str for x in command):
+        return None
+    launcher = command[0]
+    if launcher != "yoetz" and (
+        not launcher.startswith("/")
+        or len(launcher) > _MAX_PATH_CHARS
+        or str(PurePosixPath(launcher)) != launcher
+        or ".." in PurePosixPath(launcher).parts
+        or any(ord(c) < 32 or ord(c) == 127 for c in launcher)
+    ):
+        return None
+    for template, profile in (
+        (MCP_SERVE_COMMAND, "policy"),
+        (MCP_STRICT_SERVE_COMMAND, "strict"),
+        (MCP_LEGACY_SERVE_COMMAND, "policy"),
+        (MCP_LEGACY_STRICT_SERVE_COMMAND, "strict"),
+    ):
+        if command[1:] == template[1:]:
+            return cast(Literal["policy", "strict"], profile)
+    return None
 
 
 def _port_error(reason: str) -> ProtocolValueError:
@@ -144,18 +170,9 @@ class McpRegistrationPreview:
                 raise _port_error("integration_value_invalid")
             previous = warning
         validate_sha256_digest(self.preview_digest)
-        expected_command = (
-            MCP_STRICT_SERVE_COMMAND if self.route_profile == "strict" else MCP_SERVE_COMMAND
-        )
-        legacy_command = (
-            MCP_LEGACY_STRICT_SERVE_COMMAND
-            if self.route_profile == "strict"
-            else MCP_LEGACY_SERVE_COMMAND
-        )
-        if self.route_profile not in {"policy", "strict"} or self.serve_command not in {
-            expected_command,
-            legacy_command,
-        }:
+        if self.route_profile not in {"policy", "strict"} or (
+            mcp_command_profile(self.serve_command) != self.route_profile
+        ):
             raise _port_error("integration_value_invalid")
         if self.isolated_root is not None and (
             type(self.isolated_root) is not str
@@ -180,12 +197,19 @@ class McpRegistrationObservation:
     state: McpRegistrationState
     route_profile: Literal["policy", "strict"] | None
     isolation_binding: McpIsolationBinding | None = None
+    serve_command: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if type(self.harness_id) is not HarnessId:
             raise _port_error("integration_harness_invalid")
         if type(self.state) is not McpRegistrationState:
             raise _port_error("integration_state_invalid")
+        if self.serve_command is not None and (
+            self.state is not McpRegistrationState.YOETZ_OWNED
+            or self.route_profile is None
+            or mcp_command_profile(self.serve_command) != self.route_profile
+        ):
+            raise _port_error("integration_value_invalid")
         if self.route_profile is None:
             if self.isolation_binding is not None:
                 raise _port_error("integration_value_invalid")

--- a/src/yoetz/tui/runtime.py
+++ b/src/yoetz/tui/runtime.py
@@ -18,6 +18,7 @@ by the owning service and merely transcribed here.
 
 from __future__ import annotations
 
+import shlex
 import sys
 from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -100,19 +101,6 @@ def _host_admission_detail(provider: ProviderPosture) -> str:
     if all(state == "absent" for _host, state in provider.host_admission):
         return f"{summary}; 'yoetz integrate <host> admission preview' to admit the check"
     return summary
-
-
-def _serve_command_display(route_profile: Literal["policy", "strict"]) -> str:
-    """Render the exact argv this route registers, for the screen that asks for approval.
-
-    A fixed string here would show ``yoetz mcp serve`` while registering the strict command,
-    which is the one line on that screen the human is being asked to approve.
-    """
-
-    # Local import: the ports module stays off the TUI's startup path.
-    from yoetz.ports.harness_mcp import MCP_SERVE_COMMAND, MCP_STRICT_SERVE_COMMAND
-
-    return " ".join(MCP_STRICT_SERVE_COMMAND if route_profile == "strict" else MCP_SERVE_COMMAND)
 
 
 def _mapping(value: object) -> Mapping[str, object]:
@@ -452,7 +440,7 @@ class YoetzRuntime:
             reported_version=option.reported_version,
             project_root=str(root),
             route_profile=route,
-            mcp_command=_serve_command_display(route),
+            mcp_command=shlex.join(mcp_preview.serve_command),
             mcp_server_name=_MCP_SERVER_NAME,
             policy_digest=digest if isinstance(digest, str) else None,
             planned_check_ids=tuple(str(item) for item in checks)

--- a/tests/packaging/test_codex_mcp_isolated_registration.py
+++ b/tests/packaging/test_codex_mcp_isolated_registration.py
@@ -139,6 +139,11 @@ def test_installed_codex_child_receives_only_the_reviewed_isolated_root(
         monkeypatch.setenv("CODEX_HOME", str(codex_home))
         monkeypatch.setenv("CODEX_TESTING_HOME", str(codex_home))
         monkeypatch.setenv(ISOLATED_ROOT_ENV, str(isolated_root))
+        # This existing compatibility cell intentionally exercises the legacy PATH registration
+        # with a synthetic child; issue #654's test below exercises a proven installed launcher.
+        monkeypatch.setattr(
+            "yoetz.adapters.integrations.codex_mcp.installed_launcher", lambda: None
+        )
 
         binary = HarnessBinary(HarnessId.CODEX, str(codex), "0.150.1", "supported")
         service = HarnessMcpService(CodexMcpAdapter(route_profile="strict"))
@@ -215,3 +220,183 @@ def test_installed_codex_child_receives_only_the_reviewed_isolated_root(
             root.parent.rmdir()
         except OSError:
             pass
+
+
+_PACKAGED_DRIVER: Final = r"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from yoetz.adapters.integrations.codex_mcp import CodexMcpAdapter
+from yoetz.application.harness_mcp import HarnessMcpService, McpRegistrationConfirmation
+from yoetz.application.applied_mcp_route import read_applied_route
+from yoetz.cli.provider_status import mcp_route_observation
+from yoetz.config.paths import isolated_root
+from yoetz.ports.harness_mcp import HarnessBinary
+from yoetz.ports.integrations import HarnessId
+
+async def main():
+    codex, stage = sys.argv[1:]
+    binary = HarnessBinary(HarnessId.CODEX, codex, "0.150.1", "supported")
+    service = HarnessMcpService(CodexMcpAdapter(route_profile="strict" if stage == "strict" else "policy"))
+    if stage == "probe":
+        registration = subprocess.run([codex, "mcp", "get", "yoetz", "--json"], capture_output=True, check=True)
+        entry = json.loads(registration.stdout)["transport"]
+        child_env = {**os.environ, **entry["env"]}
+        isolated = subprocess.run([entry["command"], "service", "isolation", "--json"], env=child_env, capture_output=True, check=True)
+        identity = json.loads(isolated.stdout)
+        assert identity["mode"] == "isolated"
+        assert identity["binding"] == "environment_and_pin"
+        dropped = subprocess.run([entry["command"], "service", "isolation", "--json"], env=os.environ, capture_output=True, check=True)
+        pinned = json.loads(dropped.stdout)
+        assert pinned["binding"] == "runtime_pin"
+        assert pinned["identity"] == identity["identity"]
+        params = StdioServerParameters(command=entry["command"], args=entry["args"], env={**os.environ, **entry["env"]})
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as client:
+                await client.initialize()
+                tools = await client.list_tools()
+                assert len(tools.tools) == 7
+                result = await client.call_tool("read_guidance", {"uri":"yoetz://guidance/workflow.md"})
+                assert not result.isError
+                assert any("workflow" in getattr(item, "text", "") for item in result.content)
+        print(json.dumps({"tools": len(tools.tools), "guidance": "success"}))
+        return
+    if stage == "status":
+        observation = await service.observe(binary)
+        route = await mcp_route_observation(Path.cwd())
+        print(json.dumps({"state": observation.state.value, "binding": observation.isolation_binding,
+                          "profile": observation.route_profile, "route": route}))
+        return
+    removing = stage == "remove"
+    preview = await (service.preview_unregistration(binary) if removing else service.preview(binary))
+    confirm = McpRegistrationConfirmation(preview.preview_digest, True, "noninteractive_flag")
+    result = await (service.unregister(binary, confirm) if removing else service.register(binary, confirm))
+    print(json.dumps({"action": result.action.value, "after": result.state_after.value,
+                      "command": preview.serve_command, "root": str(isolated_root()),
+                      "record": read_applied_route()}))
+
+anyio.run(main)
+"""
+
+
+def test_packaged_absolute_launcher_with_real_codex() -> None:
+    """A runtime-pinned wheel is owned and usable through Codex without ambient inheritance."""
+
+    codex = _installed_codex_01501()
+    root = _short_private_root()
+    script = _REPO_ROOT / "scripts" / "provision_test_instance.py"
+    base = root / "instances"
+    base.mkdir(mode=0o700)
+    env = {name: value for name, value in os.environ.items() if not name.startswith("YOETZ_")}
+    codex_home = root / "codex"
+    codex_home.mkdir(mode=0o700)
+    env.update(CODEX_HOME=str(codex_home), CODEX_TESTING_HOME=str(codex_home))
+    try:
+        created = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "create",
+                "--base",
+                str(base),
+                "--tag",
+                "a",
+                "--lifecycle",
+                "disposable",
+                "--allow-dirty",
+                "--json",
+            ],
+            env=env,
+            capture_output=True,
+            timeout=300,
+            check=False,
+        )
+        assert created.returncode == 0, created.stderr.decode(errors="replace")
+        launcher = Path(json.loads(created.stdout)["launcher"])
+        driver = root / "driver.py"
+        driver.write_text(_PACKAGED_DRIVER, encoding="utf-8")
+
+        def run(stage: str) -> dict[str, object]:
+            result = subprocess.run(
+                [str(launcher.parent / "python"), str(driver), str(codex), stage],
+                cwd=root,
+                env=env,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            assert result.returncode == 0, result.stderr.decode(errors="replace")
+            return cast(dict[str, object], json.loads(result.stdout))
+
+        registered = run("install")
+        assert registered["action"] == "register"
+        assert registered["after"] == "yoetz_owned"
+        assert cast(list[str], registered["command"])[0] == str(launcher)
+        assert (
+            cast(dict[str, object], registered["record"])["applied_serve_command"]
+            == registered["command"]
+        )
+        assert run("install")["action"] == "noop"
+        status = run("status")
+        assert status["state"] == "yoetz_owned"
+        assert status["binding"] == "isolated_exact"
+        route = cast(dict[str, object], status["route"])
+        assert route["ownership_state"] == "external"
+        assert route["registered_profile"] == "policy"
+        assert run("probe") == {"tools": 7, "guidance": "success"}
+
+        # Codex itself starts the registered wheel, with no parent isolation variable. Its
+        # inventory must expose the real seven-tool server, not the synthetic compatibility stub.
+        capture = root / "inventory.json"
+        captured = subprocess.run(
+            [
+                sys.executable,
+                str(_REPO_ROOT / "scripts" / "capture_codex_mcp_surface.py"),
+                "--codex-binary",
+                str(codex),
+                "--codex-testing-home",
+                str(codex_home),
+                "--output",
+                str(capture),
+            ],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            timeout=60,
+            check=False,
+        )
+        assert captured.returncode == 0, captured.stderr.decode(errors="replace")
+        entries = json.loads(capture.read_bytes())["inventory"]["result"]["data"]
+        assert len(entries) == 1
+        assert len(entries[0]["tools"]) == 7
+        assert entries[0]["serverInfo"]["name"] == "yoetz"
+        assert run("strict")["action"] == "reregister"
+        assert run("status")["profile"] == "strict"
+        assert run("remove")["after"] == "absent"
+        assert run("remove")["action"] == "noop"
+    finally:
+        if (base / "a").exists():
+            disposed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "dispose",
+                    "--base",
+                    str(base),
+                    "--tag",
+                    "a",
+                    "--json",
+                ],
+                env=env,
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            assert disposed.returncode == 0, disposed.stderr.decode(errors="replace")
+        shutil.rmtree(root, ignore_errors=True)

--- a/tests/subprocess/test_setup_wizard_cli.py
+++ b/tests/subprocess/test_setup_wizard_cli.py
@@ -78,9 +78,11 @@ class _ScriptedRunner:
 
 def _yoetz_entry(
     route_profile: Literal["policy", "strict"] = "strict",
+    *,
+    launcher: str = "yoetz",
 ) -> CommandOutput:
     command = MCP_STRICT_SERVE_COMMAND if route_profile == "strict" else MCP_SERVE_COMMAND
-    return CommandOutput(0, json.dumps({"command": command[0], "args": list(command[1:])}).encode())
+    return CommandOutput(0, json.dumps({"command": launcher, "args": list(command[1:])}).encode())
 
 
 def _absent_mcp() -> list[CommandOutput]:
@@ -92,6 +94,11 @@ def _absent_mcp() -> list[CommandOutput]:
 @pytest.fixture
 def wizard_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, object]:
     """Fake discovery, adapter subprocesses, service client, and marker path."""
+
+    # These scripted entries model the legacy embedded/bare-launcher cell, not whichever
+    # wheel happens to host pytest. Absolute installation proof is supplied explicitly in
+    # the absolute CLI regression below and exercised for real by the packaged Codex test.
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.installed_launcher", lambda: None)
 
     state: dict[str, object] = {
         "binaries": (_binary(),),
@@ -1699,6 +1706,48 @@ def test_integrate_mcp_explicit_route_profile_reregisters(
     body = json.loads(result.stdout)
     assert body["action"] == "reregister"
     assert body["state_after"] == "yoetz_owned"
+
+
+def test_absolute_mcp_cli_preserves_launcher_and_route(
+    wizard_env: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    launcher = "/test/Yoetz Runtime/bin/yoetz"
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.codex_mcp.installed_launcher",
+        lambda: (launcher, "sha256:" + "e" * 64),
+    )
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: None)
+    wizard_env["outputs"] = _absent_mcp()
+    preview = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "preview", "--json"])
+    assert preview.exit_code == 0, (preview.output, preview.exception)
+    assert json.loads(preview.stdout)["serve_command"][0] == launcher
+    wizard_env["outputs"] = [
+        *_absent_mcp(),
+        *_absent_mcp(),
+        CommandOutput(0, b""),
+        _yoetz_entry(launcher=launcher),
+        _yoetz_entry(launcher=launcher),
+    ]
+    installed = _RUNNER.invoke(
+        cli.app, ["integrate", "codex", "mcp", "install", "--accept", "--json"]
+    )
+    assert installed.exit_code == 0, (installed.output, installed.exception)
+    assert json.loads(installed.stdout)["state_after"] == "yoetz_owned"
+    calls = [
+        call for group in cast(list[list[tuple[str, ...]]], wizard_env["calls"]) for call in group
+    ]
+    additions = [call for call in calls if call[1:3] == ("mcp", "add")]
+    assert additions[0][additions[0].index("--") + 1] == launcher
+
+    # No explicit route input must retain the existing policy route, even though setup's
+    # configured default in this fixture is strict.
+    wizard_env["outputs"] = [
+        _yoetz_entry("policy", launcher=launcher),
+        _yoetz_entry("policy", launcher=launcher),
+    ]
+    noop = _RUNNER.invoke(cli.app, ["integrate", "codex", "mcp", "install", "--accept", "--json"])
+    assert noop.exit_code == 0, (noop.output, noop.exception)
+    assert json.loads(noop.stdout)["action"] == "noop"
 
 
 def test_setup_surfaces_no_secret_shaped_option() -> None:

--- a/tests/unit/adapters/test_codex_absolute_launcher.py
+++ b/tests/unit/adapters/test_codex_absolute_launcher.py
@@ -1,0 +1,316 @@
+"""Absolute registrations require the current installation's byte-bound console script."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import tempfile
+from collections.abc import Iterator
+from importlib.metadata import FileHash, PackagePath
+from pathlib import Path
+
+import anyio
+import pytest
+
+from yoetz.adapters.integrations import codex_launcher
+from yoetz.adapters.integrations.codex_launcher import installed_launcher
+from yoetz.adapters.integrations.codex_mcp import CodexMcpAdapter, CommandOutput
+from yoetz.application.applied_mcp_route import read_applied_route
+from yoetz.application.harness_mcp import HarnessMcpService, McpRegistrationConfirmation
+from yoetz.config.paths import PathSafetyError
+from yoetz.ports.harness_mcp import (
+    HarnessBinary,
+    McpRegistrationAction,
+    McpRegistrationCommand,
+    McpRegistrationError,
+    McpRegistrationReason,
+    McpRegistrationState,
+)
+from yoetz.ports.integrations import HarnessId
+
+_BINARY = HarnessBinary(HarnessId.CODEX, "/test/codex", "0.150.1", "supported")
+
+
+@pytest.fixture
+def private_root() -> Iterator[Path]:
+    # The launcher gate deliberately refuses shared/writable ancestors, including /tmp.
+    with tempfile.TemporaryDirectory(prefix=".yz654-", dir=Path.home()) as root:
+        yield Path(root)
+
+
+@pytest.fixture
+def launcher(private_root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = private_root
+    script = root / "yoetz"
+    raw = b"#!/test/python\nfrom yoetz.cli.app import main\nmain()\n"
+    script.write_bytes(raw)
+    script.chmod(0o700)
+    record = PackagePath("yoetz")
+    record.hash = FileHash(
+        "sha256=" + base64.urlsafe_b64encode(hashlib.sha256(raw).digest()).rstrip(b"=").decode()
+    )
+    record.size = len(raw)
+
+    class Package:
+        files = [record]
+
+        def locate_file(self, path: PackagePath) -> Path:
+            return root / path
+
+    def package(_name: str) -> Package:
+        return Package()
+
+    def scripts(_name: str) -> str:
+        return str(root)
+
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_launcher.distribution", package)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_launcher.sysconfig.get_path", scripts)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: root)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_launcher.read_runtime_pin", lambda: None)
+    assert installed_launcher() is not None
+    return script
+
+
+def test_absolute_registration_is_owned(launcher: Path) -> None:
+    entry = {
+        "command": str(launcher),
+        "args": ["mcp", "serve", "--host", "codex"],
+        "env": {"YOETZ_ISOLATED_ROOT": str(launcher.parent)},
+    }
+    adapter = CodexMcpAdapter(lambda _: CommandOutput(0, json.dumps(entry).encode()))
+    observed = anyio.run(lambda: adapter.observe_registration(_BINARY))
+    assert observed.state is McpRegistrationState.YOETZ_OWNED
+    assert observed.route_profile == "policy"
+    assert observed.isolation_binding == "isolated_exact"
+
+
+class Host:
+    def __init__(self, entry: dict[str, object] | None = None) -> None:
+        self.entry = entry
+        self.mutations: list[tuple[str, ...]] = []
+
+    def __call__(self, argv: tuple[str, ...]) -> CommandOutput:
+        if argv[2] == "get":
+            return (
+                CommandOutput(1, b"")
+                if self.entry is None
+                else CommandOutput(0, json.dumps(self.entry).encode())
+            )
+        if argv[2] == "list":
+            return CommandOutput(0, b"[]")
+        self.mutations.append(argv)
+        if argv[2] == "remove":
+            self.entry = None
+        else:
+            index = argv.index("--")
+            entry: dict[str, object] = {"command": argv[index + 1], "args": list(argv[index + 2 :])}
+            self.entry = entry
+            if "--env" in argv:
+                key, value = argv[argv.index("--env") + 1].split("=", 1)
+                self.entry["env"] = {key: value}
+        return CommandOutput(0, b"")
+
+
+def test_absolute_lifecycle_preserves_command_and_applied_route(launcher: Path) -> None:
+    host = Host()
+    adapter = CodexMcpAdapter(host)
+    service = HarnessMcpService(adapter)
+    preview = anyio.run(lambda: adapter.preview_registration(_BINARY))
+    assert preview.action is McpRegistrationAction.REGISTER
+    assert preview.serve_command == (str(launcher), "mcp", "serve", "--host", "codex")
+    confirmation = McpRegistrationConfirmation(preview.preview_digest, True, "noninteractive_flag")
+    result = anyio.run(
+        lambda: service.register(_BINARY, confirmation, _state=launcher.parent / "store")
+    )
+    assert result.state_after is McpRegistrationState.YOETZ_OWNED
+    record = read_applied_route(_state=launcher.parent / "store")
+    assert record is not None
+    assert record["applied_serve_command"] == list(preview.serve_command)
+    noop = anyio.run(lambda: adapter.preview_registration(_BINARY))
+    assert noop.action is McpRegistrationAction.NOOP
+    anyio.run(
+        lambda: adapter.apply_registration(
+            _BINARY, McpRegistrationCommand(noop.preview_digest, True)
+        )
+    )
+    assert len(host.mutations) == 1
+    strict = CodexMcpAdapter(host, route_profile="strict")
+    changed = anyio.run(lambda: strict.preview_registration(_BINARY))
+    assert changed.action is McpRegistrationAction.REREGISTER
+    assert changed.serve_command[0] == str(launcher)
+    anyio.run(
+        lambda: strict.apply_registration(
+            _BINARY, McpRegistrationCommand(changed.preview_digest, True)
+        )
+    )
+    assert anyio.run(lambda: strict.observe_registration(_BINARY)).route_profile == "strict"
+    remove = anyio.run(lambda: strict.preview_unregistration(_BINARY))
+    assert remove.serve_command == changed.serve_command
+    anyio.run(
+        lambda: strict.apply_unregistration(
+            _BINARY, McpRegistrationCommand(remove.preview_digest, True)
+        )
+    )
+    assert anyio.run(lambda: strict.status_registration(_BINARY)) is McpRegistrationState.ABSENT
+    assert (
+        anyio.run(lambda: strict.preview_unregistration(_BINARY)).action
+        is McpRegistrationAction.NOOP
+    )
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_bare_compatibility_migrates_to_proven_absolute(launcher: Path, legacy: bool) -> None:
+    host = Host(
+        {"command": "yoetz", "args": ["mcp", "serve"] + ([] if legacy else ["--host", "codex"])}
+    )
+    adapter = CodexMcpAdapter(host)
+    assert (
+        anyio.run(lambda: adapter.status_registration(_BINARY)) is McpRegistrationState.YOETZ_OWNED
+    )
+    preview = anyio.run(lambda: adapter.preview_registration(_BINARY))
+    assert preview.action is McpRegistrationAction.REREGISTER
+    assert preview.serve_command[0] == str(launcher)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "modified",
+        "symlink",
+        "writable",
+        "missing",
+        "same_name",
+        "arguments",
+        "environment",
+        "root",
+        "cwd",
+        "dual_transport",
+        "disabled",
+    ],
+)
+def test_unsafe_absolute_entries_are_preserved(launcher: Path, change: str) -> None:
+    entry: dict[str, object] = {
+        "command": str(launcher),
+        "args": ["mcp", "serve", "--host", "codex"],
+        "env": {"YOETZ_ISOLATED_ROOT": str(launcher.parent)},
+    }
+    if change == "modified":
+        launcher.write_bytes(b"#!/bin/sh\nexit 0\n")
+    elif change == "symlink":
+        other = launcher.with_name("original")
+        launcher.rename(other)
+        launcher.symlink_to(other)
+    elif change == "writable":
+        launcher.chmod(0o777)
+    elif change == "missing":
+        launcher.unlink()
+    elif change == "same_name":
+        other_dir = launcher.parent / "foreign"
+        other_dir.mkdir()
+        other = other_dir / "yoetz"
+        other.write_bytes(launcher.read_bytes())
+        other.chmod(0o700)
+        entry["command"] = str(other)
+    elif change == "arguments":
+        entry["args"] = ["mcp", "serve", "--host", "codex", "--extra"]
+    elif change == "environment":
+        entry["env"] = {"PYTHONPATH": "/other"}
+    elif change == "root":
+        entry["env"] = {"YOETZ_ISOLATED_ROOT": str(launcher.parent / "other")}
+    elif change == "cwd":
+        entry["cwd"] = "/other"
+    elif change == "dual_transport":
+        entry["transport"] = dict(entry)
+    elif change == "disabled":
+        entry["enabled"] = False
+    host = Host(entry)
+    adapter = CodexMcpAdapter(host)
+    assert (
+        anyio.run(lambda: adapter.status_registration(_BINARY))
+        is McpRegistrationState.FOREIGN_PRESENT
+    )
+    preview = anyio.run(lambda: adapter.preview_unregistration(_BINARY))
+    with pytest.raises(McpRegistrationError):
+        anyio.run(
+            lambda: adapter.apply_unregistration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert host.mutations == []
+
+
+@pytest.mark.parametrize("removal", [False, True])
+def test_absolute_preview_rejects_route_drift(launcher: Path, removal: bool) -> None:
+    host = Host({"command": str(launcher), "args": ["mcp", "serve", "--host", "codex"]})
+    adapter = CodexMcpAdapter(host)
+    preview_method = adapter.preview_unregistration if removal else adapter.preview_registration
+    apply_method = adapter.apply_unregistration if removal else adapter.apply_registration
+    preview = anyio.run(lambda: preview_method(_BINARY))
+    assert host.entry is not None
+    host.entry["args"] = ["mcp", "serve", "--host", "codex", "--semantic", "off"]
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: apply_method(_BINARY, McpRegistrationCommand(preview.preview_digest, True))
+        )
+    assert caught.value.reason is McpRegistrationReason.PREVIEW_STALE
+    assert host.mutations == []
+
+
+@pytest.mark.parametrize(
+    "change", ["missing_hash", "unsupported_hash", "duplicate", "missing_entry", "size"]
+)
+def test_record_must_supply_unique_matching_identity(launcher: Path, change: str) -> None:
+    package = codex_launcher.distribution("yoetz")
+    entries = package.files
+    assert entries
+    if change == "missing_hash":
+        entries[0].hash = None
+    elif change == "unsupported_hash":
+        entries[0].hash = FileHash("md5=not-sha256")
+    elif change == "duplicate":
+        entries.append(entries[0])
+    elif change == "missing_entry":
+        entries.clear()
+    else:
+        entries[0].size = 1
+    assert launcher.is_file()
+    assert installed_launcher() is None
+
+
+def test_invalid_runtime_pin_never_confers_ownership(
+    launcher: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def invalid_pin() -> None:
+        raise PathSafetyError("runtime_pin_invalid")
+
+    monkeypatch.setattr(codex_launcher, "read_runtime_pin", invalid_pin)
+    assert installed_launcher() is None
+    host = Host({"command": str(launcher), "args": ["mcp", "serve", "--host", "codex"]})
+    assert (
+        anyio.run(lambda: CodexMcpAdapter(host).status_registration(_BINARY))
+        is McpRegistrationState.FOREIGN_PRESENT
+    )
+
+
+def test_preview_binds_a_replaced_but_valid_installed_script(launcher: Path) -> None:
+    host = Host()
+    adapter = CodexMcpAdapter(host)
+    preview = anyio.run(lambda: adapter.preview_registration(_BINARY))
+    raw = launcher.read_bytes() + b"# new installation\n"
+    launcher.write_bytes(raw)
+    entries = codex_launcher.distribution("yoetz").files
+    assert entries
+    entries[0].hash = FileHash(
+        "sha256=" + base64.urlsafe_b64encode(hashlib.sha256(raw).digest()).rstrip(b"=").decode()
+    )
+    entries[0].size = len(raw)
+    assert installed_launcher() is not None
+    with pytest.raises(McpRegistrationError) as caught:
+        anyio.run(
+            lambda: adapter.apply_registration(
+                _BINARY, McpRegistrationCommand(preview.preview_digest, True)
+            )
+        )
+    assert caught.value.reason is McpRegistrationReason.PREVIEW_STALE
+    assert host.mutations == []

--- a/tests/unit/adapters/test_codex_mcp_registration.py
+++ b/tests/unit/adapters/test_codex_mcp_registration.py
@@ -39,6 +39,7 @@ def scripted_registration_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     # Isolated-registration cases explicitly override this adapter lookup;
     # keep the process-wide isolation guard intact for all other test effects.
     monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: None)
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.installed_launcher", lambda: None)
 
 
 def _yoetz_entry(

--- a/tests/unit/cli/test_provider_status.py
+++ b/tests/unit/cli/test_provider_status.py
@@ -895,6 +895,55 @@ def _stub_live_route(
     monkeypatch.setattr(cli_setup, "configured_mcp_route_profile", lambda: "policy")
 
 
+@pytest.mark.parametrize("dual", [False, True])
+async def test_proven_absolute_adapter_feeds_provider_readiness(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, dual: bool
+) -> None:
+    from yoetz.adapters.integrations.codex_mcp import CommandOutput
+    from yoetz.adapters.integrations.portable_plugin import PluginManagedMcpObservation
+    from yoetz.ports.harness_mcp import HarnessBinary
+    from yoetz.ports.integrations import HarnessId
+    from yoetz.ports.plugin_artifacts import McpOwnershipState
+
+    _install(monkeypatch, tmp_path, provider=_provider())
+    monkeypatch.setattr(module, "mcp_route_observation", _REAL_ROUTE_OBSERVATION)
+    binary = HarnessBinary(HarnessId.CODEX, "/test/codex", "0.150.1", "supported")
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.codex_discovery.discover_codex_binaries", lambda: (binary,)
+    )
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp.isolated_root", lambda: None)
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.codex_mcp.installed_launcher",
+        lambda: ("/test/runtime/bin/yoetz", "sha256:" + "a" * 64),
+    )
+
+    def entry(_argv: tuple[str, ...]) -> CommandOutput:
+        return CommandOutput(
+            0,
+            json.dumps(
+                {"command": "/test/runtime/bin/yoetz", "args": ["mcp", "serve", "--host", "codex"]}
+            ).encode(),
+        )
+
+    def plugin(_root: object) -> PluginManagedMcpObservation:
+        return PluginManagedMcpObservation(
+            McpOwnershipState.PLUGIN if dual else McpOwnershipState.ABSENT,
+            "policy" if dual else None,
+            True,
+        )
+
+    monkeypatch.setattr("yoetz.adapters.integrations.codex_mcp._default_runner", entry)
+    monkeypatch.setattr(
+        "yoetz.adapters.integrations.portable_plugin.observe_plugin_managed_mcp", plugin
+    )
+    report = await module.provider_status_report(workspace_locator=tmp_path)
+    assert report["semantic_ready"] is True
+    assert report["agent_route_semantic_ready"] is (not dual)
+    route = cast(dict[str, object], report["mcp_route"])
+    assert route["external_registration_state"] == "yoetz_owned"
+    assert route["ownership_state"] == ("dual" if dual else "external")
+
+
 async def test_applied_route_drift_true_when_serving_differs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Issue

Fixes #654. Codex treated a working absolute Yoetz launcher as foreign because ownership required a literal `yoetz` token. The fix recognizes the current installation’s proven console script and preserves its exact command, route, and root through registration, status, route changes, and removal.

- Searched issues and PRs for duplicates; no focused competing fix found.
- Maintainer-requested implementation and scope recorded in [the issue](https://github.com/TheGaySupreme123/yoetz/issues/654#issuecomment-5584485036).

## Documentation

Behavior change: yes. Updated `docs/INTERFACES.md`, `docs/runbooks/codex-integration.md`, and `docs/runbooks/test-instances.md`, and the Claude Code/Cursor runbooks with launcher proof, migration, refusal, and lifecycle behavior.

## Verification

All required CI checks passed on final commit `826a21d4` ([CI run](https://github.com/TheGaySupreme123/yoetz/actions/runs/34222899526)). CodeRabbit withdrew its sole finding and resolved the thread; Macroscope was skipped.

The new ownership regression failed as `foreign_present` before the classifier change. Local validation: **202 focused tests passed**, **91 setup-wizard tests passed**, plus **2 packaged tests passed** with real Codex 0.150.1 and a fresh runtime-pinned wheel/isolated Codex home. The packaged test covers exact registered-child isolation with and without the environment binding, MCP initialization and guidance use, provider-route ownership, no-op registration, route change, and repeated removal.

```text
uv run pytest tests/unit/adapters/test_codex_absolute_launcher.py tests/unit/adapters/test_codex_mcp_registration.py tests/unit/application/test_harness_mcp_service.py tests/unit/application/test_applied_mcp_route.py tests/unit/cli/test_provider_status.py tests/unit/cli/test_registration_drift.py tests/unit/cli/test_setup_activation.py tests/unit/cli/test_setup_review_mode.py tests/unit/tui/test_runtime.py tests/unit/dogfood/test_codex_dogfood_parity.py -q
env -u YOETZ_ISOLATED_ROOT uv run pytest tests/subprocess/test_setup_wizard_cli.py -q
# PATH selects the installed Codex 0.150.1 binary for this frozen test cell:
env -u YOETZ_ISOLATED_ROOT uv run pytest tests/packaging/test_codex_mcp_isolated_registration.py -q
uv run ruff check <changed Python files>
npx --no-install pyright
uv run python scripts/sync_resource_ripple.py --check
uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

Yoetz task `tsk_8024ff05-7958-4a2e-ac92-831c2771b453` tracks the work. Both deterministic and semantic review completed (Codex subscription, Luna/high). The first review requested an explicit digest-only evidence limitation; the claim was corrected and semantic recheck completed without repeating that omission finding. The terminal check verdict is `insufficient_coverage`, not a clean certification. The acknowledged disclosure finding remains unresolved because the retained provenance gaps prevent a qualifying resolution, despite corrected wording and no repeated omission finding. Yoetz has caller-published excerpts and test reports, not independently captured execution; digest-only evidence, incomplete hook outcomes/mapping, and bounded-case omissions limit its conclusion.

## Boundaries

- [x] No private drafting material is included.
- [x] Every human or code-review-agent comment will receive a fix or a written disposition before merge.

## Summary

Launcher ownership requires the current runtime’s script location, installed RECORD SHA-256/size, safe paths, and valid pin/instance provenance when pinned. Unknown binaries are never executed for identification. Absolute preview digests bind the launcher evidence and observed command/root; the applied-route record and approval displays retain the actual argv.

Bare and legacy registrations remain recognizable for explicit migration/removal. Foreign binaries, modified or ambiguous entries, unsafe paths, unexpected arguments/environment, conflicting roots, and dual ownership stay protected. Claude Code/Cursor native-carrier rules, workflow wire schemas, hooks, privacy authorization, and receipt formats are unchanged. No full-suite or provider-dispatch certification is claimed by the packaged smoke.

CodeRabbit reviewed the implementation and raised one syntax finding. It was dispositioned as a false positive: the project requires Python >=3.14,<3.15, Ruff targets py314, and `uv run python -m py_compile src/yoetz/adapters/integrations/codex_launcher.py` succeeds under Python 3.14.6. [Review reply](https://github.com/TheGaySupreme123/yoetz/pull/655#discussion_r3957591032).

Implemented by GPT-6 in the Codex desktop harness, with Yoetz cooperative tracking.
