### PR TITLE
fix(cursor): bind explicit MCP starts to native observation

### DIFF
--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -254,6 +254,14 @@ Claude Code has no `codex exec --json` import surface. Issue #301's bounded impo
 therefore makes no Claude adapter change; Claude evidence continues through cooperative MCP and
 the native hook/observation paths below.
 
+Cursor's explicit-start repair (issue #661) leaves Claude's binder and hook subscription unchanged.
+[Claude's hooks reference](https://code.claude.com/docs/en/hooks#posttooluse), checked 2026-09-08,
+specifies `tool_response` for successful `PostToolUse`. Claude continues to pass that field from
+its exact Yoetz-scoped tool to the shared binder; Cursor's `result_json` / `tool_output` and
+server-key normalization are confined to the Cursor adapter. Cross-host regression checks cover
+Claude's structured result, single JSON text block, live-characterized JSON string, and failed
+start rejection.
+
 The native hook profile emits only `SessionStart`, scoped-Yoetz `PostToolUse`, scoped-Yoetz
 `PostToolUseFailure`, `Stop`, and `SessionEnd`. A bare MCP matcher is a negative control. Hooks call
 `yoetz hooks claude-observe` and are best-effort; timeouts/nonzero exits never authorize or block

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -1,5 +1,12 @@
 # Codex integration runbook
 
+Cursor's explicit-start repair (issue #661) leaves Codex's lifecycle binder and hook subscription
+unchanged. [The official hooks reference](https://developers.openai.com/codex/hooks), checked
+2026-09-08, specifies `tool_response` containing the MCP call result on `PostToolUse`, with
+canonical `mcp__server__tool` names. Codex keeps its existing result unwrapping and lifecycle
+locking; Cursor-only response fields and server identities are normalized only in Cursor's
+adapter. The Codex lifecycle and observation regression tests remain the compatibility check.
+
 This runbook guides you through previewing, installing, checking, replacing, and removing the
 canonical Yoetz Codex skill in one explicitly trusted project, while preserving any files you have
 modified. It also separates four facts that are easy to conflate: skill/source installation, Codex

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -305,8 +305,9 @@ expansion; the default structural profile retains the boundary above.
 
 The default structural artifact remains unchanged. An explicitly rendered ordinary-work artifact
 uses `cursor-ordinary-observation-v1` and subscribes to Cursor's generic `preToolUse`,
-`postToolUse`, and `postToolUseFailure` events plus lifecycle signals. It leaves
-`beforeShellExecution`, `afterFileEdit`, and `afterMCPExecution` out of that subscription until a
+`postToolUse`, and `postToolUseFailure` events plus lifecycle signals. `afterMCPExecution` is
+subscribed only to bind an exact Yoetz-owned successful `start`; it emits no observation,
+content, or advice in this profile. It leaves `beforeShellExecution` and `afterFileEdit` out until a
 deduplication contract proves they are distinct from the generic stream. The hook command carries
 the exact profile id with `--observation-profile`; the id records the normalization contract and
 does not certify the installed Cursor build.
@@ -451,10 +452,32 @@ root as its repository locator, so a live mapping answers `active` and the `addi
 names the task, frontier, mapped `session_id` and `writer_id`, and the `start mode=attach`
 continuation by that session id (issues #578, #580). A daemon fence refusal records
 `status_workspace_unbound` / `status_workspace_mismatch` and keeps the mapping; only a replaced
-session records `mapping_stale`. Cursor does not re-bind the mapping from the agent's own scoped
-`start`: `afterMCPExecution` is normalized to structural fields and its result is not inspected,
-so an agent that starts a separate task keeps hook rows routed to the auto-attached task. Continue
-the auto-attached task by its named `session_id` instead of a new ref pair.
+session records `mapping_stale`.
+
+A successful explicit Yoetz `start` now binds the canonical Cursor session before normal
+observation handling (issue #661). The adapter transiently decodes `result_json` on
+`afterMCPExecution`, or `tool_output` on an exactly server-scoped `postToolUse`, then passes the
+result to the existing lifecycle binder. Only validated task/session/writer IDs and an optional
+frontier token enter mapping storage. Task switching and same-task session replacement use those
+returned IDs; the workspace ambiguity guard is unchanged and never guesses a task.
+
+[Cursor's hooks reference](https://cursor.com/docs/hooks), checked 2026-09-08, documents
+`mcp_server_name` on `afterMCPExecution`. That hook admits bare `start` only for exact `yoetz` or
+`plugin-yoetz-yoetz` server keys. The adapter also accepts the existing fully scoped
+`mcp__yoetz__start`, `mcp__plugin_yoetz_yoetz__start`, `yoetz:start`, and
+`plugin-yoetz-yoetz:start` forms, rejecting a conflicting server field. Generic `MCP:start` alone
+does not identify an owner and cannot bind. The ordinary profile therefore uses the MCP-specific
+hook only for binding and keeps the generic hook as its sole tool-observation stream. Failed
+results, foreign tools, malformed IDs, and contradictory session aliases cannot replace a map.
+Unparsed or invalid admitted results and failed/deferred writes report the existing closed
+`start_bind_unparsed`, `start_bind_invalid_ids`, `start_bind_write_failed`, or
+`start_bind_deferred` diagnostics. Deferred writes follow the same lifecycle lock as recovery.
+
+After upgrading, preview and apply the ordinary native plugin update so the binding-only hook is
+installed, reconnect the MCP server with the intended project open, and call `start mode=attach`
+using the known session ID. Check `observe status` for mapping and delivery separately: successful
+MCP attachment alone is not observation recovery. Binding permits subsequent consented content
+handoff; it cannot reconstruct content that an earlier unmapped call never delivered.
 
 Cursor's hooks reference (re-read 2026-09-03) calls local `sessionStart` fire-and-forget: the hook
 process can complete this mapping and drain, but the agent loop does not wait for it. Therefore a

--- a/src/yoetz/adapters/integrations/cursor_integration.py
+++ b/src/yoetz/adapters/integrations/cursor_integration.py
@@ -125,6 +125,7 @@ CURSOR_HOOK_EVENTS: Final = (
     "stop",
 )
 CURSOR_ORDINARY_HOOK_EVENTS: Final = (
+    "afterMCPExecution",
     "postToolUse",
     "postToolUseFailure",
     "preToolUse",

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -3562,18 +3562,19 @@ def _bind_cursor_start(
     parsed = _bounded_outcome_mapping(response)
     from yoetz.cli.hooks import bind_start_mapping_outcome, record_start_bind_diagnostic
 
-    record_start_bind_diagnostic(
-        bind_start_mapping_outcome(
-            {
-                "session_id": f"{_CURSOR_SESSION_PREFIX}{session}",
-                "tool_name": "mcp__yoetz__start",
-                "tool_response": cast(JsonValue, parsed) if parsed is not None else response,
-            },
+    with contextlib.suppress(Exception):
+        record_start_bind_diagnostic(
+            bind_start_mapping_outcome(
+                {
+                    "session_id": f"{_CURSOR_SESSION_PREFIX}{session}",
+                    "tool_name": "mcp__yoetz__start",
+                    "tool_response": cast(JsonValue, parsed) if parsed is not None else response,
+                },
+                _state=_state,
+            ),
+            "PostToolUse",
             _state=_state,
-        ),
-        "PostToolUse",
-        _state=_state,
-    )
+        )
 
 
 def handle_cursor_observe(

--- a/src/yoetz/cli/observe_hooks.py
+++ b/src/yoetz/cli/observe_hooks.py
@@ -3505,6 +3505,77 @@ def handle_claude_observe(
         return 0
 
 
+_CURSOR_START_TOOL_SERVERS: Final = {
+    "mcp__yoetz__start": "yoetz",
+    "mcp__plugin_yoetz_yoetz__start": "plugin-yoetz-yoetz",
+    "yoetz:start": "yoetz",
+    "plugin-yoetz-yoetz:start": "plugin-yoetz-yoetz",
+}
+
+
+def _bind_cursor_start(
+    payload: Mapping[str, JsonValue],
+    *,
+    raw_event: str,
+    session: str,
+    _state: Path | None,
+) -> None:
+    """Bind an owned start transiently; generic ``MCP:start`` has no owner.
+
+    Cursor 3.20.0 supplies the server key only on afterMCPExecution. Its
+    ordinary postToolUse spelling cannot distinguish two servers' start tools.
+    Older scoped spellings remain admissible, but conflicting owner fields do
+    not. The shared binder still owns strict result IDs and lifecycle locking.
+    """
+
+    # A previous owned start may have raced lifecycle recovery. Retry its
+    # structural sidecar before any later event observes the old/no mapping;
+    # Cursor does not run Codex's handle_session_start pending-write drain.
+    with contextlib.suppress(Exception):
+        with acquire_session_lock(f"{_CURSOR_SESSION_PREFIX}{session}", _state=_state) as owned:
+            if owned:
+                apply_pending_mapping(f"{_CURSOR_SESSION_PREFIX}{session}", _state=_state)
+    if raw_event not in {"afterMCPExecution", "postToolUse"}:
+        return
+    tool_name = payload.get("tool_name")
+    if type(tool_name) is not str:
+        return
+    server = payload.get("mcp_server_name")
+    expected_server = _CURSOR_START_TOOL_SERVERS.get(tool_name)
+    if expected_server is not None:
+        if "mcp_server_name" in payload and server != expected_server:
+            return
+    elif not (
+        raw_event == "afterMCPExecution"
+        and tool_name == "start"
+        and type(server) is str
+        and server in {"yoetz", "plugin-yoetz-yoetz"}
+    ):
+        return
+    # A post-hook can carry a transport failure even with success-shaped data.
+    # Never allow that data to replace a valid mapping.
+    if _native_outcome_facts(payload).success is False:
+        return
+    response = payload.get("result_json" if raw_event == "afterMCPExecution" else "tool_output")
+    # Cursor serializes the whole MCP CallToolResult. Decode that outer object
+    # before the shared binder unwraps structuredContent or one JSON text block.
+    parsed = _bounded_outcome_mapping(response)
+    from yoetz.cli.hooks import bind_start_mapping_outcome, record_start_bind_diagnostic
+
+    record_start_bind_diagnostic(
+        bind_start_mapping_outcome(
+            {
+                "session_id": f"{_CURSOR_SESSION_PREFIX}{session}",
+                "tool_name": "mcp__yoetz__start",
+                "tool_response": cast(JsonValue, parsed) if parsed is not None else response,
+            },
+            _state=_state,
+        ),
+        "PostToolUse",
+        _state=_state,
+    )
+
+
 def handle_cursor_observe(
     *,
     event_name: str | None,
@@ -3543,11 +3614,9 @@ def handle_cursor_observe(
             hook_io.stdout_json({}, stdout)
         return 0
     if ordinary_profile:
-        # Cursor's generic tool events are the authoritative stream.  Shell,
-        # read-file, MCP and edit-specific hooks are deliberately supplemental
-        # and remain unsupported here until their overlap is proven distinct.
+        # Generic tool events own observation. afterMCPExecution is binding-only:
+        # it alone supplies the owner of the ordinary ``MCP:start`` tool name.
         event_map.pop("afterFileEdit")
-        event_map.pop("afterMCPExecution")
         event_map.update(
             {
                 "preToolUse": "PreToolUse",
@@ -3612,6 +3681,10 @@ def handle_cursor_observe(
                 record_hook_diagnostic(
                     "workspace_unresolvable", event_map[raw_event], _state=_state
                 )
+            return 0 if hook_io.stdout_json({}, stdout) else 0
+        _bind_cursor_start(payload, raw_event=raw_event, session=session, _state=_state)
+        if ordinary_profile and raw_event == "afterMCPExecution":
+            # No duplicate structural row, content capture, or advice delivery.
             return 0 if hook_io.stdout_json({}, stdout) else 0
         cursor_version = _token_or_none(payload.get("cursor_version"))
         capability_profile_id = (

--- a/tests/integration/application/test_native_capture_pipeline.py
+++ b/tests/integration/application/test_native_capture_pipeline.py
@@ -26,7 +26,11 @@ from tests.integration.objects.test_envelope_and_encrypted_files import (
     WrapKeyForObjectTest,
 )
 
-from yoetz.adapters.integrations.codex_lifecycle import LifecycleMapping, store_mapping
+from yoetz.adapters.integrations.codex_lifecycle import (
+    LifecycleMapping,
+    load_mapping,
+    store_mapping,
+)
 from yoetz.adapters.integrations.observation_local import LocalObservationStore
 from yoetz.adapters.objects.encrypted_files import EncryptedFilesObjectStore
 from yoetz.adapters.sqlite.migrations import initialize_bundle
@@ -173,6 +177,7 @@ async def _pipeline(
     *,
     codex_session_id: str,
     profile: str,
+    install_mapping: bool = True,
 ) -> tuple[
     Path,
     str,
@@ -198,17 +203,18 @@ async def _pipeline(
     task_id = _ids(IdKind.TASK, 1)
     yoetz_session_id = _ids(IdKind.SESSION, 2)
     writer_id = _ids(IdKind.WRITER, 3)
-    store_mapping(
-        LifecycleMapping(
-            mapping_version=1,
-            codex_session_id=codex_session_id,
-            yoetz_task_id=task_id,
-            yoetz_session_id=yoetz_session_id,
-            yoetz_writer_id=writer_id,
-            last_frontier=None,
-        ),
-        _state=state,
-    )
+    if install_mapping:
+        store_mapping(
+            LifecycleMapping(
+                mapping_version=1,
+                codex_session_id=codex_session_id,
+                yoetz_task_id=task_id,
+                yoetz_session_id=yoetz_session_id,
+                yoetz_writer_id=writer_id,
+                last_frontier=None,
+            ),
+            _state=state,
+        )
 
     bundle_root = tmp_path / "bundle"
     bundle_root.mkdir(mode=0o700)
@@ -387,6 +393,7 @@ async def test_ordinary_native_hook_content_reaches_prepared_semantic_packet(
         tmp_path,
         codex_session_id=codex_session_id,
         profile=profile,
+        install_mapping=host != "cursor",
     )
 
     def run_async(factory: Callable[[], Awaitable[object]]) -> object:
@@ -417,10 +424,54 @@ async def test_ordinary_native_hook_content_reaches_prepared_semantic_packet(
             observation_profile=profile,
         )
 
-    assert await asyncio.to_thread(run_hook, pre_event_name, pre_payload) == 0
+    if host == "cursor":
+        # #661: the cooperative task exists but this Cursor conversation has no
+        # native mapping. Only its owned MCP start result may supply the route.
+        assert load_mapping(codex_session_id, _state=tmp_path / "state") is None
+        assert await asyncio.to_thread(run_hook, pre_event_name, pre_payload) == 0
+        assert len(client.requests) == 1
+        assert local.pending_outbox_count(workspace) == 1
+        assert task_observation.list_envelopes_for_session(workspace, session_commitment) == ()
+        start_payload = {
+            "conversation_id": pre_payload["conversation_id"],
+            "tool_name": "start",
+            "mcp_server_name": "yoetz",
+            "result_json": canonical_encode(
+                {
+                    "isError": False,
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": canonical_encode(
+                                {
+                                    "ok": True,
+                                    "task_id": runtime.task_id,
+                                    "session_id": runtime.session_id,
+                                    "writer_id": runtime.writer_id,
+                                }
+                            ).decode(),
+                        }
+                    ],
+                }
+            ).decode(),
+        }
+        assert await asyncio.to_thread(run_hook, "afterMCPExecution", start_payload) == 0
+        mapping = load_mapping(codex_session_id, _state=tmp_path / "state")
+        assert mapping is not None and mapping.yoetz_task_id == runtime.task_id
+        assert mapping.yoetz_session_id == runtime.session_id
+        assert mapping.yoetz_writer_id == runtime.writer_id
+        assert len(client.requests) == 1  # Binding neither ingests nor captures another event.
+    else:
+        assert await asyncio.to_thread(run_hook, pre_event_name, pre_payload) == 0
+
     assert await asyncio.to_thread(run_hook, post_event_name, post_payload) == 0
-    assert len(client.requests) == 2, f"connector calls={client.connect_calls}"
-    pre_request, request = client.requests
+    assert len(client.requests) == (3 if host == "cursor" else 2), (
+        f"connector calls={client.connect_calls}"
+    )
+    pre_request, request = client.requests[-2:]
+    if host == "cursor":
+        assert client.requests[0].envelope.source_identity == pre_request.envelope.source_identity
+        assert local.pending_outbox_count(workspace) == 0
     assert pre_request.codex_session_id == codex_session_id
     assert pre_request.content_capture_profile == profile
     assert pre_request.content_chunks == ()

--- a/tests/unit/cli/test_cursor_observe_hooks.py
+++ b/tests/unit/cli/test_cursor_observe_hooks.py
@@ -21,18 +21,6 @@ from yoetz.kernel.policies.observation_advice import ObservationCompositionFact
 from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 
 
-@pytest.fixture(autouse=True)
-def _isolated_cursor_hook_state(  # pyright: ignore[reportUnusedFunction]
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Even normalizer-only tests now run the lifecycle binder before their
-    # mocked observe boundary. An omitted _state must never reach the live
-    # installation's mapping locks or diagnostic stream.
-    isolated = tmp_path / "inherited-state"
-    isolated.mkdir(mode=0o700)
-    monkeypatch.setenv("YOETZ_ISOLATED_ROOT", str(isolated))
-
-
 def _consented_store(tmp_path: Path) -> tuple[LocalObservationStore, str]:
     store = LocalObservationStore(_state=tmp_path)
     commitment = store.workspace_commitment(str(tmp_path.resolve()))
@@ -103,6 +91,7 @@ def test_cursor_hook_ingress_drops_every_content_and_identity_denylist_field(
             event_name="afterMCPExecution",
             stdin_bytes=canonical_encode(payload),
             workspace=str(tmp_path),
+            _state=tmp_path,
         )
         == 0
     )
@@ -179,6 +168,7 @@ def test_cursor_raw_vendor_fields_reach_structural_observation(
             stdin_bytes=json.dumps(payload, separators=(",", ":")).encode(),
             stdout=io.BytesIO(),
             workspace=str(tmp_path),
+            _state=tmp_path,
         )
         == 0
     )
@@ -221,6 +211,7 @@ def test_cursor_model_id_takes_precedence_over_vendor_model_alias(
             stdin_bytes=payload,
             stdout=io.BytesIO(),
             workspace=str(tmp_path),
+            _state=tmp_path,
         )
         == 0
     )
@@ -344,6 +335,7 @@ def test_cursor_file_edit_uses_keyed_path_commitment_and_drops_outcomes(
 
 def test_cursor_session_prefix_reserves_space_inside_token_bound(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     captured: list[Mapping[str, JsonValue]] = []
 
@@ -366,6 +358,7 @@ def test_cursor_session_prefix_reserves_space_inside_token_bound(
                 stdin_bytes=canonical_encode(payload),
                 stdout=io.BytesIO(),
                 workspace=".",
+                _state=tmp_path,
             )
             == 0
         )

--- a/tests/unit/cli/test_cursor_observe_hooks.py
+++ b/tests/unit/cli/test_cursor_observe_hooks.py
@@ -21,6 +21,18 @@ from yoetz.kernel.policies.observation_advice import ObservationCompositionFact
 from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
 
 
+@pytest.fixture(autouse=True)
+def _isolated_cursor_hook_state(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Even normalizer-only tests now run the lifecycle binder before their
+    # mocked observe boundary. An omitted _state must never reach the live
+    # installation's mapping locks or diagnostic stream.
+    isolated = tmp_path / "inherited-state"
+    isolated.mkdir(mode=0o700)
+    monkeypatch.setenv("YOETZ_ISOLATED_ROOT", str(isolated))
+
+
 def _consented_store(tmp_path: Path) -> tuple[LocalObservationStore, str]:
     store = LocalObservationStore(_state=tmp_path)
     commitment = store.workspace_commitment(str(tmp_path.resolve()))

--- a/tests/unit/cli/test_cursor_start_binding.py
+++ b/tests/unit/cli/test_cursor_start_binding.py
@@ -313,12 +313,32 @@ def test_mapping_write_failure_has_bounded_diagnostic(
 
     monkeypatch.setattr(hooks, "queue_mapping_store" if deferred else "store_mapping", fail)
     if deferred:
-        with acquire_session_lock(_SESSION, _state=tmp_path):
+        with acquire_session_lock(_SESSION, _state=tmp_path) as owned:
+            assert owned
             _run(tmp_path, _payload())
     else:
         _run(tmp_path, _payload())
     assert load_mapping(_SESSION, _state=tmp_path) is None
     assert _diagnostics(tmp_path) == ["start_bind_write_failed"]
+
+
+@pytest.mark.parametrize("boundary", ["bind_start_mapping_outcome", "record_start_bind_diagnostic"])
+def test_unexpected_binding_fault_does_not_drop_the_ordinary_observation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, boundary: str
+) -> None:
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("PRIVATE_BIND_FAULT")
+
+    seen: list[object] = []
+
+    def observe(**kwargs: object) -> int:
+        seen.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(hooks, boundary, fail)
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    _run(tmp_path, _payload("postToolUse"))
+    assert len(seen) == 1
 
 
 def test_ordinary_renderer_installs_the_owner_bearing_binding_hook(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_cursor_start_binding.py
+++ b/tests/unit/cli/test_cursor_start_binding.py
@@ -1,0 +1,348 @@
+"""Cursor-owned explicit starts bind before observation, without accepting foreign results."""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from yoetz.adapters.integrations.codex_lifecycle import (
+    acquire_session_lock,
+    load_mapping,
+    mapping_from_start_ids,
+    store_mapping,
+)
+from yoetz.adapters.integrations.cursor_integration import render_cursor_plugin
+from yoetz.cli import hooks, observe_hooks
+from yoetz.domain.observation_profiles import CURSOR_ORDINARY_OBSERVATION_PROFILE_ID
+from yoetz.ports.plugin_artifacts import PluginFormatProfile
+from yoetz.protocol.canonical import JsonValue, canonical_encode, strict_json_parse
+
+_START: dict[str, JsonValue] = {
+    "ok": True,
+    "task_id": "tsk_11111111-1111-4111-8111-111111111111",
+    "session_id": "ses_22222222-2222-4222-8222-222222222222",
+    "writer_id": "wri_33333333-3333-4333-8333-333333333333",
+    "frontier": {"sequence": "4", "head_digest": "sha256:" + "a" * 64},
+}
+_SESSION = "cursor:cursor-661"
+
+
+@pytest.mark.parametrize(
+    "event,tool,field,server",
+    [
+        ("afterMCPExecution", "start", "result_json", "yoetz"),
+        ("postToolUse", "MCP:start", "tool_output", None),
+    ],
+)
+def test_cursor_3_20_0_redacted_live_failure_shape(
+    tmp_path: Path,
+    event: str,
+    tool: str,
+    field: str,
+    server: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-09-08 IDE probe: retain identity/response types, redact all content.
+
+    The real plugin start failed with repository_identity_required before task
+    creation. This fixture pins the host carrier, NOT a successful native bind.
+    Both carriers serialized content/isError, without structuredContent; only
+    afterMCPExecution carried mcp_server_name. All IDs below are replacements.
+    """
+    payload: dict[str, JsonValue] = {
+        "hook_event_name": event,
+        "session_id": "cursor-661",
+        "conversation_id": "cursor-661",
+        "cursor_version": "3.20.0",
+        "tool_name": tool,
+        field: '{"content":[{"type":"text","text":"{\\"ok\\":false}"}],"isError":true}',
+    }
+    if server is not None:
+        payload["mcp_server_name"] = server
+
+    def observe(**_kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    _run(tmp_path, payload)
+    assert load_mapping(_SESSION, _state=tmp_path) is None
+    assert _diagnostics(tmp_path) == []
+
+
+def _payload(event: str = "afterMCPExecution", **changes: JsonValue) -> dict[str, JsonValue]:
+    response_field = "result_json" if event == "afterMCPExecution" else "tool_output"
+    return {
+        "hook_event_name": event,
+        "conversation_id": "cursor-661",
+        "cursor_version": "3.20.0",
+        "tool_name": "start" if event == "afterMCPExecution" else "mcp__yoetz__start",
+        **({"mcp_server_name": "yoetz"} if event == "afterMCPExecution" else {}),
+        response_field: json.dumps({"structuredContent": _START, "isError": False}),
+        "tool_use_id": "call-661",
+        **changes,
+    }
+
+
+def _run(state: Path, payload: dict[str, JsonValue], *, ordinary: bool = True) -> bytes:
+    out = io.BytesIO()
+    assert (
+        observe_hooks.handle_cursor_observe(
+            event_name=cast(str, payload["hook_event_name"]),
+            stdin_bytes=canonical_encode(payload),
+            stdout=out,
+            workspace=str(state),
+            _state=state,
+            skip_service=True,
+            observation_profile=CURSOR_ORDINARY_OBSERVATION_PROFILE_ID if ordinary else None,
+        )
+        == 0
+    )
+    return out.getvalue()
+
+
+def _diagnostics(state: Path) -> list[str]:
+    path = state / "observation/hook-diagnostics.jsonl"
+    return (
+        [json.loads(line)["reason"] for line in path.read_text().splitlines()]
+        if path.exists()
+        else []
+    )
+
+
+@pytest.mark.parametrize("ordinary,event", [(True, "postToolUse"), (False, "afterMCPExecution")])
+@pytest.mark.parametrize("shape", ["bare", "structured", "text", "serialized"])
+def test_owned_start_binds_before_forwarding_and_drops_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, ordinary: bool, event: str, shape: str
+) -> None:
+    responses: dict[str, JsonValue] = {
+        "bare": _START,
+        "structured": {"structuredContent": _START, "isError": False},
+        "text": {"content": [{"type": "text", "text": json.dumps(_START)}]},
+        "serialized": json.dumps(
+            {"content": [{"type": "text", "text": json.dumps(_START)}], "isError": False}
+        ),
+    }
+    seen: list[object] = []
+
+    def observe(**kwargs: object) -> int:
+        mapping = load_mapping(_SESSION, _state=tmp_path)
+        assert mapping is not None
+        assert mapping.yoetz_task_id == _START["task_id"]
+        assert mapping.yoetz_session_id == _START["session_id"]
+        assert mapping.yoetz_writer_id == _START["writer_id"]
+        assert mapping.last_frontier == "4:sha256:" + "a" * 64
+        structural = strict_json_parse(cast(bytes, kwargs["stdin_bytes"]))
+        assert isinstance(structural, Mapping)
+        assert {"result_json", "tool_output", "task_id", "writer_id", "tool_input"}.isdisjoint(
+            structural
+        )
+        seen.append(structural)
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    field = "result_json" if event == "afterMCPExecution" else "tool_output"
+    _run(tmp_path, _payload(event, **{field: responses[shape]}), ordinary=ordinary)
+    assert len(seen) == 1
+    assert _diagnostics(tmp_path) == []
+
+
+def test_ordinary_mcp_hook_binds_only_and_generic_hook_observes_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[object] = []
+
+    def observe(**kwargs: object) -> int:
+        assert load_mapping(_SESSION, _state=tmp_path) is not None
+        calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    assert json.loads(_run(tmp_path, _payload())) == {}
+    assert calls == []
+    _run(tmp_path, _payload("postToolUse", tool_name="MCP:start"))
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "name,server",
+    [
+        ("start", "yoetz"),
+        ("start", "plugin-yoetz-yoetz"),
+        ("mcp__yoetz__start", "yoetz"),
+        ("mcp__plugin_yoetz_yoetz__start", "plugin-yoetz-yoetz"),
+        ("yoetz:start", "yoetz"),
+        ("plugin-yoetz-yoetz:start", "plugin-yoetz-yoetz"),
+    ],
+)
+def test_exact_cursor_owner_names(tmp_path: Path, name: str, server: str) -> None:
+    _run(tmp_path, _payload(tool_name=name, mcp_server_name=server))
+    assert load_mapping(_SESSION, _state=tmp_path) is not None
+
+
+@pytest.mark.parametrize(
+    "event,name,server",
+    [
+        ("afterMCPExecution", "start", None),
+        ("afterMCPExecution", "start", "foreign"),
+        ("afterMCPExecution", "start", "yoetz-extra"),
+        ("afterMCPExecution", "mcp__yoetz__start", "foreign"),
+        ("afterMCPExecution", "mcp__foreign__start", "yoetz"),
+        ("afterMCPExecution", "restart", "yoetz"),
+        ("afterMCPExecution", "yoetz:start", "plugin-yoetz-yoetz"),
+        ("postToolUse", "start", "yoetz"),
+        ("postToolUse", "MCP:start", None),
+        ("postToolUse", "MCP:start", "yoetz"),
+        ("postToolUse", "mcp__foreign__start", None),
+        ("postToolUseFailure", "mcp__yoetz__start", None),
+        ("preToolUse", "mcp__yoetz__start", None),
+    ],
+)
+def test_foreign_ambiguous_or_non_success_carrier_cannot_bind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, event: str, name: str, server: str | None
+) -> None:
+    def observe(**_kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    p = _payload(event, tool_name=name)
+    p.pop("mcp_server_name", None)
+    if server is not None:
+        p["mcp_server_name"] = server
+    _run(tmp_path, p)
+    assert load_mapping(_SESSION, _state=tmp_path) is None
+    assert _diagnostics(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "response,diagnostic",
+    [
+        ("PRIVATE_RESPONSE_CANARY", "start_bind_unparsed"),
+        ('{"ok":true,"ok":false}', "start_bind_unparsed"),
+        ({"ok": 1}, "start_bind_unparsed"),
+        ({**_START, "task_id": "bad_PRIVATE_ID_CANARY"}, "start_bind_invalid_ids"),
+        ({**_START, "writer_id": None}, "start_bind_invalid_ids"),
+        ({"ok": False}, None),
+        ({"structuredContent": _START, "isError": True}, None),
+        (json.dumps({"structuredContent": _START, "isError": True}), None),
+        ({"content": [{"type": "text", "text": json.dumps(_START)}], "isError": True}, None),
+        ({"content": [{"type": "text", "text": json.dumps(_START)}] * 2}, "start_bind_unparsed"),
+    ],
+)
+def test_invalid_start_preserves_mapping_and_emits_only_closed_diagnostics(
+    tmp_path: Path, response: JsonValue, diagnostic: str | None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    original = mapping_from_start_ids(
+        codex_session_id=_SESSION,
+        last_frontier=None,
+        yoetz_task_id=cast(str, _START["task_id"]),
+        yoetz_session_id=cast(str, _START["session_id"]),
+        yoetz_writer_id=cast(str, _START["writer_id"]),
+    )
+    store_mapping(original, _state=tmp_path)
+    _run(tmp_path, _payload(result_json=response))
+    assert load_mapping(_SESSION, _state=tmp_path) == original
+    assert _diagnostics(tmp_path) == ([diagnostic] if diagnostic else [])
+    for path in tmp_path.rglob("*"):
+        if path.is_file():
+            assert b"PRIVATE_" not in path.read_bytes()
+    assert "PRIVATE_" not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("same_task", [True, False])
+def test_explicit_start_replaces_previous_task_or_session(tmp_path: Path, same_task: bool) -> None:
+    previous = mapping_from_start_ids(
+        codex_session_id=_SESSION,
+        last_frontier=None,
+        yoetz_task_id=cast(str, _START["task_id"])
+        if same_task
+        else "tsk_44444444-4444-4444-8444-444444444444",
+        yoetz_session_id="ses_55555555-5555-4555-8555-555555555555",
+        yoetz_writer_id="wri_66666666-6666-4666-8666-666666666666",
+    )
+    store_mapping(previous, _state=tmp_path)
+    _run(tmp_path, _payload())
+    current = load_mapping(_SESSION, _state=tmp_path)
+    assert current is not None and current != previous
+    assert current.yoetz_task_id == _START["task_id"]
+    assert current.yoetz_session_id == _START["session_id"]
+    assert current.yoetz_writer_id == _START["writer_id"]
+
+
+def test_canonical_session_alias_is_used_and_conflicting_pair_is_rejected(tmp_path: Path) -> None:
+    _run(tmp_path, _payload(session_id="canonical-661"))
+    assert load_mapping(_SESSION, _state=tmp_path) is None
+    mapped = load_mapping("cursor:canonical-661", _state=tmp_path)
+    assert mapped is not None
+    _run(tmp_path, _payload(session_id="conflicting-661"))
+    assert load_mapping("cursor:conflicting-661", _state=tmp_path) is None
+    assert _diagnostics(tmp_path) == ["cursor_session_ambiguous"]
+    _run(tmp_path, _payload())
+    assert load_mapping("cursor:canonical-661", _state=tmp_path) == mapped
+
+
+def test_start_mapping_deferred_under_lifecycle_lock_applies_on_next_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with acquire_session_lock(_SESSION, _state=tmp_path) as owned:
+        assert owned
+        _run(tmp_path, _payload())
+        assert load_mapping(_SESSION, _state=tmp_path) is None
+    assert _diagnostics(tmp_path) == ["start_bind_deferred"]
+
+    def observe(**_kwargs: object) -> int:
+        assert load_mapping(_SESSION, _state=tmp_path) is not None
+        return 0
+
+    monkeypatch.setattr(observe_hooks, "handle_observe", observe)
+    _run(tmp_path, _payload("postToolUse", tool_name="Shell", tool_output="{}"))
+    mapping = load_mapping(_SESSION, _state=tmp_path)
+    assert mapping is not None and mapping.yoetz_task_id == _START["task_id"]
+
+
+@pytest.mark.parametrize("deferred", [False, True])
+def test_mapping_write_failure_has_bounded_diagnostic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, deferred: bool
+) -> None:
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise OSError("PRIVATE_WRITE_CANARY")
+
+    monkeypatch.setattr(hooks, "queue_mapping_store" if deferred else "store_mapping", fail)
+    if deferred:
+        with acquire_session_lock(_SESSION, _state=tmp_path):
+            _run(tmp_path, _payload())
+    else:
+        _run(tmp_path, _payload())
+    assert load_mapping(_SESSION, _state=tmp_path) is None
+    assert _diagnostics(tmp_path) == ["start_bind_write_failed"]
+
+
+def test_ordinary_renderer_installs_the_owner_bearing_binding_hook(tmp_path: Path) -> None:
+    launcher = tmp_path / "yoetz"
+    launcher.write_text("#!/bin/sh\nexit 0\n")
+    launcher.chmod(0o700)
+    rendered = render_cursor_plugin(
+        PluginFormatProfile.CURSOR_PLUGIN_NATIVE,
+        yoetz_launcher=(str(launcher),),
+        observation_profile="ordinary",
+    )
+    definition = json.loads(rendered.members["hooks/hooks.json"])["hooks"]
+    assert set(definition) == {
+        "afterMCPExecution",
+        "postToolUse",
+        "postToolUseFailure",
+        "preToolUse",
+        "sessionStart",
+        "sessionEnd",
+        "stop",
+    }
+    hook = definition["afterMCPExecution"]
+    assert len(hook) == 1 and hook[0]["timeout"] == 5
+    assert (
+        "--observation-profile cursor-ordinary-observation-v1 --event afterMCPExecution"
+        in hook[0]["command"]
+    )


### PR DESCRIPTION
## Summary

A successful Cursor MCP `start` never reached the lifecycle binder, leaving native observations unmapped or routed to a preceding task. Bind the exact owned start response before observation, using the existing strict IDs, lifecycle lock, structural mapping, and deferred-write machinery.

Cursor IDE 3.20.0's live hook payload reports `MCP:start` without server identity on `postToolUse`. Its `afterMCPExecution` reports bare `start` plus `mcp_server_name: yoetz`. The ordinary renderer now installs that owner-bearing hook **for binding only**, with no duplicate observation, capture, or advice. Existing server-scoped generic spellings remain supported; ambiguous/foreign names and failed results cannot bind. A subsequent Cursor hook applies a deferred mapping after the lifecycle lock becomes available.

The integration regression begins without a native mapping, retains a rejected pending observation, binds from the MCP result, then proves the pending row drains and subsequent shell output reaches the intended task's encrypted store and prepared semantic packet. The workspace ambiguity guard and shared Claude/Codex binder are unchanged. Legacy Cursor normalizer tests explicitly inject temporary lifecycle state. This keeps them away from the live installation without treating pytest directories beneath Linux `/tmp` as installed roots.

## Issue

- Refs #661. This repairs the missing adapter binding; the issue remains open for the live acceptance gate below.
- Searched existing issues and PRs for duplicates. Related #609, #581, #596, and #617; no competing #661 repair found.
- Scope is restoration of the existing host-binding contract. No new protocol, storage format, privacy/egress authority, or release pipeline. The user explicitly requested this repair and PR.
- Based on current `main` (`2eb47007`), independent of open #617 and the 0.3 line.

## Documentation

Behavior change: yes. Updated all three host runbooks.

Official references checked on 2026-09-08:

- [Cursor hooks](https://cursor.com/docs/hooks): `result_json` and `mcp_server_name` on `afterMCPExecution`; `tool_output` on generic `postToolUse`.
- [Claude Code hooks](https://code.claude.com/docs/en/hooks#posttooluse): successful `PostToolUse` uses `tool_response`. Its scoped binder and subscription remain unchanged; structured, text-block, JSON-string and failure regressions pass.
- [Codex hooks](https://developers.openai.com/codex/hooks): MCP `PostToolUse` carries the MCP call result in `tool_response` and canonical `mcp__server__tool` names. Its binder, subscription, and output behavior remain unchanged; lifecycle and observation regressions pass.

## Verification

**402 focused tests passed. All required CI checks passed on `5c3541c7718c6f834914cfc731638e606912018f`; no unresolved review threads.** Ten targeted new binding/renderer tests fail on unmodified `main` and pass with this repair. Covered both carriers, canonical session aliases, task switching, same-task replacement, invalid IDs/JSON, foreign tools, failed MCP wrappers, deferred mapping application, write failures, and unexpected binder/diagnostic exceptions. Binding faults cannot cancel the ordinary observation pass. Integration coverage includes the production coordinator, SQLite ledger, encrypted objects, and semantic-case builder; transport and provider dispatch are not live in that test.

```text
uv sync
uv run pytest -q tests/unit/cli/test_cursor_observe_hooks.py --basetemp /private/tmp/yz661-ci-temp
uv run pytest -q tests/unit/cli/test_cursor_start_binding.py tests/unit/cli/test_cursor_observe_hooks.py tests/unit/cli/test_claude_observe_hooks.py tests/unit/cli/test_hooks.py tests/unit/cli/test_observe_hooks.py tests/unit/cli/test_hook_io.py tests/unit/cli/test_native_observation_profiles.py tests/unit/adapters/test_codex_lifecycle.py tests/unit/adapters/test_cursor_integration.py tests/integration/application/test_native_capture_pipeline.py tests/conformance/honesty/test_observation_captured_evidence.py
uv run ruff check src/yoetz/cli/observe_hooks.py src/yoetz/adapters/integrations/cursor_integration.py tests/unit/cli/test_cursor_start_binding.py tests/integration/application/test_native_capture_pipeline.py
uv run ruff format --check src/yoetz/cli/observe_hooks.py src/yoetz/adapters/integrations/cursor_integration.py tests/unit/cli/test_cursor_start_binding.py tests/integration/application/test_native_capture_pipeline.py
/Users/shayb/yoetz-core/node_modules/.bin/pyright
uv run python scripts/sync_resource_ripple.py --check
uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

### Live acceptance gate

The native Cursor 3.20.0 probe used the already installed, runtime-pinned `cursor-fc22` test instance built from `fc22a2e7` (#617). It established both real hook identities and the serialized `content`/`isError` response wrapper; the committed redacted fixture is explicitly a **failed-start carrier fixture**, not a successful native binding certification.

The installed MCP returned `SESSION_CONFLICT / repository_identity_required` before task creation, including after supported server reload with only the registered project open. Consequently this run does **not** establish a successful native start on the repaired wheel, actual live mapping/ingestion, authorized content delivery, provider dispatch, or a native workflow receipt. Those #661 acceptance facets remain open. The source-level repair and offline composition evidence must not be promoted into a live end-to-end claim.

Temporary probe hooks were removed. The probe copied no vault material and changed no credentials, privacy grants, installed runtime, or plugin artifact. The separate Codex work ledger recorded this repair and its coverage limits. After installing the repaired build, apply the ordinary plugin preview to add the binding-only hook and verify live mapping, drain, content selection, and receipt separately. Earlier undelivered content cannot be reconstructed by structural drain.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] Host decisions are recorded for Cursor, Claude, and Codex. CLI/MCP schemas, TUI, and receipt renderers need no changes; diagnostics use existing closed codes. No new permission or one-way lifecycle action is introduced.
- [x] No generated resource was hand-edited; the owning fixed-point check passes.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

Implemented and reviewed by GPT-6 in the Codex desktop harness. Claude/Codex compatibility here means official-document review plus regression execution, not independent live host certification or a Claude-model review.
