### PR TITLE
feat(landing): restructure yoetz.dev into three screens with clearer install steps

### DIFF
--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -188,14 +188,6 @@ for (const sc of termScripts) {
 const termLines = termScripts[0].lines;
 const firstHost = hosts[termScripts[0].host];
 
-// How it works: four nodes, one sentence each.
-const flow = [
-  { key: "publish", title: "Publish", ops: "start · publish_work", text: "The agent writes its plan, work, results, and claims to the ledger." },
-  { key: "ledger", title: "Ledger", ops: "append-only · local", text: "On your machine. Nothing is inferred from your repository." },
-  { key: "check", title: "Check", ops: "check · respond", text: "Rules catch gaps in the record. An optional reviewer model challenges the work." },
-  { key: "receipt", title: "Receipt", ops: "receipt", text: "What was checked, at what coverage, and what is still open." },
-];
-
 // Coming soon.
 const next = [
   { key: "delegate", title: "Delegate", text: "A parent mints a child task with an expiring handle. The child publishes, checks, and gets its own receipt." },

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -196,37 +196,6 @@ const flow = [
   { key: "receipt", title: "Receipt", ops: "receipt", text: "What was checked, at what coverage, and what is still open." },
 ];
 
-// Three looping scenes: what Yoetz does while the agent works.
-const scenes = [
-  { key: "records", title: "Takes in both", text: "What the agent says it did, and what it actually did." },
-  { key: "checks", title: "Checks the claim", text: "When the record disagrees, that is a finding." },
-  { key: "assists", title: "Stays until done", text: "Fix, recheck, receipt." },
-];
-
-// What's new. Every line is bounded by the release notes.
-const features = [
-  {
-    key: "hooks",
-    title: "Hooks that attach themselves",
-    text: "Observed work lands on the right task, survives reattach, and records why when it cannot.",
-  },
-  {
-    key: "consent",
-    title: "Consent in conversation",
-    text: "Your agent shows one before/after privacy preview and relays your one approval. Drift fails closed. Some hosts finish the approval in your terminal.",
-  },
-  {
-    key: "correct",
-    title: "Correct a claim, don't stack one",
-    text: "A revised completion claim names what it replaces and what fell short.",
-  },
-  {
-    key: "recheck",
-    title: "Findings clear only by recheck",
-    text: "A response records a disposition. Only a later qualifying check resolves the finding.",
-  },
-];
-
 // Coming soon.
 const next = [
   { key: "delegate", title: "Delegate", text: "A parent mints a child task with an expiring handle. The child publishes, checks, and gets its own receipt." },
@@ -267,383 +236,270 @@ const next = [
   <body>
     <!-- Hero -->
     <section id="top" class="ds-hero">
-      <div class="ds-hero-grid">
-        <div>
-          <div class="hero-top">
-            <div class="hero-brand-logo">
-              <img src="/assets/yoetz-logo.png" alt="Yoetz" />
-            </div>
-            <a class="hero-star" href={GITHUB} target="_blank" rel="noopener" aria-label="Star Yoetz on GitHub">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
-              Star us on GitHub
-            </a>
-          </div>
+      <div class="hero-stack">
+        <div class="hero-copy">
           <h1 class="ds-h1">
             <span class="line">Agents claim they're done.</span>
-            <span class="line grad">Yoetz checks if they actually did.</span>
+            <span class="line grad"><img class="h1-logo" src="/assets/yoetz-logo.png" alt="Yoetz" /> checks if they're actually done.</span>
           </h1>
-          <div class="hero-hosts" aria-label="Supported agents">
-            <span class="hero-hosts-label">Supported</span>
-            <span class="host-pill"><img src="/assets/openai.svg" alt="" /> Codex</span>
-            <span class="host-pill"><img src="/assets/claude.svg" alt="" /> Claude Code <em class="new">new</em></span>
-            <span class="host-pill"><img src="/assets/cursor.svg" alt="" /> Cursor <em class="new">new</em></span>
+          <p class="sr-only">
+            Your agent claims it is done. Yoetz checks that claim against its own ledger of the work and
+            issues a receipt: what was verified, at what coverage, and what is still open.
+          </p>
+          <div class="hx" aria-hidden="true">
+            <div class="hx-card hx-agent">
+              <div class="hx-eyebrow">Agent says</div>
+              <div class="hx-row hx-say"><span class="hx-mark">›</span>Done. Refactored, tests pass.<span class="hx-caret"></span></div>
+            </div>
+            <div class="hx-link"><span class="hx-dot hx-dot1"></span></div>
+            <div class="hx-card hx-check">
+              <div class="hx-eyebrow">Yoetz checks the record</div>
+              <div class="hx-scan"></div>
+              <div class="hx-row hx-c1"><span class="hx-mark ok">✓</span>plan · 3 obligations</div>
+              <div class="hx-row hx-c2"><span class="hx-mark ok">✓</span>edited src/limiter.py</div>
+              <div class="hx-row hx-c3"><span class="hx-mark">·</span>tests pass · 41 passed</div>
+              <div class="hx-row hx-c4 flag"><span class="hx-mark">✗</span>that run predates the last edit</div>
+            </div>
+            <div class="hx-link"><span class="hx-dot hx-dot2"></span></div>
+            <div class="hx-card hx-receipt">
+              <div class="hx-eyebrow">You get a receipt<span class="hx-stamp">issued</span></div>
+              <div class="hx-row hx-r1"><span class="hx-k">verified</span>2 of 3 obligations</div>
+              <div class="hx-row hx-r2"><span class="hx-k">coverage</span><span class="hx-bar"><span class="hx-fill"></span></span></div>
+              <div class="hx-row hx-r3 flag"><span class="hx-k">open</span>1 finding · stale run</div>
+            </div>
           </div>
 
           <div class="hero-installers">
             <div class="inst-tabs" role="group" aria-label="Install options">
-              <button class="inst-tab" type="button" data-key="pypi" data-command={INSTALL_COMMAND}>Install with PyPI</button>
-              <button class="inst-tab" type="button" data-key="npm" data-command="npx yoetz">Install with npm</button>
               <button class="inst-tab agent" type="button" id="agent-copy" data-command={AGENT_PROMPT}>
                 <span id="agent-copy-label">Set up with your agent</span> <span class="rec">recommended</span>
               </button>
+              <button class="inst-tab manual" type="button" id="manual-toggle" aria-expanded="false" aria-controls="manual-panel">
+                Install manually
+                <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+            </div>
+            <div class="manual-panel" id="manual-panel" hidden>
+              <span class="manual-label">Copy a command</span>
+              <button class="inst-tab" type="button" data-key="pypi" data-command={INSTALL_COMMAND}>Install with PyPI</button>
+              <button class="inst-tab" type="button" data-key="npm" data-command="npx yoetz">Install with npm</button>
             </div>
 
-            <div class="copy-toast" id="copy-toast" role="status" aria-live="polite" hidden>
-              <span class="ct-check" aria-hidden="true">✓</span>
-              <span class="ct-body">
-                <span class="ct-title">Copied to your clipboard</span>
-                <code class="ct-detail ct-cmd" id="copy-toast-cmd" hidden></code>
-                <span class="ct-detail" id="copy-toast-detail"></span>
-              </span>
+            <div class="next-steps" id="copy-toast" role="status" aria-live="polite" hidden>
+              <div class="ns-head">
+                <span class="ns-check" aria-hidden="true">✓</span>
+                <span class="ns-title" id="ns-title"></span>
+                <button class="ns-close" id="ns-close" type="button" aria-label="Dismiss">×</button>
+              </div>
+              <code class="ns-cmd" id="copy-toast-cmd" hidden></code>
+              <ol class="ns-steps" id="ns-steps"></ol>
+              <p class="ns-foot" id="ns-foot" hidden></p>
             </div>
 
             <p class="inst-note agent-note">
               Copies a prompt. Paste it into your agent: it installs Yoetz and shows you every change first.
             </p>
           </div>
+          <div class="hero-hosts" aria-label="Officially supported agents">
+            <span class="hero-hosts-label">Officially supports</span>
+            <span class="host-pill"><img src="/assets/openai.svg" alt="" /> Codex</span>
+            <span class="host-pill"><img src="/assets/claude.svg" alt="" /> Claude Code <em class="new">new</em></span>
+            <span class="host-pill"><img src="/assets/cursor.svg" alt="" /> Cursor <em class="new">new</em></span>
+          </div>
+          <div class="hero-meta">
+              <a class="hero-star" href={GITHUB} target="_blank" rel="noopener" aria-label="Star Yoetz on GitHub">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path></svg>
+                Star us on GitHub
+              </a>
+              <a class="hero-license" href={`${GITHUB}/blob/main/LICENSE`} target="_blank" rel="noopener">
+                <span class="l">open source</span>
+                <span class="r">Apache-2.0</span>
+              </a>
+          </div>
         </div>
 
-        <!-- Mock terminal -->
+      </div>
+    </section>
+
+    <!-- Screen 2: what you see in the terminal -->
+    <section id="see" class="see-section">
+      <div class="see-inner">
+        <div class="see-copy">
+          <span class="ds-kicker">Working in the background</span>
+          <h2 class="ds-h2"><span class="brand">Yoetz</span> makes sure your agent never loses track.</h2>
+          <p class="ds-lead">By keeping two records: what the agent says it did, and what it actually did.</p>
+          <div class="see-art" aria-hidden="true">
+            <svg viewBox="0 0 400 200" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <text x="8" y="13" class="art-tag">what it says</text>
+              <rect x="8" y="20" width="154" height="48" rx="9" class="art-box on" />
+              <text x="18" y="40" class="art-txt on">claim · done ✓</text>
+              <text x="18" y="56" class="art-txt sub">“tests pass”</text>
+
+              <text x="8" y="111" class="art-tag">what it did</text>
+              <rect x="8" y="118" width="154" height="62" rx="9" class="art-box" />
+              <text x="18" y="138" class="art-txt">edited src/limiter.py</text>
+              <text x="18" y="154" class="art-txt">pytest · 41 passed</text>
+              <text x="18" y="170" class="art-txt warn">…run before the edit</text>
+
+              <path d="M162 44 C 184 44, 184 100, 206 100" class="art-line on" />
+              <path d="M162 149 C 184 149, 184 100, 206 100" class="art-line on" />
+
+              <rect x="206" y="78" width="84" height="44" rx="10" class="art-box on solid" />
+              <text x="248" y="97" class="art-txt inv" text-anchor="middle">yoetz</text>
+              <text x="248" y="112" class="art-txt inv" text-anchor="middle" opacity="0.85">compares</text>
+
+              <path d="M290 100 C 310 100, 310 52, 326 52" class="art-line warn" />
+              <path d="M290 100 C 310 100, 310 148, 326 148" class="art-line on" />
+              <rect x="326" y="34" width="72" height="36" rx="8" class="art-box warn" />
+              <text x="362" y="49" class="art-txt warn" text-anchor="middle">finding</text>
+              <text x="362" y="62" class="art-tag warn" text-anchor="middle">stale run</text>
+              <rect x="326" y="130" width="72" height="36" rx="8" class="art-box on" />
+              <text x="362" y="145" class="art-txt on" text-anchor="middle">receipt</text>
+              <text x="362" y="158" class="art-tag on" text-anchor="middle">what’s open</text>
+            </svg>
+          </div>
+          <p class="see-note">A disagreement is a finding. The agent fixes it, rechecks, and you get a receipt.</p>
+        </div>
+        <div class="see-demo">
+        <div class="hero-demo">
+            <div class="term-card">
+            <div class="term-head">
+              <div class="term-dots"><span></span><span></span><span></span></div>
+              <img class={`term-host${firstHost.dark ? " invert" : ""}`} src={firstHost.logo} alt="" />
+              <span class="term-title">{firstHost.name} · {termScripts[0].title}</span>
+              <span class="term-pill">yoetz · local</span>
+            </div>
+            <div class="term-body" id="term" aria-hidden="true">
+              {termLines.map((ln) =>
+                ln.pre || ln.op || ln.rest ? (
+                  <div
+                    class={`tl${ln.finding ? " tl-finding" : ""}`}
+                    hidden
+                    data-d={ln.d}
+                    data-ts={ln.ts}
+                  >
+                    <span class="tl-pre" style={`color: ${ln.preC ?? faint};`}>{ln.pre}</span>
+                    {ln.op && <span class="tl-op">{ln.op}</span>}
+                    <span class="tl-rest" style={`color: ${ln.restC ?? dim};`}>{ln.rest}</span>
+                  </div>
+                ) : (
+                  <div class="tl tl-gap" data-d={ln.d} hidden></div>
+                )
+              )}
+              <div class="term-cursor-line" id="term-cursor" hidden>
+                <span class="tl-pre">$</span>
+                <span class="dx-caret"></span>
+              </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <script is:inline type="application/json" id="term-scripts" set:html={JSON.stringify(termScripts)} />
+    </section>
+
+    <!-- Screen 3: under the hood -->
+    <section id="inside" class="inside-section">
+      <div class="ds-section-head">
+        <span class="ds-kicker">Under the hood</span>
+        <h2 class="ds-h2">Hooks and MCP, one local service.</h2>
+        <p class="ds-lead centered">The agent talks to Yoetz over MCP. The host reports through hooks. One service on your machine holds the record and checks it.</p>
+      </div>
+
+      <div class="arch" aria-hidden="true">
+        <svg viewBox="0 0 960 400" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <defs>
+            <marker id="arr-on" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 z" fill="#14b8a6" /></marker>
+            <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 z" fill="#94a3b8" /></marker>
+          </defs>
+
+          <!-- boundary -->
+          <rect x="8" y="30" width="944" height="362" rx="18" class="art-box" stroke-dasharray="5 5" />
+          <text x="26" y="52" class="art-tag">your machine · nothing leaves it</text>
+
+          <!-- agent -->
+          <rect x="24" y="96" width="160" height="208" rx="14" class="art-box" />
+          <text x="104" y="124" class="art-txt strong" text-anchor="middle">your agent</text>
+          <image href="/assets/openai.svg" x="52" y="140" width="22" height="22" />
+          <image href="/assets/claude.svg" x="93" y="140" width="22" height="22" />
+          <image href="/assets/cursor.svg" x="134" y="140" width="22" height="22" />
+          <text x="104" y="182" class="art-tag" text-anchor="middle">or any MCP host</text>
+          <text x="104" y="258" class="art-txt sub" text-anchor="middle">works as usual,</text>
+          <text x="104" y="272" class="art-txt sub" text-anchor="middle">nothing to run</text>
+
+          <!-- MCP channel -->
+          <text x="352" y="88" class="art-tag on" text-anchor="middle">MCP · what the agent says it did</text>
+          <path d="M184 140 H 518" class="art-line on" marker-end="url(#arr-on)" />
+          <g class="tool-pills">
+            <rect x="204" y="104" width="88" height="20" rx="10" class="art-box on" /><text x="248" y="118" class="art-txt on" text-anchor="middle">start</text>
+            <rect x="300" y="104" width="104" height="20" rx="10" class="art-box on" /><text x="352" y="118" class="art-txt on" text-anchor="middle">publish_work</text>
+            <rect x="412" y="104" width="88" height="20" rx="10" class="art-box on" /><text x="456" y="118" class="art-txt on" text-anchor="middle">check</text>
+            <rect x="204" y="156" width="88" height="20" rx="10" class="art-box on" /><text x="248" y="170" class="art-txt on" text-anchor="middle">respond</text>
+            <rect x="300" y="156" width="104" height="20" rx="10" class="art-box on" /><text x="352" y="170" class="art-txt on" text-anchor="middle">status</text>
+            <rect x="412" y="156" width="88" height="20" rx="10" class="art-box on" /><text x="456" y="170" class="art-txt on" text-anchor="middle">receipt</text>
+          </g>
+
+          <!-- hooks channel -->
+          <text x="352" y="218" class="art-tag" text-anchor="middle">hooks · what the host actually saw</text>
+          <path d="M184 240 H 518" class="art-line" marker-end="url(#arr)" />
+          <rect x="242" y="230" width="220" height="20" rx="10" class="art-box" />
+          <text x="352" y="244" class="art-txt sub" text-anchor="middle">sessions · tool calls · edits · results</text>
+
+          <!-- return -->
+          <path d="M518 286 H 184" class="art-line on" marker-end="url(#arr-on)" />
+          <text x="352" y="304" class="art-tag on" text-anchor="middle">findings and the receipt, back in the conversation</text>
+
+          <!-- service -->
+          <rect x="520" y="62" width="416" height="306" rx="16" class="art-box on" />
+          <text x="540" y="84" class="art-tag on">yoetz service · one local process</text>
+
+          <rect x="546" y="134" width="108" height="56" rx="10" class="art-box" />
+          <text x="600" y="157" class="art-txt strong" text-anchor="middle">ledger</text>
+          <text x="600" y="172" class="art-tag" text-anchor="middle">append-only · SQLite</text>
+
+          <path d="M654 162 H 668" class="art-line on" marker-end="url(#arr-on)" />
+          <rect x="672" y="134" width="108" height="56" rx="10" class="art-box on" />
+          <text x="726" y="157" class="art-txt strong" text-anchor="middle">rules</text>
+          <text x="726" y="172" class="art-tag" text-anchor="middle">deterministic</text>
+
+          <path d="M780 162 H 794" class="art-line on" marker-end="url(#arr-on)" />
+          <rect x="798" y="134" width="108" height="56" rx="10" class="art-box on solid" />
+          <text x="852" y="157" class="art-txt inv" text-anchor="middle">receipt</text>
+          <text x="852" y="172" class="art-txt inv" text-anchor="middle" opacity="0.85">coverage-bounded</text>
+
+          <text x="600" y="214" class="art-txt sub" text-anchor="middle">says vs. did,</text>
+          <text x="600" y="228" class="art-txt sub" text-anchor="middle">as events</text>
+          <text x="726" y="214" class="art-txt sub" text-anchor="middle">same inputs,</text>
+          <text x="726" y="228" class="art-txt sub" text-anchor="middle">same findings</text>
+          <text x="852" y="214" class="art-txt sub" text-anchor="middle">verified · coverage</text>
+          <text x="852" y="228" class="art-txt sub" text-anchor="middle">· still open</text>
+
+          <path d="M726 190 V 270" class="art-line" stroke-dasharray="3 4" />
+          <rect x="652" y="272" width="148" height="52" rx="10" class="art-box" stroke-dasharray="4 3" />
+          <text x="726" y="293" class="art-txt" text-anchor="middle">reviewer model · optional</text>
+          <text x="726" y="309" class="art-tag" text-anchor="middle">your API key or ChatGPT plan</text>
+          <text x="726" y="352" class="art-tag" text-anchor="middle">runs from here · nothing goes through us</text>
+        </svg>
+      </div>
+
+      <div class="arch-notes">
         <div>
-          <div class="term-card">
-          <div class="term-head">
-            <div class="term-dots"><span></span><span></span><span></span></div>
-            <img class={`term-host${firstHost.dark ? " invert" : ""}`} src={firstHost.logo} alt="" />
-            <span class="term-title">{firstHost.name} · {termScripts[0].title}</span>
-            <span class="term-pill">yoetz · local</span>
-          </div>
-          <div class="term-body" id="term" aria-hidden="true">
-            {termLines.map((ln) =>
-              ln.pre || ln.op || ln.rest ? (
-                <div
-                  class={`tl${ln.finding ? " tl-finding" : ""}`}
-                  hidden
-                  data-d={ln.d}
-                  data-ts={ln.ts}
-                >
-                  <span class="tl-pre" style={`color: ${ln.preC ?? faint};`}>{ln.pre}</span>
-                  {ln.op && <span class="tl-op">{ln.op}</span>}
-                  <span class="tl-rest" style={`color: ${ln.restC ?? dim};`}>{ln.rest}</span>
-                </div>
-              ) : (
-                <div class="tl tl-gap" data-d={ln.d} hidden></div>
-              )
-            )}
-            <div class="term-cursor-line" id="term-cursor" hidden>
-              <span class="tl-pre">$</span>
-              <span class="dx-caret"></span>
-            </div>
-            </div>
-          </div>
-          <div class="hero-under-term">
-            <a class="hero-license" href={`${GITHUB}/blob/main/LICENSE`} target="_blank" rel="noopener">
-              <span class="l">open source</span>
-              <span class="r">Apache-2.0</span>
-            </a>
-          </div>
+          <div class="arch-k">over MCP</div>
+          <p>The agent publishes its plan, work, claims, and evidence through six tools. Any MCP host can, with nothing installed.</p>
         </div>
-        <script is:inline type="application/json" id="term-scripts" set:html={JSON.stringify(termScripts)} />
-      </div>
-    </section>
-
-    <!-- How it works: four nodes, one line each -->
-    <section id="how" class="ds-section">
-      <div class="ds-section-head">
-        <h2 class="ds-h2">A ledger between your agent and “done”</h2>
-      </div>
-
-      <div class="flow" id="flow">
-        {flow.map((n) => (
-          <div class={`fnode fnode-${n.key}`}>
-            <div class="fnode-icon" aria-hidden="true">
-              {n.key === "publish" && (
-                <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="9" y="6" width="30" height="36" rx="4" />
-                  <path d="M16 16h16M16 23h16M16 30h9" />
-                  <path class="fn-accent" d="M31 38l4-4 8 8" />
-                  <circle class="fn-accent" cx="36" cy="33" r="0" />
-                  <path class="fn-accent" d="M28 31l7-7M35 24v6M35 24h-6" />
-                </svg>
-              )}
-              {n.key === "ledger" && (
-                <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="7" y="8" width="34" height="8" rx="2" />
-                  <rect x="7" y="20" width="34" height="8" rx="2" />
-                  <rect x="7" y="32" width="34" height="8" rx="2" />
-                  <path class="fn-accent" d="M13 12h3M13 24h3M13 36h3" />
-                  <path class="fn-accent" d="M35 16v4M35 28v4" stroke-dasharray="1 2" />
-                  <path class="fn-accent" d="M28 12h7M28 24h7M28 36h7" stroke-width="1.5" opacity="0.6" />
-                </svg>
-              )}
-              {n.key === "check" && (
-                <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M24 5l15 6v11c0 9-6 16-15 20-9-4-15-11-15-20V11z" />
-                  <path class="fn-accent" d="M17 24l5 5 10-11" />
-                  <path class="fn-accent" d="M40 30l1.5 3 3 1.5-3 1.5-1.5 3-1.5-3-3-1.5 3-1.5z" stroke-width="1.5" fill="currentColor" />
-                </svg>
-              )}
-              {n.key === "receipt" && (
-                <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M10 6h28v34l-4-3-4 3-4-3-4 3-4-3-4 3-4-3z" />
-                  <path d="M16 15h16M16 22h16" />
-                  <path class="fn-accent" d="M16 29h9" />
-                  <path class="fn-accent" d="M28 29h4" stroke-dasharray="1.5 2" />
-                </svg>
-              )}
-            </div>
-            <div class="fnode-title">{n.title}</div>
-            <div class="fnode-ops">{n.ops}</div>
-            <p class="fnode-text">{n.text}</p>
-          </div>
-        ))}
-      </div>
-
-      <div class="scenes">
-        {scenes.map((sc) => (
-          <div class={`scene scene-${sc.key}`}>
-            <div class="scene-art" aria-hidden="true">
-              {sc.key === "records" && (
-                <svg viewBox="0 0 280 150" class="sc sc-a">
-                  <rect x="8" y="50" width="64" height="50" rx="10" class="sc-box" />
-                  <text x="40" y="70" class="sc-txt strong" text-anchor="middle">agent</text>
-                  <rect class="sc-bar b1" x="20" y="80" width="40" height="3" rx="1.5" />
-                  <rect class="sc-bar b2" x="20" y="87" width="26" height="3" rx="1.5" />
-                  <rect class="sc-bar b3" x="20" y="94" width="34" height="3" rx="1.5" />
-                  <rect x="186" y="22" width="86" height="106" rx="10" class="sc-box" />
-                  <text x="229" y="38" class="sc-tag" text-anchor="middle">ledger</text>
-                  <rect class="sc-row r1" x="196" y="48" width="66" height="14" rx="4" />
-                  <rect class="sc-row still" x="196" y="68" width="66" height="14" rx="4" />
-                  <rect class="sc-row still" x="196" y="88" width="66" height="14" rx="4" />
-                  <rect class="sc-row r4" x="196" y="108" width="66" height="14" rx="4" />
-                  <text x="124" y="30" class="sc-tag" text-anchor="middle">what it says</text>
-                  <g class="sc-chip c1"><rect x="76" y="40" width="96" height="18" rx="9" class="sc-chip-box claim" /><text x="124" y="52" class="sc-chip-txt" text-anchor="middle">claim · done</text></g>
-                  <g class="sc-chip c2"><rect x="76" y="92" width="96" height="18" rx="9" class="sc-chip-box work" /><text x="124" y="104" class="sc-chip-txt" text-anchor="middle">pytest · failed</text></g>
-                  <text x="124" y="126" class="sc-tag" text-anchor="middle">what it did</text>
-                </svg>
-              )}
-              {sc.key === "checks" && (
-                <svg viewBox="0 0 280 150" class="sc sc-b">
-                  <rect x="8" y="30" width="116" height="46" rx="10" class="sc-box" />
-                  <text x="66" y="49" class="sc-txt strong" text-anchor="middle">claim · done ✓</text>
-                  <text x="66" y="65" class="sc-tag" text-anchor="middle">cites: 40 passed</text>
-                  <path d="M124 53h60" class="sc-link" />
-                  <rect x="186" y="22" width="86" height="106" rx="10" class="sc-box" />
-                  <text x="229" y="38" class="sc-tag" text-anchor="middle">ledger</text>
-                  <rect class="sc-row still" x="196" y="48" width="66" height="14" rx="4" />
-                  <rect class="sc-row still" x="196" y="68" width="66" height="14" rx="4" />
-                  <rect class="sc-row warn r3" x="196" y="88" width="66" height="14" rx="4" />
-                  <text x="229" y="98" class="sc-row-txt" text-anchor="middle">1 failed</text>
-                  <rect class="sc-row still" x="196" y="108" width="66" height="14" rx="4" />
-                  <rect class="sc-scan" x="190" y="44" width="78" height="3" rx="1.5" />
-                  <g class="sc-finding"><rect x="8" y="98" width="158" height="24" rx="12" /><text x="87" y="114" text-anchor="middle">✗ failed_work_omitted</text></g>
-                </svg>
-              )}
-              {sc.key === "assists" && (
-                <svg viewBox="0 0 280 150" class="sc sc-c">
-                  <rect x="8" y="30" width="64" height="46" rx="10" class="sc-box" />
-                  <text x="40" y="49" class="sc-txt strong" text-anchor="middle">agent</text>
-                  <text x="40" y="64" class="sc-tag" text-anchor="middle">fixes it</text>
-                  <rect x="186" y="14" width="86" height="80" rx="10" class="sc-box" />
-                  <rect class="sc-row still" x="196" y="26" width="66" height="14" rx="4" />
-                  <rect class="sc-row ok r3" x="196" y="46" width="66" height="14" rx="4" />
-                  <text x="229" y="56" class="sc-row-txt" text-anchor="middle">41 passed</text>
-                  <rect class="sc-row still" x="196" y="66" width="66" height="14" rx="4" />
-                  <g class="sc-chip fixchip"><rect x="82" y="44" width="92" height="18" rx="9" class="sc-chip-box work" /><text x="128" y="56" class="sc-chip-txt" text-anchor="middle">fix · rerun</text></g>
-                  <g class="sc-receipt"><rect x="24" y="104" width="232" height="32" rx="9" /><text x="140" y="124" text-anchor="middle">receipt ✓ · coverage-bounded</text></g>
-                </svg>
-              )}
-            </div>
-            <h3>{sc.title}</h3>
-            <p>{sc.text}</p>
-          </div>
-        ))}
-      </div>
-    </section>
-
-    <!-- Semantic review on the ChatGPT plan -->
-    <section id="review" class="review-band">
-      <div class="review-inner">
-        <div class="review-copy">
-          <span class="ds-kicker">Semantic review</span>
-          <h2 class="ds-h2">A reviewer model. Your key, or the plan you already have.</h2>
-          <p class="ds-lead">A reviewer reads a bounded packet built from the ledger and challenges the work. Bring your own API key, or use the ChatGPT subscription you already pay for. Either way it runs from your machine. Nothing goes through us.</p>
-          <ul class="review-points">
-            <li><b>Always on underneath.</b> Deterministic checks run first, offline, with nothing configured.</li>
-            <li><b>Your repository stays home.</b> The reviewer sees the ledger packet, never your files.</li>
-            <li><b>No account with us.</b> Yoetz has no servers. Your key or your login never leaves your machine.</li>
-          </ul>
+        <div>
+          <div class="arch-k">through hooks</div>
+          <p>Codex, Claude Code, and Cursor also report what actually happened: sessions, tool calls, edits. Structural facts, never your files.</p>
         </div>
-        <div class="review-art" aria-hidden="true">
-          <svg viewBox="0 0 360 210" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <text x="70" y="16" class="art-tag" text-anchor="middle">pick one</text>
-            <rect x="6" y="24" width="132" height="34" rx="9" class="art-box on" />
-            <text x="72" y="45" class="art-txt on" text-anchor="middle">your own API key</text>
-            <text x="72" y="76" class="art-tag" text-anchor="middle">or</text>
-            <rect x="6" y="86" width="132" height="34" rx="9" class="art-box on" />
-            <text x="72" y="107" class="art-txt on" text-anchor="middle">your ChatGPT plan</text>
-
-            <path d="M138 41 C 164 41, 164 72, 190 72" class="art-line on" />
-            <path d="M138 103 C 164 103, 164 72, 190 72" class="art-line on" />
-
-            <rect x="192" y="50" width="88" height="44" rx="10" class="art-box on solid" />
-            <text x="236" y="69" class="art-txt inv" text-anchor="middle">reviewer</text>
-            <text x="236" y="84" class="art-txt inv" text-anchor="middle" opacity="0.85">challenges</text>
-
-            <rect x="192" y="118" width="88" height="46" rx="10" class="art-box" />
-            <text x="236" y="134" class="art-tag" text-anchor="middle">ledger packet</text>
-            <rect x="202" y="141" width="68" height="5" rx="2.5" fill="#cbd5e1" />
-            <rect x="202" y="150" width="50" height="5" rx="2.5" fill="#cbd5e1" />
-            <path d="M236 118v-24" class="art-line on" />
-            <text x="244" y="110" class="art-tag on">reads</text>
-
-            <rect x="290" y="30" width="62" height="84" rx="10" class="art-box" stroke-dasharray="4 3" />
-            <text x="321" y="52" class="art-txt sub" text-anchor="middle">your</text>
-            <text x="321" y="66" class="art-txt sub" text-anchor="middle">machine</text>
-            <text x="321" y="90" class="art-txt sub" text-anchor="middle">nothing</text>
-            <text x="321" y="103" class="art-txt sub" text-anchor="middle">via us</text>
-
-            <rect x="14" y="176" width="332" height="30" rx="10" class="art-box warn" />
-            <text x="180" y="195" class="art-txt warn" text-anchor="middle">» old-key tokens: grace window never tested</text>
-          </svg>
+        <div>
+          <div class="arch-k">in one local service</div>
+          <p>Both records land in an append-only ledger. Deterministic rules compare them, and the receipt states exactly how far the check reached.</p>
         </div>
-      </div>
-    </section>
-
-    <!-- What's new -->
-    <section id="new" class="new-section">
-      <div class="ds-section-head">
-        <span class="ds-kicker">What's new</span>
-        <h2 class="ds-h2">Now on Claude Code and Cursor, with hooks that finish the job.</h2>
-      </div>
-
-      <div class="feat-grid">
-        <div class="feat hosts">
-          <div class="hosts-row">
-            <div class="host-big">
-              <img src="/assets/openai.svg" alt="" />
-              <span>Codex</span>
-            </div>
-            <div class="host-big">
-              <img src="/assets/claude.svg" alt="" />
-              <span>Claude Code</span>
-              <em class="new">new</em>
-            </div>
-            <div class="host-big">
-              <img src="/assets/cursor.svg" alt="" />
-              <span>Cursor</span>
-              <em class="new">new</em>
-            </div>
-          </div>
-          <h3>Three hosts, first-party</h3>
-          <p>Each host gets its own plugin, hooks, and runbook of what is and is not supported. Any MCP agent still works with nothing installed.</p>
-        </div>
-
-        {features.map((f) => (
-          <div class={`feat feat-${f.key}`}>
-            <div class="feat-art" aria-hidden="true">
-              {f.key === "hooks" && (
-                <svg viewBox="0 0 240 96" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <g class="art-row was">
-                    <text x="0" y="28" class="art-tag">0.1</text>
-                    <rect x="34" y="16" width="44" height="22" rx="6" class="art-box" />
-                    <text x="56" y="31" class="art-txt" text-anchor="middle">hook</text>
-                    <path d="M80 27h28" class="art-line" />
-                    <rect x="110" y="16" width="52" height="22" rx="6" class="art-box" />
-                    <text x="136" y="31" class="art-txt" text-anchor="middle">service</text>
-                    <path d="M164 27h22" class="art-line broken" stroke-dasharray="3 4" />
-                    <text x="187" y="31" class="art-x">✗</text>
-                    <rect x="196" y="16" width="44" height="22" rx="6" class="art-box faded" />
-                  </g>
-                  <g class="art-row now">
-                    <text x="0" y="76" class="art-tag on">0.2</text>
-                    <rect x="34" y="64" width="44" height="22" rx="6" class="art-box on" />
-                    <text x="56" y="79" class="art-txt on" text-anchor="middle">hook</text>
-                    <path d="M80 75h28" class="art-line on" />
-                    <rect x="110" y="64" width="52" height="22" rx="6" class="art-box on" />
-                    <text x="136" y="79" class="art-txt on" text-anchor="middle">service</text>
-                    <path d="M164 75h30" class="art-line on" />
-                    <rect x="196" y="64" width="44" height="22" rx="6" class="art-box on solid" />
-                    <text x="218" y="79" class="art-txt inv" text-anchor="middle">ledger</text>
-                  </g>
-                </svg>
-              )}
-              {f.key === "subscription" && (
-                <svg viewBox="0 0 240 96" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="4" y="30" width="64" height="36" rx="8" class="art-box on" />
-                  <text x="36" y="45" class="art-txt on" text-anchor="middle">check</text>
-                  <text x="36" y="58" class="art-txt sub" text-anchor="middle">semantic</text>
-                  <path d="M70 40 C 100 40, 100 22, 130 22" class="art-line on" />
-                  <path d="M70 56 C 100 56, 100 74, 130 74" class="art-line" stroke-dasharray="3 4" />
-                  <rect x="132" y="8" width="104" height="28" rx="7" class="art-box on solid" />
-                  <text x="184" y="26" class="art-txt inv" text-anchor="middle">ChatGPT plan</text>
-                  <rect x="132" y="60" width="104" height="28" rx="7" class="art-box" />
-                  <text x="184" y="78" class="art-txt" text-anchor="middle">API fallback</text>
-                  <text x="72" y="76" class="art-tag" text-anchor="middle">only if primary</text>
-                  <text x="72" y="88" class="art-tag" text-anchor="middle">can't serve</text>
-                </svg>
-              )}
-              {f.key === "consent" && (
-                <svg viewBox="0 0 240 96" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M8 14h118a8 8 0 0 1 8 8v22a8 8 0 0 1-8 8H40l-14 12v-12h-18a8 8 0 0 1-8-8V22a8 8 0 0 1 8-8z" class="art-box on" />
-                  <text x="20" y="32" class="art-txt on">Expanded review?</text>
-                  <text x="20" y="45" class="art-txt sub">before → after</text>
-                  <rect x="150" y="18" width="84" height="26" rx="13" class="art-box on solid" />
-                  <text x="192" y="35" class="art-txt inv" text-anchor="middle">approve once</text>
-                  <text x="192" y="60" class="art-tag" text-anchor="middle">drift → fails closed</text>
-                  <path d="M16 76l6 6 12-12" class="art-line on" stroke-width="2.5" />
-                  <text x="42" y="84" class="art-txt sub">you keep the choice</text>
-                </svg>
-              )}
-              {f.key === "correct" && (
-                <svg viewBox="0 0 240 96" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="8" y="10" width="100" height="26" rx="6" class="art-box faded" />
-                  <text x="58" y="27" class="art-txt faded" text-anchor="middle">claim v1</text>
-                  <path d="M20 23h76" class="art-line strike" />
-                  <rect x="8" y="58" width="100" height="26" rx="6" class="art-box on solid" />
-                  <text x="58" y="75" class="art-txt inv" text-anchor="middle">claim v2</text>
-                  <path d="M58 36v22" class="art-line on" />
-                  <path d="M54 52l4 6 4-6" class="art-line on" />
-                  <text x="130" y="27" class="art-txt sub">supersedes → v1</text>
-                  <text x="130" y="48" class="art-txt sub">supporting → evidence</text>
-                  <text x="130" y="75" class="art-txt warn">limitations → failed run</text>
-                </svg>
-              )}
-              {f.key === "recheck" && (
-                <svg viewBox="0 0 240 96" fill="none" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="6" y="34" width="60" height="28" rx="7" class="art-box warn" />
-                  <text x="36" y="52" class="art-txt warn" text-anchor="middle">finding</text>
-                  <path d="M68 48h26" class="art-line" />
-                  <rect x="96" y="34" width="60" height="28" rx="7" class="art-box" />
-                  <text x="126" y="52" class="art-txt" text-anchor="middle">respond</text>
-                  <path d="M158 48h26" class="art-line" stroke-dasharray="3 4" />
-                  <text x="171" y="74" class="art-tag" text-anchor="middle">not yet</text>
-                  <rect x="186" y="34" width="50" height="28" rx="7" class="art-box on solid" />
-                  <text x="211" y="52" class="art-txt inv" text-anchor="middle">check</text>
-                  <path d="M211 32 C 211 12, 60 12, 42 30" class="art-line on" />
-                  <path d="M38 24l4 6 6-3" class="art-line on" />
-                  <text x="126" y="14" class="art-tag on" text-anchor="middle">resolves</text>
-                  <text x="126" y="86" class="art-tag" text-anchor="middle">records a disposition</text>
-                </svg>
-              )}
-            </div>
-            <h3>{f.title}</h3>
-            <p>{f.text}</p>
-          </div>
-        ))}
       </div>
 
       <p class="section-link">
-        <a href={RELEASES} target="_blank" rel="noopener">Read the release notes</a>
+        <a href={`${GITHUB}/blob/main/docs/architecture.md`} target="_blank" rel="noopener">Read the architecture</a>
+        <a href={RELEASES} target="_blank" rel="noopener">Release notes</a>
       </p>
     </section>
 
@@ -657,53 +513,33 @@ const next = [
           <p class="ds-lead on-dark">Task lineage and project coordination. <code>/lineage</code> and <code>/project</code> in the terminal.</p>
         </div>
 
-        <div class="next-art" aria-hidden="true">
-          <svg class="na-lineage" viewBox="0 0 360 226" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="120" y="14" width="120" height="36" rx="9" class="na-box parent" />
-            <text x="180" y="30" class="na-txt" text-anchor="middle">parent task</text>
-            <text x="180" y="43" class="na-sub" text-anchor="middle">tsk_9c2e · open</text>
-
-            <path d="M180 50v22" class="na-line" />
-            <path d="M180 72H90v18M180 72h90v18" class="na-line" />
-            <text x="180" y="66" class="na-tag" text-anchor="middle">delegate</text>
-
-            <rect x="28" y="90" width="124" height="36" rx="9" class="na-box child" />
-            <text x="90" y="106" class="na-txt" text-anchor="middle">child · tests</text>
-            <text x="90" y="119" class="na-sub" text-anchor="middle">receipt · clean</text>
-
-            <rect x="208" y="90" width="124" height="36" rx="9" class="na-box child warn" />
-            <text x="270" y="106" class="na-txt" text-anchor="middle">child · migration</text>
-            <text x="270" y="119" class="na-sub warn" text-anchor="middle">1 finding · open</text>
-
-            <path d="M90 126v20h90M270 126v20h-90" class="na-line" />
-            <path d="M180 146v18" class="na-line on" />
-            <path d="M175 158l5 6 5-6" class="na-line on" />
-            <text x="180" y="142" class="na-tag on" text-anchor="middle" dy="-2">rolls up</text>
-
-            <rect x="84" y="166" width="192" height="52" rx="9" class="na-box receipt" />
-            <text x="180" y="182" class="na-txt on" text-anchor="middle">parent receipt</text>
-            <text x="180" y="196" class="na-sub warn" text-anchor="middle">child finding open</text>
-            <text x="180" y="209" class="na-sub" text-anchor="middle">integration still unproven</text>
-          </svg>
-
-          <svg class="na-project" viewBox="0 0 260 226" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <text x="130" y="30" class="na-tag" text-anchor="middle">project · one repository</text>
-            <rect x="36" y="46" width="90" height="34" rx="9" class="na-box child" />
-            <text x="81" y="61" class="na-txt" text-anchor="middle">task A</text>
-            <text x="81" y="73" class="na-sub" text-anchor="middle">wt/feature</text>
-            <rect x="134" y="46" width="90" height="34" rx="9" class="na-box child" />
-            <text x="179" y="61" class="na-txt" text-anchor="middle">task B</text>
-            <text x="179" y="73" class="na-sub" text-anchor="middle">wt/hotfix</text>
-
-            <path d="M81 80v24M179 80v24" class="na-line" />
-            <path d="M81 104h98" class="na-line" />
-            <path d="M130 104v18" class="na-line warn" />
-
-            <rect x="48" y="122" width="164" height="30" rx="8" class="na-box warn" />
-            <text x="130" y="141" class="na-txt warn" text-anchor="middle">src/sessions.py</text>
-            <text x="130" y="172" class="na-tag warn" text-anchor="middle">overlap detected · disclosed under consent</text>
-            <text x="130" y="196" class="na-sub" text-anchor="middle">/lineage · /project in the terminal</text>
-          </svg>
+        <div class="nx" aria-hidden="true">
+          <div class="nx-card nx-a">
+            <div class="nx-eyebrow">Delegate</div>
+            <div class="nx-row nx-a1"><span class="nx-mark on">◆</span><span class="nx-id">tsk_9c2e</span>sessions → Redis · Codex</div>
+            <div class="nx-row nx-a2"><span class="nx-mark">└</span><span class="nx-id">tsk_c31a</span>child · tests · 30m handle</div>
+            <div class="nx-row nx-a3"><span class="nx-mark">└</span><span class="nx-id">tsk_c4f0</span>child · migration · 30m</div>
+            <div class="nx-row nx-a4"><span class="nx-mark ok">✓</span><span class="nx-id">c31a</span>check · receipt · clean</div>
+            <div class="nx-row nx-a5 flag"><span class="nx-mark">✗</span><span class="nx-id">c4f0</span>check · 1 finding · open</div>
+          </div>
+          <div class="nx-link"><span class="nx-dot nx-dot1"></span></div>
+          <div class="nx-card nx-b">
+            <div class="nx-eyebrow">Roll up</div>
+            <div class="nx-row nx-b1"><span class="nx-mark on">◆</span><span class="nx-id">tsk_9c2e</span>receipt · rolls up 2 children</div>
+            <div class="nx-row nx-b2"><span class="nx-mark ok">✓</span><span class="nx-id">c31a</span>clean · not integration</div>
+            <div class="nx-row nx-b3 flag"><span class="nx-mark">✗</span><span class="nx-id">c4f0</span>finding carried up · open</div>
+            <div class="nx-row nx-b4"><span class="nx-mark dim">·</span><span class="nx-id">parent</span>integration · unchecked</div>
+            <div class="nx-row nx-b5 on"><span class="nx-mark on">▸</span><span class="nx-id">receipt</span>unresolved_findings_remain</div>
+          </div>
+          <div class="nx-link"><span class="nx-dot nx-dot2"></span></div>
+          <div class="nx-card nx-c">
+            <div class="nx-eyebrow">Coordinate</div>
+            <div class="nx-row nx-c1"><span class="nx-mark dim">·</span><span class="nx-id">repo</span>checkout-api · 2 live tasks</div>
+            <div class="nx-row nx-c2"><span class="nx-mark on">◆</span><span class="nx-id">task A</span>wt/feature · Codex</div>
+            <div class="nx-row nx-c3"><span class="nx-mark on">◆</span><span class="nx-id">task B</span>wt/hotfix · Claude Code</div>
+            <div class="nx-row nx-c4 flag"><span class="nx-mark">!</span><span class="nx-id">overlap</span>both touch src/sessions.py</div>
+            <div class="nx-row nx-c5 on"><span class="nx-mark on">✓</span><span class="nx-id">consent</span>each told about the other</div>
+          </div>
         </div>
 
         <div class="next-grid">
@@ -724,15 +560,17 @@ const next = [
     <!-- Alpha, briefly -->
     <section id="status" class="alpha-strip">
       <div class="alpha-inner">
-        <span class="ds-badge ds-badge-next">alpha</span>
-        <p>
-          Works out of the box with no account and no network. Expect rough edges; every claim we
-          make is tracked in the repository.
-        </p>
+        <div class="alpha-copy">
+          <span class="alpha-badge"><span class="alpha-pulse"></span>alpha · {VERSION}</span>
+          <h3>New, rough in places, already useful.</h3>
+          <p>
+            Yoetz is fresh. It works today with no account and no network, and every claim on this
+            page is tracked in the repository. Expect edges; tell us where they are.
+          </p>
+        </div>
         <div class="alpha-links">
-          <a href={`${GITHUB}/issues/new`} target="_blank" rel="noopener">File an issue</a>
-          <span class="ds-footer-dot"></span>
-          <a href={`${GITHUB}/blob/main/SECURITY.md`} target="_blank" rel="noopener">Report a security issue</a>
+          <a class="alpha-btn primary" href={`${GITHUB}/issues/new`} target="_blank" rel="noopener">File an issue</a>
+          <a class="alpha-btn" href={`${GITHUB}/blob/main/SECURITY.md`} target="_blank" rel="noopener">Report a security issue</a>
         </div>
       </div>
     </section>
@@ -785,34 +623,84 @@ const next = [
       const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>(".inst-tab:not(.agent)"));
       const toast = document.getElementById("copy-toast");
       const toastCmd = document.getElementById("copy-toast-cmd");
-      const toastDetail = document.getElementById("copy-toast-detail");
-      let toastTimer: ReturnType<typeof setTimeout>;
-      function showCopyToast(detail: string, command?: string) {
-        if (!toast || !toastCmd || !toastDetail) return;
+      const nsTitle = document.getElementById("ns-title");
+      const nsSteps = document.getElementById("ns-steps");
+      const nsFoot = document.getElementById("ns-foot");
+      const nsClose = document.getElementById("ns-close");
+      const SETUP_TIME = "About two to three minutes.";
+      const HOST_NOTE =
+        "Setup connects Codex. For Claude Code or Cursor, run `yoetz integrate claude plugin preview` or `yoetz integrate cursor plugin preview` afterwards.";
+      // Steps may carry `code` spans marked with backticks; everything is built as text nodes.
+      function fillInline(el: HTMLElement, text: string) {
+        el.replaceChildren();
+        text.split("`").forEach((part, i) => {
+          if (!part) return;
+          if (i % 2 === 1) {
+            const code = document.createElement("code");
+            code.textContent = part;
+            el.appendChild(code);
+          } else {
+            el.appendChild(document.createTextNode(part));
+          }
+        });
+      }
+      async function copyText(text: string): Promise<boolean> {
+        if (!text) return false;
+        try {
+          await navigator.clipboard.writeText(text);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      function showNextSteps(title: string, steps: string[], command?: string, foot?: string) {
+        if (!toast || !toastCmd || !nsTitle || !nsSteps || !nsFoot) return;
+        nsTitle.textContent = title;
         toastCmd.textContent = command ?? "";
         toastCmd.hidden = !command;
-        toastDetail.textContent = detail;
+        nsSteps.replaceChildren();
+        for (const step of steps) {
+          const li = document.createElement("li");
+          fillInline(li, step);
+          nsSteps.appendChild(li);
+        }
+        if (foot) fillInline(nsFoot, foot);
+        nsFoot.hidden = !foot;
         toast.hidden = false;
-        clearTimeout(toastTimer);
-        toastTimer = setTimeout(() => {
-          toast.hidden = true;
-        }, 8000);
       }
+      nsClose?.addEventListener("click", () => {
+        if (toast) toast.hidden = true;
+      });
       for (const tab of tabs) {
         tab.addEventListener("click", async () => {
           const cmd = tab.dataset.command ?? "";
-          if (!navigator.clipboard || !cmd) return;
-          try {
-            await navigator.clipboard.writeText(cmd);
-          } catch {
-            return;
-          }
-          const nextStep = tab.dataset.key === "pypi"
-            ? "Paste this command into your terminal and press Enter. Once installed, run yoetz in your terminal to start setup."
-            : "Paste this command into your terminal and press Enter to start setup.";
-          showCopyToast(nextStep, cmd);
+          if (!cmd) return;
+          const copied = await copyText(cmd);
+          const steps = tab.dataset.key === "pypi"
+            ? [
+                "Paste the command into your terminal and press Enter to install.",
+                `Run \`yoetz\` to start setup, and answer its questions. ${SETUP_TIME}`,
+                HOST_NOTE,
+              ]
+            : [
+                "Paste the command into your terminal and press Enter. `npx yoetz` installs Yoetz and starts setup.",
+                `Answer setup’s questions in your terminal. ${SETUP_TIME}`,
+                HOST_NOTE,
+              ];
+          showNextSteps(copied ? "Copied. Run it in your terminal." : "Copy this command, then run it in your terminal.", steps, cmd);
         });
       }
+
+      // --- Manual install disclosure ---
+      const manualToggle = document.getElementById("manual-toggle");
+      const manualPanel = document.getElementById("manual-panel");
+      manualToggle?.addEventListener("click", () => {
+        if (!manualPanel) return;
+        const open = manualPanel.hidden;
+        manualPanel.hidden = !open;
+        manualToggle.setAttribute("aria-expanded", String(open));
+        manualToggle.classList.toggle("open", open);
+      });
 
       // --- Copy: agent setup prompt ---
       const agentBtn = document.getElementById("agent-copy");
@@ -820,13 +708,19 @@ const next = [
       const agentDefaultLabel = agentLabel?.textContent ?? "";
       let agentTimer: ReturnType<typeof setTimeout>;
       agentBtn?.addEventListener("click", async () => {
-        if (!navigator.clipboard) return;
-        try {
-          await navigator.clipboard.writeText(agentBtn.dataset.command ?? "");
-        } catch {
-          return;
-        }
-        showCopyToast("Paste the instruction into your agent’s chat, then send it to start setup.");
+        const prompt = agentBtn.dataset.command ?? "";
+        const copied = await copyText(prompt);
+        showNextSteps(
+          copied ? "Copied. Now paste it into your agent." : "Copy this prompt, then paste it into your agent.",
+          [
+            "Open Codex, Claude Code, or Cursor and paste the prompt into the chat. Send it.",
+            "Your agent installs Yoetz and hands you the terminal for setup’s questions.",
+            `Answer them in your terminal. ${SETUP_TIME}`,
+          ],
+          copied ? undefined : prompt,
+          "Any other MCP agent works too, with nothing else installed."
+        );
+        if (!copied) return;
         if (agentLabel) agentLabel.textContent = "Copied to your clipboard";
         agentBtn.classList.add("copied");
         clearTimeout(agentTimer);

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -445,32 +445,32 @@ const next = [
           <rect x="520" y="62" width="416" height="306" rx="16" class="art-box on" />
           <text x="540" y="84" class="art-tag on">yoetz service · one local process</text>
 
-          <rect x="546" y="134" width="108" height="56" rx="10" class="art-box" />
-          <text x="600" y="157" class="art-txt strong" text-anchor="middle">ledger</text>
-          <text x="600" y="172" class="art-tag" text-anchor="middle">append-only · SQLite</text>
+          <rect x="540" y="134" width="118" height="56" rx="10" class="art-box" />
+          <text x="599" y="157" class="art-txt strong" text-anchor="middle">ledger</text>
+          <text x="599" y="172" class="art-tag" text-anchor="middle">append-only · SQLite</text>
 
-          <path d="M654 162 H 668" class="art-line on" marker-end="url(#arr-on)" />
-          <rect x="672" y="134" width="108" height="56" rx="10" class="art-box on" />
-          <text x="726" y="157" class="art-txt strong" text-anchor="middle">rules</text>
-          <text x="726" y="172" class="art-tag" text-anchor="middle">deterministic</text>
+          <path d="M658 162 H 670" class="art-line on" marker-end="url(#arr-on)" />
+          <rect x="672" y="134" width="118" height="56" rx="10" class="art-box on" />
+          <text x="731" y="157" class="art-txt strong" text-anchor="middle">rules</text>
+          <text x="731" y="172" class="art-tag" text-anchor="middle">deterministic</text>
 
-          <path d="M780 162 H 794" class="art-line on" marker-end="url(#arr-on)" />
-          <rect x="798" y="134" width="108" height="56" rx="10" class="art-box on solid" />
-          <text x="852" y="157" class="art-txt inv" text-anchor="middle">receipt</text>
-          <text x="852" y="172" class="art-txt inv" text-anchor="middle" opacity="0.85">coverage-bounded</text>
+          <path d="M790 162 H 802" class="art-line on" marker-end="url(#arr-on)" />
+          <rect x="804" y="134" width="118" height="56" rx="10" class="art-box on solid" />
+          <text x="863" y="157" class="art-txt inv" text-anchor="middle">receipt</text>
+          <text x="863" y="172" class="art-txt inv" text-anchor="middle" opacity="0.85">coverage-bounded</text>
 
-          <text x="600" y="214" class="art-txt sub" text-anchor="middle">says vs. did,</text>
-          <text x="600" y="228" class="art-txt sub" text-anchor="middle">as events</text>
-          <text x="726" y="214" class="art-txt sub" text-anchor="middle">same inputs,</text>
-          <text x="726" y="228" class="art-txt sub" text-anchor="middle">same findings</text>
-          <text x="852" y="214" class="art-txt sub" text-anchor="middle">verified · coverage</text>
-          <text x="852" y="228" class="art-txt sub" text-anchor="middle">· still open</text>
+          <text x="599" y="214" class="art-txt sub" text-anchor="middle">says vs. did,</text>
+          <text x="599" y="228" class="art-txt sub" text-anchor="middle">as events</text>
+          <text x="731" y="214" class="art-txt sub" text-anchor="middle">same inputs,</text>
+          <text x="731" y="228" class="art-txt sub" text-anchor="middle">same findings</text>
+          <text x="863" y="214" class="art-txt sub" text-anchor="middle">verified · coverage</text>
+          <text x="863" y="228" class="art-txt sub" text-anchor="middle">· still open</text>
 
-          <path d="M726 190 V 270" class="art-line" stroke-dasharray="3 4" />
-          <rect x="652" y="272" width="148" height="52" rx="10" class="art-box" stroke-dasharray="4 3" />
-          <text x="726" y="293" class="art-txt" text-anchor="middle">reviewer model · optional</text>
-          <text x="726" y="309" class="art-tag" text-anchor="middle">your API key or ChatGPT plan</text>
-          <text x="726" y="352" class="art-tag" text-anchor="middle">runs from here · nothing goes through us</text>
+          <path d="M731 190 V 270" class="art-line" stroke-dasharray="3 4" />
+          <rect x="647" y="272" width="168" height="52" rx="10" class="art-box" stroke-dasharray="4 3" />
+          <text x="731" y="293" class="art-txt" text-anchor="middle">reviewer model · optional</text>
+          <text x="731" y="309" class="art-tag" text-anchor="middle">your API key or ChatGPT plan</text>
+          <text x="731" y="352" class="art-tag" text-anchor="middle">runs from here · nothing goes through us</text>
         </svg>
       </div>
 

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -434,7 +434,7 @@ const next = [
           <!-- hooks channel -->
           <text x="352" y="218" class="art-tag" text-anchor="middle">hooks · what the host actually saw</text>
           <path d="M184 240 H 518" class="art-line" marker-end="url(#arr)" />
-          <rect x="242" y="230" width="220" height="20" rx="10" class="art-box" />
+          <rect x="222" y="230" width="260" height="20" rx="10" class="art-box" />
           <text x="352" y="244" class="art-txt sub" text-anchor="middle">sessions · tool calls · edits · results</text>
 
           <!-- return -->
@@ -447,7 +447,7 @@ const next = [
 
           <rect x="540" y="134" width="118" height="56" rx="10" class="art-box" />
           <text x="599" y="157" class="art-txt strong" text-anchor="middle">ledger</text>
-          <text x="599" y="172" class="art-tag" text-anchor="middle">append-only · SQLite</text>
+          <text x="599" y="172" class="art-tag" text-anchor="middle">append-only</text>
 
           <path d="M658 162 H 670" class="art-line on" marker-end="url(#arr-on)" />
           <rect x="672" y="134" width="118" height="56" rx="10" class="art-box on" />
@@ -459,7 +459,7 @@ const next = [
           <text x="863" y="157" class="art-txt inv" text-anchor="middle">receipt</text>
           <text x="863" y="172" class="art-txt inv" text-anchor="middle" opacity="0.85">coverage-bounded</text>
 
-          <text x="599" y="214" class="art-txt sub" text-anchor="middle">says vs. did,</text>
+          <text x="599" y="214" class="art-txt sub" text-anchor="middle">SQLite · says vs. did,</text>
           <text x="599" y="228" class="art-txt sub" text-anchor="middle">as events</text>
           <text x="731" y="214" class="art-txt sub" text-anchor="middle">same inputs,</text>
           <text x="731" y="228" class="art-txt sub" text-anchor="middle">same findings</text>
@@ -467,7 +467,7 @@ const next = [
           <text x="863" y="228" class="art-txt sub" text-anchor="middle">· still open</text>
 
           <path d="M731 190 V 270" class="art-line" stroke-dasharray="3 4" />
-          <rect x="647" y="272" width="168" height="52" rx="10" class="art-box" stroke-dasharray="4 3" />
+          <rect x="625" y="272" width="212" height="52" rx="10" class="art-box" stroke-dasharray="4 3" />
           <text x="731" y="293" class="art-txt" text-anchor="middle">reviewer model · optional</text>
           <text x="731" y="309" class="art-tag" text-anchor="middle">your API key or ChatGPT plan</text>
           <text x="731" y="352" class="art-tag" text-anchor="middle">runs from here · nothing goes through us</text>

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -69,7 +69,7 @@ img { max-width: 100%; }
 /* ---------- Hero explainer: agent claims → Yoetz checks → receipt ---------- */
 .hx {
   display: flex; align-items: stretch; justify-content: center; gap: 0;
-  width: 100%; max-width: 820px; margin: 52px auto 0;
+  width: 100%; max-width: 880px; margin: 52px auto 0;
   font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; color: var(--slate-700);
   text-align: left;
 }
@@ -83,9 +83,10 @@ img { max-width: 100%; }
   font-family: var(--font-sans); font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
   color: var(--slate-500); margin-bottom: 6px;
 }
-.hx-row { display: flex; align-items: center; gap: 7px; padding: 1px 6px; margin: 0 -6px; border-radius: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hx-row { display: flex; align-items: flex-start; gap: 7px; padding: 1px 6px; margin: 0 -6px; border-radius: 6px; min-width: 0; overflow-wrap: anywhere; }
 .hx-row.flag { color: #b45309; background: rgba(245, 158, 11, 0.12); }
 .hx-mark { flex-shrink: 0; width: 12px; color: var(--slate-400); }
+.hx-row > .hx-bar { margin-top: 5px; }
 .hx-mark.ok { color: var(--brand-teal-600); }
 .hx-row.flag .hx-mark { color: #d97706; }
 .hx-agent .hx-say { color: var(--slate-900); }
@@ -347,7 +348,7 @@ em.new {
   background: rgba(2, 6, 23, 0.55); border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 14px; padding: 12px 14px 13px;
 }
 .nx-eyebrow { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--slate-400); margin-bottom: 8px; }
-.nx-row { display: flex; align-items: center; gap: 8px; padding: 2px 6px; margin: 0 -6px; border-radius: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.nx-row { display: flex; align-items: flex-start; gap: 8px; padding: 2px 6px; margin: 0 -6px; border-radius: 6px; min-width: 0; overflow-wrap: anywhere; }
 .nx-row.flag { color: #fcd34d; background: rgba(245, 158, 11, 0.12); }
 .nx-row.on { color: #5eead4; }
 .nx-mark { flex-shrink: 0; width: 12px; color: var(--slate-500); text-align: center; }
@@ -454,11 +455,16 @@ em.new {
   .see-inner { grid-template-columns: 1fr; gap: 36px; }
   .next-grid { grid-template-columns: 1fr; }
 }
+@media (max-width: 1040px) {
+  .nx { flex-direction: column; gap: 10px; max-width: 460px; }
+  .nx-card { flex: 0 0 auto; }
+  .nx-link { display: none; }
+}
 @media (max-width: 900px) {
   /* Explainer cards clip their rows below this width; stack them instead. */
-  .hx, .nx { flex-direction: column; gap: 10px; max-width: 440px; }
-  .hx-card, .nx-card { flex: 0 0 auto; }
-  .hx-link, .hx-scan, .nx-link { display: none; }
+  .hx { flex-direction: column; gap: 10px; max-width: 440px; }
+  .hx-card { flex: 0 0 auto; }
+  .hx-link, .hx-scan { display: none; }
 }
 @media (max-width: 760px) {
   /* Below this the teal line would wrap under "Agents" and the wordmark's

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -115,6 +115,7 @@ img { max-width: 100%; }
 .hx-c4     { animation: hxC4 11s ease-out infinite; }
 .hx-dot2   { animation: hxDot2 11s linear infinite; }
 .hx-r1     { animation: hxR1 11s ease-out infinite; }
+.hx-r2     { animation: hxR2 11s ease-out infinite; }
 .hx-fill   { animation: hxFill 11s ease-out infinite; }
 .hx-r3     { animation: hxR3 11s ease-out infinite; }
 .hx-stamp  { animation: hxStamp 11s ease-out infinite; }
@@ -128,6 +129,7 @@ img { max-width: 100%; }
 @keyframes hxC4 { 0%, 33% { opacity: 0; transform: translateY(3px); } 36% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
 @keyframes hxDot2 { 0%, 40% { opacity: 0; transform: translateX(-2px); } 41% { opacity: 1; } 46% { opacity: 1; transform: translateX(20px); } 47%, 100% { opacity: 0; transform: translateX(20px); } }
 @keyframes hxR1 { 0%, 48% { opacity: 0; transform: translateY(3px); } 51% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxR2 { 0%, 51% { opacity: 0; transform: translateY(3px); } 54% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
 @keyframes hxFill { 0%, 52% { width: 0; } 60% { width: 67%; } 90% { width: 67%; opacity: 1; } 95%, 100% { width: 67%; opacity: 0; } }
 @keyframes hxR3 { 0%, 62% { opacity: 0; transform: translateY(3px); } 65% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
 @keyframes hxStamp { 0%, 68% { opacity: 0; transform: scale(1.35); } 71% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -452,7 +452,10 @@ em.new {
   .ds-hero { padding-bottom: 56px; }
   .term-body { height: 360px; }
   .ds-cta-dark, .ds-section, .see-section, .inside-section { padding: 72px 20px; }
-  .see-inner { grid-template-columns: 1fr; gap: 36px; }
+  .see-inner { grid-template-columns: 1fr; gap: 40px; }
+  .see-copy { max-width: 640px; margin: 0 auto; }
+  .see-copy .ds-lead, .see-note { max-width: none; }
+  .see-art { max-width: none; margin-top: 24px; }
   .next-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 1040px) {

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -16,14 +16,19 @@ img { max-width: 100%; }
 
 /* ---------- Type ---------- */
 .ds-h1 {
-  font-size: clamp(36px, 5vw, 48px);
+  font-size: clamp(38px, 5.1vw, 66px);
   font-weight: 700;
-  line-height: 0.96;
-  letter-spacing: -0.02em;
+  line-height: 1.0;
+  letter-spacing: -0.025em;
   color: var(--slate-950);
   margin: 0;
 }
 .ds-h1 .line { display: block; }
+/* Wordmark geometry: baseline at 814/872 of the image, cap height 380/872.
+   1.62em puts its caps and x-height within 3% of Inter's; -0.108em drops its
+   bottom edge so the lettering's baseline meets the text baseline. The
+   negative top margin keeps the bars from growing the line box. */
+.h1-logo { display: inline-block; height: 1.62em; width: auto; vertical-align: -0.108em; margin: -0.65em 0.02em 0 0; }
 .ds-h1 .grad {
   background: var(--grad-hero);
   -webkit-background-clip: text;
@@ -33,8 +38,14 @@ img { max-width: 100%; }
   /* Keep gradient text from clipping descenders at tight line-height */
   padding-bottom: 0.14em;
   margin-bottom: -0.14em;
+  margin-top: 0.12em;
+}
+.ds-h2 .brand {
+  background: var(--grad-hero); -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: transparent;
 }
 .ds-h2 { font-size: clamp(28px, 4vw, 36px); font-weight: 700; line-height: 1.15; color: var(--slate-900); margin: 12px 0 0; letter-spacing: -0.01em; text-wrap: balance; }
+.ds-lead.centered { margin-left: auto; margin-right: auto; max-width: 62ch; text-wrap: pretty; }
 .ds-lead { font-size: 17px; line-height: 1.65; color: var(--slate-600); margin: 16px 0 0; max-width: 540px; }
 .ds-lead.on-dark { color: var(--slate-400); margin-left: auto; margin-right: auto; }
 .ds-lead.on-dark code { font-family: var(--font-mono); font-size: 0.9em; color: #5eead4; }
@@ -49,47 +60,104 @@ img { max-width: 100%; }
 .ds-badge-later { background: var(--slate-100); color: var(--slate-600); }
 
 /* ---------- Hero ---------- */
-.ds-hero { background: #fff; padding: 56px 24px 88px; }
-.ds-hero-grid {
-  max-width: 1280px; margin: 0 auto;
-  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.12fr);
-  gap: 56px; align-items: center;
+.ds-hero { background: #fff; padding: 96px 24px 112px; }
+.hero-stack { max-width: 1200px; margin: 0 auto; }
+.hero-copy { display: flex; flex-direction: column; align-items: center; text-align: center; }
+.hero-copy .ds-h1 { text-wrap: balance; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+
+/* ---------- Hero explainer: agent claims → Yoetz checks → receipt ---------- */
+.hx {
+  display: flex; align-items: stretch; justify-content: center; gap: 0;
+  width: 100%; max-width: 820px; margin: 52px auto 0;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; color: var(--slate-700);
+  text-align: left;
 }
-.hero-top {
-  display: flex; align-items: center; justify-content: flex-start;
-  gap: 18px; flex-wrap: wrap; margin-bottom: 36px;
+.hx-card {
+  flex: 1 1 0; min-width: 0; position: relative; overflow: hidden;
+  background: #fff; border: 1px solid var(--slate-200); border-radius: 12px; padding: 10px 12px 11px;
+  box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.35);
 }
-.hero-brand-logo { display: flex; align-items: center; height: 64px; }
-.hero-brand-logo img { height: 72px; width: auto; display: block; }
+.hx-eyebrow {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-sans); font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--slate-500); margin-bottom: 6px;
+}
+.hx-row { display: flex; align-items: center; gap: 7px; padding: 1px 6px; margin: 0 -6px; border-radius: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.hx-row.flag { color: #b45309; background: rgba(245, 158, 11, 0.12); }
+.hx-mark { flex-shrink: 0; width: 12px; color: var(--slate-400); }
+.hx-mark.ok { color: var(--brand-teal-600); }
+.hx-row.flag .hx-mark { color: #d97706; }
+.hx-agent .hx-say { color: var(--slate-900); }
+.hx-agent .hx-mark { color: var(--brand-teal-600); }
+.hx-caret { display: inline-block; width: 6px; height: 13px; background: var(--brand-teal-500); margin-left: 4px; vertical-align: -2px; animation: dxblink 1s steps(2) infinite; }
+.hx-k { flex-shrink: 0; width: 58px; color: var(--slate-400); }
+.hx-bar { flex: 1; height: 6px; border-radius: 9999px; background: var(--slate-100); overflow: hidden; }
+.hx-fill { display: block; width: 67%; height: 100%; border-radius: inherit; background: var(--grad-hero); }
+.hx-stamp {
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; text-transform: none; font-weight: 500;
+  color: var(--brand-teal-700); background: var(--brand-teal-50); border: 1px solid rgba(20, 184, 166, 0.35);
+  padding: 1px 7px; border-radius: 9999px;
+}
+.hx-scan { position: absolute; left: 0; right: 0; top: 34px; height: 20px; pointer-events: none; opacity: 0;
+  background: linear-gradient(180deg, rgba(20, 184, 166, 0) 0%, rgba(20, 184, 166, 0.14) 50%, rgba(20, 184, 166, 0) 100%); }
+.hx-link { flex: 0 0 26px; position: relative; align-self: center; height: 2px; background: var(--slate-200); }
+.hx-dot { position: absolute; top: -3px; left: 0; width: 8px; height: 8px; border-radius: 50%; background: var(--brand-teal-500);
+  box-shadow: 0 0 0 4px rgba(20, 184, 166, 0.18); opacity: 0; }
+
+/* One 11s loop. Base styles above are the final frame; keyframes reveal it in order. */
+.hx-say    { animation: hxAgent 11s ease-out infinite; }
+.hx-dot1   { animation: hxDot1 11s linear infinite; }
+.hx-scan   { animation: hxScan 11s linear infinite; }
+.hx-c1     { animation: hxC1 11s ease-out infinite; }
+.hx-c2     { animation: hxC2 11s ease-out infinite; }
+.hx-c3     { animation: hxC3 11s ease-out infinite; }
+.hx-c4     { animation: hxC4 11s ease-out infinite; }
+.hx-dot2   { animation: hxDot2 11s linear infinite; }
+.hx-r1     { animation: hxR1 11s ease-out infinite; }
+.hx-fill   { animation: hxFill 11s ease-out infinite; }
+.hx-r3     { animation: hxR3 11s ease-out infinite; }
+.hx-stamp  { animation: hxStamp 11s ease-out infinite; }
+
+@keyframes hxAgent { 0% { opacity: 0; transform: translateY(4px); } 4% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxDot1 { 0%, 8% { opacity: 0; transform: translateX(-2px); } 9% { opacity: 1; } 14% { opacity: 1; transform: translateX(20px); } 15%, 100% { opacity: 0; transform: translateX(20px); } }
+@keyframes hxScan { 0%, 15% { opacity: 0; transform: translateY(-8px); } 17% { opacity: 1; } 31% { opacity: 1; transform: translateY(78px); } 33%, 100% { opacity: 0; transform: translateY(78px); } }
+@keyframes hxC1 { 0%, 16% { opacity: 0; transform: translateY(3px); } 19% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxC2 { 0%, 21% { opacity: 0; transform: translateY(3px); } 24% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxC3 { 0%, 26% { opacity: 0; transform: translateY(3px); } 29% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxC4 { 0%, 33% { opacity: 0; transform: translateY(3px); } 36% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxDot2 { 0%, 40% { opacity: 0; transform: translateX(-2px); } 41% { opacity: 1; } 46% { opacity: 1; transform: translateX(20px); } 47%, 100% { opacity: 0; transform: translateX(20px); } }
+@keyframes hxR1 { 0%, 48% { opacity: 0; transform: translateY(3px); } 51% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxFill { 0%, 52% { width: 0; } 60% { width: 67%; } 90% { width: 67%; opacity: 1; } 95%, 100% { width: 67%; opacity: 0; } }
+@keyframes hxR3 { 0%, 62% { opacity: 0; transform: translateY(3px); } 65% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+@keyframes hxStamp { 0%, 68% { opacity: 0; transform: scale(1.35); } 71% { opacity: 1; transform: none; } 90% { opacity: 1; } 95%, 100% { opacity: 0; } }
+
 .hero-star {
-  display: inline-flex; align-items: center; gap: 6px;
-  height: 64px; padding: 0 20px; border-radius: 14px;
-  background: #fff; border: 1px solid var(--slate-200);
-  font-size: 14px; font-weight: 600; color: var(--slate-700);
-  box-shadow: var(--shadow-sm); transition: all 200ms;
-  transform: translateY(9px);
+  display: inline-flex; align-items: center; gap: 8px; height: 38px; padding: 0 14px;
+  border-radius: 9999px; border: 1px solid var(--slate-200); background: #fff;
+  color: var(--slate-700); font-size: 13.5px; font-weight: 600; box-shadow: var(--shadow-xs); transition: all 150ms;
 }
-.hero-star svg { width: 20px; height: 20px; color: var(--slate-900); }
+.hero-star svg { width: 17px; height: 17px; color: var(--slate-900); }
 .hero-star:hover { background: var(--slate-50); border-color: var(--slate-300); color: var(--slate-950); }
-.hero-under-term { display: flex; justify-content: center; margin-top: 24px; }
+.hero-meta { display: flex; align-items: center; justify-content: center; gap: 14px; margin-top: 28px; }
 .hero-license { display: flex; }
 .hero-license a, a.hero-license {
-  display: inline-flex; font-size: 11px; font-weight: 600;
+  display: inline-flex; font-size: 11.5px; font-weight: 600;
   border-radius: 4px; overflow: hidden; line-height: 1; box-shadow: var(--shadow-xs);
 }
-.hero-license .l { background: #475569; color: #f1f5f9; padding: 5px 8px; }
-.hero-license .r { background: var(--brand-teal-600); color: #fff; padding: 5px 8px; }
+.hero-license .l { background: #475569; color: #f1f5f9; padding: 6px 9px; }
+.hero-license .r { background: var(--brand-teal-600); color: #fff; padding: 6px 9px; }
 
 /* Host pills under the lead */
-.hero-hosts { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 26px; }
-.hero-hosts-label { font-size: 13.5px; font-weight: 600; color: var(--slate-700); margin-right: 4px; }
+.hero-hosts { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 8px; margin-top: 40px; }
+.hero-hosts-label { font-size: 13px; font-weight: 500; color: var(--slate-500); margin-right: 4px; }
 .host-pill {
   display: inline-flex; align-items: center; gap: 7px;
-  padding: 6px 12px; border-radius: 9999px;
+  padding: 5px 11px; border-radius: 9999px;
   background: #fff; border: 1px solid var(--slate-200); box-shadow: var(--shadow-xs);
-  font-size: 13px; font-weight: 600; color: var(--slate-900);
+  font-size: 13px; font-weight: 600; color: var(--slate-700);
 }
-.host-pill img { width: 16px; height: 16px; object-fit: contain; }
+.host-pill img { width: 15px; height: 15px; object-fit: contain; }
 .host-pill.more { color: var(--slate-500); font-weight: 500; border-style: dashed; box-shadow: none; }
 em.new {
   font-style: normal; font-size: 10.5px; font-weight: 700; line-height: 1;
@@ -150,12 +218,12 @@ em.new {
 }
 
 /* ---------- Hero install tabs ---------- */
-.hero-installers { margin-top: 26px; position: relative; }
-.inst-tabs { display: flex; gap: 8px; flex-wrap: wrap; }
+.hero-installers { margin-top: 52px; position: relative; display: flex; flex-direction: column; align-items: center; }
+.inst-tabs { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; align-items: center; }
 .inst-tab {
-  display: inline-flex; align-items: center; gap: 8px; height: 40px; padding: 0 16px;
-  border-radius: 8px; border: 1px solid var(--slate-200); background: #fff;
-  color: var(--slate-600); font-size: 13.5px; font-weight: 600; transition: all 150ms;
+  display: inline-flex; align-items: center; gap: 8px; height: 46px; padding: 0 20px;
+  border-radius: 10px; border: 1px solid var(--slate-200); background: #fff;
+  color: var(--slate-600); font-size: 15px; font-weight: 600; transition: all 150ms;
 }
 .inst-tab:hover { border-color: var(--slate-300); color: var(--slate-900); }
 .inst-tab .rec {
@@ -163,28 +231,45 @@ em.new {
   color: var(--brand-teal-700); background: var(--brand-teal-50);
   border-radius: 9999px; padding: 2px 8px;
 }
+.inst-tab.manual { height: 46px; padding: 0 18px; color: var(--slate-700); gap: 6px; }
+.inst-tab.manual .chev { transition: transform 150ms; }
+.inst-tab.manual.open .chev { transform: rotate(180deg); }
+.inst-tab.manual.open { border-color: var(--slate-300); background: var(--slate-50); }
+.manual-panel { display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; margin-top: 12px; animation: toastin 0.18s ease-out; }
+.manual-panel[hidden] { display: none; }
+.manual-panel .inst-tab { height: 40px; padding: 0 16px; font-size: 14px; border-radius: 8px; }
+.manual-label { font-size: 13.5px; font-weight: 600; color: var(--slate-500); margin-right: 4px; }
 .inst-tab.agent {
+  height: 56px; padding: 0 28px; font-size: 17.5px; gap: 10px;
   background: var(--brand-teal-500); color: #fff; border-color: var(--brand-teal-500);
-  box-shadow: 0 6px 18px rgba(20, 184, 166, 0.25);
+  box-shadow: 0 8px 22px rgba(20, 184, 166, 0.3);
 }
+.inst-tab.agent .rec { font-size: 11.5px; padding: 3px 9px; }
 .inst-tab.agent:hover { background: var(--brand-teal-400); border-color: var(--brand-teal-400); color: #fff; }
 .inst-tab.agent.copied { background: var(--brand-teal-600); border-color: var(--brand-teal-600); }
 .inst-tab.agent .rec { color: #fff; background: rgba(255, 255, 255, 0.18); }
 .inst-tab:focus-visible { outline: 2px solid var(--brand-teal-400); outline-offset: 2px; }
-.copy-toast {
-  position: absolute; left: 0; top: calc(100% + 10px); z-index: 2;
-  display: flex; align-items: flex-start; gap: 10px; max-width: 560px;
-  padding: 12px 14px; border-radius: 10px; background: var(--slate-950); color: #f8fafc;
+.next-steps {
+  width: 100%; max-width: 640px; margin-top: 16px; text-align: left;
+  padding: 14px 16px 16px; border-radius: 12px; background: var(--slate-950); color: #f8fafc;
   box-shadow: var(--shadow-md); animation: toastin 0.18s ease-out;
 }
-.copy-toast[hidden] { display: none; }
-.ct-check { color: #5eead4; font-weight: 700; line-height: 1.4; }
-.ct-title { display: block; font-size: 13.5px; font-weight: 600; }
-.ct-detail { display: block; margin-top: 4px; font-size: 13.5px; line-height: 1.5; color: var(--slate-300); overflow-wrap: anywhere; }
-.ct-cmd { font-family: var(--font-mono); font-size: 12.5px; font-variant-ligatures: none; }
-.ct-cmd[hidden] { display: none; }
+.next-steps[hidden] { display: none; }
+.ns-head { display: flex; align-items: center; gap: 10px; }
+.ns-check { color: #5eead4; font-weight: 700; }
+.ns-title { flex: 1; font-size: 15px; font-weight: 600; }
+.ns-close { background: transparent; color: var(--slate-400); font-size: 20px; line-height: 1; padding: 0 4px; border-radius: 6px; }
+.ns-close:hover { color: #fff; background: rgba(255, 255, 255, 0.08); }
+.ns-cmd { display: block; margin: 10px 0 0; padding: 8px 10px; border-radius: 8px; background: rgba(255, 255, 255, 0.06);
+  font-family: var(--font-mono); font-size: 12.5px; font-variant-ligatures: none; color: #99f6e4; overflow-wrap: anywhere; }
+.ns-cmd[hidden] { display: none; }
+.ns-steps { margin: 12px 0 0; padding: 0 0 0 22px; display: grid; gap: 6px; font-size: 13.5px; line-height: 1.55; color: var(--slate-200); }
+.ns-steps li::marker { color: #5eead4; font-weight: 600; }
+.ns-steps code, .ns-foot code { font-family: var(--font-mono); font-size: 0.92em; color: #99f6e4; background: rgba(255, 255, 255, 0.06); padding: 1px 5px; border-radius: 4px; }
+.ns-foot { margin: 12px 0 0; font-size: 12.5px; color: var(--slate-400); }
+.ns-foot[hidden] { display: none; }
 @keyframes toastin { from { opacity: 0; transform: translateY(-4px); } }
-.inst-note { margin: 10px 0 0; font-size: 13.5px; line-height: 1.6; color: var(--slate-500); max-width: 54ch; }
+.inst-note { margin: 10px 0 0; font-size: 13.5px; line-height: 1.6; color: var(--slate-500); max-width: 54ch; text-align: center; }
 .inst-note a { color: var(--brand-teal-700); font-weight: 600; }
 .inst-note code { font-family: var(--font-mono); font-size: 0.9em; color: var(--brand-sky-700); }
 .agent-note { display: none; }
@@ -199,150 +284,26 @@ em.new {
 .section-link.on-dark a:hover { color: #99f6e4; }
 
 
-/* ---------- How it works: four nodes ---------- */
-.flow {
-  max-width: 1120px; margin: 56px auto 0;
-  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0;
-  position: relative;
-}
-.fnode { position: relative; padding: 0 22px; text-align: center; }
-.fnode + .fnode::before {
-  /* connector between nodes */
-  content: ""; position: absolute; left: -14px; top: 38px;
-  width: 28px; height: 2px; background: var(--slate-200);
-}
-.fnode + .fnode::after {
-  content: ""; position: absolute; left: 8px; top: 34px;
-  width: 6px; height: 6px; border-right: 2px solid var(--slate-300); border-bottom: 2px solid var(--slate-300);
-  transform: rotate(-45deg);
-}
-.fnode-icon {
-  width: 78px; height: 78px; margin: 0 auto; border-radius: 22px;
-  display: flex; align-items: center; justify-content: center;
-  background: var(--slate-50); border: 1px solid var(--slate-200);
-  color: var(--slate-700);
-}
-.fnode-icon svg { width: 46px; height: 46px; }
-.fnode-icon .fn-accent { color: var(--brand-teal-600); stroke: var(--brand-teal-500); }
-.fnode-check .fnode-icon { background: var(--brand-teal-50); border-color: #99f6e4; }
-.fnode-receipt .fnode-icon { background: var(--slate-900); border-color: var(--slate-900); color: var(--slate-200); }
-.fnode-receipt .fnode-icon .fn-accent { stroke: #5eead4; }
-.fnode-title { margin-top: 16px; font-size: 17px; font-weight: 700; color: var(--slate-900); }
-.fnode-ops { margin-top: 4px; font-family: var(--font-mono); font-size: 11.5px; color: var(--brand-teal-700); }
-.fnode-text { margin: 10px auto 0; font-size: 14.5px; line-height: 1.6; color: var(--slate-600); max-width: 26ch; }
+/* ---------- Screen 2: in the background ---------- */
+.see-section { background: #fff; padding: 96px 24px; border-top: 1px solid var(--slate-100); }
+.see-inner { max-width: 1160px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 5fr) minmax(0, 7fr); gap: 56px; align-items: center; }
+.see-copy .ds-h2 { text-wrap: balance; }
+.see-art { margin-top: 22px; max-width: 400px; padding: 12px 14px; background: var(--slate-50); border: 1px solid var(--slate-200); border-radius: 14px; }
+.see-art svg { width: 100%; height: auto; display: block; overflow: visible; }
+.see-note { margin: 14px 0 0; font-size: 15px; line-height: 1.6; color: var(--slate-600); max-width: 50ch; }
+.see-demo { min-width: 0; }
 
-/* Three scenes: what Yoetz does while the agent works */
-.scenes { max-width: 1120px; margin: 64px auto 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 28px; }
-.scene-art { background: var(--slate-50); border: 1px solid var(--slate-200); border-radius: 14px; padding: 10px 14px; }
-.scene-art svg { width: 100%; height: auto; display: block; overflow: visible; }
-.scene h3 { margin: 14px 0 0; font-size: 16px; font-weight: 700; color: var(--slate-900); }
-.scene p { margin: 6px 0 0; font-size: 14px; line-height: 1.55; color: var(--slate-600); }
-.sc-box { fill: #fff; stroke: var(--slate-300); stroke-width: 1.5; }
-.sc-txt { font-family: var(--font-mono); font-size: 11px; fill: var(--slate-700); }
-.sc-txt.strong { font-weight: 600; fill: var(--slate-900); }
-.sc-tag { font-family: var(--font-mono); font-size: 9.5px; fill: var(--slate-600); letter-spacing: 0.03em; }
-.sc-row { fill: var(--slate-200); }
-.sc-row.still { opacity: 0.6; }
-.sc-row.warn { fill: #fde68a; }
-.sc-row.ok { fill: #99f6e4; }
-.sc-row-txt { font-family: var(--font-mono); font-size: 9px; fill: var(--slate-700); }
-.sc-bar { fill: var(--slate-300); }
-.sc-link { stroke: var(--slate-300); stroke-width: 1.5; stroke-dasharray: 3 4; }
-.sc-chip-box { fill: #fff; stroke-width: 1.5; }
-.sc-chip-box.claim { stroke: var(--brand-sky-500); }
-.sc-chip-box.work { stroke: #f59e0b; }
-.sc-chip-txt { font-family: var(--font-mono); font-size: 9.5px; fill: var(--slate-700); }
-.sc-scan { fill: var(--brand-teal-500); opacity: 0; }
-.sc-finding rect { fill: #fffbeb; stroke: #fde68a; stroke-width: 1.5; }
-.sc-finding text { font-family: var(--font-mono); font-size: 10px; font-weight: 600; fill: #b45309; }
-.sc-receipt rect { fill: var(--slate-900); stroke: #5eead4; stroke-width: 1.5; }
-.sc-receipt text { font-family: var(--font-mono); font-size: 10px; fill: #5eead4; }
-.sc-chip, .sc-finding, .sc-receipt, .sc-scan { transform-box: fill-box; }
+/* ---------- Screen 3: under the hood ---------- */
+.inside-section { background: var(--slate-50); padding: 96px 24px; border-top: 1px solid var(--slate-100); }
+.arch { max-width: 1040px; margin: 56px auto 0; padding: 18px 20px; background: #fff; border: 1px solid var(--slate-200); border-radius: 18px; overflow-x: auto; }
+.arch svg { width: 100%; min-width: 720px; height: auto; display: block; overflow: visible; }
+.arch .art-txt.strong { font-weight: 600; fill: var(--slate-900); }
+.arch-notes { max-width: 1040px; margin: 36px auto 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 32px; }
+.arch-k { font-family: var(--font-mono); font-size: 12.5px; color: var(--brand-teal-700); margin-bottom: 8px; }
+.arch-notes p { margin: 0; font-size: 14.5px; line-height: 1.6; color: var(--slate-600); }
+.section-link { margin-top: 44px; }
 
-.sc-a .c1 { animation: sc-fly 4.5s ease-in-out infinite; }
-.sc-a .c2 { animation: sc-fly 4.5s ease-in-out infinite 0.8s; }
-.sc-a .r1 { animation: sc-fill 4.5s linear infinite; }
-.sc-a .r4 { animation: sc-fill 4.5s linear infinite 0.8s; }
-.sc-a .b1 { animation: sc-pulse 1.4s ease-in-out infinite; }
-.sc-a .b2 { animation: sc-pulse 1.4s ease-in-out infinite 0.3s; }
-.sc-a .b3 { animation: sc-pulse 1.4s ease-in-out infinite 0.6s; }
-@keyframes sc-fly {
-  0% { transform: translateX(-66px); opacity: 0; }
-  10% { transform: translateX(-66px); opacity: 1; }
-  48% { transform: translateX(84px); opacity: 1; }
-  58%, 100% { transform: translateX(84px); opacity: 0; }
-}
-@keyframes sc-fill { 0%, 46% { opacity: 0.18; } 56%, 100% { opacity: 1; } }
-@keyframes sc-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
-
-.sc-b .sc-scan { animation: sc-scan 4.5s ease-in-out infinite; }
-.sc-b .r3 { animation: sc-warn 4.5s linear infinite; }
-.sc-b .sc-finding { animation: sc-pop 4.5s ease-out infinite; }
-@keyframes sc-scan {
-  0% { transform: translateY(0); opacity: 0; }
-  8% { opacity: 0.9; }
-  46% { transform: translateY(66px); opacity: 0.9; }
-  54%, 100% { transform: translateY(66px); opacity: 0; }
-}
-@keyframes sc-warn { 0%, 36% { fill: var(--slate-200); } 44%, 100% { fill: #fde68a; } }
-@keyframes sc-pop {
-  0%, 54% { opacity: 0; transform: translateY(6px); }
-  64%, 92% { opacity: 1; transform: translateY(0); }
-  100% { opacity: 0; transform: translateY(0); }
-}
-
-.sc-c .fixchip { animation: sc-drop 4.5s ease-out infinite; }
-.sc-c .r3 { animation: sc-heal 4.5s linear infinite; }
-.sc-c .sc-receipt { animation: sc-rise 4.5s ease-out infinite; }
-@keyframes sc-drop {
-  0% { opacity: 0; transform: translateY(-14px); }
-  14%, 34% { opacity: 1; transform: translateY(0); }
-  44%, 100% { opacity: 0; transform: translateY(0); }
-}
-@keyframes sc-heal { 0%, 36% { fill: #fde68a; } 46%, 100% { fill: #99f6e4; } }
-@keyframes sc-rise {
-  0%, 50% { opacity: 0; transform: translateY(10px); }
-  62%, 94% { opacity: 1; transform: translateY(0); }
-  100% { opacity: 0; transform: translateY(0); }
-}
-
-/* ---------- Semantic review band ---------- */
-.review-band { background: var(--brand-teal-50); padding: 96px 24px; border-top: 1px solid #ccfbf1; }
-.review-inner { max-width: 1120px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 48px; align-items: center; }
-.review-copy .ds-h2 { text-wrap: balance; }
-.review-copy .ds-lead { max-width: 56ch; }
-.review-points { list-style: none; padding: 0; margin: 24px 0 0; display: grid; gap: 10px; max-width: 52ch; }
-.review-points li { position: relative; padding-left: 22px; font-size: 14.5px; line-height: 1.55; color: var(--slate-600); }
-.review-points li::before { content: ""; position: absolute; left: 0; top: 7px; width: 10px; height: 10px; border-radius: 50%; background: var(--brand-teal-500); }
-.review-points b { color: var(--slate-900); font-weight: 600; }
-.review-art { background: #fff; border: 1px solid #99f6e4; border-radius: 16px; padding: 18px; }
-.review-art svg { width: 100%; height: auto; display: block; overflow: visible; }
-
-/* ---------- What's new ---------- */
-.new-section { background: var(--slate-50); padding: 96px 24px; border-top: 1px solid var(--slate-100); }
-.feat-grid {
-  max-width: 1120px; margin: 48px auto 0;
-  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 32px 28px;
-}
-.feat { display: flex; flex-direction: column; }
-.feat h3 { margin: 16px 0 0; font-size: 16.5px; font-weight: 700; color: var(--slate-900); line-height: 1.3; }
-.feat p { margin: 8px 0 0; font-size: 14px; line-height: 1.6; color: var(--slate-600); }
-.feat-art { height: 128px; display: flex; align-items: center; padding: 12px 18px; background: #fff; border: 1px solid var(--slate-200); border-radius: 12px; }
-.feat-art svg { width: 100%; height: 96px; overflow: visible; }
-.feat.hosts { grid-column: span 2; flex-direction: row; align-items: center; gap: 36px; padding: 26px 30px; background: #fff; border: 1px solid var(--slate-200); border-radius: 16px; margin-bottom: 8px; }
-.feat.hosts h3 { margin: 0; font-size: 20px; }
-.feat.hosts p { max-width: 60ch; }
-.hosts-row { display: flex; gap: 14px; flex-shrink: 0; }
-.host-big {
-  position: relative;
-  display: flex; flex-direction: column; align-items: center; gap: 10px;
-  width: 104px; padding: 8px 4px;
-  font-size: 13px; font-weight: 600; color: var(--slate-900);
-}
-.host-big img { width: 40px; height: 40px; object-fit: contain; }
-.host-big em.new { position: absolute; top: -6px; right: 2px; }
-
-/* Feature art vocabulary (shared by the 0.2 SVGs) */
+/* Diagram vocabulary (screen-two diagram) */
 .art-box { stroke: var(--slate-300); fill: #fff; stroke-width: 1.5; }
 .art-box.on { stroke: var(--brand-teal-500); }
 .art-box.solid { fill: var(--brand-teal-500); }
@@ -373,38 +334,86 @@ em.new {
   filter: blur(100px); border-radius: 50%; pointer-events: none;
 }
 .next-inner { position: relative; max-width: 1120px; margin: 0 auto; }
-.next-art { max-width: 820px; margin: 48px auto 0; display: flex; align-items: center; justify-content: center; gap: 28px; flex-wrap: wrap; }
-.next-art svg { height: auto; overflow: visible; }
-.next-art .na-lineage { flex: 0 1 400px; width: 100%; max-width: 400px; }
-.next-art .na-project { flex: 0 1 290px; width: 100%; max-width: 290px; border-left: 1px dashed var(--slate-700); padding-left: 24px; }
-.na-box { fill: rgba(15, 23, 42, 0.6); stroke: var(--slate-600); stroke-width: 1.5; }
-.na-box.parent { stroke: #5eead4; fill: rgba(20, 184, 166, 0.12); }
-.na-box.child { stroke: var(--slate-500); }
-.na-box.warn { stroke: #f59e0b; fill: rgba(245, 158, 11, 0.1); }
-.na-box.receipt { stroke: #5eead4; fill: rgba(2, 6, 23, 0.7); }
-.na-line { stroke: var(--slate-600); stroke-width: 1.5; }
-.na-line.on { stroke: #5eead4; }
-.na-line.warn { stroke: #f59e0b; }
-.na-txt { font-family: var(--font-mono); font-size: 11px; fill: var(--slate-200); font-weight: 500; }
-.na-txt.on { fill: #5eead4; }
-.na-txt.warn { fill: #fcd34d; }
-.na-sub { font-family: var(--font-mono); font-size: 9.5px; fill: var(--slate-400); }
-.na-sub.warn { fill: #fbbf24; }
-.na-tag { font-family: var(--font-mono); font-size: 9.5px; fill: var(--slate-400); letter-spacing: 0.04em; }
-.na-tag.on { fill: #5eead4; }
-.na-tag.warn { fill: #fbbf24; }
-.next-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; max-width: 960px; margin: 44px auto 0; }
+/* Coming soon: three animated cards, same loop idea as the hero explainer, on dark */
+.nx {
+  display: flex; align-items: stretch; justify-content: center; gap: 0;
+  max-width: 1080px; margin: 48px auto 0;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.5; color: var(--slate-300); text-align: left;
+}
+.nx-card {
+  flex: 1 1 0; min-width: 0; position: relative; overflow: hidden;
+  background: rgba(2, 6, 23, 0.55); border: 1px solid rgba(148, 163, 184, 0.22); border-radius: 14px; padding: 12px 14px 13px;
+}
+.nx-eyebrow { font-family: var(--font-sans); font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--slate-400); margin-bottom: 8px; }
+.nx-row { display: flex; align-items: center; gap: 8px; padding: 2px 6px; margin: 0 -6px; border-radius: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.nx-row.flag { color: #fcd34d; background: rgba(245, 158, 11, 0.12); }
+.nx-row.on { color: #5eead4; }
+.nx-mark { flex-shrink: 0; width: 12px; color: var(--slate-500); text-align: center; }
+.nx-mark.on { color: #5eead4; }
+.nx-mark.ok { color: #2dd4bf; }
+.nx-mark.dim { color: var(--slate-600); }
+.nx-row.flag .nx-mark { color: #f59e0b; }
+.nx-id { flex-shrink: 0; min-width: 54px; color: var(--slate-500); }
+.nx-row.on .nx-id { color: #99f6e4; }
+.nx-link { flex: 0 0 30px; position: relative; align-self: center; height: 2px; background: rgba(148, 163, 184, 0.25); }
+.nx-dot { position: absolute; top: -3px; left: 0; width: 8px; height: 8px; border-radius: 50%; background: #2dd4bf; box-shadow: 0 0 0 4px rgba(45, 212, 191, 0.18); opacity: 0; }
+
+/* One 14s loop; base styles are the final frame. */
+.nx-a1 { animation: nxA1 14s ease-out infinite; }  .nx-a2 { animation: nxA2 14s ease-out infinite; }
+.nx-a3 { animation: nxA3 14s ease-out infinite; }  .nx-a4 { animation: nxA4 14s ease-out infinite; }
+.nx-a5 { animation: nxA5 14s ease-out infinite; }  .nx-dot1 { animation: nxDot1 14s linear infinite; }
+.nx-b1 { animation: nxB1 14s ease-out infinite; }  .nx-b2 { animation: nxB2 14s ease-out infinite; }
+.nx-b3 { animation: nxB3 14s ease-out infinite; }  .nx-b4 { animation: nxB4 14s ease-out infinite; }
+.nx-b5 { animation: nxB5 14s ease-out infinite; }  .nx-dot2 { animation: nxDot2 14s linear infinite; }
+.nx-c1 { animation: nxC1 14s ease-out infinite; }  .nx-c2 { animation: nxC2 14s ease-out infinite; }
+.nx-c3 { animation: nxC3 14s ease-out infinite; }  .nx-c4 { animation: nxC4 14s ease-out infinite; }
+.nx-c5 { animation: nxC5 14s ease-out infinite; }
+@keyframes nxA1 { 0%, 2% { opacity: 0; transform: translateY(3px); } 5% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxA2 { 0%, 6% { opacity: 0; transform: translateY(3px); } 9% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxA3 { 0%, 9% { opacity: 0; transform: translateY(3px); } 12% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxA4 { 0%, 15% { opacity: 0; transform: translateY(3px); } 18% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxA5 { 0%, 20% { opacity: 0; transform: translateY(3px); } 23% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxDot1 { 0%, 26% { opacity: 0; transform: translateX(-2px); } 27% { opacity: 1; } 31% { opacity: 1; transform: translateX(24px); } 32%, 100% { opacity: 0; transform: translateX(24px); } }
+@keyframes nxB1 { 0%, 32% { opacity: 0; transform: translateY(3px); } 35% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxB2 { 0%, 37% { opacity: 0; transform: translateY(3px); } 40% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxB3 { 0%, 41% { opacity: 0; transform: translateY(3px); } 44% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxB4 { 0%, 46% { opacity: 0; transform: translateY(3px); } 49% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxB5 { 0%, 51% { opacity: 0; transform: translateY(3px); } 54% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxDot2 { 0%, 57% { opacity: 0; transform: translateX(-2px); } 58% { opacity: 1; } 62% { opacity: 1; transform: translateX(24px); } 63%, 100% { opacity: 0; transform: translateX(24px); } }
+@keyframes nxC1 { 0%, 63% { opacity: 0; transform: translateY(3px); } 66% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxC2 { 0%, 68% { opacity: 0; transform: translateY(3px); } 71% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxC3 { 0%, 72% { opacity: 0; transform: translateY(3px); } 75% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxC4 { 0%, 78% { opacity: 0; transform: translateY(3px); } 81% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+@keyframes nxC5 { 0%, 84% { opacity: 0; transform: translateY(3px); } 87% { opacity: 1; transform: none; } 92% { opacity: 1; } 96%, 100% { opacity: 0; } }
+
+.next-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 30px; max-width: 1080px; margin: 36px auto 0; }
 .next-item { border-top: 1px solid var(--slate-700); padding: 16px 2px 0; }
 .next-item h3 { margin: 0; font-size: 15.5px; font-weight: 700; color: #fff; }
 .next-item p { margin: 8px 0 0; font-size: 14px; line-height: 1.6; color: var(--slate-400); }
 
 /* ---------- Alpha strip ---------- */
-.alpha-strip { background: #fff; padding: 36px 24px; border-top: 1px solid var(--slate-100); }
-.alpha-inner { max-width: 960px; margin: 0 auto; display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
-.alpha-inner p { margin: 0; flex: 1; min-width: 260px; font-size: 14.5px; line-height: 1.6; color: var(--slate-600); }
-.alpha-links { display: flex; align-items: center; gap: 12px; font-size: 14px; font-weight: 600; }
-.alpha-links a { color: var(--brand-teal-700); }
-.alpha-links a:hover { color: var(--brand-teal-600); }
+.alpha-strip {
+  padding: 56px 24px; border-top: 1px solid #ccfbf1;
+  background: linear-gradient(180deg, var(--brand-teal-50) 0%, #fff 100%);
+}
+.alpha-inner { max-width: 1040px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 32px; flex-wrap: wrap; }
+.alpha-copy { flex: 1 1 420px; min-width: 0; }
+.alpha-badge {
+  display: inline-flex; align-items: center; gap: 8px; padding: 4px 11px 4px 9px; border-radius: 9999px;
+  font-family: var(--font-mono); font-size: 12px; font-weight: 500; letter-spacing: 0.02em;
+  color: var(--brand-teal-700); background: #fff; border: 1px solid #99f6e4;
+}
+.alpha-pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--brand-teal-500); animation: newpulse 2.2s ease-in-out infinite; }
+.alpha-copy h3 { margin: 14px 0 0; font-size: clamp(20px, 2.4vw, 24px); font-weight: 700; color: var(--slate-900); letter-spacing: -0.01em; }
+.alpha-copy p { margin: 8px 0 0; font-size: 15px; line-height: 1.6; color: var(--slate-600); max-width: 58ch; }
+.alpha-links { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.alpha-btn {
+  display: inline-flex; align-items: center; height: 42px; padding: 0 18px; border-radius: 10px;
+  border: 1px solid var(--slate-200); background: #fff; color: var(--slate-700); font-size: 14px; font-weight: 600; transition: all 150ms;
+}
+.alpha-btn:hover { border-color: var(--slate-300); color: var(--slate-900); }
+.alpha-btn.primary { background: var(--brand-teal-500); border-color: var(--brand-teal-500); color: #fff; box-shadow: 0 6px 16px rgba(20, 184, 166, 0.22); }
+.alpha-btn.primary:hover { background: var(--brand-teal-400); border-color: var(--brand-teal-400); color: #fff; }
 
 /* ---------- Footer ---------- */
 .ds-footer { background: var(--slate-950); color: var(--slate-400); padding: 28px 24px; border-top: 1px solid var(--slate-800); }
@@ -418,7 +427,6 @@ em.new {
 .ds-footer-links { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
 .ds-footer-links a:hover { color: var(--slate-200); }
 .ds-footer-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--slate-700); display: inline-block; }
-.alpha-links .ds-footer-dot { background: var(--slate-300); }
 
 /* Page receipt (footer) */
 .receipt-card { max-width: 620px; margin: 0 auto 36px; background: var(--slate-900); border: 1px solid var(--slate-800); border-radius: 14px; overflow: hidden; font-family: var(--font-mono); font-size: 12.5px; box-shadow: var(--shadow-xl); }
@@ -432,39 +440,47 @@ em.new {
 
 /* ---------- Responsive ---------- */
 @media (max-width: 1080px) {
-  .flow { grid-template-columns: repeat(2, minmax(0, 1fr)); row-gap: 40px; }
-  .fnode:nth-child(3)::before, .fnode:nth-child(3)::after { display: none; }
-  .feat-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .feat.hosts { grid-column: span 2; }
-  .scenes { grid-template-columns: 1fr; max-width: 520px; }
+  .arch-notes { grid-template-columns: 1fr; gap: 20px; max-width: 520px; }
 }
 @media (max-width: 960px) {
-  .ds-hero { padding: 40px 20px 64px; }
-  .ds-hero-grid { grid-template-columns: minmax(0, 1fr); gap: 40px; }
+  .ds-hero { padding: 64px 20px 64px; }
+  .hx { margin-top: 36px; }
+  .hero-installers { margin-top: 36px; }
+  .ds-hero { padding-bottom: 56px; }
   .term-body { height: 360px; }
-  .ds-cta-dark, .ds-section, .new-section, .review-band { padding: 72px 20px; }
-  .review-inner { grid-template-columns: 1fr; gap: 32px; }
-  .feat.hosts { flex-direction: column; align-items: flex-start; gap: 20px; }
+  .ds-cta-dark, .ds-section, .see-section, .inside-section { padding: 72px 20px; }
+  .see-inner { grid-template-columns: 1fr; gap: 36px; }
   .next-grid { grid-template-columns: 1fr; }
 }
+@media (max-width: 900px) {
+  /* Explainer cards clip their rows below this width; stack them instead. */
+  .hx, .nx { flex-direction: column; gap: 10px; max-width: 440px; }
+  .hx-card, .nx-card { flex: 0 0 auto; }
+  .hx-link, .hx-scan, .nx-link { display: none; }
+}
+@media (max-width: 760px) {
+  /* Below this the teal line would wrap under "Agents" and the wordmark's
+     bars would collide with it, so the wordmark takes its own line. */
+  .ds-h1 { font-size: clamp(38px, 9.5vw, 56px); }
+  .h1-logo { display: block; height: 1.55em; margin: 0 auto 0.04em; }
+}
 @media (max-width: 720px) {
-  .feat-grid { grid-template-columns: 1fr; }
-  .feat.hosts { grid-column: span 1; }
-  .hosts-row { width: 100%; }
-  .host-big { flex: 1; width: auto; }
-  .flow { grid-template-columns: 1fr; row-gap: 32px; }
-  .fnode + .fnode::before, .fnode + .fnode::after { display: none; }
-  .fnode-text { max-width: 40ch; }
-  .next-art .na-project { border-left: 0; padding-left: 0; }
 
-  /* Hero: agent setup only — no terminal, no install tabs */
+  /* Hero on phones: agent setup only, no install tabs */
   .ds-hero { padding-bottom: 48px; }
-  .ds-hero-grid { gap: 28px; }
-  .term-card { display: none; }
-  .hero-under-term { margin-top: 0; }
-  .inst-tab:not(.agent) { display: none; }
+  .term-body { height: 320px; font-size: 12.5px; }
+  .inst-tab:not(.agent), .manual-panel { display: none !important; }
+  /* Explainer: compact on phones */
+  .hx { max-width: 340px; gap: 8px; font-size: 10.5px; margin-top: 28px; }
+  .hx-card { padding: 8px 10px 9px; border-radius: 10px; }
+  .hx-eyebrow { font-size: 9.5px; margin-bottom: 4px; }
+  .hx-row { gap: 6px; padding: 1px 5px; margin: 0 -5px; }
+  .hx-k { width: 52px; }
+  .hx-caret { width: 5px; height: 11px; }
+  .hero-installers { margin-top: 30px; }
   .inst-tabs { flex-direction: column; align-items: stretch; }
-  .inst-tab.agent { height: 48px; justify-content: center; font-size: 15px; }
+  .inst-tab.agent { height: 50px; justify-content: center; font-size: 16px; padding: 0 16px; gap: 8px; white-space: nowrap; }
+  .inst-tab.agent .rec { font-size: 10.5px; padding: 2px 7px; }
   .agent-note { display: block; }
 }
 @media (max-width: 560px) {
@@ -473,11 +489,10 @@ em.new {
 }
 @media (max-width: 520px) {
   .inst-tabs { flex-direction: column; align-items: stretch; }
-  .hosts-row { flex-wrap: wrap; }
-  .host-big { min-width: 96px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
-  .tl, em.new, .copy-toast, .sc * { animation: none !important; }
+  .tl, em.new, .next-steps, .alpha-pulse, .hx, .hx *, .nx, .nx * { animation: none !important; }
+  .hx-scan { display: none; }
 }

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -464,6 +464,8 @@ em.new {
   .nx { flex-direction: column; gap: 10px; max-width: 460px; }
   .nx-card { flex: 0 0 auto; }
   .nx-link { display: none; }
+  /* Stacked cards would sit empty while the loop reaches them; show the final frame. */
+  .nx * { animation: none !important; }
 }
 @media (max-width: 860px) {
   .arch-notes { grid-template-columns: 1fr; gap: 22px; }

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -443,7 +443,7 @@ em.new {
 
 /* ---------- Responsive ---------- */
 @media (max-width: 1080px) {
-  .arch-notes { grid-template-columns: 1fr; gap: 20px; max-width: 520px; }
+
 }
 @media (max-width: 960px) {
   .ds-hero { padding: 64px 20px 64px; }
@@ -452,16 +452,21 @@ em.new {
   .ds-hero { padding-bottom: 56px; }
   .term-body { height: 360px; }
   .ds-cta-dark, .ds-section, .see-section, .inside-section { padding: 72px 20px; }
-  .see-inner { grid-template-columns: 1fr; gap: 40px; }
-  .see-copy { max-width: 640px; margin: 0 auto; }
-  .see-copy .ds-lead, .see-note { max-width: none; }
-  .see-art { max-width: none; margin-top: 24px; }
   .next-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 1100px) {
+  /* Keep the terminal beside the copy; equal columns and a tighter gap. */
+  .see-inner { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 28px; }
+  .see-art { max-width: none; }
+  .see-demo .term-body { font-size: 12.5px; }
 }
 @media (max-width: 1040px) {
   .nx { flex-direction: column; gap: 10px; max-width: 460px; }
   .nx-card { flex: 0 0 auto; }
   .nx-link { display: none; }
+}
+@media (max-width: 860px) {
+  .arch-notes { grid-template-columns: 1fr; gap: 22px; }
 }
 @media (max-width: 900px) {
   /* Explainer cards clip their rows below this width; stack them instead. */
@@ -477,6 +482,8 @@ em.new {
 }
 @media (max-width: 720px) {
 
+  .see-inner { grid-template-columns: 1fr; gap: 36px; }
+  .see-art { max-width: 460px; }
   /* Hero on phones: agent setup only, no install tabs */
   .ds-hero { padding-bottom: 48px; }
   .term-body { height: 320px; font-size: 12.5px; }


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #707
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: landing page only, no protocol, privacy, storage, or packaging change.

## Documentation

- Behavior change? `no` (site content only; runtime untouched)
- Docs updated: `n/a — no behavior change`. The install popup behavior described in `docs/usage/install-and-first-run.md` still holds: the panel confirms the copy and tells the user to paste into the agent chat or terminal.

## Verification

Commands run (paste):

```text
cd landing && npm ci
cd landing && npx astro build      # 1 page built, no errors
git diff --check
```

Checked in the browser at 1440, 1132, 820, 780, 740, and 375 px widths: headline never overlaps the wordmark, explainer rows do not clip, the manual-install disclosure toggles, and the next-steps panel appears for the agent, PyPI, and npm paths, including when the browser denies clipboard writes.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply explaining why it is invalid or out of scope.

## Summary

The landing page had too many sections and testers said the install step was unclear. This restructures it into three screens plus the coming-soon band, alpha strip, and receipt footer:

- **Hero.** Larger headline with the Yoetz wordmark set inline at the text's baseline, an animated three-card explainer (agent says, Yoetz checks, receipt), a primary "Set up with your agent" button with an "Install manually" disclosure for the PyPI and npm commands, and the hosts, GitHub star, and Apache-2.0 links underneath. The old top bar is removed.
- **Working in the background.** The terminal replay beside a short static diagram of "what it says" and "what it did" being compared into a finding or a receipt.
- **Under the hood.** One architecture graphic: the agent, an MCP channel carrying the six tools, a hooks channel carrying host observations, the local service with ledger, rules, and receipt, and an optional reviewer. Content sourced from `docs/architecture.md` and the integration adapters. Replaces the four-node flow, reviewer band, and feature cards. The unsourced "old-key tokens grace window" callout is dropped.
- **Coming soon.** Delegate, roll up, and coordinate play as animated cards using real receipt conclusion values; the roadmap captions are unchanged.
- **Alpha strip.** Shows the version from `landing/package.json`, a short headline, and issue and security links as buttons.
- **Install guidance.** Copying opens a persistent next-steps panel under the buttons instead of an auto-hiding toast. Steps follow `docs/usage/install-and-first-run.md`, including that setup detects Codex and that Claude Code and Cursor are connected afterwards with `yoetz integrate`. When the clipboard write is denied the panel still opens with the text to copy by hand.

All animations respect `prefers-reduced-motion` and render their final frame.

Model and harness: Claude Fable 5.1 in Claude Code (desktop app), driving the Astro dev server in the in-app browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Design**
  - Redesigned the landing page around claim verification, receipts, supported agents, local architecture, semantic review, and future multi-agent workflows.
  - Added new interactive visuals for terminal activity, system architecture, delegation, coordination, and alpha status.
  - Replaced previous “How it works,” scenes, and feature sections with updated explanatory layouts.

- **Installation**
  - Added setup instructions with manual-install disclosure, clipboard failure handling, and dismissible guidance panels.
  - Added next-step receipt information after installation.

- **Accessibility**
  - Improved responsive layouts and reduced-motion behavior for animated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->