### PR TITLE
fix(landing): show the next step for each setup option

### DIFF
--- a/.github/workflows/capability.yml
+++ b/.github/workflows/capability.yml
@@ -192,9 +192,10 @@ jobs:
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            "${{ runner.temp }}/dist/yoetz-0.1.0-py3-none-any.whl"
+            "${{ runner.temp }}/dist/yoetz-${candidate_version}-py3-none-any.whl"
           candidate_origin=$("${{ runner.temp }}/candidate-venv/bin/python" -I -c \
             'import pathlib, yoetz; print(pathlib.Path(yoetz.__file__).resolve())')
           case "$candidate_origin" in
@@ -295,10 +296,11 @@ jobs:
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
           "${{ runner.temp }}/candidate-venv/bin/python" -c "
           import apsw, platform, sys
@@ -371,10 +373,11 @@ jobs:
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --all-extras --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz[semantic-openai]==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz[semantic-openai]==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Fake provider cases — success/refusal/malformed/rate-limit/timeout/cancellation/late/stale
@@ -441,10 +444,11 @@ jobs:
           echo "XDG_CONFIG_HOME=$iso/.config" >> "$GITHUB_ENV"
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           uv sync --locked --all-extras --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz[semantic-openai]==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz[semantic-openai]==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Synthetic minimized live-provider case (hard request/token/spend/time caps; allowlisted network only)

--- a/.github/workflows/nightly-fault.yml
+++ b/.github/workflows/nightly-fault.yml
@@ -120,10 +120,11 @@ jobs:
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           echo "YOETZ_TEST_MARKER=nightly-fault-linux-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
           uv sync --locked --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
           "${{ runner.temp }}/candidate-venv/bin/python" -c "
           import apsw, platform, sys
@@ -223,10 +224,11 @@ jobs:
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           echo "YOETZ_TEST_MARKER=nightly-fault-macos-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
           uv sync --locked --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
           "${{ runner.temp }}/candidate-venv/bin/python" -c "
           import apsw, platform, sys
@@ -389,10 +391,11 @@ jobs:
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
           uv sync --locked --group dev
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/candidate-venv"
           uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/candidate-venv/bin/python" "yoetz==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/candidate-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Incremental vs. full replay at 10K/100K entries (page-size/hash-seed variants)

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -410,11 +410,12 @@ jobs:
 
       - name: Install the candidate wheel into an isolated environment
         run: |
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/subprocess-venv"
           uv pip install --python "${{ runner.temp }}/subprocess-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
           uv pip install --python "${{ runner.temp }}/subprocess-venv/bin/python" \
-            "yoetz[semantic-openai,portable-recovery]==0.1.0"
+            "yoetz[semantic-openai,portable-recovery]==${candidate_version}"
           echo "${{ runner.temp }}/subprocess-venv/bin" >> "$GITHUB_PATH"
 
       - name: uv sync --locked (test runner tooling only)
@@ -485,10 +486,11 @@ jobs:
 
       - name: Install the wheel outside the checkout
         run: |
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/pkg-venv"
           uv pip install --python "${{ runner.temp }}/pkg-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/pkg-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/pkg-venv/bin/python" "yoetz==${candidate_version}"
 
       - name: Isolate HOME/XDG/Yoetz app data inside job temp directory
         run: |

--- a/.github/workflows/security-privacy.yml
+++ b/.github/workflows/security-privacy.yml
@@ -392,10 +392,11 @@ jobs:
           echo "XDG_CACHE_HOME=$iso/.cache" >> "$GITHUB_ENV"
           echo "XDG_RUNTIME_DIR=$iso/.runtime" >> "$GITHUB_ENV"
           echo "YZCI_DENY_NETWORK=1" >> "$GITHUB_ENV"
