### PR TITLE
fix(landing): simplify the phone layout and drop its animations

### DIFF
--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -234,10 +234,7 @@ const next = [
             <span class="line">Agents claim they're done.</span>
             <span class="line grad"><img class="h1-logo" src="/assets/yoetz-logo.png" alt="Yoetz" /> checks if they're actually done.</span>
           </h1>
-          <p class="sr-only">
-            Your agent claims it is done. Yoetz checks that claim against its own ledger of the work and
-            issues a receipt: what was verified, at what coverage, and what is still open.
-          </p>
+          <p class="sr-only">A receipt for every claim: what was verified, and what is still open.</p>
           <div class="hx" aria-hidden="true">
             <div class="hx-card hx-agent">
               <div class="hx-eyebrow">Agent says</div>
@@ -289,10 +286,11 @@ const next = [
             </div>
 
             <p class="inst-note agent-note">
-              Copies a prompt. Paste it into your agent: it installs Yoetz and shows you every change first.
+              <span class="d">Copies a prompt. Paste it into your agent: it installs Yoetz and shows you every change first.</span>
+              <span class="m">Copies a prompt. macOS, Linux, or <a href={`${GITHUB}/blob/main/docs/usage/install-and-first-run.md#windows`}>WSL&nbsp;2</a>.</span>
             </p>
             <p class="inst-note platform-note">
-              macOS and Linux. On Windows, install inside <a href={`${GITHUB}/blob/main/docs/usage/install-and-first-run.md#windows`}>WSL 2</a>.
+              <span class="d">macOS and Linux. On Windows, install inside <a href={`${GITHUB}/blob/main/docs/usage/install-and-first-run.md#windows`}>WSL 2</a>.</span>
             </p>
           </div>
           <div class="hero-hosts" aria-label="Officially supported agents">
@@ -398,7 +396,73 @@ const next = [
       <div class="ds-section-head">
         <span class="ds-kicker">Under the hood</span>
         <h2 class="ds-h2">Hooks and MCP, one local service.</h2>
-        <p class="ds-lead centered">The agent talks to Yoetz over MCP. The host reports through hooks. One service on your machine holds the record and checks it.</p>
+        <p class="ds-lead centered">
+          <span class="d">The agent talks to Yoetz over MCP. The host reports through hooks. One service on your machine holds the record and checks it.</span>
+          <span class="m">Two records in, one receipt out. All on your machine.</span>
+        </p>
+      </div>
+
+      <!-- Phone version of the diagram below: top to bottom instead of left to right. -->
+      <div class="arch-m" aria-hidden="true">
+        <svg viewBox="0 0 320 392" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <defs>
+            <marker id="arr-on-m" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 z" fill="#14b8a6" /></marker>
+            <marker id="arr-m" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 z" fill="#94a3b8" /></marker>
+          </defs>
+
+          <rect x="4" y="4" width="312" height="384" rx="16" class="art-box" stroke-dasharray="5 5" />
+          <text x="160" y="22" class="art-tag" text-anchor="middle">your machine · nothing leaves it</text>
+
+          <!-- agent -->
+          <rect x="40" y="36" width="240" height="72" rx="12" class="art-box" />
+          <text x="160" y="58" class="art-txt strong" text-anchor="middle">your agent</text>
+          <image href="/assets/openai.svg" x="115" y="70" width="22" height="22" />
+          <image href="/assets/claude.svg" x="149" y="70" width="22" height="22" />
+          <image href="/assets/cursor.svg" x="183" y="70" width="22" height="22" />
+
+          <!-- down: MCP -->
+          <path d="M64 108 V 124" class="art-line on" />
+          <text x="64" y="142" class="art-txt on" text-anchor="middle">MCP</text>
+          <text x="64" y="155" class="art-tag on" text-anchor="middle">what it says</text>
+          <path d="M64 162 V 190" class="art-line on" marker-end="url(#arr-on-m)" />
+
+          <!-- down: hooks -->
+          <path d="M160 108 V 124" class="art-line" />
+          <text x="160" y="142" class="art-txt" text-anchor="middle">hooks</text>
+          <text x="160" y="155" class="art-tag" text-anchor="middle">what it did</text>
+          <path d="M160 162 V 190" class="art-line" marker-end="url(#arr-m)" />
+
+          <!-- up: receipt -->
+          <path d="M256 190 V 162" class="art-line on" />
+          <text x="256" y="142" class="art-txt on" text-anchor="middle">receipt</text>
+          <text x="256" y="155" class="art-tag on" text-anchor="middle">to the chat</text>
+          <path d="M256 124 V 108" class="art-line on" marker-end="url(#arr-on-m)" />
+
+          <!-- service -->
+          <rect x="16" y="190" width="288" height="152" rx="14" class="art-box on" />
+          <text x="160" y="209" class="art-tag on" text-anchor="middle">yoetz service · one local process</text>
+
+          <rect x="22" y="222" width="84" height="50" rx="10" class="art-box" />
+          <text x="64" y="243" class="art-txt strong" text-anchor="middle">ledger</text>
+          <text x="64" y="259" class="art-tag" text-anchor="middle">append-only</text>
+
+          <path d="M106 247 H 116" class="art-line on" marker-end="url(#arr-on-m)" />
+          <rect x="118" y="222" width="84" height="50" rx="10" class="art-box on" />
+          <text x="160" y="243" class="art-txt strong" text-anchor="middle">rules</text>
+          <text x="160" y="259" class="art-tag" text-anchor="middle">deterministic</text>
+
+          <path d="M202 247 H 212" class="art-line on" marker-end="url(#arr-on-m)" />
+          <rect x="214" y="222" width="84" height="50" rx="10" class="art-box on solid" />
+          <text x="256" y="243" class="art-txt inv" text-anchor="middle">receipt</text>
+          <text x="256" y="259" class="art-txt inv" text-anchor="middle" opacity="0.85">what's open</text>
+
+          <path d="M160 272 V 288" class="art-line" stroke-dasharray="3 4" />
+          <rect x="66" y="290" width="188" height="40" rx="10" class="art-box" stroke-dasharray="4 3" />
+          <text x="160" y="307" class="art-txt" text-anchor="middle">reviewer model · optional</text>
+          <text x="160" y="321" class="art-tag" text-anchor="middle">your API key or ChatGPT plan</text>
+
+          <text x="160" y="368" class="art-tag" text-anchor="middle">nothing goes through us</text>
+        </svg>
       </div>
 
       <div class="arch" aria-hidden="true">
@@ -480,15 +544,15 @@ const next = [
       <div class="arch-notes">
         <div>
           <div class="arch-k">over MCP</div>
-          <p>The agent publishes its plan, work, claims, and evidence through six tools. Any MCP host can, with nothing installed.</p>
+          <p><span class="d">The agent publishes its plan, work, claims, and evidence through six tools. Any MCP host can, with nothing installed.</span><span class="m">The agent publishes its plan, work, claims, and evidence.</span></p>
         </div>
         <div>
           <div class="arch-k">through hooks</div>
-          <p>Codex, Claude Code, and Cursor also report what actually happened: sessions, tool calls, edits. Structural facts, never your files.</p>
+          <p><span class="d">Codex, Claude Code, and Cursor also report what actually happened: sessions, tool calls, edits. Structural facts, never your files.</span><span class="m">The host reports what actually happened. Never your files.</span></p>
         </div>
         <div>
           <div class="arch-k">in one local service</div>
-          <p>Both records land in an append-only ledger. Deterministic rules compare them, and the receipt states exactly how far the check reached.</p>
+          <p><span class="d">Both records land in an append-only ledger. Deterministic rules compare them, and the receipt states exactly how far the check reached.</span><span class="m">Rules compare the two records. The receipt says how far the check reached.</span></p>
         </div>
       </div>
 

--- a/landing/src/pages/index.astro
+++ b/landing/src/pages/index.astro
@@ -264,7 +264,7 @@ const next = [
                 <span id="agent-copy-label">Set up with your agent</span> <span class="rec">recommended</span>
               </button>
               <button class="inst-tab manual" type="button" id="manual-toggle" aria-expanded="false" aria-controls="manual-panel">
-                Install manually
+                <span id="manual-label">Install manually</span>
                 <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
               </button>
             </div>
@@ -753,12 +753,14 @@ const next = [
       // --- Manual install disclosure ---
       const manualToggle = document.getElementById("manual-toggle");
       const manualPanel = document.getElementById("manual-panel");
+      const manualLabel = document.getElementById("manual-label");
       manualToggle?.addEventListener("click", () => {
         if (!manualPanel) return;
         const open = manualPanel.hidden;
         manualPanel.hidden = !open;
         manualToggle.setAttribute("aria-expanded", String(open));
         manualToggle.classList.toggle("open", open);
+        if (manualLabel) manualLabel.textContent = open ? "Install options" : "Install manually";
       });
 
       // --- Copy: agent setup prompt ---

--- a/landing/src/styles/landing.css
+++ b/landing/src/styles/landing.css
@@ -65,6 +65,8 @@ img { max-width: 100%; }
 .hero-copy { display: flex; flex-direction: column; align-items: center; text-align: center; }
 .hero-copy .ds-h1 { text-wrap: balance; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+/* Copy with a shorter phone variant: .d shows on desktop, .m on phones. */
+.m { display: none; }
 
 /* ---------- Hero explainer: agent claims → Yoetz checks → receipt ---------- */
 .hx {
@@ -300,6 +302,7 @@ em.new {
 .inside-section { background: var(--slate-50); padding: 96px 24px; border-top: 1px solid var(--slate-100); }
 .arch { max-width: 1040px; margin: 56px auto 0; padding: 18px 20px; background: #fff; border: 1px solid var(--slate-200); border-radius: 18px; overflow-x: auto; }
 .arch svg { width: 100%; min-width: 720px; height: auto; display: block; overflow: visible; }
+.arch-m { display: none; }
 .arch .art-txt.strong { font-weight: 600; fill: var(--slate-900); }
 .arch-notes { max-width: 1040px; margin: 36px auto 0; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 32px; }
 .arch-k { font-family: var(--font-mono); font-size: 12.5px; color: var(--brand-teal-700); margin-bottom: 8px; }
@@ -477,35 +480,71 @@ em.new {
   .hx-link, .hx-scan { display: none; }
 }
 @media (max-width: 760px) {
-  /* Below this the teal line would wrap under "Agents" and the wordmark's
-     bars would collide with it, so the wordmark takes its own line. */
-  .ds-h1 { font-size: clamp(38px, 9.5vw, 56px); }
-  .h1-logo { display: block; height: 1.55em; margin: 0 auto 0.04em; }
+  /* Two sentences, each its own block; the wordmark opens the second and
+     runs inline with it, as on desktop. */
+  .ds-h1 { font-size: clamp(34px, 9.5vw, 56px); }
+  .ds-h1 .line { text-wrap: balance; }
+  /* Room for the wordmark's bars, which rise above the line box. */
+  .ds-h1 .grad { margin-top: 0.75em; }
 }
 @media (max-width: 720px) {
+  /* Phones get a shorter page: no looping animations, no diagrams that need
+     a side scroll, and the button inside the first screen. */
+  .ds-hero { padding: 64px 20px 56px; }
+  .ds-cta-dark, .ds-section, .see-section, .inside-section { padding: 56px 20px; }
 
-  .see-inner { grid-template-columns: 1fr; gap: 36px; }
-  .see-art { max-width: 460px; }
+  /* Hero order: headline, one sentence, the button, hosts. The explainer
+     cards are desktop-only. */
+  .d { display: none; }
+  .m { display: inline; }
+  .hero-copy > .sr-only {
+    position: static; width: auto; height: auto; overflow: visible; clip: auto; white-space: normal;
+    font-size: 17px; line-height: 1.5; color: var(--slate-600); margin: 16px 0 0; max-width: 30ch; text-wrap: balance;
+  }
+  .hero-hosts-label, .inst-tab.agent .rec, .platform-note, a.hero-license, .hero-hosts em.new { display: none; }
+  .inst-note { margin-top: 14px; }
+  .host-pill { padding: 5px 10px; font-size: 12.5px; gap: 6px; }
+  .hero-copy .ds-h1 { order: 0; }
+  .hero-copy .sr-only { order: 1; }
+  .hero-installers { order: 2; margin-top: 30px; }
+  .hero-hosts { order: 3; margin-top: 34px; gap: 8px; }
+  .hero-meta { order: 4; margin-top: 26px; }
+  .hx { display: none; }
+  .hero-meta { flex-wrap: wrap; }
+  .hero-star { white-space: nowrap; }
+
   /* Hero on phones: agent setup only, no install tabs */
-  .ds-hero { padding-bottom: 48px; }
-  .term-body { height: 320px; font-size: 12.5px; }
   .inst-tab:not(.agent), .manual-panel { display: none !important; }
-  /* Explainer: compact on phones */
-  .hx { max-width: 340px; gap: 8px; font-size: 10.5px; margin-top: 28px; }
-  .hx-card { padding: 8px 10px 9px; border-radius: 10px; }
-  .hx-eyebrow { font-size: 9.5px; margin-bottom: 4px; }
-  .hx-row { gap: 6px; padding: 1px 5px; margin: 0 -5px; }
-  .hx-k { width: 52px; }
-  .hx-caret { width: 5px; height: 11px; }
-  .hero-installers { margin-top: 30px; }
   .inst-tabs { flex-direction: column; align-items: stretch; }
   .inst-tab.agent { height: 50px; justify-content: center; font-size: 16px; padding: 0 16px; gap: 8px; white-space: nowrap; }
   .inst-tab.agent .rec { font-size: 10.5px; padding: 2px 7px; }
   .agent-note { display: block; }
+
+  /* Working in the background: copy and the says-vs-did illustration.
+     The terminal replay is desktop-only. */
+  .see-inner { grid-template-columns: 1fr; gap: 0; }
+  .see-demo { display: none; }
+  .see-art { max-width: none; margin-top: 20px; padding: 10px 8px; }
+  .see-note { margin-top: 16px; }
+
+  /* Under the hood: the wide diagram needs a side scroll here, so a
+     top-to-bottom one takes its place, with one-line notes. */
+  .arch { display: none; }
+  .arch-m { display: block; max-width: 360px; margin: 24px auto 0; padding: 10px 8px; background: #fff; border: 1px solid var(--slate-200); border-radius: 16px; }
+  .arch-m svg { width: 100%; height: auto; display: block; overflow: visible; }
+  .arch-m .art-txt.strong { font-weight: 600; fill: var(--slate-900); }
+  .arch-notes { margin-top: 26px; gap: 14px; }
+  .arch-notes p { font-size: 14px; }
+
+  /* Coming soon: three short items, no mock ledgers. */
+  .nx { display: none; }
+  .next-grid { margin-top: 28px; }
 }
 @media (max-width: 560px) {
   .rc-line { grid-template-columns: 1fr; gap: 2px; }
-  .alpha-inner { flex-direction: column; align-items: flex-start; }
+  .alpha-inner { flex-direction: column; align-items: flex-start; gap: 20px; }
+  /* The row basis would become a 420px tall column here. */
+  .alpha-copy { flex: 0 0 auto; }
 }
 @media (max-width: 520px) {
   .inst-tabs { flex-direction: column; align-items: stretch; }


### PR DESCRIPTION
## Issue

- Linked issue: Fixes #712
- I searched existing issues and PRs for duplicates before opening this PR.
- Not design-gated: presentation only, requested by the maintainer.

## Documentation

- Behavior change? `no` (landing page presentation only)
- Docs updated: `n/a — no behavior change`

## Verification

Commands run (paste):

```text
cd landing && npm run build          # [build] Complete!
git diff --check                     # clean
```

Manual, against the local Astro dev server in the in-app browser:

- 375px and 320px viewports: scrolled the full page after each change; `document.documentElement.scrollWidth === clientWidth` at 320px (no horizontal overflow).
- Clicked "Set up with your agent" at 320px: prompt copied, next-steps panel shown with three steps.
- 800px desktop viewport: hero explainer cards, terminal replay, and wide diagram render as before.
- Desktop: clicked the manual-install toggle; label reads "Install options" with `aria-expanded="true"` and the panel shown, and "Install manually" again once closed.

## Boundaries

- [x] No material from `docs/architecture/` or other ignored private drafting inputs is included.
- [x] I will disposition every human and code-review-agent comment before merge: fix it, or reply
      explaining why it is invalid or out of scope.

## Summary

On phones the hero looped three mostly-empty explainer cards that pushed the setup button off screen, the terminal typed a transcript line by line into a tall dark card, and the architecture diagram needed a side scroll.

At the phone breakpoint (≤720px) the page now reads: two-sentence headline with the wordmark inline, one lead line, the setup button, one note, three host pills on one row, GitHub pill. The explainer cards, terminal replay, "Coming soon" mock ledger cards, and wide architecture diagram are desktop-only. "Working in the background" shows the says-vs-did illustration in place of the terminal, and "Under the hood" gets a new top-to-bottom version of the architecture diagram with one-line notes. Long copy carries a shorter phone variant through `.d` / `.m` spans. Desktop layout is unchanged.

Second commit, desktop only, requested in the same review pass: the manual-install toggle reads "Install manually" when closed and "Install options" while its panel is open, so the button matches what it reveals.

Work done by Claude Fable 5.1 in Claude Code (desktop app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a mobile-friendly architecture diagram with simplified flow details.
  - Added separate desktop and mobile installation guidance.
  - Manual installation controls now display context-specific labels when expanded or collapsed.

- **Style**
  - Improved responsive layouts for screens below 760px, including hero content, typography, section spacing, and installation controls.
  - Added alternate desktop and mobile copy, including shorter screen-reader descriptions.
  - Mobile views now hide desktop-only content and display a more compact architecture presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->