### PR TITLE
fix(docs): platform check, uv install, and no-question-tool guidance for agent installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ reverse-chronological released versions.
   instead of choosing, and hands the terminal over as if the user has never opened one.
   [Install and first run](docs/usage/install-and-first-run.md) gains the Windows section the CLI
   and README link to. Host notes checked against the September 2026 documentation of Codex,
-  Claude Code, Cursor, and Grok Build record what each does differently: where its question tool
+  Claude Code, and Cursor record what each does differently: where its question tool
   is unavailable or non-blocking, what blocks the guide fetch or the `uv` installer, and what
   native Windows means for it. The copied setup prompt now tells the agent to ask for approval
   or a pasted guide when its sandbox blocks the fetch (issue #709).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ reverse-chronological released versions.
 
 ## Unreleased
 
+### Changed
+
+- The agent install guide (`docs/usage/agent-start.md`) now opens with a platform check — macOS
+  and Linux, Windows only inside WSL 2, with the exact WSL and `uv` installation steps and which
+  side of Windows each command runs on — tells an agent whose host has no structured question
+  tool (Cursor's agent, for one) to put each decision in plain chat and wait for the answer
+  instead of choosing, and hands the terminal over as if the user has never opened one.
+  [Install and first run](docs/usage/install-and-first-run.md) gains the Windows section the CLI
+  and README link to (issue #709).
+
+### Fixed
+
+- On native Windows, `yoetz` refuses with a bounded `unsupported_platform` line naming the WSL
+  path (exit 20) instead of `internal_error` from every stateful command; `version`,
+  `--version`, and `--help` still answer (issue #709).
+
 ## 0.2.0 — 2026-09-11
 
 Official public-alpha package release. See [complete release notes](docs/releases/v0.2.0.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ reverse-chronological released versions.
   tool (Cursor's agent, for one) to put each decision in plain chat and wait for the answer
   instead of choosing, and hands the terminal over as if the user has never opened one.
   [Install and first run](docs/usage/install-and-first-run.md) gains the Windows section the CLI
-  and README link to (issue #709).
+  and README link to. Host notes checked against the September 2026 documentation of Codex,
+  Claude Code, Cursor, and Grok Build record what each does differently: where its question tool
+  is unavailable or non-blocking, what blocks the guide fetch or the `uv` installer, and what
+  native Windows means for it. The copied setup prompt now tells the agent to ask for approval
+  or a pasted guide when its sandbox blocks the fetch (issue #709).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ npx yoetz
 ```
 
 The npm package bundles no Python and no Yoetz code and never installs `uv` itself; it only
-launches the exact matching Python distribution.
+launches the exact matching Python distribution. Yoetz runs on macOS and Linux; on Windows, install
+it inside WSL 2 — see [Windows](docs/usage/install-and-first-run.md#windows).
 
 > [!TIP]
 > **Let your agent set it up.** Paste this into your coding agent and it walks you through

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ it inside WSL 2 — see [Windows](docs/usage/install-and-first-run.md#windows).
 >
 > curl -fsSL https://raw.githubusercontent.com/TheGaySupreme123/yoetz/main/docs/usage/agent-start.md
 >
-> It tells you what to run yourself, what to ask me, and where to hand me the terminal. Setup's
-> questions are mine to answer in my own terminal, and show me any proposed change before it is
+> It tells you what to run yourself, what to ask me, and where to hand me the terminal. If your
+> sandbox blocks that fetch, ask me to approve it or to paste the guide. Setup's questions are
+> mine to answer, so ask me each one and wait, and show me any proposed change before it is
 > applied.
 > ```
 

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -4867,6 +4867,12 @@ facade and are never MCP tools.
 
 ## 13. Surfaces
 
+- `cli/entry.py`: the installed console entry. It runs the `hooks observe|claude-observe|
+  cursor-observe|spool` fast paths without loading typer, then refuses native Windows
+  (`os.name == "nt"`) with the fixed `unsupported_platform` line and exit 20 — the exit an absent
+  service already carries, because no Yoetz service can be reached from that process — before the
+  full CLI loads; `version`, `--version`, and `--help` are exempt (issue #709). Everything else
+  falls through to `cli/app.py` unchanged.
 - `service/daemon.py`: sole application/runtime/vault/privacy/provider composition owner and
   ordinary-control dispatcher; starts into explicit `ready` or `locked`. Its private canonical
   installation marker owns immutable vault-mode publication. Unlock calls only

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -4871,7 +4871,7 @@ facade and are never MCP tools.
   cursor-observe|spool` fast paths without loading typer, then refuses native Windows
   (`os.name == "nt"`) with the fixed `unsupported_platform` line and exit 20 — the exit an absent
   service already carries, because no Yoetz service can be reached from that process — before the
-  full CLI loads; `version`, `--version`, and `--help` are exempt (issue #709). Everything else
+  full CLI loads; `version`, `--version`, `--help`, and `-h` are exempt (issue #709). Everything else
   falls through to `cli/app.py` unchanged.
 - `service/daemon.py`: sole application/runtime/vault/privacy/provider composition owner and
   ordinary-control dispatcher; starts into explicit `ready` or `locked`. Its private canonical

--- a/docs/usage/agent-start.md
+++ b/docs/usage/agent-start.md
@@ -20,7 +20,7 @@ you run it, and before the first decision read
 ## 0. Check the platform first — you do this
 
 Yoetz runs on macOS and Linux. Native Windows is not supported: the package installs, but every
-command except `yoetz version` and `--help` refuses with `unsupported_platform`. On Windows, Yoetz
+command except `yoetz version`, `--version`, and `--help` refuses with `unsupported_platform`. On Windows, Yoetz
 runs inside WSL 2 (Windows Subsystem for Linux), and so does everything else on this page.
 
 Find out where you are before installing anything: `uname -s` on macOS or Linux; on Windows, in
@@ -30,7 +30,8 @@ On Windows:
 
 1. **WSL is present** (a distribution such as Ubuntu is listed): run every command in this guide
    inside it. From PowerShell, `wsl -e bash -lc "<command>"` runs one command there; the user
-   opens the same environment by launching **Ubuntu** from the Start menu.
+   opens the same environment by launching the listed distribution (usually **Ubuntu**) from the
+   Start menu.
 2. **WSL is absent**: tell the user what WSL is in one sentence (a real Linux inside Windows, the
    way Microsoft supports Linux tools), then hand over the terminal: open **PowerShell as
    administrator**, run `wsl --install`, restart Windows when asked, then open **Ubuntu** from the
@@ -166,7 +167,8 @@ why the step needs their terminal rather than you.
 
 ### Host notes — what your own host does differently
 
-Checked against each host's official documentation in September 2026; a newer host may differ.
+Checked against Codex, Claude Code, and Cursor's official documentation in September 2026; a
+newer host may differ.
 Whatever the host, the rules above stand: the user decides, and a pending question pauses every
 consequential step — no install, no `setup run`, no registration until it is answered.
 
@@ -215,14 +217,12 @@ consequential step — no install, no `setup run`, no registration until it is a
   root and project, then `install` after approval. Cursor Cloud agents are not supported; install
   from a local Cursor.
 
-**Grok Build (xAI) and any other agent**
+**Any other agent**
 
-- No first-party integration. Grok Build has a structured question tool, a real `web_fetch`, and
-  native Windows binaries; the Windows rule for Yoetz is the same. Use Yoetz over MCP with no
-  integration: show the user the exact `yoetz mcp serve` entry for the host's own MCP
-  configuration before adding it, and never replace an existing entry named `yoetz`. Grok Build
-  also reads Claude Code and Cursor hook and MCP files, so a registration made for one of those
-  hosts may become visible to it; that path is untested and not claimed.
+- No first-party integration. Use Yoetz over MCP: show the user the exact `yoetz mcp serve` entry
+  for the host's own MCP configuration before adding it, and never replace an existing entry named
+  `yoetz`. The Windows rule is the same on every host. If the host has a question tool, check
+  whether it pauses the agent; if it does not, or there is none, ask in chat and wait.
 
 ## 3. Before recommending a semantic provider — inspect the installed catalog
 

--- a/docs/usage/agent-start.md
+++ b/docs/usage/agent-start.md
@@ -13,16 +13,58 @@ Codex, Claude Code, and Cursor have first-party integrations — the first-run w
 while Claude Code and Cursor are connected afterwards through `yoetz integrate claude ...` and
 `yoetz integrate cursor ...` — and any agent can still use Yoetz over MCP with no integration.
 
+Assume the user may never have opened a terminal. Explain each step in one plain sentence before
+you run it, and before the first decision read
+[Ask in chat when you have no question tool](#ask-in-chat-when-you-have-no-question-tool).
+
+## 0. Check the platform first — you do this
+
+Yoetz runs on macOS and Linux. Native Windows is not supported: the package installs, but every
+command except `yoetz version` and `--help` refuses with `unsupported_platform`. On Windows, Yoetz
+runs inside WSL 2 (Windows Subsystem for Linux), and so does everything else on this page.
+
+Find out where you are before installing anything: `uname -s` on macOS or Linux; on Windows, in
+PowerShell, `wsl --status` (or `wsl -l -v`).
+
+On Windows:
+
+1. **WSL is present** (a distribution such as Ubuntu is listed): run every command in this guide
+   inside it. From PowerShell, `wsl -e bash -lc "<command>"` runs one command there; the user
+   opens the same environment by launching **Ubuntu** from the Start menu.
+2. **WSL is absent**: tell the user what WSL is in one sentence (a real Linux inside Windows, the
+   way Microsoft supports Linux tools), then hand over the terminal: open **PowerShell as
+   administrator**, run `wsl --install`, restart Windows when asked, then open **Ubuntu** from the
+   Start menu and choose a Linux username and password when it asks. You cannot do this for
+   them: it needs administrator elevation and a restart. Continue with item 1 afterwards.
+3. Install `uv` and Yoetz inside WSL (section 1), not on the Windows side. A `yoetz` already
+   installed on Windows is unusable but harmless; uninstall it only when the user asks
+   (`uv tool uninstall yoetz` in PowerShell).
+4. Connecting a Windows-native Codex, Claude Code, or Cursor to a Yoetz inside WSL is untested
+   and not claimed. Register a host only from the same WSL environment; a Windows-side agent can
+   still drive installation and local-only use through `wsl -e`.
+
 ## 1. Install — you do this
+
+If `uv` is missing (`uv --version` fails), install it first — the same line on macOS, Linux, and
+inside WSL:
+
+```text
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source "$HOME/.local/bin/env"
+```
+
+Then install Yoetz:
 
 ```text
 uv tool install --managed-python --python 3.14.6 "yoetz==0.1.0"
 yoetz version
 ```
 
-`uvx yoetz` works for a one-off run. With `uv` already installed, `npx yoetz` launches the same
-exact-version PyPI package and installs nothing itself. The compatibility extras are aliases the
-standard install already contains — do not add them.
+`uv tool install` places `yoetz` in `~/.local/bin`. If a new terminal cannot find it, run
+`uv tool update-shell` once and open another terminal. `uvx yoetz` works for a one-off run. With
+`uv` already installed, `npx yoetz` launches the same exact-version PyPI package and installs
+nothing itself. The compatibility extras are aliases the standard install already contains — do
+not add them.
 
 ## 2. Setup — guide it in the conversation
 
@@ -69,6 +111,58 @@ OAuth credential.
 If the host cannot attest the exact chat decision, tell the user to run **`yoetz`** or
 **`yoetz --privacy`** in their own terminal and continue after the terminal result. Do not change
 their selected recipe merely because the authority continuation moved to the terminal.
+
+### Ask in chat when you have no question tool
+
+Some hosts give you a structured question tool; others, Cursor's agent among them, do not. In a
+real install on Cursor the agent asked nothing and chose for the user. The absence of a tool never
+makes a choice yours:
+
+- Put the decision in a plain message: the question, the options, your recommendation and its
+  trade-off, in that order. Then end your turn and wait. One decision per message.
+- Continue only on an answer to that message. A reply that names an option, or explicitly takes
+  your recommendation, is an answer; silence, an unrelated message, or assent to something earlier
+  is not.
+- Never use `yoetz setup run --accept` or `--non-interactive` to get past a question you could not
+  ask. Skipping a step is itself a choice the user makes.
+
+#### The questions, ready to ask
+
+Ask these in this order, one per message, in your own words but with these options and
+recommendations. Each answer decides the next step; stop after each and wait.
+
+1. **Codex.** "I found Codex at `<path>` (or: I found no Codex). Connect Yoetz to it? Yes /
+   No / (if several) which one." Recommend yes when one is found; with none, say integration is
+   skipped and everything else still works.
+2. **Review mode.** "How should Yoetz review your work? (a) Local only: nothing leaves this
+   computer, no account or key needed, every deterministic check works. (b) Semantic review: an
+   AI model also reviews, which sends parts of your work to a provider you pick." Recommend local
+   only for a first install unless they already want model review; if they choose semantic,
+   recommend Expanded first and name Assisted as the lower-disclosure option.
+3. **The exact change.** Show the preview (project skill, plugin and hook sources, MCP
+   registration) and ask "Apply exactly this? Approve / Deny." No recommendation and no default:
+   this one is theirs.
+4. **Secret storage**, only if the wizard reports system secure storage unavailable: "Yoetz needs
+   a place for secrets. Use a passphrase you choose? You will type it in your terminal."
+5. **Provider and model**, only after semantic review: list the presets from
+   `yoetz provider catalog --json` with their suggested models and ask which one, or skip for
+   now. Recommend the preset whose retention terms match what they told you about privacy.
+6. **Privacy policy**, only after semantic review: name the five options, recommend one with its
+   reason and trade-off, and ask which. Their choice is applied only through the terminal
+   ceremony or the exact prepared chat grant.
+7. **Credential**: never a question. Hand over the terminal for `yoetz provider credential set`.
+
+When every answer is in, run the setup, verify (section 5), and report each layer separately.
+Setup is finished when the user's chosen mode is reached — local only is a finished state, not a
+fallback.
+
+### Hand over the terminal like it is their first
+
+Every hand-over says four things: which application to open (Terminal on macOS, **Ubuntu** from
+the Start menu on Windows, the distribution's terminal on Linux); the exact line to type, one at a
+time; what they will see (a full-screen setup, a hidden prompt that shows nothing while they paste
+a key, a request for their passphrase); and what to tell you when it is done. Say in one sentence
+why the step needs their terminal rather than you.
 
 ## 3. Before recommending a semantic provider — inspect the installed catalog
 

--- a/docs/usage/agent-start.md
+++ b/docs/usage/agent-start.md
@@ -164,6 +164,66 @@ time; what they will see (a full-screen setup, a hidden prompt that shows nothin
 a key, a request for their passphrase); and what to tell you when it is done. Say in one sentence
 why the step needs their terminal rather than you.
 
+### Host notes — what your own host does differently
+
+Checked against each host's official documentation in September 2026; a newer host may differ.
+Whatever the host, the rules above stand: the user decides, and a pending question pauses every
+consequential step — no install, no `setup run`, no registration until it is answered.
+
+**Codex**
+
+- Questions: `request_user_input` exists only in plan mode and is unavailable in the default
+  mode. Ask in chat as above, or ask the user to switch to plan mode (`/plan`) for the setup
+  decisions.
+- Fetching this guide: the sandbox blocks network by default, so the `curl` needs a one-time
+  approval, or `network_access = true` under `[sandbox_workspace_write]` in
+  `~/.codex/config.toml`. Codex's built-in web search does not fetch raw files.
+- Windows: Codex runs natively in PowerShell; Yoetz does not. Run every Yoetz command through
+  `wsl -e bash -lc "…"`, and register the integration only from a Codex running inside WSL 2.
+- Integration: the first-run wizard (`yoetz`) connects Codex itself; the direct route is
+  `yoetz integrate codex mcp preview`, then `install` after approval. Writes under `~/.codex` are
+  outside the workspace and prompt for approval; that prompt is expected.
+
+**Claude Code**
+
+- Questions: `AskUserQuestion` is built in and waits for the answer. It is unavailable inside
+  subagents and in headless `-p` runs, so ask from the main conversation.
+- Fetching this guide: use `curl` through Bash for the exact bytes. `WebFetch` returns a small
+  model's summary of the page, not the page.
+- Install line: auto mode's classifier blocks `curl | sh` by default, and the `uv` installer is
+  one. Either the user approves it once, or hand it over as a terminal step.
+- Windows: Claude Code runs natively (PowerShell or Git Bash); Yoetz does not. Run Yoetz commands
+  through `wsl -e bash -lc "…"`. For host integration, Claude Code itself must run inside WSL 2,
+  installed and launched from the WSL terminal; the Windows-side and WSL-side `~/.claude` are
+  separate homes.
+- Integration: `yoetz integrate claude plugin preview`, then `install` after the user approves
+  the digest.
+
+**Cursor**
+
+- Questions: the "Ask questions" tool exists in every mode since Cursor 2.4, but it does not pause
+  the agent — Cursor keeps reading, editing, and running commands while the answer is pending.
+  That is how an install on Cursor asked nothing and chose for the user. After asking, stop:
+  end the turn and do nothing consequential until the answer arrives. Plan mode asks one
+  question at a time, if the user prefers.
+- Fetching this guide: shell commands outside the allowlist run in a sandbox with no network. If
+  the `curl` fails with a network error, ask the user to approve it outside the sandbox, or to
+  paste the guide into the chat.
+- Windows: Cursor's agent terminal is PowerShell on native Windows; run Yoetz commands through
+  `wsl -e bash -lc "…"`. The Cursor integration is untested on Windows and WSL.
+- Integration: `yoetz integrate cursor plugin preview` with an explicit Cursor configuration
+  root and project, then `install` after approval. Cursor Cloud agents are not supported; install
+  from a local Cursor.
+
+**Grok Build (xAI) and any other agent**
+
+- No first-party integration. Grok Build has a structured question tool, a real `web_fetch`, and
+  native Windows binaries; the Windows rule for Yoetz is the same. Use Yoetz over MCP with no
+  integration: show the user the exact `yoetz mcp serve` entry for the host's own MCP
+  configuration before adding it, and never replace an existing entry named `yoetz`. Grok Build
+  also reads Claude Code and Cursor hook and MCP files, so a registration made for one of those
+  hosts may become visible to it; that path is untested and not claimed.
+
 ## 3. Before recommending a semantic provider — inspect the installed catalog
 
 Run this read-only command instead of relying on model memory or a stale guide:

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -48,8 +48,8 @@ Compatibility extras (the standard install already contains these exact dependen
 
 Yoetz runs on macOS and Linux. On Windows it runs inside WSL 2 (Windows Subsystem for Linux),
 Microsoft's supported way to run Linux programs on Windows. A native Windows install succeeds, but
-every command except `yoetz version` and `--help` then refuses with `unsupported_platform` and
-points here.
+every command except `yoetz version`, `--version`, and `--help` then refuses with
+`unsupported_platform` and points here.
 
 1. Open **PowerShell as administrator** and run `wsl --install`. Restart Windows when asked.
 2. Open **Ubuntu** from the Start menu. The first launch asks you to choose a Linux username and

--- a/docs/usage/install-and-first-run.md
+++ b/docs/usage/install-and-first-run.md
@@ -44,6 +44,31 @@ Compatibility extras (the standard install already contains these exact dependen
 | `semantic-openai` | Existing install-command alias for the HTTP client and OpenAI SDK |
 | `portable-recovery` | Existing install-command alias for Argon2 recovery/passphrase support |
 
+## Windows
+
+Yoetz runs on macOS and Linux. On Windows it runs inside WSL 2 (Windows Subsystem for Linux),
+Microsoft's supported way to run Linux programs on Windows. A native Windows install succeeds, but
+every command except `yoetz version` and `--help` then refuses with `unsupported_platform` and
+points here.
+
+1. Open **PowerShell as administrator** and run `wsl --install`. Restart Windows when asked.
+2. Open **Ubuntu** from the Start menu. The first launch asks you to choose a Linux username and
+   password.
+3. Inside that Ubuntu window, install `uv`, then Yoetz:
+
+   ```text
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   source "$HOME/.local/bin/env"
+   uv tool install --managed-python --python 3.14.6 "yoetz==0.1.0"
+   yoetz
+   ```
+
+Everything else on this page happens inside that Ubuntu window, including `yoetz service run` and
+the steps that need your own terminal. A coding agent driving the install from the Windows side
+can run each command with `wsl -e bash -lc "..."`. Connecting a Windows-native Codex, Claude Code,
+or Cursor to a Yoetz inside WSL is untested and not claimed: connect from the same WSL
+environment, or keep Yoetz local-only through the CLI.
+
 ## First run
 
 The first bare `yoetz` on an interactive terminal opens the full-screen interface in first-run

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -15,7 +15,7 @@ const AGENT_PROMPT = `I want to install Yoetz (${GITHUB}). Start by fetching its
 
 curl -fsSL https://raw.githubusercontent.com/TheGaySupreme123/yoetz/main/docs/usage/agent-start.md
 
-It tells you what to run yourself, what to ask me, and where to hand me the terminal. Then help me through the CLI: setup's questions are mine to answer in my own terminal, and show me any proposed change before it is applied.`;
+It tells you what to run yourself, what to ask me, and where to hand me the terminal. If your sandbox blocks that fetch, ask me to approve it or to paste the guide. Then help me through the CLI: setup's questions are mine to answer, so ask me each one and wait, and show me any proposed change before it is applied.`;
 const TITLE = "Yoetz: honest completion checks for AI coding agents";
 const DESCRIPTION =
   "Yoetz is a local-first, open-source work ledger for AI coding agents. An agent publishes what it did; Yoetz checks the record and issues a receipt that states what was verified, at what coverage, and what is still open. First-party for Codex, Claude Code, and Cursor.";

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -310,6 +310,9 @@ const next = [
             <p class="inst-note agent-note">
               Copies a prompt. Paste it into your agent: it installs Yoetz and shows you every change first.
             </p>
+            <p class="inst-note platform-note">
+              macOS and Linux. On Windows, install inside <a href={`${GITHUB}/blob/main/docs/usage/install-and-first-run.md#windows`}>WSL 2</a>.
+            </p>
           </div>
         </div>
 

--- a/src/yoetz/cli/entry.py
+++ b/src/yoetz/cli/entry.py
@@ -236,6 +236,8 @@ def _unsupported_platform_exit(arguments: list[str], *, os_name: str | None = No
 
 
 def _run_full_cli() -> None:
+    """Load the typer graph and dispatch; split out so tests can prove it never loads on Windows."""
+
     from yoetz.cli.app import main as app_main
 
     app_main()

--- a/src/yoetz/cli/entry.py
+++ b/src/yoetz/cli/entry.py
@@ -8,6 +8,7 @@ full CLI unchanged, so usage errors and ``--help`` stay byte-identical.
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 from typing import Final
@@ -17,7 +18,23 @@ from typing import Final
 # measurable and is documented (~20 ms), never guessed.
 _ENTRY_MONOTONIC: Final = time.monotonic()
 
-__all__ = ["main"]
+__all__ = ["UNSUPPORTED_PLATFORM_MESSAGE", "main"]
+
+# Yoetz is POSIX-only: the service listens on an owner-only AF_UNIX socket, and every path,
+# vault, and lock check compares ``st_uid`` against ``os.geteuid()``. On native Windows the path
+# probe raised ``AttributeError`` inside the catch-all and every stateful command printed
+# ``internal_error`` (issue #709). Refusing here names the real condition and the way out.
+_NATIVE_WINDOWS: Final = "nt"
+_PLATFORM_EXEMPT_COMMANDS: Final = frozenset({"version"})
+_PLATFORM_EXEMPT_FLAGS: Final = frozenset({"--help", "-h", "--version"})
+# ``service_unavailable`` exits 20 in ``yoetz.cli.exits``: no Yoetz service can ever be reached
+# from this process, so the exit matches the public code an absent service already carries.
+_UNSUPPORTED_PLATFORM_EXIT: Final = 20
+UNSUPPORTED_PLATFORM_MESSAGE: Final = (
+    "unsupported_platform: Yoetz runs on macOS and Linux; native Windows is not supported.\n"
+    "On Windows, install and run Yoetz inside WSL 2 (Ubuntu). Setup guide:\n"
+    "  https://github.com/TheGaySupreme123/yoetz/blob/main/docs/usage/install-and-first-run.md#windows"
+)
 
 
 def _observe_fast_path(arguments: list[str]) -> int | None:
@@ -197,6 +214,33 @@ def _claude_observe_fast_path(arguments: list[str]) -> int | None:
     return 0
 
 
+def _unsupported_platform_exit(arguments: list[str], *, os_name: str | None = None) -> int | None:
+    """Return the bounded exit for native Windows, or None where Yoetz can run.
+
+    ``version``, ``--version``, and ``--help`` stay available so a user or agent can still see what
+    was installed; everything else would only reach ``internal_error``.
+    """
+
+    if (os.name if os_name is None else os_name) != _NATIVE_WINDOWS:
+        return None
+    if arguments and arguments[0] in _PLATFORM_EXEMPT_COMMANDS:
+        return None
+    if any(token in _PLATFORM_EXEMPT_FLAGS for token in arguments):
+        return None
+    try:
+        sys.stderr.write(UNSUPPORTED_PLATFORM_MESSAGE + "\n")
+        sys.stderr.flush()
+    except OSError:
+        pass
+    return _UNSUPPORTED_PLATFORM_EXIT
+
+
+def _run_full_cli() -> None:
+    from yoetz.cli.app import main as app_main
+
+    app_main()
+
+
 def main() -> None:
     """Installed console entry point."""
 
@@ -217,6 +261,7 @@ def main() -> None:
         code = _spool_fast_path(argv[2:])
         if code is not None:
             raise SystemExit(code)
-    from yoetz.cli.app import main as app_main
-
-    app_main()
+    code = _unsupported_platform_exit(argv)
+    if code is not None:
+        raise SystemExit(code)
+    _run_full_cli()

--- a/tests/conformance/surfaces/test_agent_start_guide.py
+++ b/tests/conformance/surfaces/test_agent_start_guide.py
@@ -1,0 +1,93 @@
+"""The agent install guide names the platform boundary and the no-question-tool rule (issue #709).
+
+Two first-time users hit the same two holes: an agent on Cursor, which has no structured question
+tool, asked nothing and chose for them; and an agent on native Windows watched every command fail
+as ``internal_error`` before working out that Yoetz is POSIX-only. The guide, the shipped install
+page, and the CLI refusal must keep telling the same story.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from yoetz.cli.entry import UNSUPPORTED_PLATFORM_MESSAGE
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _text(path: str) -> str:
+    return (_ROOT / path).read_text(encoding="utf-8")
+
+
+def _collapsed(path: str) -> str:
+    return " ".join(_text(path).split())
+
+
+def test_agent_start_checks_the_platform_before_installing() -> None:
+    guide = _collapsed("docs/usage/agent-start.md")
+
+    assert "## 0. Check the platform first" in guide
+    assert "Yoetz runs on macOS and Linux" in guide
+    assert "Native Windows is not supported" in guide
+    assert "WSL 2" in guide
+    assert "wsl --install" in guide
+    assert 'wsl -e bash -lc "<command>"' in guide
+    assert "PowerShell as administrator" in guide
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in guide
+    assert "uv tool update-shell" in guide
+    # Section 0 precedes the install section, so the platform is known before anything installs.
+    assert guide.index("## 0. Check the platform first") < guide.index("## 1. Install")
+    # The WSL host cell is untested, and the guide says so rather than implying support.
+    assert "untested and not claimed" in guide
+
+
+def test_agent_start_tells_an_agent_without_a_question_tool_to_ask_in_chat() -> None:
+    guide = _collapsed("docs/usage/agent-start.md")
+
+    assert "### Ask in chat when you have no question tool" in guide
+    assert "Cursor's agent among them" in guide
+    assert "One decision per message" in guide
+    assert "end your turn and wait" in guide
+    assert "Never use `yoetz setup run --accept` or `--non-interactive`" in guide
+    assert "### Hand over the terminal like it is their first" in guide
+    assert "which application to open" in guide
+
+
+def test_install_page_windows_section_matches_the_cli_refusal() -> None:
+    page = _text("docs/usage/install-and-first-run.md")
+
+    assert re.search(r"^## Windows$", page, flags=re.MULTILINE)
+    collapsed = " ".join(page.split())
+    assert "refuses with `unsupported_platform`" in collapsed
+    assert "wsl --install" in collapsed
+    assert "curl -LsSf https://astral.sh/uv/install.sh | sh" in collapsed
+    # Shipped-product voice: no repository tooling or source paths on the usage page.
+    assert "src/yoetz" not in page
+    assert "uv run" not in page
+
+    # The CLI line points at exactly that heading's GitHub anchor.
+    assert UNSUPPORTED_PLATFORM_MESSAGE.startswith("unsupported_platform: ")
+    assert "docs/usage/install-and-first-run.md#windows" in UNSUPPORTED_PLATFORM_MESSAGE
+    assert "WSL 2" in UNSUPPORTED_PLATFORM_MESSAGE
+
+    readme = " ".join(_text("README.md").split())
+    assert "docs/usage/install-and-first-run.md#windows" in readme
+
+
+def test_agent_start_lists_the_questions_in_order_with_recommendations() -> None:
+    guide = _collapsed("docs/usage/agent-start.md")
+
+    assert "#### The questions, ready to ask" in guide
+    for heading in (
+        "1. **Codex.**",
+        "2. **Review mode.**",
+        "3. **The exact change.**",
+        "4. **Secret storage**",
+        "5. **Provider and model**",
+        "6. **Privacy policy**",
+        "7. **Credential**: never a question",
+    ):
+        assert heading in guide, heading
+    assert "No recommendation and no default" in guide
+    assert "local only is a finished state, not a fallback" in guide

--- a/tests/conformance/surfaces/test_agent_start_guide.py
+++ b/tests/conformance/surfaces/test_agent_start_guide.py
@@ -101,7 +101,7 @@ def test_agent_start_host_notes_cover_every_first_party_host_and_the_generic_rou
         "**Codex**",
         "**Claude Code**",
         "**Cursor**",
-        "**Grok Build (xAI) and any other agent**",
+        "**Any other agent**",
     ):
         assert host in guide, host
     # The Cursor finding that started this: its question tool does not pause the agent.

--- a/tests/conformance/surfaces/test_agent_start_guide.py
+++ b/tests/conformance/surfaces/test_agent_start_guide.py
@@ -91,3 +91,36 @@ def test_agent_start_lists_the_questions_in_order_with_recommendations() -> None
         assert heading in guide, heading
     assert "No recommendation and no default" in guide
     assert "local only is a finished state, not a fallback" in guide
+
+
+def test_agent_start_host_notes_cover_every_first_party_host_and_the_generic_route() -> None:
+    guide = _collapsed("docs/usage/agent-start.md")
+
+    assert "### Host notes" in guide
+    for host in (
+        "**Codex**",
+        "**Claude Code**",
+        "**Cursor**",
+        "**Grok Build (xAI) and any other agent**",
+    ):
+        assert host in guide, host
+    # The Cursor finding that started this: its question tool does not pause the agent.
+    assert "it does not pause the agent" in guide
+    # Each host's fetch blocker is named, and the guide is fetched as exact bytes on Claude Code.
+    assert "the sandbox blocks network by default" in guide
+    assert "`WebFetch` returns a small model's summary" in guide
+    assert "run in a sandbox with no network" in guide
+    # Cursor Cloud stays unsupported, matching the install page.
+    assert "Cursor Cloud agents are not supported" in guide
+
+
+def test_copied_setup_prompt_matches_between_readme_and_landing() -> None:
+    # The README prompt is a blockquote; drop the `>` markers before comparing sentences.
+    readme = " ".join(token for token in _text("README.md").split() if token != ">")
+    landing = _collapsed("landing/src/pages/index.astro")
+    for sentence in (
+        "If your sandbox blocks that fetch, ask me to approve it or to paste the guide.",
+        "ask me each one and wait",
+    ):
+        assert sentence in readme, sentence
+        assert sentence in landing, sentence

--- a/tests/unit/cli/test_entry.py
+++ b/tests/unit/cli/test_entry.py
@@ -137,3 +137,84 @@ def test_main_dispatches_claude_before_loading_full_cli(monkeypatch: pytest.Monk
         entry.main()
 
     assert caught.value.code == 9
+
+
+def test_native_windows_refuses_stateful_commands_with_a_bounded_line(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = entry._unsupported_platform_exit(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        ["setup", "status", "--json"], os_name="nt"
+    )
+
+    assert code == 20
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("unsupported_platform: ")
+    assert "WSL 2" in captured.err
+    assert "install-and-first-run.md#windows" in captured.err
+    assert "internal_error" not in captured.err
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["version"],
+        ["version", "--json"],
+        ["--version"],
+        ["--help"],
+        ["setup", "--help"],
+        ["-h"],
+    ],
+)
+def test_native_windows_still_answers_version_and_help(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        entry._unsupported_platform_exit(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+            arguments, os_name="nt"
+        )
+        is None
+    )
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("arguments", [[], ["setup", "status"], ["service", "run"]])
+def test_posix_never_hits_the_platform_refusal(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        entry._unsupported_platform_exit(  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+            arguments, os_name="posix"
+        )
+        is None
+    )
+    assert capsys.readouterr().err == ""
+
+
+def test_main_refuses_before_loading_the_full_cli_on_native_windows(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["yoetz", "privacy", "show"])
+    monkeypatch.setattr(entry.os, "name", "nt")
+
+    def never() -> None:
+        raise AssertionError("full CLI must not load on native Windows")
+
+    monkeypatch.setattr(entry, "_run_full_cli", never)
+
+    with pytest.raises(SystemExit) as caught:
+        entry.main()
+
+    assert caught.value.code == 20
+    assert capsys.readouterr().err.startswith("unsupported_platform: ")
+
+
+def test_main_falls_through_to_the_full_cli_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["yoetz", "privacy", "show"])
+    monkeypatch.setattr(entry.os, "name", "posix")
+    calls: list[str] = []
+    monkeypatch.setattr(entry, "_run_full_cli", lambda: calls.append("cli"))
+
+    entry.main()
+
+    assert calls == ["cli"]


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #709
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: docs, a CLI refusal line, and tests. No protocol, egress, storage, or packaging change.

## Documentation

- Behavior change? `yes` (native Windows now refuses with `unsupported_platform` instead of `internal_error`)
- Docs updated: `docs/usage/agent-start.md`, `docs/usage/install-and-first-run.md` (new **Windows** section), `README.md`, landing install note, `docs/INTERFACES.md` §13 (`cli/entry.py`), `CHANGELOG.md`.

## Verification

Commands run (paste):

```text
uv run pytest tests/unit/cli/test_entry.py tests/conformance/surfaces -q      # 88 passed
uv run ruff check src tests
uv run ruff format --check src/yoetz/cli/entry.py tests/unit/cli/test_entry.py tests/conformance/surfaces/test_agent_start_guide.py
npx --no-install pyright src/yoetz/cli/entry.py tests/unit/cli/test_entry.py  # 0 errors
cd landing && npm run build                                                   # 1 page built
git diff --check
```

The native-Windows refusal was exercised by unit tests and a simulated `os.name = "nt"` run on macOS. It has not been run on real Windows.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

Two first-time users followed the landing page's **Set up with your agent** path and got stuck twice. On Cursor, whose agent has no structured question tool, the agent asked nothing and chose the setup answers itself. On native Windows, `uv tool install` succeeded and then every stateful command failed as `internal_error`, because the path probe calls `os.geteuid`; the agent spent a long loop before concluding Yoetz is POSIX-only and moving to WSL by hand.

What changed:

- **Agent guide** (`docs/usage/agent-start.md`, the file the copied prompt curls): opens with a platform check (macOS and Linux; Windows only inside WSL 2, with the exact `wsl --install` hand-over, the `uv` install line, and which side of Windows each command runs on); tells an agent without a question tool to put each decision in plain chat and wait, one per message, and never to use `setup run --accept` or `--non-interactive` to skip a question; lists the seven questions in order with options and recommendations so setup can be finished completely; and hands the terminal over as if the user has never opened one.
- **Install page**: new `## Windows` section in product voice. README and the landing page link to it.
- **CLI**: on native Windows, `yoetz` refuses in `cli/entry.py` before the full CLI loads, with a bounded `unsupported_platform` line pointing at that section (exit 20, the code an absent service already carries). `version`, `--version`, and `--help` still answer.
- **Tests**: entry-point unit tests for the refusal and its exemptions; a conformance test that locks the guide, the install page heading, and the CLI message's anchor to each other.

Coverage decisions: connecting a Windows-native Codex, Claude Code, or Cursor to a Yoetz inside WSL is untested, and the docs say so rather than claim it. The guide still pins `yoetz==0.1.0` because that is what PyPI serves; bump it with the 0.2.0 release.

Work done by Claude Fable 5.1 in Claude Code (desktop app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Native Windows commands now provide a clear WSL 2 guidance message instead of an internal error.
  - Version and help commands remain available on native Windows.

- **Documentation**
  - Added Windows installation instructions using WSL 2.
  - Clarified supported platforms and installation requirements.
  - Improved agent setup guidance, including chat-based questions, terminal handoff, sandbox restrictions, and host-specific notes.

- **Tests**
  - Added coverage for platform handling and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->