+          candidate_version=$(uv run --locked python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           uv venv "${{ runner.temp }}/runtime-venv"
           uv pip install --python "${{ runner.temp }}/runtime-venv/bin/python" \
-            --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==0.1.0"
-          uv pip install --python "${{ runner.temp }}/runtime-venv/bin/python" "yoetz==0.1.0"
+            --no-index --no-deps --find-links "${{ runner.temp }}/dist" "yoetz==${candidate_version}"
+          uv pip install --python "${{ runner.temp }}/runtime-venv/bin/python" "yoetz==${candidate_version}"
           echo "YOETZ_CANDIDATE_PYTHON=${{ runner.temp }}/runtime-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Prepare one exact per-run privacy canary and retained runtime root

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -14,6 +14,10 @@
 
 ## Install
 
+For guided setup, click **Set up with your agent** on [yoetz.dev](https://yoetz.dev).
+The popup confirms the instruction was copied. Paste it into your agent’s chat, then send it
+to start setup.
+
 The supported install path is Python via [`uv`](https://docs.astral.sh/uv/):
 
 ```text

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -19,6 +19,8 @@ The popup confirms the instruction was copied. Paste it into your agent’s chat
 to start setup.
 The **Install with PyPI** and **Install with npm** buttons show the copied command in the popup:
 paste it into your terminal, then press Enter.
+After the PyPI installation finishes, run `yoetz` in your terminal to start setup.
+The npm command, `npx yoetz`, starts setup directly.
 
 The supported install path is Python via [`uv`](https://docs.astral.sh/uv/):
 

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -17,6 +17,8 @@
 For guided setup, click **Set up with your agent** on [yoetz.dev](https://yoetz.dev).
 The popup confirms the instruction was copied. Paste it into your agent’s chat, then send it
 to start setup.
+The **Install with PyPI** and **Install with npm** buttons show the copied command in the popup:
+paste it into your terminal, then press Enter.
 
 The supported install path is Python via [`uv`](https://docs.astral.sh/uv/):
 

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -807,7 +807,10 @@ const next = [
           } catch {
             return;
           }
-          showCopyToast("Paste this command into your terminal, then press Enter.", cmd);
+          const nextStep = tab.dataset.key === "pypi"
+            ? "Paste this command into your terminal and press Enter. Once installed, run yoetz in your terminal to start setup."
+            : "Paste this command into your terminal and press Enter to start setup.";
+          showCopyToast(nextStep, cmd);
         });
       }
 

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -294,7 +294,7 @@ const next = [
               <button class="inst-tab" type="button" data-key="pypi" data-command={INSTALL_COMMAND}>Install with PyPI</button>
               <button class="inst-tab" type="button" data-key="npm" data-command="npx yoetz">Install with npm</button>
               <button class="inst-tab agent" type="button" id="agent-copy" data-command={AGENT_PROMPT}>
-                <span id="agent-copy-label" role="status" aria-live="polite">Set up with your agent</span> <span class="rec">recommended</span>
+                <span id="agent-copy-label">Set up with your agent</span> <span class="rec">recommended</span>
               </button>
             </div>
 
@@ -302,7 +302,7 @@ const next = [
               <span class="ct-check" aria-hidden="true">✓</span>
               <span class="ct-body">
                 <span class="ct-title">Copied to your clipboard</span>
-                <code class="ct-cmd" id="copy-toast-cmd"></code>
+                <span class="ct-detail ct-cmd" id="copy-toast-detail"></span>
               </span>
             </div>
 
@@ -783,8 +783,18 @@ const next = [
       // --- Install tabs: a click copies the command and confirms it ---
       const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".inst-tab:not(.agent)"));
       const toast = document.getElementById("copy-toast");
-      const toastCmd = document.getElementById("copy-toast-cmd");
+      const toastDetail = document.getElementById("copy-toast-detail");
       let toastTimer: ReturnType<typeof setTimeout>;
+      function showCopyToast(detail: string, isCommand = true) {
+        if (!toast || !toastDetail) return;
+        toastDetail.textContent = detail;
+        toastDetail.classList.toggle("ct-cmd", isCommand);
+        toast.hidden = false;
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => {
+          toast.hidden = true;
+        }, isCommand ? 3200 : 8000);
+      }
       for (const tab of tabs) {
         tab.addEventListener("click", async () => {
           const cmd = tab.dataset.command ?? "";
@@ -794,14 +804,7 @@ const next = [
           } catch {
             return;
           }
-          if (toast && toastCmd) {
-            toastCmd.textContent = cmd;
-            toast.hidden = false;
-            clearTimeout(toastTimer);
-            toastTimer = setTimeout(() => {
-              toast.hidden = true;
-            }, 3200);
-          }
+          showCopyToast(cmd);
         });
       }
 
@@ -817,6 +820,7 @@ const next = [
         } catch {
           return;
         }
+        showCopyToast("Paste the instruction into your agent’s chat, then send it to start setup.", false);
         if (agentLabel) agentLabel.textContent = "Copied to your clipboard";
         agentBtn.classList.add("copied");
         clearTimeout(agentTimer);

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -302,7 +302,8 @@ const next = [
               <span class="ct-check" aria-hidden="true">✓</span>
               <span class="ct-body">
                 <span class="ct-title">Copied to your clipboard</span>
-                <span class="ct-detail ct-cmd" id="copy-toast-detail"></span>
+                <code class="ct-detail ct-cmd" id="copy-toast-cmd" hidden></code>
+                <span class="ct-detail" id="copy-toast-detail"></span>
               </span>
             </div>
 
@@ -783,17 +784,19 @@ const next = [
       // --- Install tabs: a click copies the command and confirms it ---
       const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".inst-tab:not(.agent)"));
       const toast = document.getElementById("copy-toast");
+      const toastCmd = document.getElementById("copy-toast-cmd");
       const toastDetail = document.getElementById("copy-toast-detail");
       let toastTimer: ReturnType<typeof setTimeout>;
-      function showCopyToast(detail: string, isCommand = true) {
-        if (!toast || !toastDetail) return;
+      function showCopyToast(detail: string, command?: string) {
+        if (!toast || !toastCmd || !toastDetail) return;
+        toastCmd.textContent = command ?? "";
+        toastCmd.hidden = !command;
         toastDetail.textContent = detail;
-        toastDetail.classList.toggle("ct-cmd", isCommand);
         toast.hidden = false;
         clearTimeout(toastTimer);
         toastTimer = setTimeout(() => {
           toast.hidden = true;
-        }, isCommand ? 3200 : 8000);
+        }, 8000);
       }
       for (const tab of tabs) {
         tab.addEventListener("click", async () => {
@@ -804,7 +807,7 @@ const next = [
           } catch {
             return;
           }
-          showCopyToast(cmd);
+          showCopyToast("Paste this command into your terminal, then press Enter.", cmd);
         });
       }
 
@@ -820,7 +823,7 @@ const next = [
         } catch {
           return;
         }
-        showCopyToast("Paste the instruction into your agent’s chat, then send it to start setup.", false);
+        showCopyToast("Paste the instruction into your agent’s chat, then send it to start setup.");
         if (agentLabel) agentLabel.textContent = "Copied to your clipboard";
         agentBtn.classList.add("copied");
         clearTimeout(agentTimer);

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -180,7 +180,8 @@ em.new {
 .copy-toast[hidden] { display: none; }
 .ct-check { color: #5eead4; font-weight: 700; line-height: 1.4; }
 .ct-title { display: block; font-size: 13.5px; font-weight: 600; }
-.ct-cmd { display: block; margin-top: 4px; font-family: var(--font-mono); font-size: 12.5px; color: var(--slate-300); overflow-wrap: anywhere; font-variant-ligatures: none; }
+.ct-detail { display: block; margin-top: 4px; font-size: 13.5px; line-height: 1.5; color: var(--slate-300); overflow-wrap: anywhere; }
+.ct-cmd { font-family: var(--font-mono); font-size: 12.5px; font-variant-ligatures: none; }
 @keyframes toastin { from { opacity: 0; transform: translateY(-4px); } }
 .inst-note { margin: 10px 0 0; font-size: 13.5px; line-height: 1.6; color: var(--slate-500); max-width: 54ch; }
 .inst-note a { color: var(--brand-teal-700); font-weight: 600; }

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -182,6 +182,7 @@ em.new {
 .ct-title { display: block; font-size: 13.5px; font-weight: 600; }
 .ct-detail { display: block; margin-top: 4px; font-size: 13.5px; line-height: 1.5; color: var(--slate-300); overflow-wrap: anywhere; }
 .ct-cmd { font-family: var(--font-mono); font-size: 12.5px; font-variant-ligatures: none; }
+.ct-cmd[hidden] { display: none; }
 @keyframes toastin { from { opacity: 0; transform: translateY(-4px); } }
 .inst-note { margin: 10px 0 0; font-size: 13.5px; line-height: 1.6; color: var(--slate-500); max-width: 54ch; }
 .inst-note a { color: var(--brand-teal-700); font-weight: 600; }

--- a/tests/packaging/test_clean_install.py
+++ b/tests/packaging/test_clean_install.py
@@ -91,7 +91,9 @@ def _tool_install(
 ) -> tuple[Path, dict[str, str]]:
     tool_dir = root / "tool"
     bin_dir = root / "bin"
-    spec = "yoetz" + (f"[{','.join(extras)}]" if extras else "") + "==0.1.0"
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    spec = str(wheels[0]) + (f"[{','.join(extras)}]" if extras else "")
     env = {
         **os.environ,
         "HOME": str(home),
@@ -216,7 +218,7 @@ def test_version_json_reports_a_clean_installed_manifest(
     assert result.returncode == 0
     manifest = json.loads(result.stdout)
     assert manifest["package_name"] == "yoetz"
-    assert manifest["package_version"] == "0.1.0"
+    assert manifest["package_version"] == built_dist.wheel.name.split("-")[1]
     assert manifest["apsw_version"]["status"] == "present"
     assert manifest["sqlite_version"]["status"] == "present"
     marker = str(_REPO_ROOT).encode("utf-8")

--- a/tests/packaging/test_codex_subscription_config.py
+++ b/tests/packaging/test_codex_subscription_config.py
@@ -75,7 +75,9 @@ def _tool_install(dist_dir: Path, root: Path, home: Path) -> tuple[Path, dict[st
 
     tool_dir = root / "tool"
     bin_dir = root / "bin"
-    spec = "yoetz==0.1.0"
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    spec = str(wheels[0])
     env = {
         **os.environ,
         "HOME": str(home),

--- a/tests/packaging/test_instance_lifecycle.py
+++ b/tests/packaging/test_instance_lifecycle.py
@@ -82,11 +82,14 @@ def _tool_install(dist_dir: Path, root: Path, home: Path) -> tuple[Path, dict[st
     bin_dir = root / "bin"
     env = {**_clean_env(home), "UV_TOOL_DIR": str(tool_dir), "UV_TOOL_BIN_DIR": str(bin_dir)}
 
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+
     def _install(offline: bool) -> subprocess.CompletedProcess[bytes]:
         args = ["uv", "tool", "install", "--python", "3.14.6"]
         if offline:
             args.append("--offline")
-        args += ["--find-links", str(dist_dir), "yoetz==0.1.0"]
+        args += ["--find-links", str(dist_dir), str(wheels[0])]
         return subprocess.run(args, capture_output=True, timeout=180, env=env, check=False)
 
     result = _install(offline=True)

--- a/tests/packaging/test_isolated_root_boundary.py
+++ b/tests/packaging/test_isolated_root_boundary.py
@@ -64,7 +64,9 @@ def _short_home(tag: str) -> Path:
 def _tool_install(dist_dir: Path, root: Path, home: Path) -> tuple[Path, dict[str, str]]:
     tool_dir = root / "tool"
     bin_dir = root / "bin"
-    spec = "yoetz==0.1.0"
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    spec = str(wheels[0])
     env = {
         **os.environ,
         "HOME": str(home),

--- a/tests/packaging/test_missing_kdf_startup.py
+++ b/tests/packaging/test_missing_kdf_startup.py
@@ -31,7 +31,8 @@ def test_missing_installed_argon2_kdf_reports_a_bounded_startup_remedy(tmp_path:
         check=False,
     )
     assert build.returncode == 0, build.stderr.decode("utf-8", errors="replace")
-    assert any(dist.glob("*.whl")), "expected a real wheel artifact"
+    wheels = sorted(dist.glob("*.whl"))
+    assert len(wheels) == 1, "expected exactly one real wheel artifact"
     install = subprocess.run(
         [
             "uv",
@@ -41,7 +42,7 @@ def test_missing_installed_argon2_kdf_reports_a_bounded_startup_remedy(tmp_path:
             "3.14.6",
             "--find-links",
             str(dist),
-            "yoetz==0.1.0",
+            str(wheels[0]),
         ],
         capture_output=True,
         timeout=180,

--- a/tests/packaging/test_resource_ripple.py
+++ b/tests/packaging/test_resource_ripple.py
@@ -43,6 +43,8 @@ def _write(root: Path, relative_path: str, content: str) -> None:
 def _copy_checkout(destination: Path) -> None:
     """Copy the working-tree source and generated trees the ripple reads and writes."""
 
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(_REPO_ROOT / "pyproject.toml", destination / "pyproject.toml")
     ignore = shutil.ignore_patterns("__pycache__", "*.pyc")
     for relative in _CHECKOUT_TREES:
         shutil.copytree(_REPO_ROOT / relative, destination / relative, ignore=ignore)

--- a/tests/packaging/test_uninstall_and_data_retention.py
+++ b/tests/packaging/test_uninstall_and_data_retention.py
@@ -92,7 +92,9 @@ def _tool_install(
 
     tool_dir = root / "tool"
     bin_dir = root / "bin"
-    spec = "yoetz" + (f"[{','.join(extras)}]" if extras else "") + "==0.1.0"
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    spec = str(wheels[0]) + (f"[{','.join(extras)}]" if extras else "")
     # Overriding HOME isolates the *application's* paths (bundle_root() etc.), but uv's own
     # download cache must keep resolving to the real, already-warm shared cache -- otherwise an
     # --offline install has nothing to install from. Pin UV_CACHE_DIR to the real cache explicitly.

--- a/tests/packaging/test_upgrade_and_backward_read.py
+++ b/tests/packaging/test_upgrade_and_backward_read.py
@@ -1,19 +1,9 @@
-"""Prior-release data upgrade preservation.
+"""Candidate migration invariants, without claiming prior-release upgrade certification.
 
-Scope note (verbatim, not guessed around): this spec's matrix is "each supported old release ×
-advertised platform × normal upgrade, interrupted migration, rollback/restore, ...". Yoetz v0.1.0
-is the first release: ``support/runtime-support.json`` records ``"release_version": "0.1.0"`` with
-every capability cell still empty (``development_unverified``), there is no golden fixture directory
-for a prior release anywhere in the repository, and ``docs/protocol/compatibility.md`` documents
-only the current release's axes. There is therefore no real prior artifact/bundle for this file to
-install, migrate, or replay against, and this file does not fabricate one. What it proves for real
-instead, against the installed candidate package (never the source checkout), is every structural
-invariant this suite's own spec states that a genuine future upgrade will depend on: the migration
-registries are exactly contiguous and match the advertised schema versions, a fresh catalog/bundle
-initializes at exactly that version, re-running the migration runner against an already-current
-database is an inert, verified replay (not a silent no-op that skips verification), and a
-newer-than-candidate schema is refused for both reads/writes and migration -- never silently
-accepted, never downgraded, never partially applied.
+The runtime-support inventory still has no evidenced supported-old-release cell or golden
+prior-release bundles. This suite tests the newly built candidate's migration registries,
+fresh initialization, idempotent migration replay, and refusal of newer schemas. Those checks
+do not substitute for an artifact-bound upgrade/restore drill from a previous public release.
 """
 
 from __future__ import annotations
@@ -21,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -67,7 +58,7 @@ def installed(tmp_path_factory: pytest.TempPathFactory) -> _Installed:
             str(venv_dir / "bin" / "python"),
             "--find-links",
             str(dist_dir),
-            "yoetz==0.1.0",
+            str(wheels[0]),
         ],
         capture_output=True,
         timeout=180,
@@ -86,16 +77,17 @@ def _run_probe(installed: _Installed, probe: str) -> dict[str, object]:
 
 
 # ---------------------------------------------------------------------------
-# First-release status is explicit, not fabricated
+# Unsupported upgrade coverage remains explicit
 # ---------------------------------------------------------------------------
 
 
-def test_first_release_has_no_prior_supported_version_and_no_golden_fixture() -> None:
+def test_current_release_has_no_evidenced_prior_supported_cell_or_golden_fixture() -> None:
     support = json.loads(
         (_REPO_ROOT / "support" / "runtime-support.json").read_text(encoding="utf-8")
     )
-    assert support["release_version"] == "0.1.0"
-    # No supported-old-release cell has been populated yet; there is nothing to upgrade from.
+    project = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    assert support["release_version"] == project["project"]["version"]
+    # No supported-old-release cell has been evidenced; do not infer one from a package tag.
     for cell_key in ("runtime_cells", "local_service_cells"):
         assert support[cell_key] == []
     assert not (_REPO_ROOT / "fixtures" / "compat").exists()

--- a/tests/unit/adapters/test_codex_marketplace.py
+++ b/tests/unit/adapters/test_codex_marketplace.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import pytest
 
+from yoetz import __version__
 from yoetz.adapters.integrations.codex_marketplace import (
     ActivationInspection,
     ActivationPreview,
@@ -105,7 +106,7 @@ class _FakeCodex:
         elif args == ("plugin", "list", "--marketplace", "yoetz", "--json"):
             body: object
             config = self.home / "config.toml"
-            cache = self.home / "plugins/cache/yoetz/yoetz/0.1.0"
+            cache = self.home / f"plugins/cache/yoetz/yoetz/{__version__}"
             if not config.exists() or "marketplaces.yoetz" not in config.read_text(
                 encoding="utf-8"
             ):
@@ -116,7 +117,7 @@ class _FakeCodex:
                     "pluginId": "yoetz@yoetz",
                     "name": "yoetz",
                     "marketplaceName": "yoetz",
-                    "version": "0.1.0",
+                    "version": __version__,
                     "installed": installed,
                     "enabled": True,
                     "source": {
@@ -132,18 +133,18 @@ class _FakeCodex:
                 body["available" if installed else "installed"] = []
         elif args == ("plugin", "add", "yoetz@yoetz", "--json"):
             source = self.project / ".agents/plugins/yoetz"
-            destination = self.home / "plugins/cache/yoetz/yoetz/0.1.0"
+            destination = self.home / f"plugins/cache/yoetz/yoetz/{__version__}"
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(source, destination)
             body = {
                 "pluginId": "yoetz@yoetz",
                 "name": "yoetz",
                 "marketplaceName": "yoetz",
-                "version": "0.1.0",
+                "version": __version__,
                 "installedPath": str(destination),
             }
         elif args == ("plugin", "remove", "yoetz@yoetz", "--json"):
-            destination = self.home / "plugins/cache/yoetz/yoetz/0.1.0"
+            destination = self.home / f"plugins/cache/yoetz/yoetz/{__version__}"
             if destination.is_dir():
                 shutil.rmtree(destination)
             body = {"pluginId": "yoetz@yoetz"}
@@ -292,7 +293,7 @@ def test_inspect_preview_and_apply_activation(tmp_path: Path) -> None:
     assert '[plugins."yoetz@yoetz"]' in preview.config_toml_block
     assert preview.plugin_source_digest.startswith("sha256:")
     assert preview.codex_home == home
-    assert preview.plugin_install_path == home / "plugins/cache/yoetz/yoetz/0.1.0"
+    assert preview.plugin_install_path == home / f"plugins/cache/yoetz/yoetz/{__version__}"
     assert preview.plugin_install_digest.startswith("sha256:")
     assert preview.probe_command == ("--version",)
     assert preview.inventory_command == ("plugin", "list", "--marketplace", "yoetz", "--json")
@@ -332,7 +333,7 @@ def test_stable_codex_activation_serves_required_hooks_synchronously(tmp_path: P
 
     assert result.state is ActivationState.ACTIVE
     installed_hooks = json.loads(
-        (home / "plugins/cache/yoetz/yoetz/0.1.0/hooks/hooks.json").read_bytes()
+        (home / f"plugins/cache/yoetz/yoetz/{__version__}/hooks/hooks.json").read_bytes()
     )
     for event in (
         "PreToolUse",
@@ -400,7 +401,7 @@ def test_canonical_source_activates_on_async_host_and_seeds_host_rendered_cache(
     assert b'"async":true' not in source_hooks
     # The cache carries the host-specific render: async ingress hooks present.
     cache_hooks = json.loads(
-        (home / "plugins/cache/yoetz/yoetz/0.1.0/hooks/hooks.json").read_bytes()
+        (home / f"plugins/cache/yoetz/yoetz/{__version__}/hooks/hooks.json").read_bytes()
     )
     handler = cache_hooks["hooks"]["PreToolUse"][0]["hooks"][0]
     assert handler.get("async") is True
@@ -461,7 +462,7 @@ def test_inventory_enabled_modified_source_never_reads_active(tmp_path: Path) ->
         f'source = "{project}"\n\n[plugins."yoetz@yoetz"]\nenabled = true\n',
         encoding="utf-8",
     )
-    (home / "plugins/cache/yoetz/yoetz/0.1.0").mkdir(parents=True, mode=0o700)
+    (home / f"plugins/cache/yoetz/yoetz/{__version__}").mkdir(parents=True, mode=0o700)
 
     inspection = inspect_activation(target, codex_home=home)
 
@@ -488,7 +489,7 @@ def test_same_version_cache_refresh_replaces_prior_managed_render(tmp_path: Path
         approved_digest=first.preview_digest,
         _run=runner,
     )
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     # Simulate content drift since the prior activation: overwrite the cache with
     # the other renderer variant, which is exactly a prior yoetz-managed render.
     shutil.rmtree(cache)
@@ -537,7 +538,7 @@ def test_cache_refresh_between_preview_and_apply_is_stale(tmp_path: Path) -> Non
         approved_digest=first.preview_digest,
         _run=runner,
     )
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     shutil.rmtree(cache)
     cache.mkdir(mode=0o700)
     for relative_path, payload in render_plugin_install_tree(codex_version=None).items():
@@ -584,7 +585,7 @@ def test_modified_or_foreign_cache_stays_destination_conflict(tmp_path: Path) ->
         approved_digest=first.preview_digest,
         _run=runner,
     )
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     hooks = cache / "hooks/hooks.json"
     hooks.write_bytes(hooks.read_bytes() + b"# modified\n")
 
@@ -746,7 +747,7 @@ def test_cache_replacement_refuses_ancestor_swap_after_validation(tmp_path: Path
     from yoetz.adapters.integrations.codex_plugin import render_plugin_install_tree
 
     home = tmp_path / "codex-home"
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     cache.mkdir(parents=True)
     module._validate_descendant_ancestors(  # pyright: ignore[reportPrivateUsage]
         home,
@@ -755,12 +756,12 @@ def test_cache_replacement_refuses_ancestor_swap_after_validation(tmp_path: Path
     outside = tmp_path / "outside-cache"
     (home / "plugins").rename(outside)
     (home / "plugins").symlink_to(outside, target_is_directory=True)
-    sentinel = outside / "cache/yoetz/yoetz/0.1.0/sentinel.txt"
+    sentinel = outside / f"cache/yoetz/yoetz/{__version__}/sentinel.txt"
     sentinel.write_bytes(b"outside")
 
     with pytest.raises(IntegrationError) as caught:
         module._replace_cache_tree(  # pyright: ignore[reportPrivateUsage]
-            home / "plugins/cache/yoetz/yoetz/0.1.0",
+            home / f"plugins/cache/yoetz/yoetz/{__version__}",
             render_plugin_install_tree(codex_version="0.148.0-alpha.6"),
             anchor_root=home,
         )
@@ -775,7 +776,7 @@ def test_removal_preview_refuses_cache_ancestor_swap_after_validation(tmp_path: 
 
     home = tmp_path / "codex-home"
     cache_root = home / "plugins/cache/yoetz/yoetz"
-    cache = cache_root / "0.1.0"
+    cache = cache_root / __version__
     cache.mkdir(parents=True)
     expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
     for relative, payload in expected.items():
@@ -789,7 +790,7 @@ def test_removal_preview_refuses_cache_ancestor_swap_after_validation(tmp_path: 
     outside = tmp_path / "outside-cache"
     (home / "plugins").rename(outside)
     (home / "plugins").symlink_to(outside, target_is_directory=True)
-    sentinel = outside / "cache/yoetz/yoetz/0.1.0/sentinel.txt"
+    sentinel = outside / f"cache/yoetz/yoetz/{__version__}/sentinel.txt"
     sentinel.write_bytes(b"outside")
 
     with pytest.raises(IntegrationError) as caught:
@@ -904,7 +905,7 @@ def test_add_failure_after_copy_preserves_honest_partial_state_for_retry(
             _run=runner,
         )
     assert caught.value.reason is IntegrationReason.WRITE_FAILED
-    assert (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+    assert (home / f"plugins/cache/yoetz/yoetz/{__version__}").exists()
     assert (project / ".agents/plugins/marketplace.json").read_bytes() == preview.marketplace_bytes
     assert (home / "config.toml").is_file()
 
@@ -1279,7 +1280,7 @@ def test_post_host_mutation_config_conflict_is_write_failed(tmp_path: Path) -> N
 
     assert caught.value.reason is IntegrationReason.WRITE_FAILED
     assert caught.value.safe_details["conflict"] == "config_plugin"
-    assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+    assert not (home / f"plugins/cache/yoetz/yoetz/{__version__}").exists()
 
 
 def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path) -> None:
@@ -1309,7 +1310,7 @@ def test_post_host_mutation_marketplace_conflict_is_write_failed(tmp_path: Path)
     assert caught.value.reason is IntegrationReason.WRITE_FAILED
     assert caught.value.safe_details["conflict"] == "repository_marketplace"
     assert marketplace.read_bytes() == b'{"name":"foreign"}\n'
-    assert not (home / "plugins/cache/yoetz/yoetz/0.1.0").exists()
+    assert not (home / f"plugins/cache/yoetz/yoetz/{__version__}").exists()
 
 
 def test_post_host_mutation_config_read_error_is_write_failed(
@@ -1328,7 +1329,7 @@ def test_post_host_mutation_config_read_error_is_write_failed(
         codex_home=home,
         _run=runner,
     )
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     config = home / "config.toml"
     real_current_bytes = module._current_bytes  # pyright: ignore[reportPrivateUsage]
 
@@ -1367,7 +1368,7 @@ def test_mutating_host_runner_error_is_write_failed(tmp_path: Path) -> None:
         codex_home=home,
         _run=runner,
     )
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     runner.error_after_mutation = module._error(  # pyright: ignore[reportPrivateUsage]
         IntegrationReason.TARGET_UNSAFE
     )
@@ -1394,7 +1395,7 @@ def test_mutating_host_malformed_json_is_write_failed(
     _install(target)
     activation = preview_activation(target, codex_home=home)
     apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     if host_surface == "marketplace":
         shutil.rmtree(cache)
     runner = _FakeCodex(target, home)
@@ -1692,7 +1693,7 @@ def test_cache_only_removal_preserves_write_failed_for_final_verification(
 
     target, project, home = _target(tmp_path)
     _install(target)
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     expected = render_plugin_install_tree(codex_version="0.148.0-alpha.6")
     for relative, payload in expected.items():
         destination = cache / relative
@@ -1705,7 +1706,7 @@ def test_cache_only_removal_preserves_write_failed_for_final_verification(
         codex_home=home,
         _run=runner,
     )
-    assert preview.cache_versions == ("0.1.0",)
+    assert preview.cache_versions == (__version__,)
     assert preview.plugin_remove_planned is False
     assert preview.marketplace_remove_planned is False
     original_inventory = module._plugin_inventory  # pyright: ignore[reportPrivateUsage]
@@ -1752,7 +1753,7 @@ def test_removal_preview_bounds_cache_members(tmp_path: Path, overflow: str) -> 
     _install(target)
     activation = preview_activation(target, codex_home=home)
     apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     if overflow == "member_bytes":
         os.truncate(cache / "hooks/hooks.json", _MAX_MANAGED_CACHE_MEMBER_BYTES + 1)
     elif overflow == "file_count":
@@ -1787,7 +1788,7 @@ def test_removal_preview_rejects_unrepresented_empty_cache_directory(tmp_path: P
     _install(target)
     activation = preview_activation(target, codex_home=home)
     apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
-    cache = home / "plugins/cache/yoetz/yoetz/0.1.0"
+    cache = home / f"plugins/cache/yoetz/yoetz/{__version__}"
     empty = cache / "owner-empty"
     empty.mkdir()
 
@@ -2405,7 +2406,7 @@ def test_purge_cache_deletes_other_managed_versions(tmp_path: Path) -> None:
     activation = preview_activation(target, codex_home=home)
     apply_activation(target, codex_home=home, approved_digest=activation.preview_digest)
     extra = home / "plugins/cache/yoetz/yoetz/0.0.1"
-    shutil.copytree(home / "plugins/cache/yoetz/yoetz/0.1.0", extra)
+    shutil.copytree(home / f"plugins/cache/yoetz/yoetz/{__version__}", extra)
     with pytest.raises(IntegrationError) as caught:
         preview_removal(target, codex_home=home)
     assert caught.value.reason is IntegrationReason.REMOVE_REFUSED


### PR DESCRIPTION
## Summary

Each setup choice now shows a clipboard popup explaining what to do next. **Set up with your agent** asks visitors to paste into their agent chat and send. **Install with PyPI** shows the exact install command, then tells visitors to run `yoetz` after installation. **Install with npm** shows `npx yoetz` and explains that running it starts setup directly. Each popup stays visible for eight seconds and is the single live status announcement.

Implemented by GPT-6 in the Codex desktop harness.

## CI dependency

Includes the repair branch from #705 so CI exercises the current 0.2.0 candidate. #705 contains the shared release/test repair and should merge first; the landing change remains the three landing/documentation files above that branch.

## Issue

- Fixes #703.
- Searched existing issues and PRs for duplicates.
- Not design-gated; this is a small landing interaction clarification requested by the maintainer.

## Documentation

- Behavior change: yes, landing copy feedback.
- Updated `docs/usage/install-and-first-run.md` with the paste/send flow.

## Verification

```text
npm run build --prefix landing
UV_CACHE_DIR=/private/tmp/yoetz-landing-uv-cache uv run python scripts/scan_public_boundary.py --source-tree .
git diff --check
```

All passed. Agent-browser checks at desktop and 390px mobile widths confirmed the setup popup and no horizontal overflow. PyPI/npm popups match the copied commands and include terminal instructions; switching back to agent setup hides the command. No browser errors or Vite overlay were detected. Local preview: http://127.0.0.1:4321.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.
