### PR TITLE
fix(observation): recover capture inventory independently of admission

### DIFF
--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -3451,6 +3451,29 @@ egress: repository privacy selection and provider-attempt authorization remain i
 historical session-stream path is unchanged and excluded from this native ticket lane; shared
 replay, generation-fence, and teardown behavior applies across hosts.
 
+Admission-independent recovery (#695) uses private application methods, not a new RPC:
+`LocalObservationStore.capture_inventory_recovery_needed(workspace)` reports unknown scope or
+an unreconciled reservation. `pending_workspaces()` includes that durable demand even with an
+empty outbox. `ObservationCoordinator.recover_capture_inventory(workspace)` returns
+`ObservationCaptureRecoveryOutcome` or `None` when recovery is not needed. It routes only existing,
+unambiguous lifecycle mappings and invokes the same complete inventory callback under the shared
+capture lock. The READY `ObservationOutboxSweeper.capture_recovery` callback runs before per-workspace
+drain leases and outside the workflow-control gate. It rotates at most four workspace candidates
+per pass with a five-second cooperative budget, and tries at most eight mapping candidates per
+workspace before yielding. Started synchronous metadata/publication workers are joined on
+cancellation; a timed-out operation cannot publish after its capture lock has been released.
+The service callback verifies opened runtime task/session identities and supplies an internal
+`proof_guard` to `bootstrap_capture_reservations`; it rechecks the READY service/vault generation
+under the local-store publication lock. A false or failed guard leaves accounting unknown.
+
+The closed internal recovery outcomes are `capture_inventory_recovered`,
+`capture_inventory_mapping_missing`, `capture_inventory_route_unavailable`,
+`capture_inventory_unknown`, `capture_inventory_disabled`, `capture_inventory_busy`, and
+`capture_inventory_timeout`. They contribute only fixed reason counts to
+`ObservationDrainSummary.reasons`, not row delivery/attempt counts, coverage gaps, or raw
+exception text. No new diagnostic/RPC schema or task-loss event is introduced. A successful
+inventory does not clear loss identity/count history or bypass a real hard capacity limit.
+
 Outcome semantics and back-pressure vocabulary (ADR-022 decisions 12–13):
 
 - Paired `PostToolUse` materialization consumes `exit_status`, `denied`, boolean `success`, and a

--- a/docs/adr/ADR-029-smart-observation-selection.md
+++ b/docs/adr/ADR-029-smart-observation-selection.md
@@ -99,6 +99,34 @@ When older state lacks those bindings, pressure uses a conservative upper bound 
 subtracting bytes that might belong to another ticket. Content refusal preserves the structural
 observation and records both capture-budget and content-unavailable gaps.
 
+Unknown capture inventory is also durable service-maintenance demand, even when the outbox
+and selected buffer are empty. The READY observation sweep can reconcile that demand before any
+new native input is admitted (#695). It uses an existing unambiguous lifecycle mapping and the
+same authoritative catalog/bundle inventory as capture reservation; it does not invent a source
+event, a task binding, or a zero-backlog proof. Missing mappings and unreadable or inactive relevant
+routes remain unknown and are retried without requiring another hook. A healthy proven workspace
+does not request another recovery scan.
+
+A sweep rotates through at most four workspace candidates with a shared five-second cooperative
+recovery budget inside its ordinary sweep budget. A workspace turn rotates through at most eight
+existing session candidates, then performs at most one complete inventory bootstrap. Session
+cursor hints are bounded to 256 workspaces; eviction loses a hint, not accounting or authority.
+Recovery does not hold the general workflow/control gate or an outbox drain lease. Publication
+uses the same capture lock as reservation. Synchronous task metadata reads and local publication
+run off the service event loop; cancellation joins started worker operations before releasing
+the lock or runtime. These joins can exceed the cooperative deadline. The deadline is not a hard
+promise about a contended storage operation's elapsed time. Every opened runtime must match
+its catalog task/session identity. The service/vault generation is checked before inventory reads,
+after the final catalog reread, and under the local publication lock, so an obsolete READY
+instance cannot mint a replacement proof after waiting for that lock. Partial ticket enumeration
+cannot authorize releasing a reservation merely because its identity was not returned.
+
+A recovered inventory proves accounting, not spare capacity: real count, byte, pending-pair and
+capture ceilings still govern admission. Recovery neither deletes loss/quarantine history nor
+creates task coverage. Independently propagating correctly attributed local selection losses to
+task/check coverage without a later admitted envelope remains a separate #695 implementation
+slice; a recovered/empty queue is not evidence that earlier losses were absent.
+
 Detailed and larger capacity default to a current-session override. Workspace persistence is an
 explicit owner choice. A preview precedes non-default authority and describes scope, expiry,
 finite budgets, and increased storage and processing costs. Expiry, revoke, reset, and lowering a

--- a/docs/runbooks/claude-code-integration.md
+++ b/docs/runbooks/claude-code-integration.md
@@ -741,6 +741,20 @@ pressure and the complete projected buffer/outbox size; accepted replay work rem
 Hard pressure can recover to high before optional detail recovers. A generation-fenced session
 end retires pressure scheduling without deleting pending work or historical losses.
 
+Unknown capture inventory can reject new input even when the outbox is empty. The READY
+service now schedules a bounded inventory recovery pass independently of the next hook (#695),
+using an existing unambiguous mapping and the authoritative catalog/bundle inventory. An unreadable
+route or missing mapping stays blocked rather than being assumed empty; recovery retries after
+it becomes readable without requiring a fresh event. Do not reset local state, enlarge capacity,
+or toggle consent to manufacture a healthy status. Real hard limits continue to apply after
+inventory recovery, and previous loss counts and identities remain unchanged.
+
+Recovery emits fixed `capture_inventory_*` reason counts in its internal maintenance summary;
+these are not ledger receipts or a new hook diagnostic format. Historical local selection losses
+still need a separately attributed task/check propagation path when no later envelope is admitted.
+Host-shaped regression tests, including interleaved parent/worker routes and encrypted readback,
+are not a version-pinned acceptance run inside the installed vendor application.
+
 Hook and manual drain control failures have `control_` reasons. A protocol error is not a
 `ledger_rejected` result. A control failure stops further calls on that connection; the next
 hook, manual drain or service sweep can attempt the retained identity. Oversized or locally

--- a/docs/runbooks/codex-integration.md
+++ b/docs/runbooks/codex-integration.md
@@ -931,6 +931,20 @@ pressure and the complete projected buffer/outbox size; accepted replay work rem
 Hard pressure can recover to high before optional detail recovers. A generation-fenced session
 end retires pressure scheduling without deleting pending work or historical losses.
 
+Unknown capture inventory can reject new input even when the outbox is empty. The READY
+service now schedules a bounded inventory recovery pass independently of the next hook (#695),
+using an existing unambiguous mapping and the authoritative catalog/bundle inventory. An unreadable
+route or missing mapping stays blocked rather than being assumed empty; recovery retries after
+it becomes readable without requiring a fresh event. Do not reset local state, enlarge capacity,
+or toggle consent to manufacture a healthy status. Real hard limits continue to apply after
+inventory recovery, and previous loss counts and identities remain unchanged.
+
+Recovery emits fixed `capture_inventory_*` reason counts in its internal maintenance summary;
+these are not ledger receipts or a new hook diagnostic format. Historical local selection losses
+still need a separately attributed task/check propagation path when no later envelope is admitted.
+Host-shaped regression tests, including interleaved parent/worker routes and encrypted readback,
+are not a version-pinned acceptance run inside the installed vendor application.
+
 Hook and manual drain control failures have `control_` reasons. A protocol error is not a
 `ledger_rejected` result. A control failure stops further calls on that connection; the next
 hook, manual drain or service sweep can attempt the retained identity. Oversized or locally

--- a/docs/runbooks/cursor-integration.md
+++ b/docs/runbooks/cursor-integration.md
@@ -932,6 +932,20 @@ pressure and the complete projected buffer/outbox size; accepted replay work rem
 Hard pressure can recover to high before optional detail recovers. A generation-fenced session
 end retires pressure scheduling without deleting pending work or historical losses.
 
+Unknown capture inventory can reject new input even when the outbox is empty. The READY
+service now schedules a bounded inventory recovery pass independently of the next hook (#695),
+using an existing unambiguous mapping and the authoritative catalog/bundle inventory. An unreadable
+route or missing mapping stays blocked rather than being assumed empty; recovery retries after
+it becomes readable without requiring a fresh event. Do not reset local state, enlarge capacity,
+or toggle consent to manufacture a healthy status. Real hard limits continue to apply after
+inventory recovery, and previous loss counts and identities remain unchanged.
+
+Recovery emits fixed `capture_inventory_*` reason counts in its internal maintenance summary;
+these are not ledger receipts or a new hook diagnostic format. Historical local selection losses
+still need a separately attributed task/check propagation path when no later envelope is admitted.
+Host-shaped regression tests, including interleaved parent/worker routes and encrypted readback,
+are not a version-pinned acceptance run inside the installed vendor application.
+
 Hook and manual drain control failures have `control_` reasons. A protocol error is not a
 `ledger_rejected` result. A control failure stops further calls on that connection; the next
 hook, manual drain or service sweep can attempt the retained identity. Oversized or locally

--- a/docs/runbooks/observation-selection-performance.md
+++ b/docs/runbooks/observation-selection-performance.md
@@ -191,3 +191,24 @@ with an append-oriented representation, interrupt synchronous durable writes,
 or establish an end-to-end timeout guarantee. Historical quarantine cannot be
 attributed from the new diagnostic format. Keep those acceptance limits visible
 when assessing the linked PR.
+
+
+## Capture-inventory recovery regression (#695)
+
+The recovery regression must start from unknown capture accounting and an empty outbox, reject a
+new native failed-command input, then run the real service catalog inventory callback without a
+fresh hook. The test must distinguish a complete inventory from genuine spare capacity and verify
+subsequent encrypted-object readback, exact preservation of prior loss, and task isolation.
+
+The focused cases are in `tests/integration/service/test_capture_inventory_recovery.py` and
+`tests/unit/application/test_capture_recovery_scheduling.py`. They cover two real SQLite task
+stores and catalog routes, transient and permanently incomplete inventory, restart, cancellation
+while publication is running, an off-loop blocked task read, workspace/session fairness, real
+capture count pressure, and host-shaped Claude Code, Codex and Cursor parent/worker lanes. Runtime
+routing and control transport are in-process test doubles. These cases do not establish vendor
+installation, host deadline, full-daemon IPC throughput, or native concurrent delegation acceptance.
+
+Continue to run the existing fresh/retained concurrent adapter probe separately. Its latency and
+accounting measurements remain adapter-only evidence. Neither that probe nor a recovery summary
+proves that every local loss has reached task/check coverage; admission-independent loss
+propagation is a separate implementation slice of #695.

--- a/src/yoetz/adapters/integrations/observation_local.py
+++ b/src/yoetz/adapters/integrations/observation_local.py
@@ -5517,6 +5517,7 @@ class LocalObservationStore:
         *,
         observed_at: Timestamp | None = None,
         complete: bool = True,
+        proof_guard: Callable[[], bool] | None = None,
         ticket_ids_by_task: Mapping[str, tuple[str, ...]] | None = None,
     ) -> bool:
         """Account every task in a ready inventory before opening central admission.
@@ -5530,7 +5531,7 @@ class LocalObservationStore:
         """
 
         workspace = validate_commitment(workspace)
-        if type(complete) is not bool:
+        if type(complete) is not bool or (proof_guard is not None and not callable(proof_guard)):
             raise ProtocolValueError("invalid_event_value_type")
         stamp = self._wall_timestamp() if observed_at is None else observed_at
         if type(stamp) is not Timestamp:
@@ -5550,6 +5551,17 @@ class LocalObservationStore:
         )
         with self._lock:
             state = self._load(workspace)
+            # READY can change generation while this worker waits for flock.
+            # Revalidate under the store lock before replacing any accounting.
+            try:
+                current = proof_guard is None or proof_guard() is True
+            except Exception:
+                current = False
+            if not current:
+                state.capture_reservation_bootstrap = None
+                state.capture_backlog_scope_unknown = True
+                self._save(workspace, state)
+                return False
             state.capture_backlogs = snapshots
             state.capture_reservation_bootstrap = proof
             state.capture_backlog_scope_unknown = False
@@ -5573,6 +5585,21 @@ class LocalObservationStore:
                 state.capture_reservations = reconciled
             self._save(workspace, state)
         return True
+
+    @staticmethod
+    def _capture_inventory_recovery_pending(state: _WorkspaceState) -> bool:
+        """Use the same unknown dimensions as capture pressure, without summing occupancy."""
+
+        return state.capture_backlog_scope_unknown or any(
+            item.needs_reconcile for item in (state.capture_reservations or {}).values()
+        )
+
+    def capture_inventory_recovery_needed(self, workspace: str) -> bool:
+        """Read durable recovery demand independently of native-input admission."""
+
+        workspace = validate_commitment(workspace)
+        with self._lock:
+            return self._capture_inventory_recovery_pending(self._load(workspace))
 
     def capture_reservation_bootstrap_ready(
         self, workspace: str, task_id: str | None = None
@@ -6214,7 +6241,7 @@ class LocalObservationStore:
             )
 
     def pending_workspaces(self) -> tuple[str, ...]:
-        """Return opaque commitments with undelivered rows or lifecycle work."""
+        """Return opaque commitments with delivery, lifecycle, or capture recovery work."""
 
         with self._lock:
             pending: list[str] = []
@@ -6231,6 +6258,7 @@ class LocalObservationStore:
                     or state.pending_lifecycles
                     or state.admission_buffer.inputs
                     or pressure_active
+                    or self._capture_inventory_recovery_pending(state)
                 ):
                     pending.append(workspace)
             return tuple(sorted(pending, key=str.encode))

--- a/src/yoetz/application/observation_coordinator.py
+++ b/src/yoetz/application/observation_coordinator.py
@@ -46,6 +46,7 @@ from yoetz.application.observation_advice_semantic import (
     ObservationAdviceSemanticWorker,
 )
 from yoetz.application.observation_check_policy import load_observation_check_policy
+from yoetz.application.observation_drain import ObservationCaptureRecoveryOutcome
 from yoetz.application.observation_materialize import (
     MATERIALIZATION_LEGACY_MAPPING_VERSIONS,
     MATERIALIZATION_MAPPING_VERSION,
@@ -640,6 +641,9 @@ class ObservationCoordinator:
     # current coordinator has revalidated its route scope under the capture
     # lock.  Keep this fence process-local so restart/upgrade cannot reuse an
     # old proof without a fresh authoritative read.
+    _capture_recovery_sessions: dict[str, str] = field(
+        default_factory=lambda: dict[str, str](), init=False, repr=False
+    )
     _capture_bootstrap_verified_workspaces: set[str] = field(
         default_factory=_empty_capture_bootstrap_workspaces, init=False, repr=False
     )
@@ -755,6 +759,91 @@ class ObservationCoordinator:
             return
         await self._reconcile_capture_ticket_reservations(workspace, runtime, store)
 
+    def _remember_capture_bootstrap(self, workspace: str) -> None:
+        """Cache only a successfully validated inventory for this service generation."""
+
+        if (
+            workspace not in self._capture_bootstrap_verified_workspaces
+            and len(self._capture_bootstrap_verified_workspaces)
+            >= _MAX_CAPTURE_BOOTSTRAP_WORKSPACES
+        ):
+            self._capture_bootstrap_verified_workspaces.clear()
+        self._capture_bootstrap_verified_workspaces.add(workspace)
+
+    async def recover_capture_inventory(
+        self, workspace: str
+    ) -> ObservationCaptureRecoveryOutcome | None:
+        """Repair unknown inventory without requiring a newly admitted observation.
+
+        The service sweep invokes this metadata-only path. It uses existing,
+        unambiguous lifecycle mappings, not a synthetic envelope or a new grant.
+        Eight mapping candidates per turn and a bounded rotating cursor keep
+        missing parent/worker mappings from starving a usable route. The sweep
+        owns the elapsed deadline; the authoritative bootstrap joins its local
+        publication worker before cancellation can release the capture lock.
+        """
+
+        if not await self._local(partial(self.local.capture_inventory_recovery_needed, workspace)):
+            return None
+        if not self.observation_enabled or not await self._local(self.local.runtime_enabled):
+            return ObservationCaptureRecoveryOutcome.DISABLED
+        bootstrap = self.capture_budget_bootstrap
+        if bootstrap is None:
+            return ObservationCaptureRecoveryOutcome.INVENTORY_UNKNOWN
+        if self._capture_lock.locked():
+            return ObservationCaptureRecoveryOutcome.BUSY
+        sessions = await self._local(
+            partial(self.local.unambiguous_codex_sessions_for_workspace, workspace)
+        )
+        after = self._capture_recovery_sessions.get(workspace)
+        if after is not None:
+            sessions = tuple(item for item in sessions if item > after) + tuple(
+                item for item in sessions if item <= after
+            )
+        outcome = ObservationCaptureRecoveryOutcome.MAPPING_MISSING
+        for host_session in sessions[:8]:
+            if (
+                workspace not in self._capture_recovery_sessions
+                and len(self._capture_recovery_sessions) >= _MAX_CAPTURE_BOOTSTRAP_WORKSPACES
+            ):
+                # Forgetting an old hint never publishes an inventory proof.
+                self._capture_recovery_sessions.pop(next(iter(self._capture_recovery_sessions)))
+            self._capture_recovery_sessions[workspace] = host_session
+            current_runtime: TaskRuntime | None = None
+            try:
+                mapping = await self._local(
+                    partial(self.mapping_loader, host_session, _state=self.state_root)
+                )
+                if mapping is None:
+                    continue
+                current_runtime, _ = await self._route_observation_mapping(
+                    mapping, required_capabilities=frozenset({RuntimeCapability.WRITE})
+                )
+                store = self._observation_store(current_runtime)
+                # Do not queue behind another capture or hold the general
+                # workflow gate across a catalog/bundle inventory scan.
+                if self._capture_lock.locked():
+                    return ObservationCaptureRecoveryOutcome.BUSY
+                async with self._capture_lock:
+                    if not await self._local(
+                        partial(self.local.capture_inventory_recovery_needed, workspace)
+                    ):
+                        return None
+                    if await bootstrap(workspace, current_runtime, store):
+                        self._remember_capture_bootstrap(workspace)
+                        return ObservationCaptureRecoveryOutcome.RECOVERED
+                    self._capture_bootstrap_verified_workspaces.discard(workspace)
+                    # One complete-inventory attempt per workspace turn. A
+                    # sibling mapping cannot repair the same unreadable catalog.
+                    return ObservationCaptureRecoveryOutcome.INVENTORY_UNKNOWN
+            except Exception:
+                self._capture_bootstrap_verified_workspaces.discard(workspace)
+                outcome = ObservationCaptureRecoveryOutcome.ROUTE_UNAVAILABLE
+            finally:
+                if current_runtime is not None:
+                    await self.runtime.release(current_runtime)
+        return outcome
+
     async def _reserve_capture_ticket(
         self,
         workspace: str,
@@ -786,15 +875,7 @@ class ObservationCoordinator:
                             "Observation capture budget scope is unknown.",
                             retryable=False,
                         )
-                    if (
-                        workspace not in self._capture_bootstrap_verified_workspaces
-                        and len(self._capture_bootstrap_verified_workspaces)
-                        >= _MAX_CAPTURE_BOOTSTRAP_WORKSPACES
-                    ):
-                        # Forgetting the bounded verification cache forces a
-                        # fresh route read; it never authorizes a stale proof.
-                        self._capture_bootstrap_verified_workspaces.clear()
-                    self._capture_bootstrap_verified_workspaces.add(workspace)
+                    self._remember_capture_bootstrap(workspace)
             except PublicOperationError:
                 self._capture_bootstrap_verified_workspaces.discard(workspace)
                 raise

--- a/src/yoetz/application/observation_drain.py
+++ b/src/yoetz/application/observation_drain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import heapq
+import math
 from asyncio import Future
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -33,6 +34,7 @@ __all__ = [
     "DEFAULT_OBSERVATION_SWEEP_LIMIT",
     "EXPECTED_OBSERVATION_BACKPRESSURE_REASONS",
     "MAX_CONSECUTIVE_OBSERVATION_REJECTIONS",
+    "ObservationCaptureRecoveryOutcome",
     "ObservationDrainAction",
     "ObservationDrainDecision",
     "ObservationDrainSummary",
@@ -81,6 +83,18 @@ WORKSPACE_GLOBAL_OBSERVATION_STOP_REASONS: Final = frozenset(
 SAFE_OBSERVATION_REJECTION_REASONS: Final = frozenset(
     {item.value for item in ObservationGapCode} | RETRYABLE_OBSERVATION_REJECTIONS | {"duplicate"}
 )
+
+
+class ObservationCaptureRecoveryOutcome(str, Enum):  # noqa: UP042 - stable internal value
+    """Payload-free maintenance outcomes, never ledger or input-loss dispositions."""
+
+    RECOVERED = "capture_inventory_recovered"
+    MAPPING_MISSING = "capture_inventory_mapping_missing"
+    ROUTE_UNAVAILABLE = "capture_inventory_route_unavailable"
+    INVENTORY_UNKNOWN = "capture_inventory_unknown"
+    DISABLED = "capture_inventory_disabled"
+    BUSY = "capture_inventory_busy"
+    TIMEOUT = "capture_inventory_timeout"
 
 
 class ObservationDrainAction(str, Enum):  # noqa: UP042 - stable internal value
@@ -220,6 +234,13 @@ class ObservationOutboxSweeper:
     # behind the entire 20-second sweep. Local outbox bookkeeping stays outside the gate and is
     # already fenced by the per-workspace lease.
     ingest_gate: asyncio.Lock | None = None
+    # Recovery owns no hook output and no observation row. It runs outside the
+    # control/ingest gate, under the coordinator's capture lock instead.
+    capture_recovery: (
+        Callable[[str], Awaitable[ObservationCaptureRecoveryOutcome | None]] | None
+    ) = None
+    capture_recovery_budget_seconds: float = 5.0
+    _capture_recovery_after: str | None = field(default=None, init=False, repr=False)
     # Tests may provide a monotonic source so budget boundaries can be exercised without wall
     # clock sleeps. Production leaves this unset and uses the running loop's monotonic clock.
     _monotonic: Callable[[], float] | None = field(default=None, repr=False)
@@ -235,6 +256,58 @@ class ObservationOutboxSweeper:
             type(self.budget_seconds) is not float or not self.budget_seconds > 0.0
         ):
             raise ValueError("observation_sweep_budget_invalid")
+
+        if (
+            type(self.capture_recovery_budget_seconds) is not float
+            or not math.isfinite(self.capture_recovery_budget_seconds)
+            or self.capture_recovery_budget_seconds <= 0.0
+        ):
+            raise ValueError("observation_capture_recovery_budget_invalid")
+
+    async def _recover_capture_inventory(
+        self, workspaces: tuple[str, ...], *, remaining: float | None
+    ) -> tuple[ObservationCaptureRecoveryOutcome, ...]:
+        """Give at most four workspace lanes a fair, bounded maintenance turn.
+
+        Neither an empty outbox nor native admission pressure can suppress this
+        turn. An exhausted deadline rotates the next pass past the slow lane.
+        The callback must join side-effecting workers before cancellation returns.
+        """
+
+        recover = self.capture_recovery
+        if recover is None or not workspaces:
+            return ()
+        budget = self.capture_recovery_budget_seconds
+        if remaining is not None:
+            budget = min(budget, remaining)
+        if budget <= 0.0:
+            return ()
+        ordered = sorted(set(workspaces), key=str.encode)
+        after = self._capture_recovery_after
+        if after is not None:
+            ordered = [item for item in ordered if item > after] + [
+                item for item in ordered if item <= after
+            ]
+        deadline = asyncio.get_running_loop().time() + budget
+        outcomes: list[ObservationCaptureRecoveryOutcome] = []
+        for workspace in ordered[:4]:
+            available = deadline - asyncio.get_running_loop().time()
+            if available <= 0.0:
+                break
+            self._capture_recovery_after = workspace
+            try:
+                async with asyncio.timeout(available):
+                    result = await recover(workspace)
+            except TimeoutError:
+                result = ObservationCaptureRecoveryOutcome.TIMEOUT
+            except Exception:
+                # Do not copy exception text, paths, or payloads into diagnostics.
+                result = ObservationCaptureRecoveryOutcome.INVENTORY_UNKNOWN
+            if result is not None:
+                if type(result) is not ObservationCaptureRecoveryOutcome:
+                    result = ObservationCaptureRecoveryOutcome.INVENTORY_UNKNOWN
+                outcomes.append(result)
+        return tuple(outcomes)
 
     def _off_loop[ResultT](self, call: Callable[[], ResultT]) -> Future[ResultT]:
         """Run one blocking local-store call off the caller's event loop.
@@ -295,6 +368,9 @@ class ObservationOutboxSweeper:
         workspaces = tuple(
             dict.fromkeys((*lifecycle_workspaces, *(workspace for workspace, _row in rows)))
         )
+        remaining = None if deadline is None else deadline - monotonic()
+        for outcome in await self._recover_capture_inventory(workspaces, remaining=remaining):
+            reasons[outcome.value] = reasons.get(outcome.value, 0) + 1
         for workspace in workspaces:
             if deadline is not None and monotonic() >= deadline:
                 # Budget spent: return what this pass resolved so far. The rows

--- a/src/yoetz/service/ready_composition.py
+++ b/src/yoetz/service/ready_composition.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import contextvars
 import hashlib
 import io
 import os
@@ -193,6 +194,7 @@ from yoetz.ports.objects import (
 from yoetz.ports.observation import TaskObservationPort
 from yoetz.ports.privacy import HumanAuthorityCapability
 from yoetz.ports.runtime import (
+    BundleRuntimePort,
     OwnershipFence,
     RouteAccess,
     RouteCommand,
@@ -2430,6 +2432,208 @@ def _observation_workspace_for_runtime(runtime: TaskRuntime) -> str | None:
     return workspace
 
 
+async def _run_capture_inventory_joined[ResultT](
+    call: Callable[[], ResultT], *, operation: str
+) -> ResultT:
+    """Keep the executor future owned until metadata/publication actually settles.
+
+    READY teardown may cancel all Tasks, including a to_thread intermediary.
+    Await the executor Future directly so that cancellation of such a Task
+    cannot orphan an active proof mutation and release capture exclusion early.
+    """
+
+    worker = asyncio.get_running_loop().run_in_executor(
+        None, partial(contextvars.copy_context().run, call)
+    )
+    try:
+        await asyncio.wait((worker,))
+        return worker.result()
+    except asyncio.CancelledError:
+        while not worker.done():
+            try:
+                await asyncio.wait((worker,))
+            except asyncio.CancelledError:
+                continue
+        try:
+            worker.result()
+        except BaseException as worker_error:
+            if not isinstance(worker_error, asyncio.CancelledError):
+                record_unexpected_exception_without_raising(
+                    worker_error,
+                    component="service.ready_composition",
+                    operation=operation,
+                )
+        raise
+
+
+async def _bootstrap_capture_reservations(
+    workspace: str,
+    current_runtime: TaskRuntime,
+    current_store: TaskObservationPort,
+    *,
+    catalog: StartCatalogPort,
+    runtime: BundleRuntimePort,
+    local_observation: LocalObservationStore,
+    clock: ClockPort,
+    generation_is_current: Callable[[], bool],
+) -> bool:
+    """Read the complete catalog inventory before central admission.
+
+    The coordinator invokes this callback while its process-wide capture
+    lock is held.  The current route's repository commitment scopes the
+    inventory; matching routes are all accounted for, while an unreadable
+    or inactive route fails closed instead of being silently omitted.
+    """
+
+    try:
+        if not generation_is_current():
+            raise ValueError("capture_generation_changed")
+        current_route = await catalog.resolve_route(current_runtime.session_id)
+        if (
+            current_route is None
+            or current_route.state is not TaskRouteState.ACTIVE
+            or current_route.task_id != current_runtime.task_id
+            or current_route.repository_privacy_commitment is None
+        ):
+            raise ValueError("capture_current_route_unavailable")
+        repository = current_route.repository_privacy_commitment
+        recovery_routes = getattr(catalog, "recovery_routes", None)
+        if not callable(recovery_routes):
+            raise ValueError("capture_catalog_inventory_unavailable")
+        raw_routes = await cast(Callable[[], Awaitable[tuple[TaskRoute, ...]]], recovery_routes)()
+        if type(raw_routes) is not tuple:
+            raise ValueError("capture_catalog_inventory_invalid")
+        if any(type(route) is not TaskRoute for route in raw_routes):
+            raise ValueError("capture_catalog_inventory_invalid")
+        all_routes = raw_routes
+        if len({route.task_id for route in all_routes}) != len(all_routes):
+            raise ValueError("capture_catalog_inventory_duplicate")
+        routes = tuple(
+            route
+            for route in all_routes
+            if route.repository_privacy_commitment in {repository, None}
+        )
+        if not routes or len(routes) > 256:
+            raise ValueError("capture_catalog_inventory_incomplete")
+        if any(route.state is not TaskRouteState.ACTIVE for route in routes):
+            raise ValueError("capture_catalog_inventory_inactive")
+        if current_route.task_id not in {route.task_id for route in routes}:
+            raise ValueError("capture_catalog_inventory_incomplete")
+        inventory: dict[str, ObservationCaptureBacklog] = {}
+        ticket_ids_by_task: dict[str, tuple[str, ...]] = {}
+        for route in sorted(routes, key=lambda item: item.task_id.encode()):
+            task_runtime: TaskRuntime | None = None
+            release = False
+            try:
+                if route.task_id == current_runtime.task_id:
+                    task_runtime = current_runtime
+                    task_store = current_store
+                else:
+                    binding = await catalog.session_binding(route.session_id)
+                    if (
+                        binding is None
+                        or binding.task_id != route.task_id
+                        or binding.session_id != route.session_id
+                    ):
+                        raise ValueError("capture_route_binding_unavailable")
+                    task_runtime = await runtime.route(
+                        RouteCommand(
+                            session_id=route.session_id,
+                            writer_id=binding.writer_id,
+                            access=RouteAccess.WRITE,
+                            required_capabilities=frozenset({RuntimeCapability.WRITE}),
+                        )
+                    )
+                    release = True
+                    task_store = task_runtime.observation
+                if (
+                    task_runtime.task_id != route.task_id
+                    or task_runtime.session_id != route.session_id
+                ):
+                    raise ValueError("capture_task_route_changed")
+                if task_store is None:
+                    raise ValueError("capture_task_observation_unavailable")
+                reader = getattr(task_store, "capture_backlog", None)
+                if not callable(reader):
+                    raise ValueError("capture_task_backlog_unavailable")
+                # Task metadata adapters are synchronous and may encounter
+                # a SQLite busy wait. Keep that wait off the control loop,
+                # joining before releasing the runtime on cancellation.
+                backlog = await _run_capture_inventory_joined(
+                    partial(reader, workspace), operation="capture_inventory_backlog_read_failed"
+                )
+                if type(backlog) is not ObservationCaptureBacklog:
+                    raise ValueError("capture_task_backlog_invalid")
+                inventory[route.task_id] = backlog
+                list_pending = getattr(task_store, "list_pending_capture_tickets", None)
+                if callable(list_pending):
+                    raw_tickets = await _run_capture_inventory_joined(
+                        partial(list_pending, route.task_id),
+                        operation="capture_inventory_ticket_read_failed",
+                    )
+                    tickets = cast(tuple[object, ...], raw_tickets)
+                    if type(raw_tickets) is not tuple or any(
+                        type(ticket) is not ObservationCaptureTicket for ticket in tickets
+                    ):
+                        raise ValueError("capture_task_ticket_inventory_invalid")
+                    scoped_ids: list[str] = []
+                    typed_tickets = cast(tuple[ObservationCaptureTicket, ...], tickets)
+                    for ticket in typed_tickets:
+                        if ticket.task_id != route.task_id:
+                            raise ValueError("capture_task_ticket_owner_invalid")
+                        if ticket.workspace_commitment == workspace:
+                            ticket_id = observation_capture_ticket_id(ticket)
+                            if ticket_id in scoped_ids:
+                                raise ValueError("capture_task_ticket_duplicate")
+                            scoped_ids.append(ticket_id)
+                    if len(scoped_ids) == backlog.count and all(
+                        ticket.workspace_commitment == workspace for ticket in typed_tickets
+                    ):
+                        ticket_ids_by_task[route.task_id] = tuple(
+                            sorted(scoped_ids, key=str.encode)
+                        )
+            finally:
+                if release and task_runtime is not None:
+                    with contextlib.suppress(Exception):
+                        await runtime.release(task_runtime)
+        # Re-read the catalog after all bundle reads.  A route change while
+        # the inventory was in flight must not mint a proof for a stale set.
+        final_raw_routes = await cast(
+            Callable[[], Awaitable[tuple[TaskRoute, ...]]], recovery_routes
+        )()
+        if not generation_is_current():
+            raise ValueError("capture_generation_changed")
+        if final_raw_routes != raw_routes:
+            raise ValueError("capture_catalog_inventory_changed")
+        bootstrap = getattr(local_observation, "bootstrap_capture_reservations", None)
+        if not callable(bootstrap):
+            raise ValueError("capture_bootstrap_unavailable")
+        observed_at = timestamp_from_datetime(clock.now_utc())
+        return bool(
+            await _run_capture_inventory_joined(
+                partial(
+                    bootstrap,
+                    workspace,
+                    inventory,
+                    observed_at=observed_at,
+                    complete=True,
+                    proof_guard=generation_is_current,
+                    ticket_ids_by_task=ticket_ids_by_task or None,
+                ),
+                operation="observation_capture_inventory_publish",
+            )
+        )
+    except Exception:
+        mark_unknown = getattr(local_observation, "mark_capture_backlog_scope_unknown", None)
+        if callable(mark_unknown):
+            with contextlib.suppress(Exception):
+                await _run_capture_inventory_joined(
+                    partial(mark_unknown, workspace),
+                    operation="observation_capture_inventory_unknown",
+                )
+        return False
+
+
 async def _reconcile_observation_capture(
     runtime: TaskRuntime,
     local_observation: LocalObservationStore,
@@ -3530,139 +3734,18 @@ async def provide_service_ready_context(
         current_runtime: TaskRuntime,
         current_store: TaskObservationPort,
     ) -> bool:
-        """Read the complete catalog inventory before central admission.
-
-        The coordinator invokes this callback while its process-wide capture
-        lock is held.  The current route's repository commitment scopes the
-        inventory; matching routes are all accounted for, while an unreadable
-        or inactive route fails closed instead of being silently omitted.
-        """
-
-        try:
-            current_route = await catalog.resolve_route(current_runtime.session_id)
-            if (
-                current_route is None
-                or current_route.state is not TaskRouteState.ACTIVE
-                or current_route.task_id != current_runtime.task_id
-                or current_route.repository_privacy_commitment is None
-            ):
-                raise ValueError("capture_current_route_unavailable")
-            repository = current_route.repository_privacy_commitment
-            recovery_routes = getattr(catalog, "recovery_routes", None)
-            if not callable(recovery_routes):
-                raise ValueError("capture_catalog_inventory_unavailable")
-            raw_routes = await cast(
-                Callable[[], Awaitable[tuple[TaskRoute, ...]]], recovery_routes
-            )()
-            if type(raw_routes) is not tuple:
-                raise ValueError("capture_catalog_inventory_invalid")
-            if any(type(route) is not TaskRoute for route in raw_routes):
-                raise ValueError("capture_catalog_inventory_invalid")
-            all_routes = raw_routes
-            if len({route.task_id for route in all_routes}) != len(all_routes):
-                raise ValueError("capture_catalog_inventory_duplicate")
-            routes = tuple(
-                route
-                for route in all_routes
-                if route.repository_privacy_commitment in {repository, None}
-            )
-            if not routes or len(routes) > 256:
-                raise ValueError("capture_catalog_inventory_incomplete")
-            if any(route.state is not TaskRouteState.ACTIVE for route in routes):
-                raise ValueError("capture_catalog_inventory_inactive")
-            if current_route.task_id not in {route.task_id for route in routes}:
-                raise ValueError("capture_catalog_inventory_incomplete")
-            inventory: dict[str, ObservationCaptureBacklog] = {}
-            ticket_ids_by_task: dict[str, tuple[str, ...]] = {}
-            for route in sorted(routes, key=lambda item: item.task_id.encode()):
-                task_runtime: TaskRuntime | None = None
-                release = False
-                try:
-                    if route.task_id == current_runtime.task_id:
-                        task_runtime = current_runtime
-                        task_store = current_store
-                    else:
-                        binding = await catalog.session_binding(route.session_id)
-                        if (
-                            binding is None
-                            or binding.task_id != route.task_id
-                            or binding.session_id != route.session_id
-                        ):
-                            raise ValueError("capture_route_binding_unavailable")
-                        task_runtime = await runtime.route(
-                            RouteCommand(
-                                session_id=route.session_id,
-                                writer_id=binding.writer_id,
-                                access=RouteAccess.WRITE,
-                                required_capabilities=frozenset({RuntimeCapability.WRITE}),
-                            )
-                        )
-                        release = True
-                        task_store = task_runtime.observation
-                    if task_store is None:
-                        raise ValueError("capture_task_observation_unavailable")
-                    reader = getattr(task_store, "capture_backlog", None)
-                    if not callable(reader):
-                        raise ValueError("capture_task_backlog_unavailable")
-                    backlog = reader(workspace)
-                    if type(backlog) is not ObservationCaptureBacklog:
-                        raise ValueError("capture_task_backlog_invalid")
-                    inventory[route.task_id] = backlog
-                    list_pending = getattr(task_store, "list_pending_capture_tickets", None)
-                    if callable(list_pending):
-                        raw_tickets = list_pending(route.task_id)
-                        tickets = cast(tuple[object, ...], raw_tickets)
-                        if type(raw_tickets) is not tuple or any(
-                            type(ticket) is not ObservationCaptureTicket for ticket in tickets
-                        ):
-                            raise ValueError("capture_task_ticket_inventory_invalid")
-                        scoped_ids: list[str] = []
-                        typed_tickets = cast(tuple[ObservationCaptureTicket, ...], tickets)
-                        for ticket in typed_tickets:
-                            if ticket.task_id != route.task_id:
-                                raise ValueError("capture_task_ticket_owner_invalid")
-                            if ticket.workspace_commitment == workspace:
-                                ticket_id = observation_capture_ticket_id(ticket)
-                                if ticket_id in scoped_ids:
-                                    raise ValueError("capture_task_ticket_duplicate")
-                                scoped_ids.append(ticket_id)
-                        if all(
-                            ticket.workspace_commitment == workspace for ticket in typed_tickets
-                        ):
-                            ticket_ids_by_task[route.task_id] = tuple(
-                                sorted(scoped_ids, key=str.encode)
-                            )
-                finally:
-                    if release and task_runtime is not None:
-                        with contextlib.suppress(Exception):
-                            await runtime.release(task_runtime)
-            # Re-read the catalog after all bundle reads.  A route change while
-            # the inventory was in flight must not mint a proof for a stale set.
-            final_raw_routes = await cast(
-                Callable[[], Awaitable[tuple[TaskRoute, ...]]], recovery_routes
-            )()
-            if final_raw_routes != raw_routes:
-                raise ValueError("capture_catalog_inventory_changed")
-            bootstrap = getattr(local_observation, "bootstrap_capture_reservations", None)
-            if not callable(bootstrap):
-                raise ValueError("capture_bootstrap_unavailable")
-            observed_at = timestamp_from_datetime(clock.now_utc())
-            return bool(
-                await asyncio.to_thread(
-                    bootstrap,
-                    workspace,
-                    inventory,
-                    observed_at=observed_at,
-                    complete=True,
-                    ticket_ids_by_task=ticket_ids_by_task or None,
-                )
-            )
-        except Exception:
-            mark_unknown = getattr(local_observation, "mark_capture_backlog_scope_unknown", None)
-            if callable(mark_unknown):
-                with contextlib.suppress(Exception):
-                    await asyncio.to_thread(mark_unknown, workspace)
-            return False
+        return await _bootstrap_capture_reservations(
+            workspace,
+            current_runtime,
+            current_store,
+            catalog=catalog,
+            runtime=runtime,
+            local_observation=local_observation,
+            clock=clock,
+            generation_is_current=lambda: generation_is_current(
+                service_generation, vault_generation
+            ),
+        )
 
     async def reconcile_observation_capture(runtime: TaskRuntime) -> None:
         store = runtime.observation
@@ -3825,6 +3908,7 @@ async def provide_service_ready_context(
         observation_coordinator,
         budget_seconds=DEFAULT_OBSERVATION_SWEEP_BUDGET_SECONDS,
         ingest_gate=observation_gate,
+        capture_recovery=observation_coordinator.recover_capture_inventory,
     )
     legacy_spool_forwarder = _LegacyHookSpoolForwarder(paths.state)
 

--- a/tests/integration/application/test_native_capture_pipeline.py
+++ b/tests/integration/application/test_native_capture_pipeline.py
@@ -214,6 +214,7 @@ async def _pipeline(
     codex_session_id: str,
     profile: str | None,
     install_mapping: bool = True,
+    identity: tuple[str, str, str] | None = None,
 ) -> tuple[
     Path,
     str,
@@ -237,9 +238,11 @@ async def _pipeline(
         local.enable_content_capture(workspace, profile)
     session_commitment = local.bind_codex_session(workspace, codex_session_id)
 
-    task_id = _ids(IdKind.TASK, 1)
-    yoetz_session_id = _ids(IdKind.SESSION, 2)
-    writer_id = _ids(IdKind.WRITER, 3)
+    task_id, yoetz_session_id, writer_id = identity or (
+        _ids(IdKind.TASK, 1),
+        _ids(IdKind.SESSION, 2),
+        _ids(IdKind.WRITER, 3),
+    )
     if install_mapping:
         store_mapping(
             LifecycleMapping(
@@ -2221,3 +2224,95 @@ async def test_disabled_native_content_never_enters_service_request(tmp_path: Pa
     assert len(pending) == 1
     assert pending[0].envelope.event_kind == "PostToolUse"
     assert pending[0].envelope.content_object_refs == ()
+
+
+@pytest.mark.anyio
+async def test_service_recovers_unknown_inventory_without_a_fresh_native_event(
+    tmp_path: Path,
+) -> None:
+    """A rejected failed-command hook must not be the only path to inventory repair."""
+
+    from yoetz.application.observation_drain import ObservationOutboxSweeper
+    from yoetz.domain.observation import ObservationCaptureBacklog
+
+    profile = CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID
+    (
+        project,
+        workspace,
+        session,
+        local,
+        observation,
+        _ledger,
+        runtime,
+        coordinator,
+        client,
+        connect,
+    ) = await _pipeline(tmp_path, codex_session_id="claude:inventory-recovery", profile=profile)
+    run_hook = _claude_hook_runner(
+        project=project, state=tmp_path / "state", connect=connect, profile=profile
+    )
+    local.bootstrap_capture_reservations(
+        workspace, {runtime.task_id: ObservationCaptureBacklog(0, 0, None)}
+    )
+    local.mark_capture_backlog_scope_unknown(workspace)
+    callback = coordinator.capture_budget_bootstrap
+    assert callback is not None
+    bootstrap_calls: list[str] = []
+
+    async def bootstrap(workspace: str, current: TaskRuntime, store: TaskObservationPort) -> bool:
+        bootstrap_calls.append(workspace)
+        return await callback(workspace, current, store)
+
+    coordinator.capture_budget_bootstrap = bootstrap
+    assert (
+        await asyncio.to_thread(
+            run_hook,
+            "PostToolUseFailure",
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "session_id": "inventory-recovery",
+                "tool_name": "Bash",
+                "tool_use_id": "rejected-before-recovery",
+                "error": "synthetic failed command",
+                "exit_status": 1,
+            },
+        )
+        == 0
+    )
+    assert local.pending_outbox_count(workspace) == 0
+    assert local.selection_accounting(workspace)["unrecoverable_input_count"] == 1
+    assert bootstrap_calls == []
+    assert client.requests == []
+
+    sweeper = ObservationOutboxSweeper(
+        local, coordinator, capture_recovery=coordinator.recover_capture_inventory
+    )
+    try:
+        summary = await sweeper.sweep()
+        assert summary.attempted == 0
+        assert bootstrap_calls == [workspace]
+        assert local.capture_reservation_bootstrap_ready(workspace, runtime.task_id)
+        assert local.selection_runtime_status(workspace, session)["admission_allowed"] is True
+        assert local.selection_accounting(workspace)["unrecoverable_input_count"] == 1
+        assert (
+            await asyncio.to_thread(
+                run_hook,
+                "PostToolUse",
+                {
+                    "hook_event_name": "PostToolUse",
+                    "session_id": "inventory-recovery",
+                    "tool_name": "Bash",
+                    "tool_use_id": "accepted-after-recovery",
+                    "tool_response": "capture-recovery-marker-695",
+                    "exit_status": 1,
+                },
+            )
+            == 0
+        )
+        assert any(request.capture_only for request in client.requests)
+        envelopes = observation.list_envelopes_for_session(workspace, session)
+        assert envelopes
+        assert local.selection_accounting(workspace)["unrecoverable_input_count"] == 1
+    finally:
+        sweeper.close()
+        coordinator.close()

--- a/tests/integration/service/test_capture_inventory_recovery.py
+++ b/tests/integration/service/test_capture_inventory_recovery.py
@@ -1,0 +1,972 @@
+"""Issue #695: real catalog inventory recovery is independent of native admission."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import threading
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from functools import partial
+from pathlib import Path
+from typing import cast
+
+import apsw
+import pytest
+
+import yoetz.service.ready_composition as ready_module
+from conformance.adapters import test_start_catalog_port as catalog_fixture
+from integration.application import test_native_capture_pipeline as native
+from yoetz.adapters.integrations.observation_local import LocalObservationStore
+from yoetz.adapters.sqlite.migrations import initialize_bundle
+from yoetz.adapters.sqlite.observation import SqliteObservationStore
+from yoetz.adapters.sqlite.start_catalog import SqliteStartCatalog
+from yoetz.application.observation_coordinator import ObservationCoordinator
+from yoetz.application.observation_drain import (
+    ObservationCaptureRecoveryOutcome,
+    ObservationOutboxSweeper,
+)
+from yoetz.application.semantic_content import resolve_captured_semantic_content
+from yoetz.domain.observation import (
+    ObservationCaptureBacklog,
+    ObservationCaptureTicket,
+    ObservationCursor,
+    ObservationIngestRequest,
+    ObservationSource,
+)
+from yoetz.domain.observation_budget import BudgetLimits, CapacityProfile
+from yoetz.domain.observation_profiles import (
+    CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
+    CURSOR_ORDINARY_OBSERVATION_PROFILE_ID,
+)
+from yoetz.domain.values import timestamp_from_datetime
+from yoetz.ports.ledger import FrozenCase
+from yoetz.ports.runtime import BundleRuntimePort, RouteCommand, TaskRuntime
+from yoetz.ports.start_catalog import StartAllocation, StartCatalogPort, TaskRoute, TaskRouteState
+from yoetz.protocol.canonical import JsonValue as CanonicalJsonValue
+from yoetz.protocol.canonical import canonical_encode
+from yoetz.protocol.ids import IdKind
+
+_REPOSITORY = "hmac-sha256:" + "7" * 64
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _Routes:
+    """Route real observation stores, with explicit fault/latency injection."""
+
+    def __init__(self, runtimes: tuple[TaskRuntime, ...]) -> None:
+        self.runtimes = {item.session_id: item for item in runtimes}
+        self.held: list[TaskRuntime] = []
+        self.calls: list[str] = []
+        self.block_session: str | None = None
+        self.entered = asyncio.Event()
+        self.resume = asyncio.Event()
+
+    async def route(self, command: RouteCommand) -> TaskRuntime:
+        self.calls.append(command.session_id)
+        if command.session_id == self.block_session:
+            self.entered.set()
+            await self.resume.wait()
+        current = self.runtimes[command.session_id]
+        self.held.append(current)
+        return current
+
+    async def release(self, current: TaskRuntime) -> None:
+        self.held.remove(current)
+
+
+@dataclass
+class _World:
+    root: Path
+    project: Path
+    workspace: str
+    session: str
+    local: LocalObservationStore
+    catalog: SqliteStartCatalog
+    routes: _Routes
+    runtime: TaskRuntime
+    sibling: TaskRuntime
+    observation: SqliteObservationStore
+    sibling_observation: SqliteObservationStore
+    sibling_database: apsw.Connection
+    coordinator: ObservationCoordinator
+    requests: list[ObservationIngestRequest]
+    connect: Callable[[object], Awaitable[object]]
+    host_session: str
+
+    def wire(self, *, generation_is_current: Callable[[], bool] = lambda: True) -> None:
+        self.coordinator.runtime = cast(BundleRuntimePort, self.routes)
+        self.coordinator.local = self.local
+        self.coordinator.capture_budget_bootstrap = partial(
+            ready_module._bootstrap_capture_reservations,  # pyright: ignore[reportPrivateUsage]
+            catalog=cast(StartCatalogPort, self.catalog),
+            runtime=cast(BundleRuntimePort, self.routes),
+            local_observation=self.local,
+            clock=self.coordinator.clock,
+            generation_is_current=generation_is_current,
+        )
+
+    def sweep(self, *, capture_recovery_budget_seconds: float = 5.0) -> ObservationOutboxSweeper:
+        return ObservationOutboxSweeper(
+            self.local,
+            self.coordinator,
+            capture_recovery=self.coordinator.recover_capture_inventory,
+            capture_recovery_budget_seconds=capture_recovery_budget_seconds,
+        )
+
+
+async def _world(tmp_path: Path, *, host: str = "claude") -> _World:
+    """Create two completed real SQLite catalog routes and two task SQLite stores."""
+
+    clock = catalog_fixture._Clock(datetime(2026, 9, 10, tzinfo=UTC))  # pyright: ignore[reportPrivateUsage]
+    installation = native._ids(IdKind.INSTALLATION, 695)  # pyright: ignore[reportPrivateUsage]
+    catalog = catalog_fixture._sqlite_catalog(installation, clock)  # pyright: ignore[reportPrivateUsage]
+    allocations: list[StartAllocation] = []
+    for seed in (1, 2):
+        request = await catalog_fixture._command(  # pyright: ignore[reportPrivateUsage]
+            catalog,
+            operation_id=native._ids(IdKind.REQUEST, 700 + seed),  # pyright: ignore[reportPrivateUsage]
+            workspace_ref=f"synthetic-workspace-{seed}",
+            external_ref=f"synthetic-task-{seed}",
+            repository_privacy_commitment=_REPOSITORY,
+        )
+        allocation = await catalog.reserve_or_resume(request)
+        await catalog_fixture._finish(catalog, allocation)  # pyright: ignore[reportPrivateUsage]
+        allocations.append(allocation)
+    first, second = allocations
+    profile = {
+        "claude": CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
+        "cursor": CURSOR_ORDINARY_OBSERVATION_PROFILE_ID,
+        "codex": None,
+    }[host]
+    host_session = "inventory-recovery" if host == "codex" else f"{host}:inventory-recovery"
+    (
+        project,
+        workspace,
+        session,
+        local,
+        observation,
+        _ledger,
+        runtime,
+        coordinator,
+        client,
+        connect,
+    ) = await native._pipeline(  # pyright: ignore[reportPrivateUsage]
+        tmp_path,
+        codex_session_id=host_session,
+        profile=profile,
+        identity=(first.task_id, first.session_id, first.writer_id),
+    )
+    sibling_db = apsw.Connection(str(tmp_path / "sibling.sqlite3"))
+    initialize_bundle(
+        sibling_db,
+        {"task_id": second.task_id, "owner_generation": "1", "owner_nonce": "test-nonce"},
+    )
+    sibling_store = SqliteObservationStore(sibling_db)
+    sibling = replace(
+        runtime,
+        task_id=second.task_id,
+        session_id=second.session_id,
+        writer_id=second.writer_id,
+        observation=sibling_store,
+    )
+    routes = _Routes((runtime, sibling))
+    world = _World(
+        tmp_path,
+        project,
+        workspace,
+        session,
+        local,
+        catalog,
+        routes,
+        runtime,
+        sibling,
+        observation,
+        sibling_store,
+        sibling_db,
+        coordinator,
+        client.requests,
+        cast(Callable[[object], Awaitable[object]], connect),
+        host_session,
+    )
+    world.wire()
+    local.set_capture_reservation_bootstrap_required(True)
+    local.bootstrap_capture_reservations(
+        workspace, {runtime.task_id: ObservationCaptureBacklog(0, 0, None)}
+    )
+    local.update_capture_backlog(
+        workspace, 0, 0, None, timestamp_from_datetime(clock.now_utc()), route_id=sibling.task_id
+    )
+    assert not local.capture_reservation_bootstrap_ready(workspace)
+    assert local.pending_outbox_count(workspace) == 0
+    return world
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("restart", (False, True), ids=("live", "restart"))
+async def test_real_catalog_recovers_both_routes_with_no_new_host_event(
+    tmp_path: Path,
+    restart: bool,
+) -> None:
+    world = await _world(tmp_path)
+    if restart:
+        world.coordinator.close()
+        world.local = LocalObservationStore(_state=tmp_path / "state")
+        world.local.set_capture_reservation_bootstrap_required(True)
+        world.coordinator = ObservationCoordinator(
+            runtime=cast(BundleRuntimePort, world.routes),
+            local=world.local,
+            clock=world.coordinator.clock,
+            ids=world.coordinator.ids,
+            state_root=tmp_path / "state",
+        )
+        world.wire()
+    sweeper = world.sweep()
+    try:
+        summary = await sweeper.sweep()
+        assert summary.attempted == summary.acknowledged == 0
+        assert summary.reasons == (("capture_inventory_recovered", 1),)
+        for current in (world.runtime, world.sibling):
+            assert world.local.capture_reservation_bootstrap_ready(world.workspace, current.task_id)
+        assert (
+            world.local.selection_runtime_status(world.workspace, world.session)[
+                "admission_allowed"
+            ]
+            is True
+        )
+        assert not world.routes.held
+        assert world.requests == []
+        calls = len(world.routes.calls)
+        await sweeper.sweep()
+        assert len(world.routes.calls) == calls  # no repeated healthy catalog scan
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_transient_bundle_read_failure_retries_without_native_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    world = await _world(tmp_path)
+    original = world.sibling_observation.capture_backlog
+
+    def unreadable(_workspace: str) -> ObservationCaptureBacklog:
+        raise OSError("synthetic-private-path-must-not-enter-diagnostics")
+
+    monkeypatch.setattr(world.sibling_observation, "capture_backlog", unreadable)
+    sweeper = world.sweep()
+    try:
+        failed = await sweeper.sweep()
+        assert failed.reasons == (("capture_inventory_unknown", 1),)
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+        assert world.local.pending_workspaces() == (world.workspace,)
+        assert not world.routes.held
+        monkeypatch.setattr(world.sibling_observation, "capture_backlog", original)
+        recovered = await sweeper.sweep()
+        assert recovered.reasons == (("capture_inventory_recovered", 1),)
+        assert world.local.capture_reservation_bootstrap_ready(
+            world.workspace, world.sibling.task_id
+        )
+        assert world.requests == []
+        assert not world.routes.held
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "fault",
+    (
+        "inactive",
+        "missing-current",
+        "duplicate",
+        "changed",
+        "missing-binding",
+        "corrupt-bundle",
+        "missing-observation",
+        "unknown-repository-unreadable",
+        "bad-backlog",
+    ),
+)
+async def test_incomplete_inventory_never_clears_unknown_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    world = await _world(tmp_path)
+    routes = await world.catalog.recovery_routes()
+    calls = 0
+
+    async def inventory() -> tuple[TaskRoute, ...]:
+        nonlocal calls
+        calls += 1
+        if fault == "missing-current":
+            return tuple(route for route in routes if route.task_id != world.runtime.task_id)
+        if fault == "duplicate":
+            return (*routes, routes[0])
+        if fault == "changed" and calls > 1:
+            return tuple(reversed(routes))
+        if fault in {"inactive", "unknown-repository-unreadable"}:
+            return tuple(
+                replace(route, state=TaskRouteState.INITIALIZING)
+                if fault == "inactive" and route.task_id == world.sibling.task_id
+                else replace(route, repository_privacy_commitment=None)
+                if fault == "unknown-repository-unreadable"
+                and route.task_id == world.sibling.task_id
+                else route
+                for route in routes
+            )
+        return routes
+
+    monkeypatch.setattr(world.catalog, "recovery_routes", inventory)
+    if fault == "missing-binding":
+
+        async def no_binding(_session: str) -> None:
+            return None
+
+        monkeypatch.setattr(world.catalog, "session_binding", no_binding)
+    if fault in {"corrupt-bundle", "unknown-repository-unreadable"}:
+        world.sibling_database.execute("DROP TABLE observation_capture_tickets")
+    if fault == "missing-observation":
+        world.routes.runtimes[world.sibling.session_id] = replace(world.sibling, observation=None)
+    if fault == "bad-backlog":
+
+        def no_backlog(_workspace: str) -> None:
+            return None
+
+        monkeypatch.setattr(world.sibling_observation, "capture_backlog", no_backlog)
+    sweeper = world.sweep()
+    try:
+        summary = await sweeper.sweep()
+        assert summary.reasons == (("capture_inventory_unknown", 1),)
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+        assert (
+            world.local.selection_runtime_status(world.workspace, world.session)[
+                "admission_allowed"
+            ]
+            is False
+        )
+        assert world.requests == []
+        assert not world.routes.held
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_unrelated_quarantined_repository_does_not_poison_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    world = await _world(tmp_path)
+    original = await world.catalog.recovery_routes()
+
+    async def inventory() -> tuple[TaskRoute, ...]:
+        return tuple(
+            replace(
+                route,
+                repository_privacy_commitment="hmac-sha256:" + "8" * 64,
+                state=TaskRouteState.QUARANTINED,
+            )
+            if route.task_id == world.sibling.task_id
+            else route
+            for route in original
+        )
+
+    monkeypatch.setattr(world.catalog, "recovery_routes", inventory)
+    try:
+        result = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert result is ObservationCaptureRecoveryOutcome.RECOVERED
+        assert world.sibling.session_id not in world.routes.calls
+        assert world.local.capture_reservation_bootstrap_ready(
+            world.workspace, world.runtime.task_id
+        )
+        assert not world.routes.held
+    finally:
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_slow_inventory_does_not_hold_the_control_gate(tmp_path: Path) -> None:
+    world = await _world(tmp_path)
+    gate = asyncio.Lock()
+    sweeper = ObservationOutboxSweeper(
+        world.local,
+        world.coordinator,
+        ingest_gate=gate,
+        capture_recovery=world.coordinator.recover_capture_inventory,
+    )
+    world.routes.block_session = world.sibling.session_id
+    operation = asyncio.create_task(sweeper.sweep())
+    try:
+        await asyncio.wait_for(world.routes.entered.wait(), 2.0)
+        async with asyncio.timeout(0.5):
+            async with gate:
+                assert not operation.done()
+        world.routes.resume.set()
+        result = await operation
+        assert result.reasons == (("capture_inventory_recovered", 1),)
+        assert not world.routes.held
+    finally:
+        world.routes.resume.set()
+        if not operation.done():
+            operation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_cancellation_joins_publication_before_releasing_capture_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    world = await _world(tmp_path)
+    entered = threading.Event()
+    resume = threading.Event()
+    original = world.local.bootstrap_capture_reservations
+    order: list[str] = []
+
+    def blocking_publish(*args: object, **kwargs: object) -> bool:
+        entered.set()
+        assert resume.wait(5), "test must release the bounded publication worker"
+        result = original(*args, **kwargs)  # type: ignore[arg-type]
+        order.append("published")
+        return result
+
+    monkeypatch.setattr(world.local, "bootstrap_capture_reservations", blocking_publish)
+    operation = asyncio.create_task(world.coordinator.recover_capture_inventory(world.workspace))
+    lock = world.coordinator._capture_lock  # pyright: ignore[reportPrivateUsage]
+    try:
+        assert await asyncio.to_thread(entered.wait, 2)
+        # READY shutdown can cancel all asyncio Tasks. A separately cancellable
+        # to_thread Task would lose the future while its thread still commits.
+        assert not any(
+            getattr(task.get_coro(), "__qualname__", None) == "to_thread"
+            for task in asyncio.all_tasks()
+        )
+        operation.cancel()
+        for _ in range(3):
+            await asyncio.sleep(0)
+        operation.cancel()  # a second deadline must not orphan the committing worker
+        await asyncio.sleep(0)
+        assert lock.locked()
+        assert not operation.done()
+
+        async def later_capture() -> None:
+            async with lock:
+                order.append("later-capture")
+
+        later = asyncio.create_task(later_capture())
+        resume.set()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+        await later
+        assert order == ["published", "later-capture"]
+        assert not world.routes.held
+        assert not lock.locked()
+    finally:
+        resume.set()
+        if not operation.done():
+            operation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+        world.coordinator.close()
+
+
+def _native_failed_command(
+    world: _World,
+    host: str,
+    identity: str,
+    marker: str,
+    raw_session: str = "inventory-recovery",
+) -> int:
+    """Invoke actual host normalizers/handlers, not the installed vendor application."""
+
+    def run_async(factory: Callable[[], Awaitable[object]]) -> object:
+        return asyncio.run(factory())
+
+    common = {
+        "cwd": str(world.project),
+        "session_id": raw_session,
+        "tool_name": "Bash",
+        "tool_use_id": identity,
+        "tool_input": {"command": "exit 1"},
+        "tool_response": {"stdout": marker, "aggregated_output": marker, "exit_code": 1},
+    }
+    stdout = io.BytesIO()
+    if host == "cursor":
+        payload = {
+            "conversation_id": raw_session,
+            "tool_use_id": identity,
+            "tool_name": "shell",
+            "tool_input": {"command": "exit 1"},
+            "tool_output": canonical_encode({"stdout": marker, "exitCode": 1}).decode(),
+            "exit_code": 1,
+        }
+        return native.handle_cursor_observe(
+            event_name="postToolUse",
+            stdin_bytes=canonical_encode(cast(CanonicalJsonValue, payload)),
+            workspace=str(world.project),
+            _state=world.root / "state",
+            stdout=stdout,
+            connect=cast(object, world.connect),  # type: ignore[arg-type]
+            run_async=run_async,
+            observation_profile=CURSOR_ORDINARY_OBSERVATION_PROFILE_ID,
+        )
+    if host == "claude":
+        return native.handle_claude_observe(
+            event_name="PostToolUse",
+            stdin_bytes=canonical_encode(cast(CanonicalJsonValue, common)),
+            workspace=str(world.project),
+            _state=world.root / "state",
+            stdout=stdout,
+            connect=cast(object, world.connect),  # type: ignore[arg-type]
+            run_async=run_async,
+            observation_profile=CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
+        )
+    return native.handle_observe(
+        event_name="PostToolUse",
+        stdin_bytes=canonical_encode(cast(CanonicalJsonValue, common)),
+        workspace=str(world.project),
+        _state=world.root / "state",
+        stdout=stdout,
+        connect=cast(object, world.connect),  # type: ignore[arg-type]
+        run_async=run_async,
+        source=ObservationSource.CODEX_HOOK,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("host", ("claude", "cursor", "codex"))
+async def test_failed_native_command_after_real_recovery_has_encrypted_readback(
+    tmp_path: Path,
+    host: str,
+) -> None:
+    world = await _world(tmp_path, host=host)
+    sweeper = world.sweep()
+    try:
+        assert (
+            await asyncio.to_thread(
+                _native_failed_command, world, host, "before-recovery", "lost-native-marker"
+            )
+            == 0
+        )
+        assert world.requests == []
+        assert world.local.pending_outbox_count(world.workspace) == 0
+        before = world.local.selection_accounting(world.workspace)
+        assert before["unrecoverable_input_count"] == 1
+        summary = await sweeper.sweep()
+        assert summary.reasons == (("capture_inventory_recovered", 1),)
+        assert summary.attempted == 0
+        marker = f"{host}-encrypted-recovery-readback-695"
+        assert (
+            await asyncio.to_thread(_native_failed_command, world, host, "after-recovery", marker)
+            == 0
+        )
+        assert any(request.capture_only for request in world.requests)
+        assert world.local.pending_outbox_count(world.workspace) == 0
+        after = world.local.selection_accounting(world.workspace)
+        assert after["unrecoverable_input_count"] == before["unrecoverable_input_count"]
+        assert after["loss_identity_commitment"] == before["loss_identity_commitment"]
+        frontier = await world.runtime.ledger.load_frontier()
+        frozen = await world.runtime.ledger.freeze_case(
+            world.runtime.session_id,
+            cast(str, world.runtime.writer_id),
+            frontier.sequence,
+            native._ids(IdKind.REQUEST, 911),  # pyright: ignore[reportPrivateUsage]
+            "sha256:" + "0" * 64,
+        )
+        assert isinstance(frozen, FrozenCase)
+        resolved = await resolve_captured_semantic_content(
+            runtime=world.runtime,
+            frozen=frozen,
+            workspace_commitment=world.workspace,
+            local_observation=world.local,
+        )
+        assert len(resolved.content) == 1
+        assert marker.encode() in resolved.content[0].content
+        for path in (tmp_path / "bundle").rglob("*"):
+            if path.is_file():
+                assert marker.encode() not in path.read_bytes(), (
+                    "content must not persist in plaintext"
+                )
+        assert not world.routes.held
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_unmapped_parent_worker_candidates_do_not_starve_a_usable_mapping(
+    tmp_path: Path,
+) -> None:
+    world = await _world(tmp_path)
+    for number in range(9):
+        world.local.bind_codex_session(world.workspace, f"aaa-unmapped-worker-{number}")
+    try:
+        first = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert first is ObservationCaptureRecoveryOutcome.MAPPING_MISSING
+        assert world.routes.calls == []
+        second = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert second is ObservationCaptureRecoveryOutcome.RECOVERED
+        assert world.local.capture_reservation_bootstrap_ready(
+            world.workspace, world.sibling.task_id
+        )
+    finally:
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_ambiguous_host_session_cannot_publish_an_inventory(tmp_path: Path) -> None:
+    world = await _world(tmp_path)
+    unrelated = tmp_path / "unrelated-project"
+    unrelated.mkdir()
+    other_workspace = world.local.workspace_commitment(str(unrelated))
+    world.local.grant_consent(other_workspace)
+    world.local.bind_codex_session(other_workspace, world.host_session)
+    try:
+        result = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert result is ObservationCaptureRecoveryOutcome.MAPPING_MISSING
+        assert world.routes.calls == []
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+    finally:
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("disabled_by", ("config", "local-gate", "busy-capture"))
+async def test_recovery_respects_runtime_fences_without_waiting_for_capture(
+    tmp_path: Path,
+    disabled_by: str,
+) -> None:
+    world = await _world(tmp_path)
+    lock = world.coordinator._capture_lock  # pyright: ignore[reportPrivateUsage]
+    if disabled_by == "config":
+        world.coordinator.observation_enabled = False
+    elif disabled_by == "local-gate":
+        world.local.set_runtime_enabled(False)
+    else:
+        await lock.acquire()
+    try:
+        async with asyncio.timeout(0.5):
+            result = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert result is (
+            ObservationCaptureRecoveryOutcome.BUSY
+            if disabled_by == "busy-capture"
+            else ObservationCaptureRecoveryOutcome.DISABLED
+        )
+        assert world.routes.calls == []
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+    finally:
+        if lock.locked():
+            lock.release()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_recovered_inventory_preserves_real_pending_ticket_pressure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    world = await _world(tmp_path)
+    limits = BudgetLimits.for_profile(CapacityProfile.STANDARD)
+
+    def small_capture_budget(
+        cls: type[BudgetLimits], profile: CapacityProfile | int | str
+    ) -> BudgetLimits:
+        del cls, profile
+        return replace(limits, capture_tickets=2)
+
+    monkeypatch.setattr(BudgetLimits, "for_profile", classmethod(small_capture_budget))
+    stamp = timestamp_from_datetime(world.coordinator.clock.now_utc())
+    for number, (current, store) in enumerate(
+        (
+            (world.runtime, world.observation),
+            (world.sibling, world.sibling_observation),
+        ),
+        start=1,
+    ):
+        store.record_capture_ticket(
+            ObservationCaptureTicket(
+                workspace_commitment=world.workspace,
+                task_id=current.task_id,
+                yoetz_session_id=current.session_id,
+                session_commitment=world.session,
+                source=ObservationSource.CLAUDE_HOOK,
+                source_identity=f"retained-{number}",
+                cursor=ObservationCursor(1, 0, number, "hmac-sha256:" + "a" * 64, "fixture-v1"),
+                logical_identity=f"retained-{number}",
+                content_capture_profile=CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
+                authority_generation="sha256:" + "0" * 64,
+                object_ids=(),
+                captured_at=stamp,
+            )
+        )
+    try:
+        result = await world.coordinator.recover_capture_inventory(world.workspace)
+        assert result is ObservationCaptureRecoveryOutcome.RECOVERED
+        assert world.local.capture_reservation_bootstrap_ready(
+            world.workspace, world.runtime.task_id
+        )
+        status = world.local.selection_runtime_status(world.workspace, world.session)
+        assert status["admission_allowed"] is False
+        assert status["pressure_state"] == "hard_limit"
+        assert world.local.capture_backlog(world.workspace)["count"] == 2
+        assert (
+            await asyncio.to_thread(
+                _native_failed_command, world, "claude", "real-capacity-rejection", "not-retainable"
+            )
+            == 0
+        )
+        assert world.requests == []
+        assert world.local.selection_accounting(world.workspace)["unrecoverable_input_count"] == 1
+        assert world.observation.capture_backlog(world.workspace).count == 1
+        assert world.sibling_observation.capture_backlog(world.workspace).count == 1
+    finally:
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_blocking_task_metadata_read_leaves_control_loop_responsive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    world = await _world(tmp_path)
+    entered = threading.Event()
+    resume = threading.Event()
+    original = world.sibling_observation.capture_backlog
+
+    def blocked_read(workspace: str) -> ObservationCaptureBacklog:
+        entered.set()
+        if not resume.wait(5):
+            raise TimeoutError("bounded-test-rendezvous")
+        return original(workspace)
+
+    monkeypatch.setattr(world.sibling_observation, "capture_backlog", blocked_read)
+    operation = asyncio.create_task(world.coordinator.recover_capture_inventory(world.workspace))
+    try:
+        assert await asyncio.to_thread(entered.wait, 1)
+        # A synchronous adapter wait must not run on the service event loop.
+        # The event is released only after ordinary loop work has completed.
+        async with asyncio.timeout(0.5):
+            gate = asyncio.Lock()
+            async with gate:
+                assert not operation.done()
+        resume.set()
+        assert await operation is ObservationCaptureRecoveryOutcome.RECOVERED
+        assert world.routes.held == []
+    finally:
+        resume.set()
+        if not operation.done():
+            operation.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await operation
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("host", ("claude", "cursor", "codex"))
+async def test_parent_worker_routes_recover_and_keep_encrypted_content_task_scoped(
+    tmp_path: Path, host: str
+) -> None:
+    """Interleaved host-shaped lanes, not a vendor-native delegated session."""
+
+    world = await _world(tmp_path, host=host)
+    worker_root = tmp_path / "worker"
+    worker_root.mkdir(mode=0o700)
+    profile = {
+        "claude": CLAUDE_CODE_ORDINARY_OBSERVATION_PROFILE_ID,
+        "cursor": CURSOR_ORDINARY_OBSERVATION_PROFILE_ID,
+        "codex": None,
+    }[host]
+    raw_worker = "inventory-worker"
+    worker_session = raw_worker if host == "codex" else f"{host}:{raw_worker}"
+    worker = await native._pipeline(  # pyright: ignore[reportPrivateUsage]
+        worker_root,
+        codex_session_id=worker_session,
+        profile=profile,
+        identity=(
+            world.sibling.task_id,
+            world.sibling.session_id,
+            cast(str, world.sibling.writer_id),
+        ),
+    )
+    worker[7].close()  # Both native lanes must use the one service coordinator below.
+    world.sibling = worker[6]
+    world.sibling_observation = worker[4]
+    world.routes.runtimes[world.sibling.session_id] = world.sibling
+    world.local.bind_codex_session(world.workspace, worker_session)
+    native.store_mapping(
+        native.LifecycleMapping(
+            mapping_version=1,
+            codex_session_id=worker_session,
+            yoetz_task_id=world.sibling.task_id,
+            yoetz_session_id=world.sibling.session_id,
+            yoetz_writer_id=cast(str, world.sibling.writer_id),
+            last_frontier=None,
+        ),
+        _state=tmp_path / "state",
+    )
+    sweeper = world.sweep()
+    lanes = ("inventory-recovery", raw_worker)
+    try:
+        for lane in lanes:
+            assert (
+                await asyncio.to_thread(
+                    _native_failed_command, world, host, "lost-before-recovery", "lost", lane
+                )
+                == 0
+            )
+        before = world.local.selection_accounting(world.workspace)
+        assert before["unrecoverable_input_count"] == 2
+        assert world.local.pending_outbox_count(world.workspace) == 0
+        assert world.requests == []
+        assert (await sweeper.sweep()).reasons == (("capture_inventory_recovered", 1),)
+        # Interleave lanes through the same shared local store and service; no
+        # second independently bootstrapped coordinator may mint a partial proof.
+        for index in range(3):
+            for lane in lanes:
+                marker = f"{host}-{lane}-encrypted-{index}-695"
+                assert (
+                    await asyncio.to_thread(
+                        _native_failed_command, world, host, f"tool-{index}", marker, lane
+                    )
+                    == 0
+                )
+        after = world.local.selection_accounting(world.workspace)
+        assert after["unrecoverable_input_count"] == 2
+        assert after["loss_identity_commitment"] == before["loss_identity_commitment"]
+        for index, (runtime, lane) in enumerate(zip((world.runtime, world.sibling), lanes)):
+            frontier = await runtime.ledger.load_frontier()
+            frozen = await runtime.ledger.freeze_case(
+                runtime.session_id,
+                cast(str, runtime.writer_id),
+                frontier.sequence,
+                native._ids(IdKind.REQUEST, 950 + index),  # pyright: ignore[reportPrivateUsage]
+                "sha256:" + "0" * 64,
+            )
+            assert isinstance(frozen, FrozenCase)
+            resolved = await resolve_captured_semantic_content(
+                runtime=runtime,
+                frozen=frozen,
+                workspace_commitment=world.workspace,
+                local_observation=world.local,
+            )
+            assert len(resolved.content) == 3
+            plaintext = b"\n".join(item.content for item in resolved.content)
+            for number in range(3):
+                assert f"{host}-{lane}-encrypted-{number}-695".encode() in plaintext
+            other = lanes[1 - index]
+            assert f"{host}-{other}-encrypted".encode() not in plaintext
+        assert not world.routes.held
+        assert world.local.pending_outbox_count(world.workspace) == 0
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("stage", ("before-read", "during-read", "waiting-to-publish"))
+async def test_changed_ready_generation_cannot_publish_recovered_capacity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    world = await _world(tmp_path)
+    current = stage != "before-read"
+    world.wire(generation_is_current=lambda: current)
+    if stage == "during-read":
+        original = world.sibling_observation.capture_backlog
+
+        def change_while_reading(workspace: str) -> ObservationCaptureBacklog:
+            nonlocal current
+            current = False
+            return original(workspace)
+
+        monkeypatch.setattr(world.sibling_observation, "capture_backlog", change_while_reading)
+    if stage == "waiting-to-publish":
+        original_join = ready_module._run_capture_inventory_joined  # pyright: ignore[reportPrivateUsage]
+
+        async def change_before_local_lock[ResultT](
+            call: Callable[[], ResultT], *, operation: str
+        ) -> ResultT:
+            nonlocal current
+            if operation == "observation_capture_inventory_publish":
+                current = False
+            return await original_join(call, operation=operation)
+
+        monkeypatch.setattr(ready_module, "_run_capture_inventory_joined", change_before_local_lock)
+    sweeper = world.sweep()
+    try:
+        assert (await sweeper.sweep()).reasons == (("capture_inventory_unknown", 1),)
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+        assert not world.local.selection_runtime_status(world.workspace, world.session)[
+            "admission_allowed"
+        ]
+        assert world.workspace in world.local.pending_workspaces()
+        assert not world.routes.held
+        assert world.requests == []
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_runtime_with_wrong_task_identity_cannot_supply_a_route_inventory(
+    tmp_path: Path,
+) -> None:
+    world = await _world(tmp_path)
+    world.routes.runtimes[world.sibling.session_id] = world.runtime
+    sweeper = world.sweep()
+    try:
+        assert (await sweeper.sweep()).reasons == (("capture_inventory_unknown", 1),)
+        assert not world.local.capture_reservation_bootstrap_ready(world.workspace)
+        assert not world.local.selection_runtime_status(world.workspace, world.session)[
+            "admission_allowed"
+        ]
+        assert not world.routes.held
+    finally:
+        sweeper.close()
+        world.coordinator.close()
+
+
+@pytest.mark.anyio
+async def test_partial_ticket_ids_do_not_release_an_unlisted_reservation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    world = await _world(tmp_path)
+    zero = ObservationCaptureBacklog(0, 0, None)
+    world.local.bootstrap_capture_reservations(
+        world.workspace,
+        {world.runtime.task_id: zero, world.sibling.task_id: zero},
+    )
+    world.local.reserve_capture_ticket(
+        world.workspace, "sha256:" + "c" * 64, world.runtime.task_id, 17
+    )
+    world.local.mark_capture_backlog_scope_unknown(world.workspace)
+    stamp = timestamp_from_datetime(world.coordinator.clock.now_utc())
+
+    def retained_without_complete_ids(workspace: str) -> ObservationCaptureBacklog:
+        assert workspace == world.workspace
+        return ObservationCaptureBacklog(1, 0, stamp)
+
+    monkeypatch.setattr(world.observation, "capture_backlog", retained_without_complete_ids)
+    # The real empty store returns no IDs, while the injected legacy aggregate
+    # reports one retained ticket. An empty enumeration is not an absence proof.
+    try:
+        assert await world.coordinator.recover_capture_inventory(world.workspace) is (
+            ObservationCaptureRecoveryOutcome.RECOVERED
+        )
+        status = world.local.capture_backlog(world.workspace)
+        assert status["count"] == 2
+        assert status["byte_count"] == 17
+        assert not world.routes.held
+    finally:
+        world.coordinator.close()

--- a/tests/unit/adapters/test_observation_capture_bootstrap.py
+++ b/tests/unit/adapters/test_observation_capture_bootstrap.py
@@ -105,3 +105,29 @@ def test_new_route_invalidates_the_previous_root_proof(tmp_path: Path) -> None:
     )
     assert store.capture_reservation_bootstrap_ready(workspace) is False
     assert store.capture_backlog(workspace)["capture_backlog_scope"] == "unknown"
+
+
+def test_unknown_inventory_is_durable_maintenance_work_with_an_empty_outbox(
+    tmp_path: Path,
+) -> None:
+    store = LocalObservationStore(_state=tmp_path)
+    workspace = _workspace(store, tmp_path)
+    store.bootstrap_capture_reservations(
+        workspace, {"tsk_first": ObservationCaptureBacklog(0, 0, None)}
+    )
+    assert store.pending_workspaces() == ()
+    store.update_capture_backlog(workspace, 0, 0, None, _OBSERVED, route_id="tsk_second")
+    assert store.pending_outbox_count(workspace) == 0
+    assert store.pending_workspaces() == (workspace,)
+    reopened = LocalObservationStore(_state=tmp_path)
+    assert reopened.pending_workspaces() == (workspace,)
+    assert reopened.capture_inventory_recovery_needed(workspace)
+    reopened.bootstrap_capture_reservations(
+        workspace,
+        {
+            "tsk_first": ObservationCaptureBacklog(0, 0, None),
+            "tsk_second": ObservationCaptureBacklog(0, 0, None),
+        },
+    )
+    assert not reopened.capture_inventory_recovery_needed(workspace)
+    assert reopened.pending_workspaces() == ()

--- a/tests/unit/application/test_capture_recovery_scheduling.py
+++ b/tests/unit/application/test_capture_recovery_scheduling.py
@@ -1,0 +1,144 @@
+"""Bounded, fair scheduling for admission-independent capture recovery (#695)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+
+from yoetz.adapters.integrations.observation_local import LocalObservationStore
+from yoetz.application.observation_drain import (
+    ObservationCaptureRecoveryOutcome as Outcome,
+)
+from yoetz.application.observation_drain import (
+    ObservationIngestCoordinator,
+    ObservationOutboxSweeper,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _sweeper(
+    callback: Callable[[str], Awaitable[Outcome | None]], *, budget: float = 5.0
+) -> ObservationOutboxSweeper:
+    # These tests exercise the scheduling boundary only. The service integration
+    # tests supply the real local store, SQLite catalog, and capture callback.
+    return ObservationOutboxSweeper(
+        cast(LocalObservationStore, None),
+        cast(ObservationIngestCoordinator, None),
+        capture_recovery=callback,
+        capture_recovery_budget_seconds=budget,
+    )
+
+
+async def _pass(
+    sweeper: ObservationOutboxSweeper,
+    workspaces: tuple[str, ...],
+    remaining: float | None = None,
+) -> tuple[Outcome, ...]:
+    return await sweeper._recover_capture_inventory(  # pyright: ignore[reportPrivateUsage]
+        workspaces, remaining=remaining
+    )
+
+
+@pytest.mark.anyio
+async def test_recovery_rotates_four_unique_workspace_lanes() -> None:
+    calls: list[str] = []
+
+    async def recover(workspace: str) -> Outcome:
+        calls.append(workspace)
+        return Outcome.RECOVERED
+
+    sweeper = _sweeper(recover)
+    workspaces = ("f", "b", "a", "d", "c", "e", "a")
+    assert await _pass(sweeper, workspaces) == (Outcome.RECOVERED,) * 4
+    assert calls == ["a", "b", "c", "d"]
+    assert await _pass(sweeper, workspaces) == (Outcome.RECOVERED,) * 4
+    assert calls == ["a", "b", "c", "d", "e", "f", "a", "b"]
+
+
+@pytest.mark.anyio
+async def test_timeout_rotates_next_pass_past_slow_workspace() -> None:
+    calls: list[str] = []
+    cancelled = asyncio.Event()
+
+    async def recover(workspace: str) -> Outcome:
+        calls.append(workspace)
+        if workspace == "a":
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+        return Outcome.RECOVERED
+
+    sweeper = _sweeper(recover, budget=0.02)
+    async with asyncio.timeout(1):
+        assert await _pass(sweeper, ("a", "b")) == (Outcome.TIMEOUT,)
+        assert cancelled.is_set()
+        assert calls == ["a"]
+        assert await _pass(sweeper, ("a", "b")) == (Outcome.RECOVERED, Outcome.TIMEOUT)
+        assert calls == ["a", "b", "a"]
+
+
+@pytest.mark.anyio
+async def test_sweep_cancellation_is_not_reported_as_recovery_failure() -> None:
+    entered = asyncio.Event()
+    finalized = asyncio.Event()
+
+    async def recover(_workspace: str) -> Outcome:
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finalized.set()
+        return Outcome.RECOVERED
+
+    operation = asyncio.create_task(_pass(_sweeper(recover), ("a",)))
+    async with asyncio.timeout(1):
+        await entered.wait()
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+    assert finalized.is_set()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("remaining", (0.0, -1.0))
+async def test_spent_sweep_budget_starts_no_inventory_read(remaining: float) -> None:
+    async def recover(_workspace: str) -> Outcome:
+        raise AssertionError("must not start after the sweep budget")
+
+    assert await _pass(_sweeper(recover), ("a",), remaining) == ()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_result", (False, True))
+async def test_callback_failures_have_only_closed_structural_outcomes(bad_result: bool) -> None:
+    async def recover(_workspace: str) -> Outcome:
+        if bad_result:
+            return cast(Outcome, "private-untrusted-detail")
+        raise OSError("private-untrusted-detail")
+
+    assert await _pass(_sweeper(recover), ("a",)) == (Outcome.INVENTORY_UNKNOWN,)
+
+
+@pytest.mark.anyio
+async def test_healthy_workspace_creates_no_recovery_result() -> None:
+    async def recover(_workspace: str) -> None:
+        return None
+
+    assert await _pass(_sweeper(recover), ("a",)) == ()
+
+
+@pytest.mark.parametrize("budget", (0.0, -1.0, float("nan"), float("inf"), 1, True, "5"))
+def test_recovery_budget_must_be_finite_positive_float(budget: object) -> None:
+    async def recover(_workspace: str) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="^observation_capture_recovery_budget_invalid$"):
+        _sweeper(recover, budget=cast(float, budget))


### PR DESCRIPTION
## Issue

- **Refs #695.** This is the primary capture-inventory recovery repair, not a claim that every acceptance criterion in the issue is complete.
- Existing issues and all-state PRs were searched for duplicates. The separate `codex/fix-695-capture-recovery` branch contains another implementation and is deliberately left untouched; reconcile the alternatives before combining them.
- The maintainer explicitly requested this scoped implementation and then requested publication as a PR. Publication acknowledgement is recorded at https://github.com/TheGaySupreme123/yoetz/issues/695#issuecomment-5634066729.
- Base remains `codex/repair-host-observation` at `c2db3120fc0096b904111bc9e7ab4287f6b84508`, containing the #693 regression. No retargeting to `main`.

## Summary

PR #693 correctly made new-input admission fail closed under hard pressure. However, unknown capture inventory could only be repaired through a callback downstream of that same admission gate. With an empty outbox, the workspace could be excluded from maintenance entirely. The result was sustained rejection rather than recovery.

This change preserves the atomic admission guard and makes the authoritative inventory callback reachable independently:

- Unknown capture inventory and unreconciled reservations keep a workspace discoverable even with no outbox rows or selection buffer. No new persisted field, schema, migration, or reset flag is introduced.
- The coordinator uses existing, unambiguous session mappings and the shared capture lock to invoke service-owned catalog/bundle inventory recovery. It does not create tasks, mappings, consent, or authority. Missing, inactive, corrupt, unreadable, inconsistent, or changing relevant routes remain unknown rather than being counted as zero.
- The sweeper runs recovery before delivery, outside the broad workflow-control gate and per-workspace drain lease. Workspaces and mapping candidates rotate within bounded per-pass limits. Recovery-only progress does not fabricate delivery acknowledgements or trigger the daemon's delivery-progress fast loop.
- Synchronous metadata reads and private-store publication run off the event loop. Cancellation joins the actual executor Future before capture exclusion is released. Service/vault generation is checked again under the local proof-publication lock. Wrong runtime identities are rejected; incomplete ticket enumeration cannot release unlisted reservations.
- Prior losses, identity commitments, and quarantine evidence survive recovery. A later encrypted readback proves new capture only, not recovery of previously lost input.

The recovery budget is **cooperative**, not a hard five-second bound on every contended storage operation. This slice retains the existing complete `recovery_routes()` catalog API. Very-large-catalog latency is not certified, and no catalog scan is added to every hook.

## Exact candidate and publication

| Item | Identity |
| --- | --- |
| Previously tested local commit | `8ad6252a07afe0e700027e1accdeeb917356ba9c` |
| Published commit | `b44b488836b03985dcc1930a6c89399298e2bb98` |
| Identical source tree | `73024c9079c8783536dda53821c14b86d4cfa97b` |
| Parent/base | `c2db3120fc0096b904111bc9e7ab4287f6b84508` |
| Supplied patch SHA-256 | `bc329e29b5c08be481108a57f2df8311c2c8da827544ae44ea150df4e66a141c` |

Publication preserves the previously delivered source bytes. The patch was reapplied to a clean base and compared with all **1,375 source ZIP files**. The GitHub comparison contains **one commit, 14 changed files, 1,767 insertions, and 147 deletions**, with no workflow changes. The different publication commit ID is not a different tested source tree. **Publication itself is not a fresh test run or a new CI pass.**

## Documentation

Behavior change: **yes**.

Updated ADR-029, `docs/INTERFACES.md`, the Claude Code, Cursor, and Codex integration runbooks, and the observation-selection performance runbook. These describe independent maintenance, fail-closed proof boundaries, cancellation/generation handling, cooperative limits, historical-loss preservation, and the remaining host/performance acceptance gaps. Packaged resource bytes do not change; their fixed-point check passed on the tested candidate.

## Verification

Prior local verification of the exact source tree above:

| Check | Result |
| --- | --- |
| Observation/capture/coordinator/storage/host-shaped matrix, 71 selected files | **1,099 passed, 2 skipped, 1 deselected** |
| Focused recovery/scheduling/bootstrap set | **53 passed**, included in the broader total |
| Strict Pyright | **0 errors, 0 warnings** |
| Ruff lint and formatting | Passed |
| Resource fixed point | Passed: 136 schemas, 188 resources, committed agent trees and descriptor digests |
| Wheel and source-distribution build | Passed |
| Source and both distributions public-boundary scan | Passed: 2,286 files scanned |
| Clean-base patch application and diff whitespace checks | Passed; rechecked for publication |
| Complete installed packaging gate | **Not passed**, details below |
| Actual vendor-native host acceptance | **Not run** |

The new tests exercise the actual production inventory callback with real SQLite catalogs/task stores. They cover empty-outbox recovery with no fresh host event, restart, a second route, transient/inactive/missing/corrupt routes, changing inventories, missing or ambiguous mappings, disabled observation, rotating candidates, busy capture locks, blocking metadata reads, timeout fairness, repeated cancellation, stale service generations, wrong runtime identities, incomplete ticket listings, and real capture occupancy that must still reach the hard limit.

Claude, Cursor, and Codex tests invoke the real Yoetz adapters with host-shaped failed-command payloads: unknown inventory rejects input, idle maintenance restores a complete proof, a subsequent event is admitted, and its content is read back from the real encrypted object store. Prior loss counts and commitments are preserved. Parent/worker-shaped interleavings verify task-scoped encrypted readback across two real task stores. Their routing and control transport are in-process fixtures, **not installed vendor applications or a full native daemon/MCP session**.

The local environment used an exported repository-pinned runtime with `uv run --no-sync`. Versions: Python 3.14.6, uv 0.11.29, Node 26.5.0, Ruff 0.15.22, Pyright 1.1.411, pytest 9.1.1, APSW 3.53.3.1, cryptography 50.0.0. Reproducing in a fresh online environment first requires `uv sync --locked --all-extras --group dev` and `npm ci --ignore-scripts`.

Focused commands from the verification record:

```sh
uv run --no-sync pytest \
  tests/integration/service/test_capture_inventory_recovery.py \
  tests/unit/application/test_capture_recovery_scheduling.py \
  tests/unit/adapters/test_observation_capture_bootstrap.py \
  -q --timeout=60

uv run --no-sync ruff check .
uv run --no-sync ruff format --check .
# Pyright was run through the exact pinned Node binary and installed npm package,
# equivalent to the repository command: npx --no-install pyright
uv run --no-sync python scripts/sync_resource_ripple.py --check
uv build --no-sources --out-dir <isolated-dist>
uv run --no-sync python scripts/scan_public_boundary.py --source-tree . \
  --artifact <isolated-dist>/yoetz-0.1.0-py3-none-any.whl \
  --artifact <isolated-dist>/yoetz-0.1.0.tar.gz
git diff --check

uv run --no-sync python scripts/benchmark_observation_hooks.py --host all --fanout 8
uv run --no-sync python scripts/benchmark_observation_hooks.py --host all --fanout 8 --retained
```

The isolated output directory placeholders above replace environment-specific paths, not additional repository files. Packaging runs must remain serial.

<details>
<summary>Complete 71-file matrix selection and command</summary>

The recorded run used the following paths with `uv run --no-sync pytest`, the marker expression `not fault and not kill_matrix and not soak and not live and not live_provider and not live_keyring`, and `-q --timeout=90`. These are prior test results, not a claim that publication reran the matrix.

```text
tests/capability/test_observation_dogfood_matrix.py
tests/conformance/honesty/test_observation_captured_evidence.py
tests/conformance/protocol/test_control_native_capture_fixture.py
tests/conformance/protocol/test_control_observation_status_fixture.py
tests/conformance/protocol/test_observation_summary_fixture.py
tests/integration/application/test_capture_control_cleanup.py
tests/integration/application/test_native_capture_expected_parts.py
tests/integration/application/test_native_capture_lane.py
tests/integration/application/test_native_capture_pipeline.py
tests/integration/observation/test_self_observation_workflow.py
tests/integration/service/test_capture_inventory_recovery.py
tests/integration/storage/test_capture_freeze_barrier.py
tests/integration/storage/test_capture_freeze_barrier_races.py
tests/integration/storage/test_capture_ticket_consent_cleanup.py
tests/integration/storage/test_codex_capture_ticket_sqlite.py
tests/integration/storage/test_migration_0002_observation.py
tests/integration/storage/test_migration_0003_observation.py
tests/integration/storage/test_migration_0004_observation.py
tests/integration/storage/test_migration_0008_observation.py
tests/integration/storage/test_migration_0009_observation.py
tests/integration/storage/test_migration_0010_observation.py
tests/integration/storage/test_migration_0011_observation.py
tests/unit/adapters/test_memory_observation.py
tests/unit/adapters/test_observation_admission.py
tests/unit/adapters/test_observation_batch.py
tests/unit/adapters/test_observation_capture_backlog.py
tests/unit/adapters/test_observation_capture_bootstrap.py
tests/unit/adapters/test_observation_capture_legacy_accounting.py
tests/unit/adapters/test_observation_content_fences.py
tests/unit/adapters/test_observation_local_advice_delivery.py
tests/unit/adapters/test_observation_pre_lifecycle.py
tests/unit/adapters/test_observation_pressure_runtime.py
tests/unit/adapters/test_observation_provenance_versions.py
tests/unit/adapters/test_observation_read_protection.py
tests/unit/adapters/test_observation_self_observation_policy.py
tests/unit/adapters/test_observation_state_bounds.py
tests/unit/adapters/test_observation_store_lock.py
tests/unit/adapters/test_sqlite_capture_budget.py
tests/unit/adapters/test_sqlite_observation.py
tests/unit/application/test_capture_recovery_scheduling.py
tests/unit/application/test_observation_advice.py
tests/unit/application/test_observation_advice_semantic.py
tests/unit/application/test_observation_capture_budget_coordinator.py
tests/unit/application/test_observation_capture_fence.py
tests/unit/application/test_observation_check_policy.py
tests/unit/application/test_observation_coordinator.py
tests/unit/application/test_observation_drain.py
tests/unit/application/test_observation_health.py
tests/unit/application/test_observation_secret_persistence.py
tests/unit/application/test_observation_verification_worker.py
tests/unit/application/test_outbox_selection.py
tests/unit/cli/test_claude_observe_hooks.py
tests/unit/cli/test_cursor_observe_hooks.py
tests/unit/cli/test_native_observation_profiles.py
tests/unit/cli/test_observation_selection_boundary.py
tests/unit/cli/test_observe_cli.py
tests/unit/cli/test_observe_hooks.py
tests/unit/cli/test_observe_hooks_codex_capture.py
tests/unit/cli/test_observe_hooks_native_reservation.py
tests/unit/cli/test_observe_hooks_teardown.py
tests/unit/cli/test_observe_selection_content_limits.py
tests/unit/cli/test_observe_selection_flow.py
tests/unit/cli/test_state_capture.py
tests/unit/config/test_observation_config.py
tests/unit/domain/test_observation.py
tests/unit/domain/test_observation_budget.py
tests/unit/domain/test_observation_routine_summary.py
tests/unit/domain/test_observation_selection.py
tests/unit/domain/test_observation_settings.py
tests/unit/kernel/test_observation_advice_policies.py
tests/unit/observability/test_observation_selection_benchmark.py
```

Recorded result: `1099 passed, 2 skipped, 1 deselected in 128.69s (0:02:08)`.

</details>

## Draft acceptance limits and negative evidence

**Do not close #695 or treat this as merge/release acceptance.**

1. Independent propagation of locally recorded losses into task/CHECK state without a later admitted envelope remains **unimplemented**. Recovery preserves those losses but does not solve that separate projection path.
2. The final eight-way retained-state synthetic adapter probe still leaves **2 Claude inputs and 2 Cursor inputs unaccounted**: each retained 6/8. Codex retained 8/8, with a maximum sample of approximately **4.30 seconds**. Fresh-state probes retained 8/8 on all three hosts. The unchanged affected base also exhibits unaccounted inputs (Codex 7/8, Claude 6/8, Cursor 6/8), so the failure class predates this patch, but is neither acceptable nor resolved. These probes exclude RPC, a running vendor host, and a service recovery pass. No performance improvement or native latency guarantee is claimed.
3. Installed vendor-native acceptance, including real parent/subagent identity mapping and UI behavior, remains **unverified**. Host-shaped tests are not a substitute.
4. The development packaging attempt was interrupted after **76 passing tests, 2 failed assertions, and 17 setup errors**. It is not a completed final-commit packaging gate. The two Claude/Cursor diagnostic-file assertions also fail on an unchanged-base clone. A separate final-wheel resolver probe failed because `anyio==4.14.2` was absent from the offline dependency cache and network installation was unavailable. Building/scanning the distributions passed; a clean dependency-resolved installed-wheel acceptance run did not. No tests or dependency constraints were weakened to hide these results.
5. Reconcile the separately advanced `codex/fix-695-capture-recovery` implementation before combining branches. This PR intentionally publishes the exact delivered candidate rather than silently substituting that other implementation.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] No live installation, vault, credentials, host registration, consent, or production data was changed or copied for this publication.
- [x] No workflow/transfer files, implementation scratch, release, merge, or auto-merge is included.
- [ ] Disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

Model/harness: **GPT-6 Astra Pro in ChatGPT**, with the previously completed local-container implementation and verification. This publication does not claim a new native-host run, a CodeRabbit review, or a newly green CI result.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover capture inventory independently of admission in `ObservationOutboxSweeper`
> - Adds bounded capture-inventory recovery to `ObservationOutboxSweeper.sweep` in [observation_drain.py](https://github.com/TheGaySupreme123/yoetz/pull/698/files#diff-666b0255009b50af09cae4f70561b7ace69f7718f22751b1af88730234d8be77), running up to four workspaces per pass within the remaining sweep deadline, without creating hook output or observation rows
> - Moves `_bootstrap_capture_reservations` to module scope in [ready_composition.py](https://github.com/TheGaySupreme123/yoetz/pull/698/files#diff-aa060b3002474d342468ec0065563958ded4194ac7027914db3c0ebf18a940c6) with generation checks before and after inventory reads, runtime identity validation, executor-joined synchronous work, and cancellation joining
> - Updates `LocalObservationStore` in [observation_local.py](https://github.com/TheGaySupreme123/yoetz/pull/698/files#diff-dcc1feb8bc7f834d09056738e52fec58f85bdd06640418a241feda997cb5be82) with a proof guard on `bootstrap_capture_reservations`, recovery-demand detection via `capture_inventory_recovery_needed`, and `pending_workspaces` inclusion for unknown capture scope
> - Adds `ObservationCaptureRecoveryOutcome` enum with closed structural outcomes (recovered, missing mappings, unavailable routes, unknown, disabled, busy, timeout) and validates the recovery budget as a finite positive float
> - Behavioral Change: `pending_workspaces` now returns workspaces with unknown capture scope or unreconciled reservations even when they have no outbox rows; bootstrap publication now rejects stale or failed proof validation under the store lock and persists recovery-required state instead of publishing new capture inventory
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b44b488.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->